### PR TITLE
feat: ADB logcat stability, UI enhancements, and shortcut remapping

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+language: en
+reviews:
+  profile: chill
+  auto_review:
+    enabled: true
+    drafts: false

--- a/docs/ADB_LOGCAT_ARCHITECTURE.md
+++ b/docs/ADB_LOGCAT_ARCHITECTURE.md
@@ -1,0 +1,253 @@
+# ADB Logcat Live Source Architecture
+
+This document describes the data flow for ADB logcat live sources in klogg,
+covering both the default memory/temp-file mode and the "Save Live Log As"
+persistent-file mode.
+
+## Overview
+
+```
+adb logcat (QProcess stdout)
+  -> ProcessLiveSourceTransport::bytesReceived
+  -> AdbLogcatSource -> StreamingLogData::appendUtf8()
+  -> CaptureStore::appendUtf8() -> commitLine()
+    -> Memory segment (Segment.memoryData)
+    -> When memoryBytes_ > 32 MB: spillSegmentToDisk()
+    -> If bound output file: appendOutputBytes() with immediate flush
+  -> CrawlerWidget / LogFilteredData reads from CaptureStore
+  -> UI display (main view + filter view)
+```
+
+## Key Parameters
+
+| Parameter              | Value                   | Location                  |
+|------------------------|-------------------------|---------------------------|
+| Segment size limit     | 1 MB                    | `capturestore.h` Limits   |
+| Total memory budget    | 32 MB                   | `capturestore.h` Limits   |
+| Temp spill directory   | `QDir::tempPath()/klogg_live/{captureId}/` | `capturestore.cpp` |
+| Segment file format    | `segment_000000.log`    | `capturestore.cpp`        |
+| Bound file flush       | Immediate (every line)  | `appendOutputBytes()`     |
+| Active segment spill   | Never                   | `enforceMemoryBudget()`   |
+| UI notification signal | `fileChanged(DataAdded)` per `appendUtf8()` | `streaminglogdata.cpp` |
+
+## Mode A: Memory / Temp File (Default)
+
+```mermaid
+sequenceDiagram
+    participant ADB as adb logcat<br/>(QProcess)
+    participant PLT as ProcessLiveSource<br/>Transport
+    participant ALS as AdbLogcatSource
+    participant SLD as StreamingLogData
+    participant CS as CaptureStore
+    participant Seg as Memory Segment<br/>(QByteArray)
+    participant Disk as Temp Spill File<br/>klogg_live/{captureId}/
+    participant CW as CrawlerWidget
+    participant UI as LogMainView
+
+    ADB->>PLT: readyReadStandardOutput
+    PLT->>PLT: readAllStandardOutput()
+    PLT-->>ALS: Q_EMIT bytesReceived(data)
+    ALS->>SLD: appendUtf8(data)
+    SLD->>CS: appendUtf8(data)
+
+    Note over CS: partialLine_.append(data)<br/>scan for '\n', extract complete lines
+
+    loop For each complete line
+        CS->>CS: commitLine(lineBytes, true)
+        CS->>Seg: memoryData->append(lineBytes + '\n')
+        Note over CS: Record lineOffsets / lineLengths
+        CS->>CS: appendOutputBytes()
+        Note over CS: No boundOutputHandle_<br/>-> return (NO-OP)
+        CS->>CS: rotateSegmentIfNeeded()
+        Note over CS: byteSize >= 1 MB -> create new Segment
+
+        CS->>CS: enforceMemoryBudget()
+        opt memoryBytes_ > 32 MB
+            CS->>Disk: spillSegmentToDisk(oldest_segment)
+            Note over Disk: Write segment_XXXXXX.log
+            CS->>Seg: memoryData.reset()<br/>release memory
+        end
+    end
+
+    SLD-->>CW: Q_EMIT fileChanged(DataAdded)
+    CW->>CW: fileChangedHandler()
+    CW->>UI: trigger view refresh
+
+    UI->>CS: lineAt(lineNumber)
+    CS->>CS: readSegmentLine(segment, localLine)
+    alt Segment in memory
+        CS->>Seg: memoryData->mid(offset, length)
+    else Segment spilled to disk
+        CS->>Disk: QFile::read(offset, length)
+    end
+    CS-->>UI: return line text
+
+    Note over ADB,UI: On disconnect / error
+    ALS->>SLD: finishInput()
+    SLD->>CS: finishInput()
+    CS->>CS: commitLine(partialLine_, false)<br/>commit unterminated last line
+```
+
+### Call Chain (Mode A)
+
+```
+QProcess::readyReadStandardOutput
+  -> ProcessLiveSourceTransport::lambda           [livesourcetransport.cpp:28]
+     -> readAllStandardOutput()
+     -> Q_EMIT bytesReceived(data)
+  -> AdbLogcatSource::lambda                      [adblogcatsource.cpp:61]
+     -> StreamingLogData::appendUtf8(data)        [streaminglogdata.cpp:16]
+        -> CaptureStore::appendUtf8(data)         [capturestore.cpp:110]
+           -> partialLine_.append(data)
+           -> for each '\n':
+              -> commitLine(lineBytes, true)       [capturestore.cpp:350]
+                 -> ensureActiveSegment()          [capturestore.cpp:384]
+                 -> segment.memoryData->append()
+                 -> appendOutputBytes()            [capturestore.cpp:568]
+                    -> return (no bound file)
+                 -> rotateSegmentIfNeeded()
+                 -> enforceMemoryBudget()          [capturestore.cpp:424]
+                    -> spillSegmentToDisk()         [capturestore.cpp:470]
+        -> Q_EMIT fileChanged(DataAdded)           [streaminglogdata.cpp:21]
+  -> CrawlerWidget::fileChangedHandler()
+     -> UI refresh
+        -> CaptureStore::lineAt()                  [capturestore.cpp:280]
+           -> readSegmentLine()                    [capturestore.cpp:503]
+              -> memory read or disk read
+```
+
+## Mode B: Save Live Log As (Bound Persistent File)
+
+```mermaid
+sequenceDiagram
+    participant User as User
+    participant MW as MainWindow
+    participant ALS as AdbLogcatSource
+    participant SLD as StreamingLogData
+    participant CS as CaptureStore
+    participant Seg as Memory Segment
+    participant BF as Persistent File<br/>(boundOutputHandle_)
+    participant Disk as Temp Spill File
+
+    User->>MW: Save Live Log As -> select path
+    MW->>ALS: bindOutputFile(outputPath)
+    ALS->>SLD: bindOutputFile(outputPath)
+    SLD->>CS: bindOutputFile(outputPath)
+    CS->>BF: QFile::open(WriteOnly | Truncate)
+    CS->>CS: writeCaptureToDevice(file)
+    Note over CS,BF: Write ALL existing segments<br/>to persistent file
+    CS->>BF: flush()
+    Note over CS: boundOutputHandle_ = file
+
+    Note over CS,BF: -- Every subsequent line writes to both --
+
+    par Subsequent data arrives
+        Note over CS: commitLine(lineBytes, true)
+        CS->>Seg: memoryData->append(lineBytes)
+        CS->>BF: write(lineBytes + '\n')
+        CS->>BF: flush()
+        Note over BF: Immediate flush per line
+
+        opt memoryBytes_ > 32 MB
+            CS->>Disk: spillSegmentToDisk()
+            Note over Disk: Temp files + persistent file<br/>coexist independently
+        end
+    end
+
+    Note over CS,BF: On disconnect
+    CS->>CS: finishInput()
+    CS->>Seg: commitLine(partial, false)
+    CS->>BF: write(partial_line), flush()
+```
+
+### Binding Call Chain (Mode B)
+
+```
+User: "Save Live Log As" -> outputPath
+  -> AdbLogcatSource::bindOutputFile(outputPath)   [adblogcatsource.cpp:148]
+     -> StreamingLogData::bindOutputFile()          [streaminglogdata.cpp:45]
+        -> CaptureStore::bindOutputFile()           [capturestore.cpp:186]
+           -> QFile::open(WriteOnly | Truncate)
+           -> writeCaptureToDevice(file)            [capturestore.cpp:557]
+              -> writeSegmentToDevice() for each segment
+           -> flush()
+           -> boundOutputHandle_ = file
+
+Subsequent lines:
+  -> CaptureStore::commitLine()                     [capturestore.cpp:350]
+     -> appendOutputBytes(lineBytes + '\n')         [capturestore.cpp:568]
+        -> boundOutputHandle_->write(bytes)
+        -> boundOutputHandle_->flush()              [immediate!]
+```
+
+## Mode Comparison
+
+```
+Mode A (default):
+  adb stdout -> CaptureStore -> [memory segments] --spill--> [temp files]
+                                       |
+                                    UI reads
+
+Mode B (bound file):
+  adb stdout -> CaptureStore -> [memory segments] --spill--> [temp files]
+                    |                      |
+                    +----------> [persistent file]   UI reads
+                              (flush per line)
+```
+
+The persistent file and the memory/spill mechanism are fully independent.
+The persistent file receives an immediate copy of every line. Even if klogg
+crashes, data already flushed to the persistent file is preserved.
+
+## Latency Analysis
+
+**Can adb logcat output be delayed in klogg display?** Yes, but typically negligible:
+
+- QProcess buffers stdout data until the event loop processes `readyReadStandardOutput`
+- If the main thread blocks (large search, file loading), pipe buffers accumulate
+- Normal latency: < 1 event loop cycle (~16 ms)
+- Worst case: during CPU-intensive operations (regex search on large data), display may lag
+
+## Lifecycle
+
+### Connect
+
+```
+AdbLogcatSource::connectSource()
+  -> ProcessLiveSourceTransport::connectTransport()
+     -> QProcess::start("adb", ["-s", serial, "logcat", ...])
+     -> waitForStarted(3000)
+     -> grace period polling (250 ms)
+     -> setState(Connected)
+```
+
+### Disconnect (intentional)
+
+```
+AdbLogcatSource::disconnectSource()
+  -> ProcessLiveSourceTransport::disconnectTransport()
+     -> disconnectRequested_ = true
+     -> process_->terminate()
+     -> waitForFinished(1500), fallback kill()
+     -> setState(Disconnected)
+  -> StreamingLogData::finishInput()
+     -> CaptureStore::finishInput()  [commit partial line]
+```
+
+### Disconnect (unexpected -- USB unplug, device sleep, adb kill-server)
+
+```
+QProcess::errorOccurred / finished
+  -> if disconnectRequested_: suppress error (Task 3 fix)
+  -> otherwise: setState(Error), emit errorOccurred(message)
+  -> Tab shows [error] suffix + error in tooltip (Task 4)
+```
+
+### Reconnect
+
+```
+AdbLogcatSource::reconnectSource()
+  -> disconnectSource()
+  -> append "----- reconnected {timestamp} -----" marker
+  -> connectSource()
+```

