### PR TITLE
feat: batched flush, async disconnect, highlighter coexistence, status bar pending

### DIFF
--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -1,6 +1,7 @@
 #ifndef CAPTURESTORE_H
 #define CAPTURESTORE_H
 
+#include <chrono>
 #include <memory>
 #include <mutex>
 
@@ -87,6 +88,13 @@ class CaptureStore {
     bool writeSegmentToDevice( const Segment& segment, QIODevice* device ) const;
     bool writeCaptureToDevice( QIODevice* device ) const;
     void appendOutputBytes( const QByteArray& bytes );
+    void flushOutputIfNeeded();
+    void resetOutputFlushCounters();
+
+    static constexpr qint64 OutputFlushBytesThreshold = 64 * 1024;
+    static constexpr int OutputFlushLinesThreshold = 100;
+    static constexpr std::chrono::steady_clock::duration OutputFlushTimeThreshold
+        = std::chrono::seconds( 1 );
 
   private:
     QString captureId_;
@@ -106,6 +114,10 @@ class CaptureStore {
     QDateTime lastModified_;
     bool persistBufferedSegmentsOnDestroy_ = true;
     mutable std::recursive_mutex mutex_;
+
+    qint64 unflushedOutputBytes_ = 0;
+    int unflushedOutputLines_ = 0;
+    std::chrono::steady_clock::time_point lastOutputFlushTime_{};
 };
 
 #endif

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <QRegularExpression>
+#include <QTimer>
 
 #include "capturestore.h"
 #include "searchablelogdata.h"
@@ -50,6 +51,8 @@ class StreamingLogData : public SearchableLogData {
 
   private:
     void scheduleLoadingFinished();
+    void startOutputFlushTimer();
+    void stopOutputFlushTimer();
     klogg::vector<QString> getLines( LineNumber first, LinesCount number ) const;
 
   private:
@@ -57,6 +60,7 @@ class StreamingLogData : public SearchableLogData {
     TextCodecHolder codec_;
     QRegularExpression prefilterPattern_;
     bool loadingFinishedQueued_ = false;
+    QTimer outputFlushTimer_;
 };
 
 #endif

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -133,17 +133,21 @@ void CaptureStore::appendUtf8( const QByteArray& data )
 void CaptureStore::finishInput()
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
-    if ( partialLine_.isEmpty() ) {
-        return;
+    if ( !partialLine_.isEmpty() ) {
+        auto lineBytes = partialLine_;
+        partialLine_.clear();
+        if ( lineBytes.endsWith( '\r' ) ) {
+            lineBytes.chop( 1 );
+        }
+
+        commitLine( lineBytes, false );
     }
 
-    auto lineBytes = partialLine_;
-    partialLine_.clear();
-    if ( lineBytes.endsWith( '\r' ) ) {
-        lineBytes.chop( 1 );
+    // Flush any pending output data
+    if ( boundOutputHandle_ && unflushedOutputBytes_ > 0 ) {
+        boundOutputHandle_->flush();
+        resetOutputFlushCounters();
     }
-
-    commitLine( lineBytes, false );
 }
 
 void CaptureStore::flush()
@@ -151,6 +155,7 @@ void CaptureStore::flush()
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
     if ( boundOutputHandle_ ) {
         boundOutputHandle_->flush();
+        resetOutputFlushCounters();
     }
 }
 
@@ -205,6 +210,7 @@ bool CaptureStore::bindOutputFile( const QString& outputPath )
     }
 
     boundOutputHandle_ = std::move( outputFile );
+    resetOutputFlushCounters();
     return true;
 }
 
@@ -681,10 +687,41 @@ void CaptureStore::appendOutputBytes( const QByteArray& bytes )
         return;
     }
 
