### PR TITLE
revert: restore SKIP_INSTALL_RPATH for macOS targets

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -99,15 +99,8 @@ if(WIN32)
   target_sources(klogg_grep PRIVATE ${ProductVersionResourceFiles})
 
 elseif(APPLE)
-  # macdeployqt handles rpath adjustment and Qt framework bundling.
-  # BUILD_WITH_INSTALL_RPATH ensures the build binary already has the
-  # install rpath (@executable_path/../Frameworks), so cmake's install
-  # step has no rpath changes to make — avoiding install_name_tool
-  # -delete_rpath errors when CPack runs after macdeployqt.
-  set_target_properties(klogg klogg_portable PROPERTIES
-    INSTALL_RPATH "@executable_path/../Frameworks"
-    BUILD_WITH_INSTALL_RPATH ON
-  )
+  set_target_properties(klogg PROPERTIES SKIP_INSTALL_RPATH ON)
+  set_target_properties(klogg_portable PROPERTIES SKIP_INSTALL_RPATH ON)
   set_source_files_properties(${ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   set_source_files_properties(${NOTICE_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION SharedSupport)
   set_source_files_properties(${COPYING_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION SharedSupport)


### PR DESCRIPTION
BUILD_WITH_INSTALL_RPATH ON causes klogg_smoke test to fail because the build binary uses @executable_path/../Frameworks as rpath, but Qt frameworks aren't there until macdeployqt runs (which happens after tests). SKIP_INSTALL_RPATH ON preserves the build-time rpath pointing to the Qt installation, allowing tests to pass. The existing error handling in macdeployqtfix.py (44d58b34) already covers the rpath deletion issue during packaging.