--- a/src/settings/include/shortcuts.h
+++ b/src/settings/include/shortcuts.h
@@ -77,6 +77,8 @@ struct ShortcutAction {
     static constexpr auto MainWindowCopyPathToClipboard = "mainwindow.copy_path_to_clipboard";
     static constexpr auto MainWindowOpenFromClipboard = "mainwindow.open_from_clipboard";
     static constexpr auto MainWindowOpenFromUrl = "mainwindow.open_from_url";
+    static constexpr auto MainWindowDisconnectSource = "mainwindow.disconnect_source";
+    static constexpr auto MainWindowReconnectSource = "mainwindow.reconnect_source";
 
     static constexpr auto LogViewMark = "logview.mark";
     static constexpr auto LogViewDeleteMark = "logview.delete_mark";

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -245,6 +245,20 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             },
         },
         {
+            MainWindowDisconnectSource,
+            {
+                QApplication::tr( "Disconnect live source" ),
+                QStringList{ "Ctrl+Shift+D" },
+            },
+        },
+        {
+            MainWindowReconnectSource,
+            {
+                QApplication::tr( "Reconnect live source" ),
+                QStringList{ "Ctrl+Shift+R" },
+            },
+        },
+        {
             MainWindowFollowFile,
             {
                 QApplication::tr( "Monitor file changes" ),
@@ -312,21 +326,21 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             CrawlerChangeVisibilityToMarksAndMatches,
             {
                 QApplication::tr( "Change filtered lines visibility to marks and matches" ),
-                QStringList{ QKeySequence( Qt::Key_1 ).toString() },
+                QStringList{ "Ctrl+Shift+1" },
             },
         },
         {
             CrawlerChangeVisibilityToMarks,
             {
                 QApplication::tr( "Change filtered lines visibility to marks" ),
-                QStringList{ QKeySequence( Qt::Key_2 ).toString() },
+                QStringList{ "Ctrl+Shift+2" },
             },
         },
         {
             CrawlerChangeVisibilityToMatches,
             {
                 QApplication::tr( "Change filtered lines visibility to matches" ),
-                QStringList{ QKeySequence( Qt::Key_3 ).toString() },
+                QStringList{ "Ctrl+Shift+3" },
             },
         },
         {
@@ -347,42 +361,42 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             CrawlerEnableCaseMatching,
             {
                 QApplication::tr( "Enable case matching" ),
-                QStringList{ QKeySequence( Qt::Key_4 ).toString() },
+                QStringList{ "Ctrl+Shift+4" },
             },
         },
         {
             CrawlerEnableRegex,
             {
                 QApplication::tr( "Enable regex" ),
-                QStringList{ QKeySequence( Qt::Key_5 ).toString() },
+                QStringList{ "Ctrl+Shift+5" },
             },
         },
         {
             CrawlerEnableInverseMatching,
             {
                 QApplication::tr( "Enable inverse matching" ),
-                QStringList{ QKeySequence( Qt::Key_6 ).toString() },
+                QStringList{ "Ctrl+Shift+6" },
             },
         },
         {
             CrawlerEnableRegexCombining,
             {
                 QApplication::tr( "Enable regex combining" ),
-                QStringList{ QKeySequence( Qt::Key_7 ).toString() },
+                QStringList{ "Ctrl+Shift+7" },
             },
         },
         {
             CrawlerEnableAutoRefresh,
             {
                 QApplication::tr( "Enable auto refresh" ),
-                QStringList{ QKeySequence( Qt::Key_8 ).toString() },
+                QStringList{ "Ctrl+Shift+8" },
             },
         },
         {
             CrawlerKeepResults,
             {
                 QApplication::tr( "Keep search results" ),
-                QStringList{ QKeySequence( Qt::Key_9 ).toString() },
+                QStringList{ "Ctrl+Shift+9" },
             },
         },
         // remove by commit 0b75b9d6
@@ -544,63 +558,63 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             LogViewAddColorLabel1,
             {
                 QApplication::tr( "Highlight text with color 1" ),
-                QStringList{ "Ctrl+Shift+1" },
+                QStringList{ QKeySequence( Qt::Key_1 ).toString() },
             },
         },
         {
             LogViewAddColorLabel2,
             {
                 QApplication::tr( "Highlight text with color 2" ),
-                QStringList{ "Ctrl+Shift+2" },
+                QStringList{ QKeySequence( Qt::Key_2 ).toString() },
             },
         },
         {
             LogViewAddColorLabel3,
             {
                 QApplication::tr( "Highlight text with color 3" ),
-                QStringList{ "Ctrl+Shift+3" },
+                QStringList{ QKeySequence( Qt::Key_3 ).toString() },
             },
         },
         {
             LogViewAddColorLabel4,
             {
                 QApplication::tr( "Highlight text with color 4" ),
-                QStringList{ "Ctrl+Shift+4" },
+                QStringList{ QKeySequence( Qt::Key_4 ).toString() },
             },
         },
         {
             LogViewAddColorLabel5,
             {
                 QApplication::tr( "Highlight text with color 5" ),
-                QStringList{ "Ctrl+Shift+5" },
+                QStringList{ QKeySequence( Qt::Key_5 ).toString() },
             },
         },
         {
             LogViewAddColorLabel6,
             {
                 QApplication::tr( "Highlight text with color 6" ),
-                QStringList{ "Ctrl+Shift+6" },
+                QStringList{ QKeySequence( Qt::Key_6 ).toString() },
             },
         },
         {
             LogViewAddColorLabel7,
             {
                 QApplication::tr( "Highlight text with color 7" ),
-                QStringList{ "Ctrl+Shift+7" },
+                QStringList{ QKeySequence( Qt::Key_7 ).toString() },
             },
         },
         {
             LogViewAddColorLabel8,
             {
                 QApplication::tr( "Highlight text with color 8" ),
-                QStringList{ "Ctrl+Shift+8" },
+                QStringList{ QKeySequence( Qt::Key_8 ).toString() },
             },
         },
         {
             LogViewAddColorLabel9,
             {
                 QApplication::tr( "Highlight text with color 9" ),
-                QStringList{ "Ctrl+Shift+9" },
+                QStringList{ QKeySequence( Qt::Key_9 ).toString() },
             },
         },
         {

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -228,6 +228,7 @@ class MainWindow : public QMainWindow {
     void updateShortcuts();
     void persistSessionState();
     void registerAdbLogcatSource( CrawlerWidget* crawler );
+    void updateLiveTabAppearance( CrawlerWidget* crawler );
 
     WindowSession session_;
     QString loadingFileName;

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -615,7 +615,7 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
             }
 
             colorLablesActionGroup = new QActionGroup( colorLabelsMenu_ );
-            colorLablesActionGroup->setExclusive( true );
+            colorLablesActionGroup->setExclusive( false );
             connect( colorLablesActionGroup, &QActionGroup::triggered, this,
                      &AbstractLogView::setColorLabel );
 

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -41,6 +41,9 @@ ProcessLiveSourceTransport::ProcessLiveSourceTransport( QObject* parent )
     } );
 
     connect( process_.get(), &QProcess::errorOccurred, this, [ this ]( QProcess::ProcessError ) {
+        if ( disconnectRequested_ ) {
+            return;
+        }
         lastError_ = process_->errorString();
         setState( State::Error );
         Q_EMIT errorOccurred( lastError_ );

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -2288,6 +2288,10 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
                  }
                  updateLiveTabAppearance( crawler );
              } );