-    if ( boundOutputHandle_->write( bytes ) != bytes.size()
-         || !boundOutputHandle_->flush() ) {
+    if ( boundOutputHandle_->write( bytes ) != bytes.size() ) {
         LOG_WARNING << "Bound output file write failed, unbinding: " << boundOutputFile_;
         boundOutputHandle_.reset();
         boundOutputFile_.clear();
+        return;
     }
+
+    unflushedOutputBytes_ += bytes.size();
+    unflushedOutputLines_++;
+    flushOutputIfNeeded();
+}
+
+void CaptureStore::flushOutputIfNeeded()
+{
+    if ( !boundOutputHandle_ || unflushedOutputBytes_ == 0 ) {
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if ( unflushedOutputBytes_ >= OutputFlushBytesThreshold
+         || unflushedOutputLines_ >= OutputFlushLinesThreshold
+         || now - lastOutputFlushTime_ >= OutputFlushTimeThreshold ) {
+        if ( !boundOutputHandle_->flush() ) {
+            LOG_WARNING << "Bound output file flush failed, unbinding: " << boundOutputFile_;
+            boundOutputHandle_.reset();
+            boundOutputFile_.clear();
+            return;
+        }
+        resetOutputFlushCounters();
+    }
+}
+
+void CaptureStore::resetOutputFlushCounters()
+{
+    unflushedOutputBytes_ = 0;
+    unflushedOutputLines_ = 0;
+    lastOutputFlushTime_ = std::chrono::steady_clock::now();
 }

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -11,6 +11,11 @@ StreamingLogData::StreamingLogData( QString captureId, QString captureRoot )
 {
     captureStore_.loadFromDisk();
     scheduleLoadingFinished();
+
+    outputFlushTimer_.setInterval( 1000 );
+    connect( &outputFlushTimer_, &QTimer::timeout, this, [this] {
+        captureStore_.flush();
+    } );
 }
 
 void StreamingLogData::appendUtf8( const QByteArray& data )
@@ -25,6 +30,7 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
 
 void StreamingLogData::finishInput()
 {
+    stopOutputFlushTimer();
     const auto previousLineCount = captureStore_.lineCount();
     captureStore_.finishInput();
     if ( captureStore_.lineCount() != previousLineCount ) {
@@ -35,6 +41,7 @@ void StreamingLogData::finishInput()
 
 void StreamingLogData::clearCapture()
 {
+    stopOutputFlushTimer();
     captureStore_.clear();
     Q_EMIT fileChanged( MonitoredFileStatus::Truncated );
     scheduleLoadingFinished();
@@ -42,7 +49,12 @@ void StreamingLogData::clearCapture()
 
 bool StreamingLogData::bindOutputFile( const QString& outputPath )
 {
-    return captureStore_.bindOutputFile( outputPath );
+    stopOutputFlushTimer();
+    const auto result = captureStore_.bindOutputFile( outputPath );
+    if ( !outputPath.isEmpty() && result ) {
+        startOutputFlushTimer();
+    }
+    return result;
 }
 
 QString StreamingLogData::boundOutputFile() const
@@ -185,6 +197,18 @@ void StreamingLogData::scheduleLoadingFinished()
             Q_EMIT loadingFinished( LoadingStatus::Successful );
         },
         Qt::QueuedConnection );
+}
+
+void StreamingLogData::startOutputFlushTimer()
+{
+    if ( !outputFlushTimer_.isActive() ) {
+        outputFlushTimer_.start();
+    }
+}
+
+void StreamingLogData::stopOutputFlushTimer()
+{
+    outputFlushTimer_.stop();
 }
 
 klogg::vector<QString> StreamingLogData::getLines( LineNumber first, LinesCount number ) const

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -112,6 +112,8 @@ class CrawlerWidget : public QSplitter,
 
     bool isTextWrapEnabled() const;
 
+    qint64 searchPendingLines() const { return searchPendingLines_; }
+
     void registerShortcuts();
 
   public Q_SLOTS:
@@ -172,6 +174,8 @@ class CrawlerWidget : public QSplitter,
 
     void sendToScratchpad( QString );
     void replaceDataInScratchpad( QString );
+
+    void searchPendingLinesChanged();
 
     // "auto-refresh" check has been changed
     void searchRefreshChanged( bool isRefreshing );
@@ -451,6 +455,8 @@ class CrawlerWidget : public QSplitter,
     QString encodingText_;
 
     ColorLabelsManager colorLabelsManager_;
+
+    qint64 searchPendingLines_ = 0;
 };
 
 #endif

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -56,6 +56,7 @@ class ProcessLiveSourceTransport : public LiveSourceTransport {
 
   private:
     void setState( State state );
+    void createProcess();
 
   private:
     std::unique_ptr<QProcess> process_;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -157,6 +157,7 @@ class MainWindow : public QMainWindow {
     // Must be passed as the internal (starts at 0) line number.
     void lineNumberHandler( LineNumber startLine, LinesCount nLines, LineColumn startCol,
                             LineLength nSymbols );
+    void refreshLineNumberField();
 
     // Instructs the widget to update the loading progress gauge
     void updateLoadingProgress( int progress );
@@ -250,6 +251,12 @@ class MainWindow : public QMainWindow {
     QLabel* lineNbField;
     QLabel* sizeField;
     QLabel* dateField;
+
+    // Last known selection for refreshing line number field
+    LineNumber lastStartLine_{ 0 };
+    LinesCount lastNLines_{ 0 };
+    LineColumn lastStartCol_{ 0 };
+    LineLength lastNSymbols_{ 0 };
     QLabel* encodingField;
     std::vector<QAction*> infoToolbarSeparators;
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2892,8 +2892,8 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
 
         const auto isWholeLineSelected = selection_.isLineSelected( lineNumber );
 
+        // Set base colors
         if ( isWholeLineSelected ) {
-            // Reverse the selected line
             foreColor = palette.color( QPalette::HighlightedText );
             backColor = palette.color( QPalette::Highlight );
             painter->setPen( palette.color( QPalette::Text ) );
@@ -2901,33 +2901,33 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
         else {
             foreColor = palette.color( QPalette::Text );
             backColor = palette.color( QPalette::Base );
+        }
 
-            // Apply search range graying only if the view type allows it (LogMainView only, not FilteredView)
-            // and the line is outside the search range
-            if ( shouldApplySearchRangeGraying() && ( lineNumber < searchStartIndex || lineNumber >= searchEndIndex ) ) {
-                foreColor = palette.brush( QPalette::Disabled, QPalette::Text ).color();
+        // Apply search range graying for lines outside the search range
+        const auto isOutsideSearchRange = shouldApplySearchRangeGraying()
+            && ( lineNumber < searchStartIndex || lineNumber >= searchEndIndex );
+        if ( !isWholeLineSelected && isOutsideSearchRange ) {
+            foreColor = palette.brush( QPalette::Disabled, QPalette::Text ).color();
+        }
+        else if ( !isOutsideSearchRange ) {
+            const auto highlightType = highlighterSet.matchLine( logLine, highlighterMatches );
+
+            // LineMatch whole-line coloring only applies when not selected
+            if ( highlightType == HighlighterMatchType::LineMatch && !isWholeLineSelected ) {
+                foreColor = highlighterMatches.front().foreColor();
+                backColor = highlighterMatches.front().backColor();
             }
-            else {
-                const auto highlightType = highlighterSet.matchLine( logLine, highlighterMatches );
 
-                if ( highlightType == HighlighterMatchType::LineMatch ) {
-                    // color applies to whole line
-                    foreColor = highlighterMatches.front().foreColor();
-                    backColor = highlighterMatches.front().backColor();
-                }
+            if ( patternHighlight ) {
+                klogg::vector<HighlightedMatch> patternMatches;
+                patternHighlight->matchLine( logLine, patternMatches );
+                highlighterMatches.addMatches( patternMatches );
+            }
 
-                if ( patternHighlight ) {
-                    klogg::vector<HighlightedMatch> patternMatches;
-                    patternHighlight->matchLine( logLine, patternMatches );
-                    highlighterMatches.addMatches( patternMatches );
-                }
-
-                // highlighterMatches.reserve( additionalHighlighters.size() );
-                for ( const auto& highlighter : additionalHighlighters ) {
-                    klogg::vector<HighlightedMatch> patternMatches;
-                    highlighter.matchLine( logLine, patternMatches );
-                    highlighterMatches.addMatches( patternMatches );
-                }
+            for ( const auto& highlighter : additionalHighlighters ) {
+                klogg::vector<HighlightedMatch> patternMatches;
+                highlighter.matchLine( logLine, patternMatches );
+                highlighterMatches.addMatches( patternMatches );
             }
         }
 

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -576,11 +576,17 @@ void CrawlerWidget::updateFilteredView( LinesCount nbMatches, int progress,
     searchInfoLine_->show();
 
     if ( progress == 100 ) {
+        // Reset pending lines when search completes
+        if ( searchPendingLines_ != 0 ) {
+            searchPendingLines_ = 0;
+            Q_EMIT searchPendingLinesChanged();
+        }
+
         // Searching done - apply context lines if mode is active
         if ( contextLinesMode_ > 0 && contextLinesSpinBox_->value() > 0 ) {
             applyContextLines();
         }
-        
+
         printSearchInfoMessage( nbMatches );
         searchInfoLine_->hideGauge();
         // De-activate the stop button
@@ -602,6 +608,13 @@ void CrawlerWidget::updateFilteredView( LinesCount nbMatches, int progress,
             const auto totalLines = logData_->getNbLine();
             const auto remaining = totalLines.get()
                                  * static_cast<LinesCount::UnderlyingType>( 100 - progress ) / 100;
+
+            // Update pending lines for status bar display
+            const auto newPending = static_cast<qint64>( remaining );
+            if ( newPending != searchPendingLines_ ) {
+                searchPendingLines_ = newPending;
+                Q_EMIT searchPendingLinesChanged();
+            }
 
             QString progressText;
             if ( logData_->isLiveSource() && remaining > 0 ) {

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -4,6 +4,7 @@
 #include <QElapsedTimer>
 #include <QMetaType>
 #include <QProcess>
+#include <QTimer>
 
 #include "log.h"
 
@@ -21,8 +22,13 @@ LiveSourceTransport::LiveSourceTransport( QObject* parent ) : QObject( parent )
 
 ProcessLiveSourceTransport::ProcessLiveSourceTransport( QObject* parent )
     : LiveSourceTransport( parent )
-    , process_( std::make_unique<QProcess>() )
 {
+    createProcess();
+}
+
+void ProcessLiveSourceTransport::createProcess()
+{
+    process_ = std::make_unique<QProcess>();
     process_->setProcessChannelMode( QProcess::SeparateChannels );
 
     connect( process_.get(), &QProcess::readyReadStandardOutput, this, [ this ] {
@@ -136,15 +142,38 @@ void ProcessLiveSourceTransport::disconnectTransport()
         return;
     }
 
-    disconnectRequested_ = true;
-    process_->terminate();
-    if ( !process_->waitForFinished( 1500 ) ) {
-        process_->kill();
-        process_->waitForFinished( 1500 );
-    }
+    // Detach old process and cut all signal connections
+    auto* dying = process_.release();
+    dying->disconnect( this );
 
     disconnectRequested_ = false;
-    setState( State::Disconnected );
+
+    // Terminate the old process
+    if ( destroyed_ ) {
+        // Destructor path: synchronous cleanup, no need to create a new process
+        setState( State::Disconnected );
+        dying->terminate();
+        if ( !dying->waitForFinished( 1500 ) ) {
+            dying->kill();
+            dying->waitForFinished( 1500 );
+        }
+        delete dying;
+    }
+    else {
+        // Create fresh process for future connections
+        createProcess();
+        setState( State::Disconnected );
+
+        // Async cleanup, non-blocking
+        dying->terminate();
+        QObject::connect( dying, &QProcess::finished,
+                          dying, &QObject::deleteLater );
+        QTimer::singleShot( 1500, dying, [ dying ] {
+            if ( dying->state() != QProcess::NotRunning ) {
+                dying->kill();
+            }
+        } );
+    }
 }
 
 bool ProcessLiveSourceTransport::clearRemote( QString* error )

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -119,6 +119,13 @@ bool ProcessLiveSourceTransport::connectTransport()
             && startupTimer.elapsed() < StartupFailureGracePeriodMs ) {
         process_->waitForFinished( StartupFailurePollIntervalMs );
         QCoreApplication::processEvents();
+
+        // A disconnect may have been processed during processEvents(),
+        // swapping process_ with a fresh idle instance.  Bail out cleanly
+        // instead of misdiagnosing the new process as a startup failure.
+        if ( state_ == State::Disconnected ) {
+            return false;
+        }
     }
 
     if ( state_ == State::Error || process_->state() == QProcess::NotRunning ) {

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -167,7 +167,8 @@ void ProcessLiveSourceTransport::disconnectTransport()
 
         // Async cleanup, non-blocking
         dying->terminate();
-        QObject::connect( dying, &QProcess::finished,
+        QObject::connect( dying,
+                          qOverload<int, QProcess::ExitStatus>( &QProcess::finished ),
                           dying, &QObject::deleteLater );
         QPointer<QProcess> guard( dying );
         QTimer::singleShot( 1500, dying, [ guard ] {

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -3,6 +3,7 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QMetaType>
+#include <QPointer>
 #include <QProcess>
 #include <QTimer>
 
@@ -168,9 +169,10 @@ void ProcessLiveSourceTransport::disconnectTransport()
         dying->terminate();
         QObject::connect( dying, &QProcess::finished,
                           dying, &QObject::deleteLater );
-        QTimer::singleShot( 1500, dying, [ dying ] {
-            if ( dying->state() != QProcess::NotRunning ) {
-                dying->kill();
+        QPointer<QProcess> guard( dying );
+        QTimer::singleShot( 1500, dying, [ guard ] {
+            if ( guard && guard->state() != QProcess::NotRunning ) {
+                guard->kill();
             }
         } );
     }

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -176,6 +176,8 @@ MainWindow::MainWindow( WindowSession session )
     signalMux_.connect(
         SIGNAL( newSelection( LineNumber, LinesCount, LineColumn, LineLength ) ), this,
         SLOT( lineNumberHandler( LineNumber, LinesCount, LineColumn, LineLength ) ) );
+    signalMux_.connect( SIGNAL( searchPendingLinesChanged() ), this,
+                        SLOT( refreshLineNumberField() ) );
     signalMux_.connect( SIGNAL( sendToScratchpad( QString ) ), this,
                         SLOT( sendToScratchpad( QString ) ) );
 
@@ -1597,6 +1599,11 @@ void MainWindow::changeFollowMode( bool follow )
 void MainWindow::lineNumberHandler( LineNumber startLine, LinesCount nLines, LineColumn startCol,
                                     LineLength nSymbols )
 {
+    lastStartLine_ = startLine;
+    lastNLines_ = nLines;
+    lastStartCol_ = startCol;
+    lastNSymbols_ = nSymbols;
+
     // The line number received is the internal (starts at 0)
     uint64_t fileSize{};
     uint64_t fileNbLine{};
@@ -1605,32 +1612,46 @@ void MainWindow::lineNumberHandler( LineNumber startLine, LinesCount nLines, Lin
     session_.getFileInfo( currentCrawlerWidget(), &fileSize, &fileNbLine, &lastModified );
 
     if ( fileNbLine != 0 ) {
+        QString lineText;
         if ( nSymbols.get() == 0 ) {
-            lineNbField->setText( tr( "Ln:%1/%2" ).arg( startLine.get() + 1 ).arg( fileNbLine ) );
+            lineText = tr( "Ln:%1/%2" ).arg( startLine.get() + 1 ).arg( fileNbLine );
         }
         else {
             if ( nLines.get() == 1 ) {
-                // portion selection on one line
-                lineNbField->setText( tr( "Ln:%1/%2 Col:%3 Sel:%4|%5" )
-                                          .arg( startLine.get() + 1 )
-                                          .arg( fileNbLine )
-                                          .arg( startCol.get() )
-                                          .arg( nSymbols.get() )
-                                          .arg( nLines.get() ) );
+                lineText = tr( "Ln:%1/%2 Col:%3 Sel:%4|%5" )
+                               .arg( startLine.get() + 1 )
+                               .arg( fileNbLine )
+                               .arg( startCol.get() )
+                               .arg( nSymbols.get() )
+                               .arg( nLines.get() );
             }
             else {
-                // multiple lines selection
-                lineNbField->setText( tr( "Ln:%1/%2 Sel:%4|%5" )
-                                          .arg( startLine.get() + 1 )
-                                          .arg( fileNbLine )
-                                          .arg( nSymbols.get() )
-                                          .arg( nLines.get() ) );
+                lineText = tr( "Ln:%1/%2 Sel:%4|%5" )
+                               .arg( startLine.get() + 1 )
+                               .arg( fileNbLine )
+                               .arg( nSymbols.get() )
+                               .arg( nLines.get() );
             }
         }
+
+        const auto* crawler = currentCrawlerWidget();
+        if ( crawler ) {
+            const auto pending = crawler->searchPendingLines();
+            if ( pending > 0 ) {
+                lineText += tr( " (+%1 pending)" ).arg( pending );
+            }
+        }
+
+        lineNbField->setText( lineText );
     }
     else {
         lineNbField->clear();
     }
+}
+
+void MainWindow::refreshLineNumberField()
+{
+    lineNumberHandler( lastStartLine_, lastNLines_, lastStartCol_, lastNSymbols_ );
 }
 
 void MainWindow::updateLoadingProgress( int progress )

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -275,7 +275,6 @@ TEST_CASE( "ProcessLiveSourceTransport async disconnect returns immediately" )
 TEST_CASE( "ProcessLiveSourceTransport reconnects immediately after async disconnect" )
 {
     LongRunningTestTransport transport;
-    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
 
     REQUIRE( transport.connectTransport() );
     transport.disconnectTransport();

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -22,6 +22,7 @@
 #include <QComboBox>
 #include <QCoreApplication>
 #include <QDialogButtonBox>
+#include <QElapsedTimer>
 #include <QGuiApplication>
 #include <QLineEdit>
 #include <QPushButton>
@@ -249,6 +250,45 @@ TEST_CASE( "ProcessLiveSourceTransport suppresses errorOccurred during intention
     const auto lastState
         = stateSpy.at( stateSpy.count() - 1 ).at( 0 ).value<LiveSourceTransport::State>();
     CHECK( lastState == LiveSourceTransport::State::Disconnected );
+}
+
+TEST_CASE( "ProcessLiveSourceTransport async disconnect returns immediately" )
+{
+    LongRunningTestTransport transport;
+
+    REQUIRE( transport.connectTransport() );
+
+    QElapsedTimer timer;
+    timer.start();
+    transport.disconnectTransport();
+    const auto elapsed = timer.elapsed();
+
+    // Disconnect should complete in well under 100ms (no blocking waitForFinished)
+    CHECK( elapsed < 100 );
+
+    // Process events to let async cleanup finish
+    QCoreApplication::processEvents();
+    QTest::qWait( 2000 );
+    QCoreApplication::processEvents();
+}
+
+TEST_CASE( "ProcessLiveSourceTransport reconnects immediately after async disconnect" )
+{
+    LongRunningTestTransport transport;
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+
+    REQUIRE( transport.connectTransport() );
+    transport.disconnectTransport();
+
+    // Immediately reconnect — should work since createProcess() made a fresh QProcess
+    REQUIRE( transport.connectTransport() );
+
+    transport.disconnectTransport();
+
+    // Process events to let async cleanup finish
+    QCoreApplication::processEvents();
+    QTest::qWait( 2000 );
+    QCoreApplication::processEvents();
 }
 
 TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edits on accept" )

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -404,3 +404,105 @@ TEST_CASE( "CaptureStore buildRawLines snapshot spans in-memory and spilled segm
     REQUIRE( store.lineAt( LineNumber( 9 ), codec, QRegularExpression{} )
              == QStringLiteral( "juliet" ) );
 }
+
+TEST_CASE( "CaptureStore batched output defers flush below threshold" )
+{
+    const auto rootPath = makeTestDir( "capturestore_batched_flush" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "batched.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append a small amount of data (well below 64KB and 100 lines)
+    for ( int i = 0; i < 10; ++i ) {
+        store.appendUtf8( QStringLiteral( "short-line-%1\n" ).arg( i ).toUtf8() );
+    }
+
+    // Before explicit flush, data may not yet be on disk (deferred)
+    {
+        QFile preFlush( outputPath );
+        REQUIRE( preFlush.open( QIODevice::ReadOnly ) );
+        // The file exists (bindOutputFile wrote existing data), but the 10 new
+        // lines should not have been flushed yet since we are below all thresholds.
+        const auto preContent = QString::fromUtf8( preFlush.readAll() );
+        CHECK_FALSE( preContent.contains( QStringLiteral( "short-line-9" ) ) );
+    }
+
+    // After explicit flush, all data should be on disk
+    store.flush();
+    const auto content = readUtf8File( outputPath );
+    REQUIRE( content.contains( QStringLiteral( "short-line-9" ) ) );
+}
+
+TEST_CASE( "CaptureStore batched output auto-flushes after byte threshold" )
+{
+    const auto rootPath = makeTestDir( "capturestore_byte_threshold" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "big.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append more than 64KB of data to trigger auto-flush
+    const QByteArray bigLine = QByteArray( 1024, 'X' ) + "\n";
+    for ( int i = 0; i < 70; ++i ) {
+        store.appendUtf8( bigLine );
+    }
+
+    // Data should have been auto-flushed (70KB > 64KB threshold)
+    QFile output( outputPath );
+    REQUIRE( output.open( QIODevice::ReadOnly ) );
+    REQUIRE( output.size() > 64 * 1024 );
+}
+
+TEST_CASE( "CaptureStore batched output auto-flushes after line threshold" )
+{
+    const auto rootPath = makeTestDir( "capturestore_line_threshold" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "lines.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append more than 100 lines (each small enough to stay under 64KB total)
+    for ( int i = 0; i < 110; ++i ) {
+        store.appendUtf8( QStringLiteral( "ln-%1\n" ).arg( i ).toUtf8() );
+    }
+
+    // Data should have been auto-flushed (110 lines > 100 line threshold)
+    const auto content = readUtf8File( outputPath );
+    REQUIRE( content.contains( QStringLiteral( "ln-0" ) ) );
+}
+
+TEST_CASE( "CaptureStore finishInput flushes pending output data" )
+{
+    const auto rootPath = makeTestDir( "capturestore_finish_flush" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "finish.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append small amount (under all thresholds)
+    store.appendUtf8( QByteArrayLiteral( "pending-data\n" ) );
+
+    // finishInput should flush remaining data
+    store.finishInput();
+
+    const auto content = readUtf8File( outputPath );
+    REQUIRE( content.contains( QStringLiteral( "pending-data" ) ) );
+}
+
+TEST_CASE( "CaptureStore clear flushes and resets output" )
+{
+    const auto rootPath = makeTestDir( "capturestore_clear_flush" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "clear.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    store.appendUtf8( QByteArrayLiteral( "before-clear\n" ) );
+    store.clear();
+
+    // After clear, the output file should have been truncated
+    QFile output( outputPath );
+    REQUIRE( output.open( QIODevice::ReadOnly ) );
+    REQUIRE( output.size() == 0 );
+}

--- a/tests/unit/highlighter_vectorscan_test.cpp
+++ b/tests/unit/highlighter_vectorscan_test.cpp
@@ -186,3 +186,32 @@ TEST_CASE( "HighlighterSetCollection restore compiles the active set",
     REQUIRE( matchType == HighlighterMatchType::WordMatch );
     REQUIRE_FALSE( matches.empty() );
 }
+
+TEST_CASE( "HighlighterSet matchLine produces matches regardless of selection context",
+           "[vectorscan][highlighter]" )
+{
+    auto& config = Configuration::getSynced();
+    configureProductLikeRegexpEngine( config );
+
+    QTemporaryDir tempDir( QDir::tempPath() + QStringLiteral( "/vectorscan-selection-XXXXXX" ) );
+    REQUIRE( tempDir.isValid() );
+
+    auto collection = loadHighlighterSetCollection(
+        tempDir.filePath( QStringLiteral( "collection.ini" ) ), makeRegressionPatterns() );
+
+    const auto& set = collection.currentActiveSet();
+
+    // matchLine should always return matches — it has no knowledge of selection state
+    const auto testLine = QStringLiteral( "ERROR at https://example.com/path?q=1" );
+
+    HighlightedMatchRanges matches1;
+    const auto type1 = set.matchLine( testLine, matches1 );
+    REQUIRE( type1 == HighlighterMatchType::WordMatch );
+    REQUIRE_FALSE( matches1.empty() );
+
+    // Call again — results should be consistent
+    HighlightedMatchRanges matches2;
+    const auto type2 = set.matchLine( testLine, matches2 );
+    REQUIRE( type2 == type1 );
+    REQUIRE( matches2.matches().size() == matches1.matches().size() );
+}

--- a/tests/unit/highlighter_vectorscan_test.cpp
+++ b/tests/unit/highlighter_vectorscan_test.cpp
@@ -207,11 +207,11 @@ TEST_CASE( "HighlighterSet matchLine produces matches regardless of selection co
     HighlightedMatchRanges matches1;
     const auto type1 = set.matchLine( testLine, matches1 );
     REQUIRE( type1 == HighlighterMatchType::WordMatch );
-    REQUIRE_FALSE( matches1.empty() );
+    REQUIRE( matches1.matches().size() == 2 );
 
     // Call again — results should be consistent
     HighlightedMatchRanges matches2;
     const auto type2 = set.matchLine( testLine, matches2 );
     REQUIRE( type2 == type1 );
-    REQUIRE( matches2.matches().size() == matches1.matches().size() );
+    REQUIRE( matches2.matches().size() == 2 );
 }


### PR DESCRIPTION
## Summary

- **Selected line highlighting coexists with Highlighters**: selected lines still run highlighter matching so keyword colors are preserved on top of the selection background
- **CaptureStore batched output flush**: replace per-line flush with triple threshold (64 KB / 100 lines / 1 second) plus a QTimer in StreamingLogData for idle-period coverage
- **Async disconnect for live source transport**: detach the old QProcess immediately (signals disconnected, fresh process created), then terminate/kill asynchronously so the UI never blocks
- **Search pending lines in status bar**: display pending line count in the status bar as `Ln:X/Y (+N pending)` instead of in searchInfoLine
- **Unit tests**: cover flush thresholds, async disconnect timing, reconnect after disconnect, and highlighter independence from selection

## Test plan

- [ ] Select a line containing highlighted keywords — verify keyword colors are preserved
- [ ] High-speed append 100k lines with bound output file — verify no UI stutter and file integrity
- [ ] Ctrl+Shift+D disconnect — UI does not freeze; immediate reconnect works
- [ ] Run a search and observe `Ln:X/Y (+N pending)` in the status bar; verify it clears on completion
- [ ] `klogg_tests --reporter compact` — all 70 test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line number display shows pending search results and updates live.
  * Adaptive, timer-driven output flushing to reduce frequent writes and improve performance.

* **Bug Fixes**
  * Improved search-result highlighting and graying behavior in the log view.
  * Non-blocking process disconnects for more reliable cleanup and reconnects.

* **Tests**
  * Added unit tests for output batching, highlighter matching, and transport disconnect timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->