+
+    // Sync tab appearance immediately in case the source is already
+    // in Error or Disconnected state (e.g. during session restore).
+    updateLiveTabAppearance( crawler );
 }
 
 // Updates the actions for the recent files.
@@ -2810,22 +2814,26 @@ std::vector<QString> MainWindow::showMergeFilesDialog( const QStringList& filePa
     // dialog.exec() blocks until the dialog closes, keeping it alive.
     connect( listWidget, &QListWidget::itemChanged,
              [ &checkCounter, listWidget, updateSequenceNumbers ]( QListWidgetItem* item ) {
-                 if ( item->checkState() == Qt::Checked ) {
-                     item->setData( Qt::UserRole + 2, ++checkCounter );
-                 }
-                 else {
-                     // Uncheck: compact remaining order values so re-check gets the next slot
-                     const int removedOrder = item->data( Qt::UserRole + 2 ).toInt();
-                     item->setData( Qt::UserRole + 2, 0 );
-                     // Shift down orders above the removed item
-                     for ( int i = 0; i < listWidget->count(); ++i ) {
-                         auto* other = listWidget->item( i );
-                         const int otherOrder = other->data( Qt::UserRole + 2 ).toInt();
-                         if ( otherOrder > removedOrder ) {
-                             other->setData( Qt::UserRole + 2, otherOrder - 1 );
-                         }
+                 // Block signals while mutating item data to prevent recursive
+                 // itemChanged from corrupting checkCounter.
+                 {
+                     const QSignalBlocker blocker( listWidget );
+                     if ( item->checkState() == Qt::Checked ) {
+                         item->setData( Qt::UserRole + 2, ++checkCounter );
                      }
-                     --checkCounter;
+                     else {
+                         // Uncheck: compact remaining order values so re-check gets the next slot
+                         const int removedOrder = item->data( Qt::UserRole + 2 ).toInt();
+                         item->setData( Qt::UserRole + 2, 0 );
+                         for ( int i = 0; i < listWidget->count(); ++i ) {
+                             auto* other = listWidget->item( i );
+                             const int otherOrder = other->data( Qt::UserRole + 2 ).toInt();
+                             if ( otherOrder > removedOrder ) {
+                                 other->setData( Qt::UserRole + 2, otherOrder - 1 );
+                             }
+                         }
+                         --checkCounter;
+                     }
                  }
                  updateSequenceNumbers();
              } );

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1287,11 +1287,7 @@ void MainWindow::saveCurrentLiveLog()
         return;
     }
 
-    const auto toolTip = session_.getAssociatedPath( crawler ).isEmpty()
-                             ? session_.getDisplayName( crawler )
-                             : session_.getAssociatedPath( crawler );
-    mainTabWidget_.updateCrawler( mainTabWidget_.currentIndex(), session_.getDisplayName( crawler ),
-                                  toolTip );
+    updateLiveTabAppearance( crawler );
     updateMenuBarFromDocument( crawler );
     updateOpenedFilesMenu();
     updateInfoLine();
@@ -2234,6 +2230,37 @@ void MainWindow::addRecentFile( const QString& fileName )
     updateRecentFileActions();
 }
 
+void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
+{
+    const auto tabIndex = mainTabWidget_.indexOf( crawler );
+    if ( tabIndex < 0 ) {
+        return;
+    }
+
+    auto* source = session_.getAdbLogcatSource( crawler );
+    const auto displayName = session_.getDisplayName( crawler );
+    const auto baseTip = session_.getAssociatedPath( crawler ).isEmpty()
+                             ? displayName
+                             : session_.getAssociatedPath( crawler );
+
+    QString title = displayName;
+    QString toolTip = baseTip;
+    if ( source ) {
+        const auto state = source->state();
+        if ( state == AdbLogcatSource::State::Error ) {
+            title += tr( " [error]" );
+            if ( !source->lastError().isEmpty() ) {
+                toolTip = tr( "%1\nError: %2" ).arg( baseTip, source->lastError() );
+            }
+        }
+        else if ( state == AdbLogcatSource::State::Disconnected ) {
+            title += tr( " [disconnected]" );
+        }
+    }
+
+    mainTabWidget_.updateCrawler( tabIndex, title, toolTip );
+}
+
 void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
 {
     if ( !crawler || session_.getDocumentKind( crawler ) != DocumentKind::AdbLogcat ) {
@@ -2246,45 +2273,20 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
     }
 
     connect( adbSource, &AdbLogcatSource::stateChanged, this,
-             [ this, crawler ]( AdbLogcatSource::State state ) {
+             [ this, crawler ]( AdbLogcatSource::State ) {
                  if ( currentCrawlerWidget() == crawler ) {
                      updateMenuBarFromDocument( crawler );
                      updateInfoLine();
                  }
                  updateOpenedFilesMenu();
-
-                 const auto tabIndex = mainTabWidget_.indexOf( crawler );
-                 if ( tabIndex >= 0 ) {
-                     const auto displayName = session_.getDisplayName( crawler );
-                     const auto toolTip = session_.getAssociatedPath( crawler ).isEmpty()
-                                              ? displayName
-                                              : session_.getAssociatedPath( crawler );
-                     if ( state == AdbLogcatSource::State::Error ) {
-                         mainTabWidget_.updateCrawler( tabIndex, displayName + tr( " [error]" ),
-                                                       toolTip );
-                     }
-                     else if ( state == AdbLogcatSource::State::Disconnected ) {
-                         mainTabWidget_.updateCrawler(
-                             tabIndex, displayName + tr( " [disconnected]" ), toolTip );
-                     }
-                     else {
-                         mainTabWidget_.updateCrawler( tabIndex, displayName, toolTip );
-                     }
-                 }
+                 updateLiveTabAppearance( crawler );
              } );
     connect( adbSource, &AdbLogcatSource::errorOccurred, this,
-             [ this, crawler ]( const QString& error ) {
+             [ this, crawler ]( const QString& ) {
                  if ( currentCrawlerWidget() == crawler ) {
                      updateInfoLine();
                  }
-                 if ( !error.isEmpty() ) {
-                     const auto tabIndex = mainTabWidget_.indexOf( crawler );
-                     if ( tabIndex >= 0 ) {
-                         const auto currentTip = mainTabWidget_.tabToolTip( tabIndex );
-                         mainTabWidget_.setTabToolTip(
-                             tabIndex, tr( "%1\nError: %2" ).arg( currentTip, error ) );
-                     }
-                 }
+                 updateLiveTabAppearance( crawler );
              } );
 }
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -255,6 +255,11 @@ void MainWindow::reloadGeometry()
 
     session_.restoreGeometry( &geometry );
     restoreGeometry( geometry );
+
+    // Prevent restoring in minimized state (can happen if session was saved while minimized)
+    if ( windowState().testFlag( Qt::WindowMinimized ) ) {
+        setWindowState( windowState() & ~Qt::WindowMinimized );
+    }
 }
 
 void MainWindow::reloadSession()
@@ -804,6 +809,8 @@ void MainWindow::updateShortcuts()
     setShortcuts( selectOpenFileAction, ShortcutAction::MainWindowSelectOpenFile );
     setShortcuts( goToLineAction, ShortcutAction::LogViewJumpToLine );
     setShortcuts( optionsAction, ShortcutAction::MainWindowPreference );
+    setShortcuts( disconnectSourceAction, ShortcutAction::MainWindowDisconnectSource );
+    setShortcuts( reconnectSourceAction, ShortcutAction::MainWindowReconnectSource );
 }
 
 void MainWindow::loadIcons()
@@ -2238,17 +2245,45 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
         return;
     }
 
-    connect( adbSource, &AdbLogcatSource::stateChanged, this, [ this, crawler ] {
-        if ( currentCrawlerWidget() == crawler ) {
-            updateMenuBarFromDocument( crawler );
-            updateInfoLine();
-        }
-        updateOpenedFilesMenu();
-    } );
+    connect( adbSource, &AdbLogcatSource::stateChanged, this,
+             [ this, crawler ]( AdbLogcatSource::State state ) {
+                 if ( currentCrawlerWidget() == crawler ) {
+                     updateMenuBarFromDocument( crawler );
+                     updateInfoLine();
+                 }
+                 updateOpenedFilesMenu();
+
+                 const auto tabIndex = mainTabWidget_.indexOf( crawler );
+                 if ( tabIndex >= 0 ) {
+                     const auto displayName = session_.getDisplayName( crawler );
+                     const auto toolTip = session_.getAssociatedPath( crawler ).isEmpty()
+                                              ? displayName
+                                              : session_.getAssociatedPath( crawler );
+                     if ( state == AdbLogcatSource::State::Error ) {
+                         mainTabWidget_.updateCrawler( tabIndex, displayName + tr( " [error]" ),
+                                                       toolTip );
+                     }
+                     else if ( state == AdbLogcatSource::State::Disconnected ) {
+                         mainTabWidget_.updateCrawler(
+                             tabIndex, displayName + tr( " [disconnected]" ), toolTip );
+                     }
+                     else {
+                         mainTabWidget_.updateCrawler( tabIndex, displayName, toolTip );
+                     }
+                 }
+             } );
     connect( adbSource, &AdbLogcatSource::errorOccurred, this,
              [ this, crawler ]( const QString& error ) {
-                 if ( currentCrawlerWidget() == crawler && !error.isEmpty() ) {
-                     QMessageBox::warning( this, tr( "ADB logcat" ), error );
+                 if ( currentCrawlerWidget() == crawler ) {
+                     updateInfoLine();
+                 }
+                 if ( !error.isEmpty() ) {
+                     const auto tabIndex = mainTabWidget_.indexOf( crawler );
+                     if ( tabIndex >= 0 ) {
+                         const auto currentTip = mainTabWidget_.tabToolTip( tabIndex );
+                         mainTabWidget_.setTabToolTip(
+                             tabIndex, tr( "%1\nError: %2" ).arg( currentTip, error ) );
+                     }
                  }
              } );
 }
@@ -2720,69 +2755,78 @@ std::vector<QString> MainWindow::showMergeFilesDialog( const QStringList& filePa
     dialog.setMinimumWidth( 400 );
 
     auto* layout = new QVBoxLayout( &dialog );
-    layout->addWidget( new QLabel( tr( "Select and order files to merge:" ) ) );
+    layout->addWidget( new QLabel( tr( "Check files in desired merge order:" ) ) );
 
     auto* listWidget = new QListWidget( &dialog );
+    // Qt::UserRole = file path, Qt::UserRole+1 = original display name, Qt::UserRole+2 = check order
+    int checkCounter = 0;
 
     for ( const auto& filePath : filePaths ) {
         const auto displayName = QFileInfo( filePath ).fileName();
         auto* item = new QListWidgetItem( displayName );
         item->setData( Qt::UserRole, filePath );
         item->setData( Qt::UserRole + 1, displayName );
+        item->setData( Qt::UserRole + 2, 0 );
         item->setCheckState( Qt::Unchecked );
         item->setFlags( item->flags() | Qt::ItemIsUserCheckable );
         listWidget->addItem( item );
     }
     layout->addWidget( listWidget );
 
-    // Lambda to update sequence numbers on checked items
+    // Lambda to update sequence numbers based on check order
     auto updateSequenceNumbers = [ listWidget ]() {
+        // Collect checked items with their check order
+        std::vector<std::pair<int, int>> checkedItems; // (check order, list index)
+        for ( int i = 0; i < listWidget->count(); ++i ) {
+            auto* item = listWidget->item( i );
+            if ( item->checkState() == Qt::Checked ) {
+                checkedItems.emplace_back( item->data( Qt::UserRole + 2 ).toInt(), i );
+            }
+        }
+        std::sort( checkedItems.begin(), checkedItems.end() );
+
         listWidget->blockSignals( true );
-        int seq = 1;
+        // Reset all to original names first
         for ( int i = 0; i < listWidget->count(); ++i ) {
             auto* item = listWidget->item( i );
             const auto originalName = item->data( Qt::UserRole + 1 ).toString();
-            if ( item->checkState() == Qt::Checked ) {
-                item->setText( QString( "%1. %2" ).arg( seq++ ).arg( originalName ) );
-            }
-            else {
+            if ( item->checkState() != Qt::Checked ) {
                 item->setText( originalName );
             }
+        }
+        // Number checked items by check order
+        int seq = 1;
+        for ( const auto& [ order, idx ] : checkedItems ) {
+            auto* item = listWidget->item( idx );
+            const auto originalName = item->data( Qt::UserRole + 1 ).toString();
+            item->setText( QString( "%1. %2" ).arg( seq++ ).arg( originalName ) );
         }
         listWidget->blockSignals( false );
     };
 
-    connect( listWidget, &QListWidget::itemChanged, [ updateSequenceNumbers ]( QListWidgetItem* ) {
-        updateSequenceNumbers();
-    } );
-
-    // Up/Down buttons
-    auto* buttonLayout = new QHBoxLayout();
-    auto* upButton = new QPushButton( tr( "Move Up" ), &dialog );
-    auto* downButton = new QPushButton( tr( "Move Down" ), &dialog );
-    buttonLayout->addWidget( upButton );
-    buttonLayout->addWidget( downButton );
-    layout->addLayout( buttonLayout );
-
-    connect( upButton, &QPushButton::clicked, [ listWidget, updateSequenceNumbers ]() {
-        const int row = listWidget->currentRow();
-        if ( row > 0 ) {
-            auto* item = listWidget->takeItem( row );
-            listWidget->insertItem( row - 1, item );
-            listWidget->setCurrentRow( row - 1 );
-            updateSequenceNumbers();
-        }
-    } );
-
-    connect( downButton, &QPushButton::clicked, [ listWidget, updateSequenceNumbers ]() {
-        const int row = listWidget->currentRow();
-        if ( row >= 0 && row < listWidget->count() - 1 ) {
-            auto* item = listWidget->takeItem( row );
-            listWidget->insertItem( row + 1, item );
-            listWidget->setCurrentRow( row + 1 );
-            updateSequenceNumbers();
-        }
-    } );
+    // checkCounter lives on the stack of showMergeFilesDialog; safe because
+    // dialog.exec() blocks until the dialog closes, keeping it alive.
+    connect( listWidget, &QListWidget::itemChanged,
+             [ &checkCounter, listWidget, updateSequenceNumbers ]( QListWidgetItem* item ) {
+                 if ( item->checkState() == Qt::Checked ) {
+                     item->setData( Qt::UserRole + 2, ++checkCounter );
+                 }
+                 else {
+                     // Uncheck: compact remaining order values so re-check gets the next slot
+                     const int removedOrder = item->data( Qt::UserRole + 2 ).toInt();
+                     item->setData( Qt::UserRole + 2, 0 );
+                     // Shift down orders above the removed item
+                     for ( int i = 0; i < listWidget->count(); ++i ) {
+                         auto* other = listWidget->item( i );
+                         const int otherOrder = other->data( Qt::UserRole + 2 ).toInt();
+                         if ( otherOrder > removedOrder ) {
+                             other->setData( Qt::UserRole + 2, otherOrder - 1 );
+                         }
+                     }
+                     --checkCounter;
+                 }
+                 updateSequenceNumbers();
+             } );
 
     auto* dialogButtons
         = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog );
@@ -2794,13 +2838,21 @@ std::vector<QString> MainWindow::showMergeFilesDialog( const QStringList& filePa
         return {};
     }
 
-    // Collect checked files in order
-    std::vector<QString> result;
+    // Collect checked files sorted by check order
+    std::vector<std::pair<int, QString>> checkedFiles;
     for ( int i = 0; i < listWidget->count(); ++i ) {
         auto* item = listWidget->item( i );
         if ( item->checkState() == Qt::Checked ) {
-            result.push_back( item->data( Qt::UserRole ).toString() );
+            checkedFiles.emplace_back( item->data( Qt::UserRole + 2 ).toInt(),
+                                       item->data( Qt::UserRole ).toString() );
         }
+    }
+    std::sort( checkedFiles.begin(), checkedFiles.end() );
+
+    std::vector<QString> result;
+    result.reserve( checkedFiles.size() );
+    for ( auto& [ order, path ] : checkedFiles ) {
+        result.push_back( std::move( path ) );
     }
 
     if ( result.size() < 2 ) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(klogg_tests
     patternmatcher_test.cpp
     quicklabelpattern_test.cpp
     sessioninfo_test.cpp
+    shortcut_bindings_test.cpp
     streaminglogdata_test.cpp
     tabgroupdropresolver_test.cpp
     tabgroupmanager_test.cpp

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -196,6 +196,61 @@ TEST_CASE( "OptionsDialog loads and persists adb settings" )
              == QStringLiteral( "-v threadtime ActivityManager:I *:S" ) );
 }
 
+namespace {
+// A minimal ProcessLiveSourceTransport subclass that runs a long-lived process
+// without ADB-specific argument decoration, for testing disconnect behavior.
+class LongRunningTestTransport : public ProcessLiveSourceTransport {
+  public:
+    Command streamingCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "ping" ), { QStringLiteral( "-n" ), QStringLiteral( "60" ),
+                                             QStringLiteral( "127.0.0.1" ) } };
+#else
+        return { QStringLiteral( "sleep" ), { QStringLiteral( "60" ) } };
+#endif
+    }
+
+    Command clearCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "cmd" ), { QStringLiteral( "/c" ), QStringLiteral( "echo" ) } };
+#else
+        return { QStringLiteral( "true" ), {} };
+#endif
+    }
+};
+} // namespace
+
+TEST_CASE( "ProcessLiveSourceTransport suppresses errorOccurred during intentional disconnect" )
+{
+    LongRunningTestTransport transport;
+
+    SafeQSignalSpy errorSpy( &transport, SIGNAL( errorOccurred( QString ) ) );
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+
+    // Connect — the long-running process starts successfully
+    REQUIRE( transport.connectTransport() );
+
+    // Disconnect — sets disconnectRequested_ = true before terminating
+    transport.disconnectTransport();
+
+    // Process events to let any queued signals through
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+
+    // Verify: no errorOccurred signals should have been emitted during disconnect
+    // (the disconnectRequested_ guard should suppress them)
+    CHECK( errorSpy.count() == 0 );
+
+    // The final state should be Disconnected (not Error)
+    REQUIRE( stateSpy.count() >= 1 );
+    const auto lastState
+        = stateSpy.at( stateSpy.count() - 1 ).at( 0 ).value<LiveSourceTransport::State>();
+    CHECK( lastState == LiveSourceTransport::State::Disconnected );
+}
+
 TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edits on accept" )
 {
     if ( isHeadlessDialogTestEnvironment() ) {

--- a/tests/unit/shortcut_bindings_test.cpp
+++ b/tests/unit/shortcut_bindings_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QKeySequence>
+#include <QString>
+
+#include "shortcuts.h"
+
+TEST_CASE( "Shortcut bindings: disconnect and reconnect source have defaults" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    SECTION( "MainWindowDisconnectSource is bound to Ctrl+Shift+D" )
+    {
+        auto it = shortcuts.find( ShortcutAction::MainWindowDisconnectSource );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+D" ) ) );
+    }
+
+    SECTION( "MainWindowReconnectSource is bound to Ctrl+Shift+R" )
+    {
+        auto it = shortcuts.find( ShortcutAction::MainWindowReconnectSource );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+R" ) ) );
+    }
+}
+
+TEST_CASE( "Shortcut bindings: color labels use plain digit keys 1-9" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    const std::string colorLabelActions[] = {
+        ShortcutAction::LogViewAddColorLabel1, ShortcutAction::LogViewAddColorLabel2,
+        ShortcutAction::LogViewAddColorLabel3, ShortcutAction::LogViewAddColorLabel4,
+        ShortcutAction::LogViewAddColorLabel5, ShortcutAction::LogViewAddColorLabel6,
+        ShortcutAction::LogViewAddColorLabel7, ShortcutAction::LogViewAddColorLabel8,
+        ShortcutAction::LogViewAddColorLabel9,
+    };
+
+    for ( int i = 0; i < 9; ++i ) {
+        DYNAMIC_SECTION( "Color label " << ( i + 1 ) << " is bound to plain digit key" )
+        {
+            auto it = shortcuts.find( colorLabelActions[ i ] );
+            REQUIRE( it != shortcuts.end() );
+            const auto expectedKey = QKeySequence( Qt::Key_1 + i ).toString();
+            REQUIRE( it->second.keySequence.contains( expectedKey ) );
+        }
+    }
+}
+
+TEST_CASE( "Shortcut bindings: crawler visibility and filter options use Ctrl+Shift+digit" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    SECTION( "Marks and matches visibility is Ctrl+Shift+1" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerChangeVisibilityToMarksAndMatches );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+1" ) ) );
+    }
+
+    SECTION( "Marks visibility is Ctrl+Shift+2" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerChangeVisibilityToMarks );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+2" ) ) );
+    }
+
+    SECTION( "Matches visibility is Ctrl+Shift+3" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerChangeVisibilityToMatches );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+3" ) ) );
+    }
+
+    SECTION( "Case matching is Ctrl+Shift+4" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerEnableCaseMatching );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+4" ) ) );
+    }
+
+    SECTION( "Regex is Ctrl+Shift+5" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerEnableRegex );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+5" ) ) );
+    }
+
+    SECTION( "Inverse matching is Ctrl+Shift+6" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerEnableInverseMatching );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+6" ) ) );
+    }
+
+    SECTION( "Regex combining is Ctrl+Shift+7" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerEnableRegexCombining );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+7" ) ) );
+    }
+
+    SECTION( "Auto refresh is Ctrl+Shift+8" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerEnableAutoRefresh );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+8" ) ) );
+    }
+
+    SECTION( "Keep results is Ctrl+Shift+9" )
+    {
+        auto it = shortcuts.find( ShortcutAction::CrawlerKeepResults );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QStringLiteral( "Ctrl+Shift+9" ) ) );
+    }
+}
+
+TEST_CASE( "Shortcut bindings: no duplicate key bindings across all default shortcuts" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    // Build a map from key binding → list of actions that use it
+    std::map<QString, std::vector<std::string>> keyToActions;
+    for ( const auto& [ action, shortcut ] : shortcuts ) {
+        for ( const auto& key : shortcut.keySequence ) {
+            if ( !key.isEmpty() ) {
+                keyToActions[ key ].push_back( action );
+            }
+        }
+    }
+
+    // Check that the swapped keys don't have conflicts
+    QStringList keysToCheck = { "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                                "Ctrl+Shift+1", "Ctrl+Shift+2", "Ctrl+Shift+3",
+                                "Ctrl+Shift+4", "Ctrl+Shift+5", "Ctrl+Shift+6",
+                                "Ctrl+Shift+7", "Ctrl+Shift+8", "Ctrl+Shift+9",
+                                "Ctrl+Shift+D", "Ctrl+Shift+R" };
+
+    for ( const auto& key : keysToCheck ) {
+        DYNAMIC_SECTION( "Key " << key.toStdString() << " has at most one binding" )
+        {
+            auto it = keyToActions.find( key );
+            if ( it != keyToActions.end() ) {
+                INFO( "Actions using key: " );
+                for ( const auto& action : it->second ) {
+                    INFO( "  " << action );
+                }
+                CHECK( it->second.size() <= 1 );
+            }
+        }
+    }
+}

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -60,4 +60,47 @@ TEST_CASE( "TabbedCrawlerWidget keeps live tab title and tooltip across group re
              == QDir::toNativeSeparators( QStringLiteral( "/tmp/pixel-saved.log" ) ) );
 }
 
+TEST_CASE( "TabbedCrawlerWidget updateCrawler reflects disconnect and error state in tab text" )
+{
+    TabbedCrawlerWidget tabWidget;
+    auto* crawler = new DummyCrawlerWidget();
+
+    const auto index = tabWidget.addCrawler( crawler, QStringLiteral( "adb://capture-456" ),
+                                             QStringLiteral( "Galaxy S24" ),
+                                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    SECTION( "tab text shows [disconnected] suffix" )
+    {
+        tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [disconnected]" ),
+                                 QStringLiteral( "/tmp/galaxy.log" ) );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24 [disconnected]" ) );
+    }
+
+    SECTION( "tab text shows [error] suffix" )
+    {
+        tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [error]" ),
+                                 QStringLiteral( "/tmp/galaxy.log" ) );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24 [error]" ) );
+    }
+
+    SECTION( "tab text restores to normal on reconnect" )
+    {
+        tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [disconnected]" ),
+                                 QStringLiteral( "/tmp/galaxy.log" ) );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24 [disconnected]" ) );
+
+        tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24" ),
+                                 QStringLiteral( "/tmp/galaxy.log" ) );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24" ) );
+    }
+
+    SECTION( "tab text persists across group refreshes" )
+    {
+        tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [error]" ),
+                                 QStringLiteral( "/tmp/galaxy.log" ) );
+        tabWidget.onGroupsChanged();
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24 [error]" ) );
+    }
+}
+
 #include "tabbedcrawlerwidget_test.moc"


### PR DESCRIPTION
- Fix "Process crashed" popup during intentional disconnect by guarding errorOccurred with disconnectRequested_ flag
- Add tab disconnect indicator ([disconnected]/[error] suffix) and show error details in tab tooltip instead of blocking QMessageBox
- Add Ctrl+Shift+D / Ctrl+Shift+R shortcuts for disconnect/reconnect
- Remap color label shortcuts to plain 1-9 keys; move crawler visibility/filter options to Ctrl+Shift+1-9
- Fix color label checkmark visibility by using non-exclusive QActionGroup
- Simplify merge dialog: remove Up/Down buttons, track check order with compact renumbering on uncheck
- Prevent session restore from showing minimized windows
- Add CodeRabbit configuration for automated PR reviews
- Add unit tests for disconnect guard, tab state text, shortcut bindings, and key conflict detection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for disconnect/reconnect live sources (Ctrl+Shift+D, Ctrl+Shift+R).
  * Added project configuration enabling automated reviews.

* **Bug Fixes**
  * Prevented restoring window minimized state after session load.
  * Suppressed spurious error notifications during intentional live-source disconnects.

* **UI/UX Improvements**
  * Merge-files dialog reworked to support check-based ordering.
  * Color labels can be selected simultaneously; live-source tabs reflect error/disconnected states.
  * Many crawler shortcuts moved to Ctrl+Shift+digit; color-labels use plain digits.

* **Documentation**
  * Added ADB Logcat architecture and data-flow documentation.

* **Tests**
  * Added unit tests for shortcut bindings, live-source transport, and tab state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->