### PR TITLE
Add iOS live log streaming and ANSI output controls

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -124,8 +124,7 @@ QSet<QString> retainedAdbCaptureIds( const SessionInfo& sessionInfo )
     for ( const auto& windowId : windows ) {
         const auto openFiles = sessionInfo.openFiles( windowId );
         for ( const auto& openFile : openFiles ) {
-            if ( openFile.sourceType != QStringLiteral( "adb_logcat" )
-                 && openFile.sourceType != QStringLiteral( "ios_log_stream" ) ) {
+            if ( !AdbLogcatSessionData::isPersistedSourceType( openFile.sourceType ) ) {
                 continue;
             }
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -124,7 +124,8 @@ QSet<QString> retainedAdbCaptureIds( const SessionInfo& sessionInfo )
     for ( const auto& windowId : windows ) {
         const auto openFiles = sessionInfo.openFiles( windowId );
         for ( const auto& openFile : openFiles ) {
-            if ( openFile.sourceType != QStringLiteral( "adb_logcat" ) ) {
+            if ( openFile.sourceType != QStringLiteral( "adb_logcat" )
+                 && openFile.sourceType != QStringLiteral( "ios_log_stream" ) ) {
                 continue;
             }
 

--- a/src/logdata/CMakeLists.txt
+++ b/src/logdata/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   klogg_logdata STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/abstractlogdata.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/ansicolorprocessor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/capturestore.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/concatenatedlogdata.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/compressedlinestorage.h
@@ -19,6 +20,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/filedigest.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/readablesize.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/abstractlogdata.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/ansicolorprocessor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/capturestore.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/concatenatedlogdata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/compressedlinestorage.cpp

--- a/src/logdata/include/abstractlogdata.h
+++ b/src/logdata/include/abstractlogdata.h
@@ -44,6 +44,7 @@
 #include <QStringList>
 #include <QTextCodec>
 
+#include "ansicolorprocessor.h"
 #include "linetypes.h"
 
 // Base class representing a set of data.
@@ -56,6 +57,8 @@ class AbstractLogData : public QObject {
     QString getLineString( LineNumber line ) const;
     // Returns the line passed as a QString, with tabs expanded
     QString getExpandedLineString( LineNumber line ) const;
+    // Returns ANSI color spans for the line after ANSI sequences are stripped.
+    klogg::vector<AnsiColorSpan> getLineAnsiColors( LineNumber line ) const;
     // Returns a set of lines as a QStringList
     klogg::vector<QString> getLines( LineNumber first_line, LinesCount number ) const;
     // Returns a set of lines with tabs expanded
@@ -96,6 +99,7 @@ class AbstractLogData : public QObject {
     virtual QString doGetLineString( LineNumber line ) const = 0;
     // Internal function called to get a given line
     virtual QString doGetExpandedLineString( LineNumber line ) const = 0;
+    virtual klogg::vector<AnsiColorSpan> doGetLineAnsiColors( LineNumber line ) const;
     // Internal function called to get a set of lines
     virtual klogg::vector<QString> doGetLines( LineNumber first_line, LinesCount number ) const = 0;
     // Internal function called to get a set of expanded lines

--- a/src/logdata/include/ansicolorprocessor.h
+++ b/src/logdata/include/ansicolorprocessor.h
@@ -1,0 +1,32 @@
+#ifndef ANSICOLORPROCESSOR_H
+#define ANSICOLORPROCESSOR_H
+
+#include <optional>
+
+#include <QString>
+#include <QtGlobal>
+
+#include "containers.h"
+#include "linetypes.h"
+
+enum class AnsiProcessingMode {
+    Plain,
+    Strip,
+    Render,
+};
+
+struct AnsiColorSpan {
+    LineColumn startColumn;
+    LineLength length;
+    std::optional<quint32> foreground;
+    std::optional<quint32> background;
+};
+
+struct ProcessedAnsiLine {
+    QString text;
+    klogg::vector<AnsiColorSpan> colorSpans;
+};
+
+ProcessedAnsiLine processAnsiSequences( QString line, AnsiProcessingMode mode );
+
+#endif // ANSICOLORPROCESSOR_H

--- a/src/logdata/include/concatenatedlogdata.h
+++ b/src/logdata/include/concatenatedlogdata.h
@@ -74,6 +74,7 @@ class ConcatenatedLogData : public AbstractLogData {
   protected:
     QString doGetLineString( LineNumber line ) const override;
     QString doGetExpandedLineString( LineNumber line ) const override;
+    klogg::vector<AnsiColorSpan> doGetLineAnsiColors( LineNumber line ) const override;
     klogg::vector<QString> doGetLines( LineNumber first, LinesCount number ) const override;
     klogg::vector<QString> doGetExpandedLines( LineNumber first, LinesCount number ) const override;
     LineNumber doGetLineNumber( LineNumber index ) const override;

--- a/src/logdata/include/logdata.h
+++ b/src/logdata/include/logdata.h
@@ -104,6 +104,7 @@ class LogData : public SearchableLogData {
     QTextCodec* getDetectedEncoding() const override;
 
     void setPrefilter( const QString& prefilterPattern ) override;
+    void setAnsiProcessingMode( AnsiProcessingMode mode ) override;
 
     RawLines getLinesRaw( LineNumber first, LinesCount number ) const override;
 
@@ -119,6 +120,7 @@ class LogData : public SearchableLogData {
     // Implementation of virtual functions
     QString doGetLineString( LineNumber line ) const override;
     QString doGetExpandedLineString( LineNumber line ) const override;
+    klogg::vector<AnsiColorSpan> doGetLineAnsiColors( LineNumber line ) const override;
     klogg::vector<QString> doGetLines( LineNumber first, LinesCount number ) const override;
     klogg::vector<QString> doGetExpandedLines( LineNumber first, LinesCount number ) const override;
     LineNumber doGetLineNumber( LineNumber index ) const override;
@@ -156,6 +158,7 @@ class LogData : public SearchableLogData {
     MonitoredFileStatus fileChangedOnDisk_;
 
     QString prefilterPattern_;
+    AnsiProcessingMode ansiProcessingMode_ = AnsiProcessingMode::Plain;
 
     QMetaObject::Connection fileWatcherConnection_;
     QMetaObject::Connection workerIndexingProgressConnection_;

--- a/src/logdata/include/logfiltereddata.h
+++ b/src/logdata/include/logfiltereddata.h
@@ -186,6 +186,7 @@ class LogFilteredData : public AbstractLogData {
     // Implementation of virtual functions
     QString doGetLineString( LineNumber line ) const override;
     QString doGetExpandedLineString( LineNumber line ) const override;
+    klogg::vector<AnsiColorSpan> doGetLineAnsiColors( LineNumber line ) const override;
     klogg::vector<QString> doGetLines( LineNumber first, LinesCount number ) const override;
     klogg::vector<QString> doGetExpandedLines( LineNumber first, LinesCount number ) const override;
     klogg::vector<QString> doGetLines( LineNumber first, LinesCount number,

--- a/src/logdata/include/searchablelogdata.h
+++ b/src/logdata/include/searchablelogdata.h
@@ -10,6 +10,7 @@
 #include <QTextCodec>
 
 #include "abstractlogdata.h"
+#include "ansicolorprocessor.h"
 #include "encodingdetector.h"
 #include "loadingstatus.h"
 
@@ -31,9 +32,11 @@ class SearchableLogData : public AbstractLogData {
         TextDecoder textDecoder;
 
         QRegularExpression prefilterPattern;
+        AnsiProcessingMode ansiProcessingMode = AnsiProcessingMode::Plain;
 
       public:
         klogg::vector<QString> decodeLines() const;
+        klogg::vector<klogg::vector<AnsiColorSpan>> decodeLineAnsiColors() const;
         klogg::vector<std::string_view> buildUtf8View() const;
 
       private:
@@ -49,6 +52,7 @@ class SearchableLogData : public AbstractLogData {
     virtual void reload( QTextCodec* forcedEncoding = nullptr ) = 0;
     virtual QTextCodec* getDetectedEncoding() const = 0;
     virtual void setPrefilter( const QString& prefilterPattern ) = 0;
+    virtual void setAnsiProcessingMode( AnsiProcessingMode mode ) = 0;
     virtual RawLines getLinesRaw( LineNumber first, LinesCount number ) const = 0;
 
     virtual bool isLiveSource() const

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -32,12 +32,14 @@ class StreamingLogData : public SearchableLogData {
     void reload( QTextCodec* forcedEncoding = nullptr ) override;
     QTextCodec* getDetectedEncoding() const override;
     void setPrefilter( const QString& prefilterPattern ) override;
+    void setAnsiProcessingMode( AnsiProcessingMode mode ) override;
     RawLines getLinesRaw( LineNumber first, LinesCount number ) const override;
     bool isLiveSource() const override;
 
   protected:
     QString doGetLineString( LineNumber line ) const override;
     QString doGetExpandedLineString( LineNumber line ) const override;
+    klogg::vector<AnsiColorSpan> doGetLineAnsiColors( LineNumber line ) const override;
     klogg::vector<QString> doGetLines( LineNumber first, LinesCount number ) const override;
     klogg::vector<QString> doGetExpandedLines( LineNumber first, LinesCount number ) const override;
     LineNumber doGetLineNumber( LineNumber index ) const override;
@@ -59,6 +61,7 @@ class StreamingLogData : public SearchableLogData {
     CaptureStore captureStore_;
     TextCodecHolder codec_;
     QRegularExpression prefilterPattern_;
+    AnsiProcessingMode ansiProcessingMode_ = AnsiProcessingMode::Plain;
     bool loadingFinishedQueued_ = false;
     QTimer outputFlushTimer_;
 };

--- a/src/logdata/src/abstractlogdata.cpp
+++ b/src/logdata/src/abstractlogdata.cpp
@@ -56,6 +56,16 @@ QString AbstractLogData::getExpandedLineString( LineNumber line ) const
     return doGetExpandedLineString( line );
 }
 
+klogg::vector<AnsiColorSpan> AbstractLogData::getLineAnsiColors( LineNumber line ) const
+{
+    return doGetLineAnsiColors( line );
+}
+
+klogg::vector<AnsiColorSpan> AbstractLogData::doGetLineAnsiColors( LineNumber ) const
+{
+    return {};
+}
+
 // Simple wrapper in order to use a clean Template Method
 klogg::vector<QString> AbstractLogData::getLines( LineNumber first_line, LinesCount number ) const
 {

--- a/src/logdata/src/ansicolorprocessor.cpp
+++ b/src/logdata/src/ansicolorprocessor.cpp
@@ -1,0 +1,239 @@
+#include "ansicolorprocessor.h"
+
+#include <QChar>
+
+namespace {
+constexpr ushort Escape = 0x1B;
+constexpr ushort Csi = '[';
+
+struct AttrState {
+    std::optional<quint32> foreground;
+    std::optional<quint32> background;
+
+    bool hasColor() const
+    {
+        return foreground.has_value() || background.has_value();
+    }
+};
+
+bool isCsiFinalByte( const QChar ch )
+{
+    const auto value = ch.unicode();
+    return value >= 0x40 && value <= 0x7e;
+}
+
+std::optional<int> parseInt( QStringView value )
+{
+    if ( value.isEmpty() ) {
+        return 0;
+    }
+
+    int number = 0;
+    for ( const auto ch : value ) {
+        if ( !ch.isDigit() ) {
+            return {};
+        }
+        number = number * 10 + ch.digitValue();
+    }
+    return number;
+}
+
+klogg::vector<int> parseParameters( QStringView parameters )
+{
+    klogg::vector<int> parsed;
+    if ( parameters.isEmpty() ) {
+        parsed.push_back( 0 );
+        return parsed;
+    }
+
+    qsizetype start = 0;
+    for ( qsizetype i = 0; i <= parameters.size(); ++i ) {
+        if ( i == parameters.size() || parameters[ i ] == QLatin1Char( ';' )
+             || parameters[ i ] == QLatin1Char( ':' ) ) {
+            const auto value = parseInt( parameters.mid( start, i - start ) );
+            parsed.push_back( value.value_or( -1 ) );
+            start = i + 1;
+        }
+    }
+
+    return parsed;
+}
+
+quint32 rgb( int r, int g, int b )
+{
+    return ( static_cast<quint32>( r ) << 16 ) | ( static_cast<quint32>( g ) << 8 )
+           | static_cast<quint32>( b );
+}
+
+std::optional<quint32> standardColor( int code )
+{
+    static constexpr quint32 normal[] = {
+        0x010101, 0xde382b, 0x39b54a, 0xffc706, 0x006fb8, 0x762671, 0x2cb5e9,
+        0xcccccc,
+    };
+    static constexpr quint32 bright[] = {
+        0x808080, 0xff0000, 0x00ff00, 0xffff00, 0x0000ff, 0xff00ff, 0x00ffff, 0xffffff,
+    };
+
+    if ( code >= 30 && code <= 37 ) {
+        return normal[ code - 30 ];
+    }
+    if ( code >= 40 && code <= 47 ) {
+        return normal[ code - 40 ];
+    }
+    if ( code >= 90 && code <= 97 ) {
+        return bright[ code - 90 ];
+    }
+    if ( code >= 100 && code <= 107 ) {
+        return bright[ code - 100 ];
+    }
+    return {};
+}
+
+std::optional<quint32> extendedColor( const klogg::vector<int>& params, size_t& index )
+{
+    if ( index + 1 >= params.size() ) {
+        return {};
+    }
+
+    const auto colorMode = params[ index + 1 ];
+    if ( colorMode == 5 ) {
+        if ( index + 2 >= params.size() ) {
+            return {};
+        }
+        const auto value = params[ index + 2 ];
+        index += 2;
+        if ( value < 0 || value > 255 ) {
+            return {};
+        }
+
+        if ( value <= 7 ) {
+            return standardColor( 30 + value );
+        }
+        if ( value <= 15 ) {
+            return standardColor( 90 + value - 8 );
+        }
+        if ( value >= 232 ) {
+            const auto gray = ( value - 232 ) * 10 + 8;
+            return rgb( gray, gray, gray );
+        }
+
+        static constexpr int values[] = { 0, 95, 135, 175, 215, 255 };
+        const auto colorIndex = value - 16;
+        const auto remainder = colorIndex % 36;
+        return rgb( values[ colorIndex / 36 ], values[ remainder / 6 ],
+                    values[ remainder % 6 ] );
+    }
+
+    if ( colorMode == 2 ) {
+        if ( index + 4 >= params.size() ) {
+            return {};
+        }
+        const auto r = params[ index + 2 ];
+        const auto g = params[ index + 3 ];
+        const auto b = params[ index + 4 ];
+        index += 4;
+        if ( r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255 ) {
+            return {};
+        }
+        return rgb( r, g, b );
+    }
+
+    return {};
+}
+
+void applySgr( QStringView parameters, AttrState& state )
+{
+    const auto params = parseParameters( parameters );
+    for ( size_t i = 0; i < params.size(); ++i ) {
+        const auto code = params[ i ];
+        if ( code == 0 ) {
+            state = {};
+        }
+        else if ( code == 39 ) {
+            state.foreground.reset();
+        }
+        else if ( code == 49 ) {
+            state.background.reset();
+        }
+        else if ( ( code >= 30 && code <= 37 ) || ( code >= 90 && code <= 97 ) ) {
+            state.foreground = standardColor( code );
+        }
+        else if ( ( code >= 40 && code <= 47 ) || ( code >= 100 && code <= 107 ) ) {
+            state.background = standardColor( code );
+        }
+        else if ( code == 38 || code == 48 ) {
+            const auto color = extendedColor( params, i );
+            if ( color.has_value() ) {
+                if ( code == 38 ) {
+                    state.foreground = color;
+                }
+                else {
+                    state.background = color;
+                }
+            }
+        }
+    }
+}
+
+void appendColorSpan( klogg::vector<AnsiColorSpan>& spans, const AttrState& state, int start,
+                      int end )
+{
+    if ( !state.hasColor() || end <= start ) {
+        return;
+    }
+
+    spans.push_back( AnsiColorSpan{ LineColumn{ start }, LineLength{ end - start },
+                                    state.foreground, state.background } );
+}
+} // namespace
+
+ProcessedAnsiLine processAnsiSequences( QString line, AnsiProcessingMode mode )
+{
+    if ( mode == AnsiProcessingMode::Plain || line.isEmpty() ) {
+        return { std::move( line ), {} };
+    }
+
+    ProcessedAnsiLine processed;
+    processed.text.reserve( line.size() );
+
+    AttrState state;
+    int colorSpanStart = 0;
+
+    for ( int i = 0; i < line.size(); ) {
+        const auto ch = line[ i ];
+        if ( ch.unicode() != Escape || i + 1 >= line.size() || line[ i + 1 ].unicode() != Csi ) {
+            processed.text.append( ch );
+            ++i;
+            continue;
+        }
+
+        int end = i + 2;
+        while ( end < line.size() && !isCsiFinalByte( line[ end ] ) ) {
+            ++end;
+        }
+
+        if ( end >= line.size() ) {
+            processed.text.append( ch );
+            ++i;
+            continue;
+        }
+
+        if ( mode == AnsiProcessingMode::Render ) {
+            appendColorSpan( processed.colorSpans, state, colorSpanStart, processed.text.size() );
+
+            if ( line[ end ] == QLatin1Char( 'm' ) ) {
+                applySgr( QStringView{ line }.mid( i + 2, end - i - 2 ), state );
+            }
+            colorSpanStart = processed.text.size();
+        }
+
+        i = end + 1;
+    }
+
+    if ( mode == AnsiProcessingMode::Render ) {
+        appendColorSpan( processed.colorSpans, state, colorSpanStart, processed.text.size() );
+    }
+
+    return processed;
+}

--- a/src/logdata/src/ansicolorprocessor.cpp
+++ b/src/logdata/src/ansicolorprocessor.cpp
@@ -198,7 +198,7 @@ ProcessedAnsiLine processAnsiSequences( QString line, AnsiProcessingMode mode )
     processed.text.reserve( line.size() );
 
     AttrState state;
-    int colorSpanStart = 0;
+    qsizetype colorSpanStart = 0;
 
     for ( int i = 0; i < line.size(); ) {
         const auto ch = line[ i ];
@@ -220,7 +220,8 @@ ProcessedAnsiLine processAnsiSequences( QString line, AnsiProcessingMode mode )
         }
 
         if ( mode == AnsiProcessingMode::Render ) {
-            appendColorSpan( processed.colorSpans, state, colorSpanStart, processed.text.size() );
+            appendColorSpan( processed.colorSpans, state, static_cast<int>( colorSpanStart ),
+                             static_cast<int>( processed.text.size() ) );
 
             if ( line[ end ] == QLatin1Char( 'm' ) ) {
                 applySgr( QStringView{ line }.mid( i + 2, end - i - 2 ), state );
@@ -232,7 +233,8 @@ ProcessedAnsiLine processAnsiSequences( QString line, AnsiProcessingMode mode )
     }
 
     if ( mode == AnsiProcessingMode::Render ) {
-        appendColorSpan( processed.colorSpans, state, colorSpanStart, processed.text.size() );
+        appendColorSpan( processed.colorSpans, state, static_cast<int>( colorSpanStart ),
+                         static_cast<int>( processed.text.size() ) );
     }
 
     return processed;

--- a/src/logdata/src/concatenatedlogdata.cpp
+++ b/src/logdata/src/concatenatedlogdata.cpp
@@ -139,6 +139,17 @@ QString ConcatenatedLogData::doGetExpandedLineString( LineNumber line ) const
     return source ? source->getExpandedLineString( localLine ) : QString{};
 }
 
+klogg::vector<AnsiColorSpan> ConcatenatedLogData::doGetLineAnsiColors( LineNumber line ) const
+{
+    if ( sources_.empty() || line.get() >= totalLines_.get() ) {
+        return {};
+    }
+
+    const auto [ srcIdx, localLine ] = mapToSource( line );
+    const auto source = sourceAt( srcIdx );
+    return source ? source->getLineAnsiColors( localLine ) : klogg::vector<AnsiColorSpan>{};
+}
+
 klogg::vector<QString> ConcatenatedLogData::doGetLines( LineNumber first, LinesCount number ) const
 {
     klogg::vector<QString> result;

--- a/src/logdata/src/logdata.cpp
+++ b/src/logdata/src/logdata.cpp
@@ -127,6 +127,12 @@ void LogData::setPrefilter( const QString& prefilterPattern )
     prefilterPattern_ = prefilterPattern;
 }
 
+void LogData::setAnsiProcessingMode( AnsiProcessingMode mode )
+{
+    IndexingData::MutateAccessor scopedAccessor{ indexing_data_.get() };
+    ansiProcessingMode_ = mode;
+}
+
 void LogData::attachFile( const QString& fileName )
 {
     LOG_DEBUG << "LogData::attachFile " << fileName.toStdString();
@@ -364,6 +370,13 @@ QString LogData::doGetExpandedLineString( LineNumber line ) const
     return untabify( doGetLineString( line ) );
 }
 
+klogg::vector<AnsiColorSpan> LogData::doGetLineAnsiColors( LineNumber line ) const
+{
+    const auto rawLines = getLinesRaw( line, 1_lcount );
+    const auto colors = rawLines.decodeLineAnsiColors();
+    return colors.empty() ? klogg::vector<AnsiColorSpan>{} : colors.front();
+}
+
 // Note this function is also called from the LogFilteredDataWorker thread, so
 // data must be protected because they are changed in the main thread (by
 // indexingFinished).
@@ -407,6 +420,7 @@ LogData::RawLines LogData::getLinesRaw( LineNumber firstLine, LinesCount number 
                   ? QRegularExpression( prefilterPattern_,
                                         QRegularExpression::CaseInsensitiveOption )
                   : QRegularExpression{};
+        rawLines.ansiProcessingMode = ansiProcessingMode_;
 
         ScopedFileHolder<FileHolder> fileHolder( attached_file_.get() );
 

--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -780,6 +780,25 @@ QString LogFilteredData::doGetExpandedLineString( LineNumber index ) const
     return sourceLogData_->getExpandedLineString( line );
 }
 
+klogg::vector<AnsiColorSpan> LogFilteredData::doGetLineAnsiColors( LineNumber index ) const
+{
+    if ( !sourceLogData_ ) {
+        return {};
+    }
+
+    if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
+        if ( !contextLinesListValid_ ) {
+            rebuildContextLinesList();
+        }
+        if ( index.get() < static_cast<LineNumber::UnderlyingType>( contextLinesList_.size() ) ) {
+            return sourceLogData_->getLineAnsiColors( contextLinesList_[ index.get() ] );
+        }
+        return {};
+    }
+
+    return sourceLogData_->getLineAnsiColors( findLogDataLine( index ) );
+}
+
 // Implementation of the virtual function.
 klogg::vector<QString> LogFilteredData::doGetLines( LineNumber first_line, LinesCount number ) const
 {

--- a/src/logdata/src/searchablelogdata.cpp
+++ b/src/logdata/src/searchablelogdata.cpp
@@ -46,6 +46,7 @@ klogg::vector<QString> SearchableLogData::RawLines::decodeLines() const
             auto decodedLine = textDecoder.decoder->toUnicode(
                 buffer.data() + lineStart, type_safe::narrow_cast<int>( length ) );
 
+            decodedLine = processAnsiSequences( std::move( decodedLine ), ansiProcessingMode ).text;
             if ( !prefilterPattern.pattern().isEmpty() ) {
                 decodedLine.remove( prefilterPattern );
             }
@@ -68,6 +69,41 @@ klogg::vector<QString> SearchableLogData::RawLines::decodeLines() const
     return decodedLines;
 }
 
+klogg::vector<klogg::vector<AnsiColorSpan>> SearchableLogData::RawLines::decodeLineAnsiColors() const
+{
+    klogg::vector<klogg::vector<AnsiColorSpan>> colors;
+    if ( this->endOfLines.empty() || ansiProcessingMode != AnsiProcessingMode::Render ) {
+        colors.resize( this->endOfLines.size() );
+        return colors;
+    }
+
+    colors.reserve( this->endOfLines.size() );
+
+    try {
+        qint64 lineStart = 0;
+        const auto lineFeedWidth = textDecoder.encodingParams.lineFeedWidth;
+        for ( const auto& lineEnd : this->endOfLines ) {
+            const auto length = lineEnd - lineStart - lineFeedWidth;
+
+            if ( length < 0 || lineStart + length > klogg::ssize( buffer ) ) {
+                break;
+            }
+
+            auto decodedLine = textDecoder.decoder->toUnicode(
+                buffer.data() + lineStart, type_safe::narrow_cast<int>( length ) );
+            colors.push_back(
+                processAnsiSequences( std::move( decodedLine ), ansiProcessingMode ).colorSpans );
+
+            lineStart = lineEnd;
+        }
+    } catch ( const std::bad_alloc& ) {
+        LOG_ERROR << "not enough memory";
+    }
+
+    colors.resize( this->endOfLines.size() );
+    return colors;
+}
+
 klogg::vector<std::string_view> SearchableLogData::RawLines::buildUtf8View() const
 {
     klogg::vector<std::string_view> lines;
@@ -80,7 +116,8 @@ klogg::vector<std::string_view> SearchableLogData::RawLines::buildUtf8View() con
 
         std::string_view wholeString;
 
-        if ( prefilterPattern.pattern().isEmpty() && textDecoder.encodingParams.isUtf8Compatible ) {
+        if ( ansiProcessingMode == AnsiProcessingMode::Plain && prefilterPattern.pattern().isEmpty()
+             && textDecoder.encodingParams.isUtf8Compatible ) {
             wholeString = std::string_view( buffer.data(), buffer.size() );
         }
         else {
@@ -91,6 +128,10 @@ klogg::vector<std::string_view> SearchableLogData::RawLines::buildUtf8View() con
             }
             else {
                 utf16Data = textDecoder.decoder->toUnicode( buffer.data(), klogg::isize( buffer ) );
+            }
+
+            if ( ansiProcessingMode != AnsiProcessingMode::Plain ) {
+                utf16Data = processAnsiSequences( std::move( utf16Data ), ansiProcessingMode ).text;
             }
 
             if ( !prefilterPattern.pattern().isEmpty() ) {

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -148,9 +148,16 @@ void StreamingLogData::setPrefilter( const QString& prefilterPattern )
     prefilterPattern_.setPattern( prefilterPattern );
 }
 
+void StreamingLogData::setAnsiProcessingMode( AnsiProcessingMode mode )
+{
+    ansiProcessingMode_ = mode;
+}
+
 SearchableLogData::RawLines StreamingLogData::getLinesRaw( LineNumber first, LinesCount number ) const
 {
-    return captureStore_.buildRawLines( first, number, codec_.codec(), prefilterPattern_ );
+    auto rawLines = captureStore_.buildRawLines( first, number, codec_.codec(), prefilterPattern_ );
+    rawLines.ansiProcessingMode = ansiProcessingMode_;
+    return rawLines;
 }
 
 bool StreamingLogData::isLiveSource() const
@@ -160,12 +167,21 @@ bool StreamingLogData::isLiveSource() const
 
 QString StreamingLogData::doGetLineString( LineNumber line ) const
 {
-    return captureStore_.lineAt( line, codec_.codec(), prefilterPattern_ );
+    return processAnsiSequences( captureStore_.lineAt( line, codec_.codec(), prefilterPattern_ ),
+                                 ansiProcessingMode_ )
+        .text;
 }
 
 QString StreamingLogData::doGetExpandedLineString( LineNumber line ) const
 {
     return doGetLineString( line );
+}
+
+klogg::vector<AnsiColorSpan> StreamingLogData::doGetLineAnsiColors( LineNumber line ) const
+{
+    return processAnsiSequences( captureStore_.lineAt( line, codec_.codec(), prefilterPattern_ ),
+                                 ansiProcessingMode_ )
+        .colorSpans;
 }
 
 klogg::vector<QString> StreamingLogData::doGetLines( LineNumber first, LinesCount number ) const

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -426,6 +426,15 @@ class Configuration final : public Persistable<Configuration> {
         adbLogcatExtraArgs_ = std::move( adbLogcatExtraArgs );
     }
 
+    bool adbLogcatAnsiOutputEnabled() const
+    {
+        return adbLogcatAnsiOutputEnabled_;
+    }
+    void setAdbLogcatAnsiOutputEnabled( bool enabled )
+    {
+        adbLogcatAnsiOutputEnabled_ = enabled;
+    }
+
     QString iosLogExecutable() const
     {
         return iosLogExecutable_;
@@ -442,6 +451,15 @@ class Configuration final : public Persistable<Configuration> {
     void setIosLogExtraArgs( QString iosLogExtraArgs )
     {
         iosLogExtraArgs_ = std::move( iosLogExtraArgs );
+    }
+
+    bool iosLogAnsiOutputEnabled() const
+    {
+        return iosLogAnsiOutputEnabled_;
+    }
+    void setIosLogAnsiOutputEnabled( bool enabled )
+    {
+        iosLogAnsiOutputEnabled_ = enabled;
     }
 
     bool forceFontAntialiasing() const
@@ -665,8 +683,10 @@ class Configuration final : public Persistable<Configuration> {
     bool verifySslPeers_ = true;
     QString adbExecutable_;
     QString adbLogcatExtraArgs_;
+    bool adbLogcatAnsiOutputEnabled_ = false;
     QString iosLogExecutable_;
     QString iosLogExtraArgs_;
+    bool iosLogAnsiOutputEnabled_ = false;
 
     bool forceFontAntialiasing_ = false;
     bool enableQtHighDpi_ = true;

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -605,6 +605,14 @@ class Configuration final : public Persistable<Configuration> {
     {
         hideAnsiColorSequences_ = hide;
     }
+    bool renderAnsiColorSequences() const
+    {
+        return renderAnsiColorSequences_;
+    }
+    void setRenderAnsiColorSequences( bool render )
+    {
+        renderAnsiColorSequences_ = render;
+    }
 
     int defaultEncodingMib() const
     {
@@ -707,6 +715,7 @@ class Configuration final : public Persistable<Configuration> {
     bool optimizeForNotLatinEncodings_ = false;
 
     bool hideAnsiColorSequences_ = false;
+    bool renderAnsiColorSequences_ = false;
 
     int defaultEncodingMib_ = 106; // UTF-8
 

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -426,6 +426,24 @@ class Configuration final : public Persistable<Configuration> {
         adbLogcatExtraArgs_ = std::move( adbLogcatExtraArgs );
     }
 
+    QString iosLogExecutable() const
+    {
+        return iosLogExecutable_;
+    }
+    void setIosLogExecutable( QString iosLogExecutable )
+    {
+        iosLogExecutable_ = std::move( iosLogExecutable );
+    }
+
+    QString iosLogExtraArgs() const
+    {
+        return iosLogExtraArgs_;
+    }
+    void setIosLogExtraArgs( QString iosLogExtraArgs )
+    {
+        iosLogExtraArgs_ = std::move( iosLogExtraArgs );
+    }
+
     bool forceFontAntialiasing() const
     {
         return forceFontAntialiasing_;
@@ -647,6 +665,8 @@ class Configuration final : public Persistable<Configuration> {
     bool verifySslPeers_ = true;
     QString adbExecutable_;
     QString adbLogcatExtraArgs_;
+    QString iosLogExecutable_;
+    QString iosLogExtraArgs_;
 
     bool forceFontAntialiasing_ = false;
     bool enableQtHighDpi_ = true;

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -281,10 +281,18 @@ void Configuration::retrieveFromStorage( QSettings& settings )
     adbLogcatExtraArgs_
         = settings.value( "adb.logcatExtraArgs", DefaultConfiguration.adbLogcatExtraArgs_ )
               .toString();
+    adbLogcatAnsiOutputEnabled_
+        = settings
+              .value( "adb.logcatAnsiOutput",
+                      DefaultConfiguration.adbLogcatAnsiOutputEnabled_ )
+              .toBool();
     iosLogExecutable_
         = settings.value( "iosLog.executable", DefaultConfiguration.iosLogExecutable_ ).toString();
     iosLogExtraArgs_
         = settings.value( "iosLog.extraArgs", DefaultConfiguration.iosLogExtraArgs_ ).toString();
+    iosLogAnsiOutputEnabled_
+        = settings.value( "iosLog.ansiOutput", DefaultConfiguration.iosLogAnsiOutputEnabled_ )
+              .toBool();
 
     // View settings
     overviewVisible_
@@ -454,8 +462,10 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "net.verifySslPeers", verifySslPeers_ );
     settings.setValue( "adb.executable", adbExecutable_ );
     settings.setValue( "adb.logcatExtraArgs", adbLogcatExtraArgs_ );
+    settings.setValue( "adb.logcatAnsiOutput", adbLogcatAnsiOutputEnabled_ );
     settings.setValue( "iosLog.executable", iosLogExecutable_ );
     settings.setValue( "iosLog.extraArgs", iosLogExtraArgs_ );
+    settings.setValue( "iosLog.ansiOutput", iosLogAnsiOutputEnabled_ );
 
     settings.setValue( "view.overviewVisible", overviewVisible_ );
     settings.setValue( "view.lineNumbersVisibleInMain", lineNumbersVisibleInMain_ );

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -312,6 +312,13 @@ void Configuration::retrieveFromStorage( QSettings& settings )
         = settings
               .value( "view.hideAnsiColorSequences", DefaultConfiguration.hideAnsiColorSequences_ )
               .toBool();
+    renderAnsiColorSequences_
+        = settings
+              .value( "view.renderAnsiColorSequences", DefaultConfiguration.renderAnsiColorSequences_ )
+              .toBool();
+    if ( hideAnsiColorSequences_ && renderAnsiColorSequences_ ) {
+        renderAnsiColorSequences_ = false;
+    }
 
     useTextWrap_ = settings.value( "view.textWrap", DefaultConfiguration.useTextWrap() ).toBool();
 
@@ -480,6 +487,7 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "view.scaleFactorRounding", scaleFactorRounding_ );
 
     settings.setValue( "view.hideAnsiColorSequences", hideAnsiColorSequences_ );
+    settings.setValue( "view.renderAnsiColorSequences", renderAnsiColorSequences_ );
 
     settings.setValue( "defaultView.searchAutoRefresh", searchAutoRefresh_ );
     settings.setValue( "defaultView.searchIgnoreCase", searchIgnoreCase_ );

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -281,6 +281,10 @@ void Configuration::retrieveFromStorage( QSettings& settings )
     adbLogcatExtraArgs_
         = settings.value( "adb.logcatExtraArgs", DefaultConfiguration.adbLogcatExtraArgs_ )
               .toString();
+    iosLogExecutable_
+        = settings.value( "iosLog.executable", DefaultConfiguration.iosLogExecutable_ ).toString();
+    iosLogExtraArgs_
+        = settings.value( "iosLog.extraArgs", DefaultConfiguration.iosLogExtraArgs_ ).toString();
 
     // View settings
     overviewVisible_
@@ -450,6 +454,8 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "net.verifySslPeers", verifySslPeers_ );
     settings.setValue( "adb.executable", adbExecutable_ );
     settings.setValue( "adb.logcatExtraArgs", adbLogcatExtraArgs_ );
+    settings.setValue( "iosLog.executable", iosLogExecutable_ );
+    settings.setValue( "iosLog.extraArgs", iosLogExtraArgs_ );
 
     settings.setValue( "view.overviewVisible", overviewVisible_ );
     settings.setValue( "view.lineNumbersVisibleInMain", lineNumbersVisibleInMain_ );

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -30,9 +30,23 @@ QStringList getKeyBindings( QKeySequence::StandardKey standardKey )
     auto bindings = QKeySequence::keyBindings( standardKey );
     QStringList stringBindings;
     std::transform( bindings.cbegin(), bindings.cend(), std::back_inserter( stringBindings ),
-                    []( const auto& keySequence ) { return keySequence.toString(); } );
+                    []( const auto& keySequence ) {
+                        return keySequence.toString( QKeySequence::PortableText );
+                    } );
 
     return stringBindings;
+}
+
+QStringList uniqueKeyBindings( const QStringList& bindings )
+{
+    QStringList uniqueBindings;
+    for ( const auto& binding : bindings ) {
+        const auto normalized = QKeySequence( binding ).toString( QKeySequence::PortableText );
+        if ( !normalized.isEmpty() && !uniqueBindings.contains( normalized ) ) {
+            uniqueBindings.push_back( normalized );
+        }
+    }
+    return uniqueBindings;
 }
 
 QStringList ShortcutAction::defaultShortcutKeys( const std::string& action )
@@ -234,7 +248,10 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             MainWindowOpenFromClipboard,
             {
                 QApplication::tr( "Paste text from clipboard" ),
-                getKeyBindings( QKeySequence::Paste ),
+                // Do not bind this to QKeySequence::Paste by default. It is an
+                // application command, not text editing, and stealing Cmd/Ctrl+V
+                // breaks paste in child dialogs and platform-native panels.
+                QStringList{},
             },
         },
         {
@@ -524,14 +541,14 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             LogViewQfForward,
             {
                 QApplication::tr( "Main view: find next" ),
-                getKeyBindings( QKeySequence::FindNext ) << "Ctrl+G",
+                uniqueKeyBindings( getKeyBindings( QKeySequence::FindNext ) << "Ctrl+G" ),
             },
         },
         {
             LogViewQfBackward,
             { QApplication::tr( "Main view: find previous" ),
-              getKeyBindings( QKeySequence::FindPrevious ) << "Shift+N"
-                                                           << "Ctrl+Shift+G" },
+              uniqueKeyBindings( getKeyBindings( QKeySequence::FindPrevious ) << "Shift+N"
+                                                                               << "Ctrl+Shift+G" ) },
         },
         {
             LogViewQfSelectedForward,

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/savefavoritedialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/filterdiffdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/infoline.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogdialog.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogprocesstransport.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathline.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/livesourcetransport.h
@@ -77,6 +79,8 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/savefavoritedialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/filterdiffdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/infoline.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogdialog.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogprocesstransport.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pathline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/livesourcetransport.cpp

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adblogcatdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adbprocesstransport.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adblogcatsource.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/commandargumenttokenizer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crawlerwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/filteredview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersdialog.h

--- a/src/ui/include/adblogcatdialog.h
+++ b/src/ui/include/adblogcatdialog.h
@@ -7,6 +7,7 @@
 
 class QComboBox;
 class QDialogButtonBox;
+class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
@@ -32,6 +33,7 @@ class AdbLogcatDialog : public QDialog {
     QPushButton* refreshButton_ = nullptr;
     QComboBox* deviceCombo_ = nullptr;
     QLineEdit* extraArgsEdit_ = nullptr;
+    QCheckBox* ansiOutputCheckBox_ = nullptr;
     QLabel* statusLabel_ = nullptr;
     QDialogButtonBox* buttonBox_ = nullptr;
 };

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -23,6 +23,7 @@ struct AdbLogcatSessionData {
     QString captureId;
     QString boundOutputFile;
     LiveLogSourceType sourceType = LiveLogSourceType::AdbLogcat;
+    bool ansiOutputEnabled = false;
 
     QString displayName() const;
     QString documentId() const;

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -10,6 +10,11 @@
 
 class StreamingLogData;
 
+enum class LiveLogSourceType {
+    AdbLogcat,
+    IosLogStream,
+};
+
 struct AdbLogcatSessionData {
     QString adbExecutable;
     QString deviceSerial;
@@ -17,10 +22,12 @@ struct AdbLogcatSessionData {
     QString extraArgs;
     QString captureId;
     QString boundOutputFile;
+    LiveLogSourceType sourceType = LiveLogSourceType::AdbLogcat;
 
     QString displayName() const;
     QString documentId() const;
     QString associatedPath() const;
+    QString persistedSourceType() const;
 
     QJsonObject toJson() const;
     static AdbLogcatSessionData fromJson( const QString& json );

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -29,8 +29,11 @@ struct AdbLogcatSessionData {
     QString documentId() const;
     QString associatedPath() const;
     QString persistedSourceType() const;
+    bool isValid() const;
 
     QJsonObject toJson() const;
+    static QString persistedSourceType( LiveLogSourceType sourceType );
+    static bool isPersistedSourceType( const QString& sourceType );
     static AdbLogcatSessionData fromJson( const QString& json );
 };
 

--- a/src/ui/include/adbprocesstransport.h
+++ b/src/ui/include/adbprocesstransport.h
@@ -16,7 +16,7 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
 
   public:
     AdbProcessTransport( QString adbExecutable, QString deviceSerial, QString extraArgs,
-                         QObject* parent = nullptr );
+                         bool ansiOutputEnabled = false, QObject* parent = nullptr );
 
     static QList<AdbDeviceInfo> listDevices( const QString& adbExecutable, QString* error );
 
@@ -39,6 +39,7 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
     QString adbExecutable_;
     QString deviceSerial_;
     QString extraArgs_;
+    bool ansiOutputEnabled_;
 };
 
 #endif

--- a/src/ui/include/commandargumenttokenizer.h
+++ b/src/ui/include/commandargumenttokenizer.h
@@ -1,0 +1,88 @@
+#ifndef COMMANDARGUMENTTOKENIZER_H
+#define COMMANDARGUMENTTOKENIZER_H
+
+#include <QString>
+#include <QStringList>
+
+namespace ui::internal {
+
+inline bool canEscapeArgumentCharacter( const QChar nextChar, const QChar quoteChar )
+{
+    if ( quoteChar == QLatin1Char( '"' ) ) {
+        return nextChar == QLatin1Char( '"' ) || nextChar == QLatin1Char( '\\' );
+    }
+
+    if ( quoteChar == QLatin1Char( '\'' ) ) {
+        return false;
+    }
+
+    return nextChar.isSpace() || nextChar == QLatin1Char( '"' )
+           || nextChar == QLatin1Char( '\'' ) || nextChar == QLatin1Char( '\\' );
+}
+
+inline QStringList splitCommandArguments( const QString& arguments )
+{
+    QStringList tokens;
+    QString currentToken;
+    QChar quoteChar;
+    bool tokenStarted = false;
+
+    for ( int i = 0; i < arguments.size(); ++i ) {
+        const auto ch = arguments.at( i );
+        if ( ch == QLatin1Char( '\\' ) ) {
+            const auto nextIndex = i + 1;
+            if ( nextIndex < arguments.size() ) {
+                const auto nextChar = arguments.at( nextIndex );
+                if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
+                    tokenStarted = true;
+                    currentToken.append( nextChar );
+                    ++i;
+                    continue;
+                }
+            }
+
+            tokenStarted = true;
+            currentToken.append( ch );
+            continue;
+        }
+
+        if ( !quoteChar.isNull() ) {
+            if ( ch == quoteChar ) {
+                quoteChar = QChar{};
+            }
+            else {
+                tokenStarted = true;
+                currentToken.append( ch );
+            }
+            continue;
+        }
+
+        if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
+            tokenStarted = true;
+            quoteChar = ch;
+            continue;
+        }
+
+        if ( ch.isSpace() ) {
+            if ( tokenStarted ) {
+                tokens.push_back( currentToken );
+                currentToken.clear();
+                tokenStarted = false;
+            }
+            continue;
+        }
+
+        tokenStarted = true;
+        currentToken.append( ch );
+    }
+
+    if ( tokenStarted ) {
+        tokens.push_back( currentToken );
+    }
+
+    return tokens;
+}
+
+} // namespace ui::internal
+
+#endif // COMMANDARGUMENTTOKENIZER_H

--- a/src/ui/include/ioslogdialog.h
+++ b/src/ui/include/ioslogdialog.h
@@ -1,0 +1,39 @@
+#ifndef IOSLOGDIALOG_H
+#define IOSLOGDIALOG_H
+
+#include <QDialog>
+
+#include "adblogcatsource.h"
+
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+
+class IosLogDialog : public QDialog {
+    Q_OBJECT
+
+  public:
+    explicit IosLogDialog( QWidget* parent = nullptr );
+
+    AdbLogcatSessionData sessionData() const;
+
+  private Q_SLOTS:
+    void refreshDevices();
+
+  private:
+    void updateAcceptState();
+    void loadSettings();
+    void saveSettings() const;
+
+  private:
+    QLineEdit* executableEdit_ = nullptr;
+    QPushButton* refreshButton_ = nullptr;
+    QComboBox* deviceCombo_ = nullptr;
+    QLineEdit* extraArgsEdit_ = nullptr;
+    QLabel* statusLabel_ = nullptr;
+    QDialogButtonBox* buttonBox_ = nullptr;
+};
+
+#endif

--- a/src/ui/include/ioslogdialog.h
+++ b/src/ui/include/ioslogdialog.h
@@ -7,6 +7,7 @@
 
 class QComboBox;
 class QDialogButtonBox;
+class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
@@ -32,6 +33,7 @@ class IosLogDialog : public QDialog {
     QPushButton* refreshButton_ = nullptr;
     QComboBox* deviceCombo_ = nullptr;
     QLineEdit* extraArgsEdit_ = nullptr;
+    QCheckBox* ansiOutputCheckBox_ = nullptr;
     QLabel* statusLabel_ = nullptr;
     QDialogButtonBox* buttonBox_ = nullptr;
 };

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -1,0 +1,40 @@
+#ifndef IOSLOGPROCESSTRANSPORT_H
+#define IOSLOGPROCESSTRANSPORT_H
+
+#include <QList>
+
+#include "livesourcetransport.h"
+
+struct IosDeviceInfo {
+    QString udid;
+    QString displayName;
+    QString description;
+};
+
+class IosLogProcessTransport : public ProcessLiveSourceTransport {
+    Q_OBJECT
+
+  public:
+    IosLogProcessTransport( QString executable, QString deviceUdid, QString extraArgs,
+                            QObject* parent = nullptr );
+
+    static QList<IosDeviceInfo> listDevices( const QString& executable, QString* error );
+    static QString detectIosSyslogExecutable();
+
+    bool clearRemote( QString* error ) override;
+
+  protected:
+    Command streamingCommand() const override;
+    Command clearCommand() const override;
+
+  private:
+    QString normalizedExecutable() const;
+    QStringList streamArguments() const;
+
+  private:
+    QString executable_;
+    QString deviceUdid_;
+    QString extraArgs_;
+};
+
+#endif

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -31,7 +31,6 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     QString normalizedExecutable() const;
     QStringList streamArguments() const;
 
-  private:
     QString executable_;
     QString deviceUdid_;
     QString extraArgs_;

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -16,7 +16,7 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
 
   public:
     IosLogProcessTransport( QString executable, QString deviceUdid, QString extraArgs,
-                            QObject* parent = nullptr );
+                            bool ansiOutputEnabled = false, QObject* parent = nullptr );
 
     static QList<IosDeviceInfo> listDevices( const QString& executable, QString* error );
     static QString detectIosSyslogExecutable();
@@ -35,6 +35,7 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     QString executable_;
     QString deviceUdid_;
     QString extraArgs_;
+    bool ansiOutputEnabled_;
 };
 
 #endif

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -108,6 +108,7 @@ class MainWindow : public QMainWindow {
   private Q_SLOTS:
     void open();
     void openAdbLogcat();
+    void openIosLogStream();
     void openFileFromRecent( QAction* action );
     void openFileFromFavorites( QAction* action );
     void switchToOpenedFile( QAction* action );
@@ -265,6 +266,7 @@ class MainWindow : public QMainWindow {
     QAction* newWindowAction;
     QAction* openAction;
     QAction* openAdbLogcatAction;
+    QAction* openIosLogStreamAction;
     QAction* closeAction;
     QAction* closeAllAction;
     QAction* exitAction;

--- a/src/ui/include/optionsdialog.h
+++ b/src/ui/include/optionsdialog.h
@@ -50,6 +50,9 @@
 
 #include "ui_optionsdialog.h"
 
+class QGroupBox;
+class QLineEdit;
+
 class KeySequencePresenter : public QWidget {
     Q_OBJECT
   public:
@@ -64,7 +67,10 @@ class KeySequencePresenter : public QWidget {
     void showEditor();
 
   private:
+    void setKeySequence( const QString& keySequence );
+
     QLabel* keySequenceLabel_;
+    QString keySequence_;
 };
 
 // Implements the main option dialog box
@@ -93,6 +99,11 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
 
     void checkShortcutsOnDuplicate() const;
     void openLogFile();
+    void resetGeneralDefaults();
+    void resetViewDefaults();
+    void resetFileDefaults();
+    void resetShortcutsDefaults();
+    void resetAdvancedDefaults();
 
   private:
     void setupTabs();
@@ -105,10 +116,14 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     void setupStyles();
     void setupEncodings();
     void setupLanguageList();
+    void setupIosLogSettings();
+    void setupPanelResetButtons();
 
     int updateTranslate();
 
     void buildShortcutsTable(bool useDefaultsOnly);
+    void updateDialogFromConfiguration( const Configuration& config );
+    void updateFontSizePreservingSelection( const QString& fontFamily, int preferredPointSize );
 
     int getRegexpTypeIndex( SearchRegexpType syntax ) const;
     SearchRegexpType getRegexpTypeFromIndex( int index ) const;
@@ -120,6 +135,9 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
 
     QColor mainSearchColor_;
     QColor qfSearchColor_;
+    QGroupBox* iosLogGroupBox_ = nullptr;
+    QLineEdit* iosLogExecutableLineEdit_ = nullptr;
+    QLineEdit* iosLogArgsLineEdit_ = nullptr;
 };
 
 #endif

--- a/src/ui/include/optionsdialog.h
+++ b/src/ui/include/optionsdialog.h
@@ -50,6 +50,7 @@
 
 #include "ui_optionsdialog.h"
 
+class QCheckBox;
 class QGroupBox;
 class QLineEdit;
 
@@ -136,8 +137,10 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     QColor mainSearchColor_;
     QColor qfSearchColor_;
     QGroupBox* iosLogGroupBox_ = nullptr;
+    QCheckBox* adbAnsiOutputCheckBox_ = nullptr;
     QLineEdit* iosLogExecutableLineEdit_ = nullptr;
     QLineEdit* iosLogArgsLineEdit_ = nullptr;
+    QCheckBox* iosLogAnsiOutputCheckBox_ = nullptr;
 };
 
 #endif

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -504,6 +504,19 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="renderAnsiColorsCheckBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Render ANSI Colors (search performance will be reduced)</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2910,6 +2910,19 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
             foreColor = palette.brush( QPalette::Disabled, QPalette::Text ).color();
         }
         else if ( !isOutsideSearchRange ) {
+            const auto ansiColorSpans = logData_->getLineAnsiColors( lineNumber );
+            for ( const auto& span : ansiColorSpans ) {
+                const auto toColor = []( quint32 rgb ) {
+                    return QColor( static_cast<int>( ( rgb >> 16 ) & 0xff ),
+                                   static_cast<int>( ( rgb >> 8 ) & 0xff ),
+                                   static_cast<int>( rgb & 0xff ) );
+                };
+                highlighterMatches.addMatch( HighlightedMatch{
+                    span.startColumn, span.length,
+                    span.foreground.has_value() ? toColor( *span.foreground ) : foreColor,
+                    span.background.has_value() ? toColor( *span.background ) : backColor } );
+            }
+
             const auto highlightType = highlighterSet.matchLine( logLine, highlighterMatches );
 
             // LineMatch whole-line coloring only applies when not selected

--- a/src/ui/src/adblogcatdialog.cpp
+++ b/src/ui/src/adblogcatdialog.cpp
@@ -1,5 +1,6 @@
 #include "adblogcatdialog.h"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QFormLayout>
@@ -38,10 +39,13 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
     extraArgsEdit_ = new QLineEdit( this );
     extraArgsEdit_->setObjectName( QStringLiteral( "extraArgsEdit" ) );
     extraArgsEdit_->setPlaceholderText( tr( "Optional logcat args, appended after 'adb -s <serial> logcat'" ) );
+    ansiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), this );
+    ansiOutputCheckBox_->setObjectName( QStringLiteral( "ansiOutputCheckBox" ) );
 
     formLayout->addRow( tr( "ADB executable" ), adbRowLayout );
     formLayout->addRow( tr( "Device" ), deviceCombo_ );
     formLayout->addRow( tr( "Extra logcat args" ), extraArgsEdit_ );
+    formLayout->addRow( QString{}, ansiOutputCheckBox_ );
 
     statusLabel_ = new QLabel( this );
     statusLabel_->setObjectName( QStringLiteral( "adbStatusLabel" ) );
@@ -76,6 +80,8 @@ AdbLogcatSessionData AdbLogcatDialog::sessionData() const
         extraArgsEdit_->text().trimmed(),
         QUuid::createUuid().toString( QUuid::WithoutBraces ),
         {},
+        LiveLogSourceType::AdbLogcat,
+        ansiOutputCheckBox_->isChecked(),
     };
 }
 
@@ -113,6 +119,7 @@ void AdbLogcatDialog::loadSettings()
     const auto& config = Configuration::get();
     adbExecutableEdit_->setText( config.adbExecutable() );
     extraArgsEdit_->setText( config.adbLogcatExtraArgs() );
+    ansiOutputCheckBox_->setChecked( config.adbLogcatAnsiOutputEnabled() );
 }
 
 void AdbLogcatDialog::saveSettings() const
@@ -120,5 +127,6 @@ void AdbLogcatDialog::saveSettings() const
     auto& config = Configuration::get();
     config.setAdbExecutable( adbExecutableEdit_->text().trimmed() );
     config.setAdbLogcatExtraArgs( extraArgsEdit_->text().trimmed() );
+    config.setAdbLogcatAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
     config.save();
 }

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -36,12 +36,14 @@ std::unique_ptr<LiveSourceTransport> makeTransport( const AdbLogcatSessionData& 
     if ( sessionData.sourceType == LiveLogSourceType::IosLogStream ) {
         return std::make_unique<IosLogProcessTransport>( sessionData.adbExecutable,
                                                          sessionData.deviceSerial,
-                                                         sessionData.extraArgs );
+                                                         sessionData.extraArgs,
+                                                         sessionData.ansiOutputEnabled );
     }
 
     return std::make_unique<AdbProcessTransport>( sessionData.adbExecutable,
                                                   sessionData.deviceSerial,
-                                                  sessionData.extraArgs );
+                                                  sessionData.extraArgs,
+                                                  sessionData.ansiOutputEnabled );
 }
 } // namespace
 
@@ -77,6 +79,7 @@ QJsonObject AdbLogcatSessionData::toJson() const
         { QStringLiteral( "extraArgs" ), extraArgs },
         { QStringLiteral( "captureId" ), captureId },
         { QStringLiteral( "boundOutputFile" ), boundOutputFile },
+        { QStringLiteral( "ansiOutputEnabled" ), ansiOutputEnabled },
     };
 }
 
@@ -91,6 +94,7 @@ AdbLogcatSessionData AdbLogcatSessionData::fromJson( const QString& json )
         jsonObject.value( QStringLiteral( "captureId" ) ).toString(),
         jsonObject.value( QStringLiteral( "boundOutputFile" ) ).toString(),
         sourceTypeFromString( jsonObject.value( QStringLiteral( "sourceType" ) ).toString() ),
+        jsonObject.value( QStringLiteral( "ansiOutputEnabled" ) ).toBool( false ),
     };
 }
 

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -171,11 +171,13 @@ bool AdbLogcatSource::clearAndRestart()
     const auto wasConnected = state_ == State::Connected;
     disconnectSource();
 
-    QString error;
-    if ( !transport_ || !transport_->clearRemote( &error ) ) {
-        lastError_ = error.isEmpty() ? tr( "Failed to clear logcat buffer" ) : error;
-        setState( State::Error );
-        return false;
+    if ( sessionData_.sourceType != LiveLogSourceType::IosLogStream ) {
+        QString error;
+        if ( !transport_ || !transport_->clearRemote( &error ) ) {
+            lastError_ = error.isEmpty() ? tr( "Failed to clear logcat buffer" ) : error;
+            setState( State::Error );
+            return false;
+        }
     }
 
     if ( logData_ ) {

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -4,9 +4,46 @@
 #include <QJsonDocument>
 
 #include "adbprocesstransport.h"
+#include "ioslogprocesstransport.h"
 #include "log.h"
 #include "livesourcetransport.h"
 #include "streaminglogdata.h"
+
+namespace {
+QString sourceTypeToString( LiveLogSourceType sourceType )
+{
+    switch ( sourceType ) {
+    case LiveLogSourceType::IosLogStream:
+        return QStringLiteral( "ios_log_stream" );
+    case LiveLogSourceType::AdbLogcat:
+        return QStringLiteral( "adb_logcat" );
+    }
+
+    return QStringLiteral( "adb_logcat" );
+}
+
+LiveLogSourceType sourceTypeFromString( const QString& sourceType )
+{
+    if ( sourceType == QStringLiteral( "ios_log_stream" ) ) {
+        return LiveLogSourceType::IosLogStream;
+    }
+
+    return LiveLogSourceType::AdbLogcat;
+}
+
+std::unique_ptr<LiveSourceTransport> makeTransport( const AdbLogcatSessionData& sessionData )
+{
+    if ( sessionData.sourceType == LiveLogSourceType::IosLogStream ) {
+        return std::make_unique<IosLogProcessTransport>( sessionData.adbExecutable,
+                                                         sessionData.deviceSerial,
+                                                         sessionData.extraArgs );
+    }
+
+    return std::make_unique<AdbProcessTransport>( sessionData.adbExecutable,
+                                                  sessionData.deviceSerial,
+                                                  sessionData.extraArgs );
+}
+} // namespace
 
 QString AdbLogcatSessionData::displayName() const
 {
@@ -15,7 +52,9 @@ QString AdbLogcatSessionData::displayName() const
 
 QString AdbLogcatSessionData::documentId() const
 {
-    return QStringLiteral( "adb://%1" ).arg( captureId );
+    const auto scheme = sourceType == LiveLogSourceType::IosLogStream ? QStringLiteral( "ios-log" )
+                                                                      : QStringLiteral( "adb" );
+    return QStringLiteral( "%1://%2" ).arg( scheme, captureId );
 }
 
 QString AdbLogcatSessionData::associatedPath() const
@@ -23,9 +62,15 @@ QString AdbLogcatSessionData::associatedPath() const
     return boundOutputFile;
 }
 
+QString AdbLogcatSessionData::persistedSourceType() const
+{
+    return sourceTypeToString( sourceType );
+}
+
 QJsonObject AdbLogcatSessionData::toJson() const
 {
     return QJsonObject{
+        { QStringLiteral( "sourceType" ), sourceTypeToString( sourceType ) },
         { QStringLiteral( "adbExecutable" ), adbExecutable },
         { QStringLiteral( "deviceSerial" ), deviceSerial },
         { QStringLiteral( "deviceDescription" ), deviceDescription },
@@ -45,6 +90,7 @@ AdbLogcatSessionData AdbLogcatSessionData::fromJson( const QString& json )
         jsonObject.value( QStringLiteral( "extraArgs" ) ).toString(),
         jsonObject.value( QStringLiteral( "captureId" ) ).toString(),
         jsonObject.value( QStringLiteral( "boundOutputFile" ) ).toString(),
+        sourceTypeFromString( jsonObject.value( QStringLiteral( "sourceType" ) ).toString() ),
     };
 }
 
@@ -53,9 +99,7 @@ AdbLogcatSource::AdbLogcatSource( AdbLogcatSessionData sessionData,
     : QObject( parent )
     , sessionData_( std::move( sessionData ) )
     , logData_( std::move( logData ) )
-    , transport_( std::make_unique<AdbProcessTransport>( sessionData_.adbExecutable,
-                                                         sessionData_.deviceSerial,
-                                                         sessionData_.extraArgs ) )
+    , transport_( makeTransport( sessionData_ ) )
 {
     connect( transport_.get(), &LiveSourceTransport::bytesReceived, this,
              [ this ]( const QByteArray& data ) {

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -10,21 +10,10 @@
 #include "streaminglogdata.h"
 
 namespace {
-QString sourceTypeToString( LiveLogSourceType sourceType )
-{
-    switch ( sourceType ) {
-    case LiveLogSourceType::IosLogStream:
-        return QStringLiteral( "ios_log_stream" );
-    case LiveLogSourceType::AdbLogcat:
-        return QStringLiteral( "adb_logcat" );
-    }
-
-    return QStringLiteral( "adb_logcat" );
-}
-
 LiveLogSourceType sourceTypeFromString( const QString& sourceType )
 {
-    if ( sourceType == QStringLiteral( "ios_log_stream" ) ) {
+    if ( sourceType == AdbLogcatSessionData::persistedSourceType(
+                           LiveLogSourceType::IosLogStream ) ) {
         return LiveLogSourceType::IosLogStream;
     }
 
@@ -66,13 +55,36 @@ QString AdbLogcatSessionData::associatedPath() const
 
 QString AdbLogcatSessionData::persistedSourceType() const
 {
-    return sourceTypeToString( sourceType );
+    return persistedSourceType( sourceType );
+}
+
+bool AdbLogcatSessionData::isValid() const
+{
+    return !captureId.isEmpty();
+}
+
+QString AdbLogcatSessionData::persistedSourceType( LiveLogSourceType sourceType )
+{
+    switch ( sourceType ) {
+    case LiveLogSourceType::IosLogStream:
+        return QStringLiteral( "ios_log_stream" );
+    case LiveLogSourceType::AdbLogcat:
+        return QStringLiteral( "adb_logcat" );
+    }
+
+    return QStringLiteral( "adb_logcat" );
+}
+
+bool AdbLogcatSessionData::isPersistedSourceType( const QString& sourceType )
+{
+    return sourceType == persistedSourceType( LiveLogSourceType::AdbLogcat )
+           || sourceType == persistedSourceType( LiveLogSourceType::IosLogStream );
 }
 
 QJsonObject AdbLogcatSessionData::toJson() const
 {
     return QJsonObject{
-        { QStringLiteral( "sourceType" ), sourceTypeToString( sourceType ) },
+        { QStringLiteral( "sourceType" ), persistedSourceType() },
         { QStringLiteral( "adbExecutable" ), adbExecutable },
         { QStringLiteral( "deviceSerial" ), deviceSerial },
         { QStringLiteral( "deviceDescription" ), deviceDescription },

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -106,6 +106,7 @@ QStringList splitCommandArguments( const QString& arguments )
     QStringList tokens;
     QString currentToken;
     QChar quoteChar;
+    bool tokenStarted = false;
 
     for ( int i = 0; i < arguments.size(); ++i ) {
         const auto ch = arguments.at( i );
@@ -114,12 +115,14 @@ QStringList splitCommandArguments( const QString& arguments )
             if ( nextIndex < arguments.size() ) {
                 const auto nextChar = arguments.at( nextIndex );
                 if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
+                    tokenStarted = true;
                     currentToken.append( nextChar );
                     ++i;
                     continue;
                 }
             }
 
+            tokenStarted = true;
             currentToken.append( ch );
             continue;
         }
@@ -129,28 +132,32 @@ QStringList splitCommandArguments( const QString& arguments )
                 quoteChar = QChar{};
             }
             else {
+                tokenStarted = true;
                 currentToken.append( ch );
             }
             continue;
         }
 
         if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
+            tokenStarted = true;
             quoteChar = ch;
             continue;
         }
 
         if ( ch.isSpace() ) {
-            if ( !currentToken.isEmpty() ) {
+            if ( tokenStarted ) {
                 tokens.push_back( currentToken );
                 currentToken.clear();
+                tokenStarted = false;
             }
             continue;
         }
 
+        tokenStarted = true;
         currentToken.append( ch );
     }
 
-    if ( !currentToken.isEmpty() ) {
+    if ( tokenStarted ) {
         tokens.push_back( currentToken );
     }
 
@@ -159,11 +166,13 @@ QStringList splitCommandArguments( const QString& arguments )
 } // namespace
 
 AdbProcessTransport::AdbProcessTransport( QString adbExecutable, QString deviceSerial,
-                                          QString extraArgs, QObject* parent )
+                                          QString extraArgs, bool ansiOutputEnabled,
+                                          QObject* parent )
     : ProcessLiveSourceTransport( parent )
     , adbExecutable_( std::move( adbExecutable ) )
     , deviceSerial_( std::move( deviceSerial ) )
     , extraArgs_( std::move( extraArgs ) )
+    , ansiOutputEnabled_( ansiOutputEnabled )
 {
 }
 
@@ -268,6 +277,9 @@ QString AdbProcessTransport::detectAdbExecutable()
 QStringList AdbProcessTransport::logcatArguments() const
 {
     QStringList arguments{ QStringLiteral( "-s" ), deviceSerial_, QStringLiteral( "logcat" ) };
+    if ( ansiOutputEnabled_ ) {
+        arguments.append( { QStringLiteral( "-v" ), QStringLiteral( "color" ) } );
+    }
     const auto trimmedExtraArgs = extraArgs_.trimmed();
     if ( !trimmedExtraArgs.isEmpty() ) {
         arguments.append( splitCommandArguments( trimmedExtraArgs ) );

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -1,4 +1,5 @@
 #include "adbprocesstransport.h"
+#include "commandargumenttokenizer.h"
 
 #include <QDir>
 #include <QFile>
@@ -87,83 +88,9 @@ bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
     return false;
 }
 
-bool canEscapeArgumentCharacter( const QChar nextChar, const QChar quoteChar )
-{
-    if ( quoteChar == QLatin1Char( '"' ) ) {
-        return nextChar == QLatin1Char( '"' ) || nextChar == QLatin1Char( '\\' );
-    }
-
-    if ( quoteChar == QLatin1Char( '\'' ) ) {
-        return false;
-    }
-
-    return nextChar.isSpace() || nextChar == QLatin1Char( '"' )
-           || nextChar == QLatin1Char( '\'' ) || nextChar == QLatin1Char( '\\' );
-}
-
-QStringList splitCommandArguments( const QString& arguments )
-{
-    QStringList tokens;
-    QString currentToken;
-    QChar quoteChar;
-    bool tokenStarted = false;
-
-    for ( int i = 0; i < arguments.size(); ++i ) {
-        const auto ch = arguments.at( i );
-        if ( ch == QLatin1Char( '\\' ) ) {
-            const auto nextIndex = i + 1;
-            if ( nextIndex < arguments.size() ) {
-                const auto nextChar = arguments.at( nextIndex );
-                if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
-                    tokenStarted = true;
-                    currentToken.append( nextChar );
-                    ++i;
-                    continue;
-                }
-            }
-
-            tokenStarted = true;
-            currentToken.append( ch );
-            continue;
-        }
-
-        if ( !quoteChar.isNull() ) {
-            if ( ch == quoteChar ) {
-                quoteChar = QChar{};
-            }
-            else {
-                tokenStarted = true;
-                currentToken.append( ch );
-            }
-            continue;
-        }
-
-        if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
-            tokenStarted = true;
-            quoteChar = ch;
-            continue;
-        }
-
-        if ( ch.isSpace() ) {
-            if ( tokenStarted ) {
-                tokens.push_back( currentToken );
-                currentToken.clear();
-                tokenStarted = false;
-            }
-            continue;
-        }
-
-        tokenStarted = true;
-        currentToken.append( ch );
-    }
-
-    if ( tokenStarted ) {
-        tokens.push_back( currentToken );
-    }
-
-    return tokens;
-}
 } // namespace
+
+using ui::internal::splitCommandArguments;
 
 AdbProcessTransport::AdbProcessTransport( QString adbExecutable, QString deviceSerial,
                                           QString extraArgs, bool ansiOutputEnabled,

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -83,8 +83,6 @@
 #include "savedsearches.h"
 #include "shortcuts.h"
 
-static constexpr char AnsiColorSequenceRegex[] = "\\x1B\\[([0-9]{1,4}((;|:)[0-9]{1,3})*)?[mK]";
-
 // Throttle intervals (ms) for coalescing search updates during live streaming.
 static constexpr int kSearchThrottleActiveMs = 250;
 static constexpr int kSearchThrottleInactiveMs = 1000;
@@ -811,12 +809,16 @@ void CrawlerWidget::applyConfiguration()
 
     font.setBold( config.useBoldFont() );
 
-    if ( config.hideAnsiColorSequences() ) {
-        logData_->setPrefilter( AnsiColorSequenceRegex );
+    if ( config.renderAnsiColorSequences() ) {
+        logData_->setAnsiProcessingMode( AnsiProcessingMode::Render );
+    }
+    else if ( config.hideAnsiColorSequences() ) {
+        logData_->setAnsiProcessingMode( AnsiProcessingMode::Strip );
     }
     else {
-        logData_->setPrefilter( {} );
+        logData_->setAnsiProcessingMode( AnsiProcessingMode::Plain );
     }
+    logData_->setPrefilter( {} );
 
     logMainView_->setLineNumbersVisible( config.mainLineNumbersVisible() );
 

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QTimer>
 #include <QVBoxLayout>
 #include <QUuid>
 
@@ -69,7 +70,7 @@ IosLogDialog::IosLogDialog( QWidget* parent )
     connect( buttonBox_, &QDialogButtonBox::rejected, this, &QDialog::reject );
 
     loadSettings();
-    refreshDevices();
+    QTimer::singleShot( 0, this, &IosLogDialog::refreshDevices );
 }
 
 AdbLogcatSessionData IosLogDialog::sessionData() const

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -1,0 +1,126 @@
+#include "ioslogdialog.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QUuid>
+
+#include "configuration.h"
+#include "ioslogprocesstransport.h"
+
+IosLogDialog::IosLogDialog( QWidget* parent )
+    : QDialog( parent )
+{
+    setWindowTitle( tr( "Open iOS Log Stream" ) );
+    setModal( true );
+    resize( 720, 220 );
+
+    auto* rootLayout = new QVBoxLayout( this );
+    auto* formLayout = new QFormLayout();
+
+    auto* executableRowLayout = new QHBoxLayout();
+    executableEdit_ = new QLineEdit( this );
+    executableEdit_->setObjectName( QStringLiteral( "iosLogExecutableEdit" ) );
+    executableEdit_->setPlaceholderText( QStringLiteral( "pymobiledevice3" ) );
+    refreshButton_ = new QPushButton( tr( "Refresh Devices" ), this );
+    refreshButton_->setObjectName( QStringLiteral( "refreshDevicesButton" ) );
+    executableRowLayout->addWidget( executableEdit_ );
+    executableRowLayout->addWidget( refreshButton_ );
+
+    deviceCombo_ = new QComboBox( this );
+    deviceCombo_->setObjectName( QStringLiteral( "deviceCombo" ) );
+    deviceCombo_->setSizeAdjustPolicy( QComboBox::AdjustToContents );
+    extraArgsEdit_ = new QLineEdit( this );
+    extraArgsEdit_->setObjectName( QStringLiteral( "extraArgsEdit" ) );
+    extraArgsEdit_->setPlaceholderText(
+        tr( "Optional args, appended after 'pymobiledevice3 syslog live --udid <udid>'" ) );
+
+    formLayout->addRow( tr( "pymobiledevice3 executable" ), executableRowLayout );
+    formLayout->addRow( tr( "Device" ), deviceCombo_ );
+    formLayout->addRow( tr( "Extra iOS log args" ), extraArgsEdit_ );
+
+    statusLabel_ = new QLabel( this );
+    statusLabel_->setObjectName( QStringLiteral( "iosLogStatusLabel" ) );
+    statusLabel_->setWordWrap( true );
+
+    buttonBox_ = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this );
+    buttonBox_->setObjectName( QStringLiteral( "buttonBox" ) );
+
+    rootLayout->addLayout( formLayout );
+    rootLayout->addWidget( statusLabel_ );
+    rootLayout->addWidget( buttonBox_ );
+
+    connect( refreshButton_, &QPushButton::clicked, this, &IosLogDialog::refreshDevices );
+    connect( deviceCombo_, qOverload<int>( &QComboBox::currentIndexChanged ), this,
+             &IosLogDialog::updateAcceptState );
+    connect( buttonBox_, &QDialogButtonBox::accepted, this, [ this ] {
+        saveSettings();
+        accept();
+    } );
+    connect( buttonBox_, &QDialogButtonBox::rejected, this, &QDialog::reject );
+
+    loadSettings();
+    refreshDevices();
+}
+
+AdbLogcatSessionData IosLogDialog::sessionData() const
+{
+    return AdbLogcatSessionData{
+        executableEdit_->text().trimmed(),
+        deviceCombo_->currentData( Qt::UserRole ).toString(),
+        deviceCombo_->currentText(),
+        extraArgsEdit_->text().trimmed(),
+        QUuid::createUuid().toString( QUuid::WithoutBraces ),
+        {},
+        LiveLogSourceType::IosLogStream,
+    };
+}
+
+void IosLogDialog::refreshDevices()
+{
+    deviceCombo_->clear();
+
+    QString error;
+    const auto devices = IosLogProcessTransport::listDevices( executableEdit_->text(), &error );
+    for ( const auto& device : devices ) {
+        deviceCombo_->addItem( device.displayName, device.udid );
+        deviceCombo_->setItemData( deviceCombo_->count() - 1, device.description, Qt::ToolTipRole );
+    }
+
+    if ( devices.isEmpty() ) {
+        statusLabel_->setText( error.isEmpty() ? tr( "No iOS devices detected." ) : error );
+    }
+    else {
+        statusLabel_->setText(
+            tr( "Data stays in temp capture storage until you explicitly save or close the tab." ) );
+    }
+
+    updateAcceptState();
+}
+
+void IosLogDialog::updateAcceptState()
+{
+    if ( auto* okButton = buttonBox_->button( QDialogButtonBox::Ok ) ) {
+        okButton->setEnabled( deviceCombo_->count() > 0 && deviceCombo_->currentIndex() >= 0 );
+    }
+}
+
+void IosLogDialog::loadSettings()
+{
+    const auto& config = Configuration::get();
+    executableEdit_->setText( config.iosLogExecutable() );
+    extraArgsEdit_->setText( config.iosLogExtraArgs() );
+}
+
+void IosLogDialog::saveSettings() const
+{
+    auto& config = Configuration::get();
+    config.setIosLogExecutable( executableEdit_->text().trimmed() );
+    config.setIosLogExtraArgs( extraArgsEdit_->text().trimmed() );
+    config.save();
+}

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -1,5 +1,6 @@
 #include "ioslogdialog.h"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QFormLayout>
@@ -39,10 +40,13 @@ IosLogDialog::IosLogDialog( QWidget* parent )
     extraArgsEdit_->setObjectName( QStringLiteral( "extraArgsEdit" ) );
     extraArgsEdit_->setPlaceholderText(
         tr( "Optional args, appended after 'pymobiledevice3 syslog live --udid <udid>'" ) );
+    ansiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), this );
+    ansiOutputCheckBox_->setObjectName( QStringLiteral( "ansiOutputCheckBox" ) );
 
     formLayout->addRow( tr( "pymobiledevice3 executable" ), executableRowLayout );
     formLayout->addRow( tr( "Device" ), deviceCombo_ );
     formLayout->addRow( tr( "Extra iOS log args" ), extraArgsEdit_ );
+    formLayout->addRow( QString{}, ansiOutputCheckBox_ );
 
     statusLabel_ = new QLabel( this );
     statusLabel_->setObjectName( QStringLiteral( "iosLogStatusLabel" ) );
@@ -78,6 +82,7 @@ AdbLogcatSessionData IosLogDialog::sessionData() const
         QUuid::createUuid().toString( QUuid::WithoutBraces ),
         {},
         LiveLogSourceType::IosLogStream,
+        ansiOutputCheckBox_->isChecked(),
     };
 }
 
@@ -115,6 +120,7 @@ void IosLogDialog::loadSettings()
     const auto& config = Configuration::get();
     executableEdit_->setText( config.iosLogExecutable() );
     extraArgsEdit_->setText( config.iosLogExtraArgs() );
+    ansiOutputCheckBox_->setChecked( config.iosLogAnsiOutputEnabled() );
 }
 
 void IosLogDialog::saveSettings() const
@@ -122,5 +128,6 @@ void IosLogDialog::saveSettings() const
     auto& config = Configuration::get();
     config.setIosLogExecutable( executableEdit_->text().trimmed() );
     config.setIosLogExtraArgs( extraArgsEdit_->text().trimmed() );
+    config.setIosLogAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
     config.save();
 }

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -1,0 +1,324 @@
+#include "ioslogprocesstransport.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QProcess>
+#include <QStandardPaths>
+
+#include <utility>
+
+namespace {
+bool canEscapeArgumentCharacter( const QChar nextChar, const QChar quoteChar )
+{
+    if ( quoteChar == QLatin1Char( '"' ) ) {
+        return nextChar == QLatin1Char( '"' ) || nextChar == QLatin1Char( '\\' );
+    }
+
+    if ( quoteChar == QLatin1Char( '\'' ) ) {
+        return false;
+    }
+
+    return nextChar.isSpace() || nextChar == QLatin1Char( '"' )
+           || nextChar == QLatin1Char( '\'' ) || nextChar == QLatin1Char( '\\' );
+}
+
+QStringList splitCommandArguments( const QString& arguments )
+{
+    QStringList tokens;
+    QString currentToken;
+    QChar quoteChar;
+
+    for ( int i = 0; i < arguments.size(); ++i ) {
+        const auto ch = arguments.at( i );
+        if ( ch == QLatin1Char( '\\' ) ) {
+            const auto nextIndex = i + 1;
+            if ( nextIndex < arguments.size() ) {
+                const auto nextChar = arguments.at( nextIndex );
+                if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
+                    currentToken.append( nextChar );
+                    ++i;
+                    continue;
+                }
+            }
+
+            currentToken.append( ch );
+            continue;
+        }
+
+        if ( !quoteChar.isNull() ) {
+            if ( ch == quoteChar ) {
+                quoteChar = QChar{};
+            }
+            else {
+                currentToken.append( ch );
+            }
+            continue;
+        }
+
+        if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
+            quoteChar = ch;
+            continue;
+        }
+
+        if ( ch.isSpace() ) {
+            if ( !currentToken.isEmpty() ) {
+                tokens.push_back( currentToken );
+                currentToken.clear();
+            }
+            continue;
+        }
+
+        currentToken.append( ch );
+    }
+
+    if ( !currentToken.isEmpty() ) {
+        tokens.push_back( currentToken );
+    }
+
+    return tokens;
+}
+
+bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
+{
+    if ( process.waitForFinished( timeoutMs ) ) {
+        return true;
+    }
+
+    process.kill();
+    process.waitForFinished( 1500 );
+    return false;
+}
+
+QString findExecutableAtKnownLocation( const QString& executable )
+{
+#ifdef Q_OS_MAC
+    const QStringList candidates{
+        QDir::cleanPath( QStringLiteral( "/opt/homebrew/bin/" ) + executable ),
+        QDir::cleanPath( QStringLiteral( "/usr/local/bin/" ) + executable ),
+    };
+
+    for ( const auto& candidate : candidates ) {
+        const QFileInfo info( candidate );
+        if ( info.exists() && info.isFile() && info.isExecutable() ) {
+            return info.absoluteFilePath();
+        }
+    }
+
+    const auto fromPath = QStandardPaths::findExecutable( executable );
+    if ( !fromPath.isEmpty() ) {
+        return fromPath;
+    }
+#else
+    Q_UNUSED( executable );
+#endif
+
+    return {};
+}
+
+QString normalizedIosSyslogExecutable( const QString& executable )
+{
+    const auto trimmed = executable.trimmed();
+    if ( !trimmed.isEmpty() ) {
+        return trimmed;
+    }
+
+    const auto detected = findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
+    if ( !detected.isEmpty() ) {
+        return detected;
+    }
+
+    return QStringLiteral( "pymobiledevice3" );
+}
+
+QString firstStringValue( const QJsonObject& object, std::initializer_list<const char*> keys )
+{
+    for ( const auto* key : keys ) {
+        const auto value = object.value( QLatin1String( key ) );
+        if ( value.isString() ) {
+            const auto text = value.toString().trimmed();
+            if ( !text.isEmpty() ) {
+                return text;
+            }
+        }
+    }
+
+    return {};
+}
+
+QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output )
+{
+    const auto document = QJsonDocument::fromJson( output );
+    if ( !document.isArray() ) {
+        return {};
+    }
+
+    QList<IosDeviceInfo> devices;
+    for ( const auto& value : document.array() ) {
+        QString udid;
+        QString name;
+
+        if ( value.isString() ) {
+            udid = value.toString().trimmed();
+        }
+        else if ( value.isObject() ) {
+            const auto object = value.toObject();
+            udid = firstStringValue( object, { "Identifier", "UDID", "UniqueDeviceID",
+                                               "SerialNumber", "serial", "udid" } );
+            name = firstStringValue( object, { "DeviceName", "Name", "ProductName", "name" } );
+        }
+
+        if ( udid.isEmpty() ) {
+            continue;
+        }
+
+        const auto displayName = name.isEmpty() ? udid : QStringLiteral( "%1 (%2)" ).arg( name, udid );
+        devices.push_back( IosDeviceInfo{ udid, displayName, name.isEmpty() ? udid : name } );
+    }
+
+    return devices;
+}
+
+QList<IosDeviceInfo> parsePymobiledeviceSimpleDeviceList( const QByteArray& output )
+{
+    const auto parsed = parsePymobiledeviceDeviceList( output );
+    if ( !parsed.isEmpty() ) {
+        return parsed;
+    }
+
+    QList<IosDeviceInfo> devices;
+    const auto lines = QString::fromUtf8( output ).split( '\n' );
+    for ( auto line : lines ) {
+        const auto udid = line.trimmed();
+        if ( udid.isEmpty() || udid.startsWith( QLatin1Char( '[' ) )
+             || udid.startsWith( QLatin1Char( ']' ) ) ) {
+            continue;
+        }
+
+        devices.push_back( IosDeviceInfo{ udid, udid, udid } );
+    }
+
+    return devices;
+}
+
+bool runPymobiledeviceListCommand( const QString& executable, const QStringList& arguments,
+                                   QList<IosDeviceInfo>* devices, QString* error )
+{
+    QProcess process;
+    process.start( executable, arguments );
+    if ( !process.waitForStarted( 3000 ) ) {
+        if ( error ) {
+            *error = process.errorString();
+        }
+        return false;
+    }
+
+    if ( !waitForFinishedOrKill( process, 5000 ) ) {
+        if ( error ) {
+            *error = QObject::tr( "Timed out waiting for iOS device list output" );
+        }
+        return false;
+    }
+
+    const auto stdOut = process.readAllStandardOutput();
+    if ( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ) {
+        if ( error ) {
+            const auto stdErr = QString::fromUtf8( process.readAllStandardError() ).trimmed();
+            *error = stdErr.isEmpty() ? process.errorString() : stdErr;
+        }
+        return false;
+    }
+
+    *devices = parsePymobiledeviceSimpleDeviceList( stdOut );
+    return true;
+}
+
+QStringList pymobiledeviceListArguments()
+{
+    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ), QStringLiteral( "--simple" ) };
+}
+
+QStringList pymobiledeviceStreamingArguments( const QString& deviceUdid )
+{
+    if ( deviceUdid.isEmpty() ) {
+        return { QStringLiteral( "syslog" ), QStringLiteral( "live" ) };
+    }
+
+    return { QStringLiteral( "syslog" ), QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+             deviceUdid };
+}
+
+} // namespace
+
+IosLogProcessTransport::IosLogProcessTransport( QString executable, QString deviceUdid,
+                                                QString extraArgs, QObject* parent )
+    : ProcessLiveSourceTransport( parent )
+    , executable_( std::move( executable ) )
+    , deviceUdid_( std::move( deviceUdid ) )
+    , extraArgs_( std::move( extraArgs ) )
+{
+}
+
+QList<IosDeviceInfo> IosLogProcessTransport::listDevices( const QString& executable,
+                                                          QString* error )
+{
+#ifndef Q_OS_MAC
+    if ( error ) {
+        *error = QObject::tr( "iOS log streaming is supported only on macOS." );
+    }
+    return {};
+#else
+    QList<IosDeviceInfo> devices;
+    const auto pymobiledeviceExecutable = normalizedIosSyslogExecutable( executable );
+    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceListArguments(),
+                                        &devices, error ) ) {
+        return {};
+    }
+
+    if ( devices.isEmpty() && error ) {
+        *error = QObject::tr( "No iOS devices reported by pymobiledevice3." );
+    }
+    return devices;
+#endif
+}
+
+QString IosLogProcessTransport::detectIosSyslogExecutable()
+{
+    return findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
+}
+
+bool IosLogProcessTransport::clearRemote( QString* error )
+{
+    if ( error ) {
+        *error = tr( "iOS live logs cannot be cleared remotely." );
+    }
+    return false;
+}
+
+ProcessLiveSourceTransport::Command IosLogProcessTransport::streamingCommand() const
+{
+    return Command{ normalizedExecutable(), streamArguments() };
+}
+
+ProcessLiveSourceTransport::Command IosLogProcessTransport::clearCommand() const
+{
+    return Command{ normalizedExecutable(), {} };
+}
+
+QString IosLogProcessTransport::normalizedExecutable() const
+{
+    return normalizedIosSyslogExecutable( executable_ );
+}
+
+QStringList IosLogProcessTransport::streamArguments() const
+{
+    QStringList arguments = pymobiledeviceStreamingArguments( deviceUdid_ );
+    const auto trimmedExtraArgs = extraArgs_.trimmed();
+    if ( !trimmedExtraArgs.isEmpty() ) {
+        arguments.append( splitCommandArguments( trimmedExtraArgs ) );
+    }
+    return arguments;
+}

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -1,4 +1,5 @@
 #include "ioslogprocesstransport.h"
+#include "commandargumenttokenizer.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -12,82 +13,8 @@
 #include <utility>
 
 namespace {
-bool canEscapeArgumentCharacter( const QChar nextChar, const QChar quoteChar )
-{
-    if ( quoteChar == QLatin1Char( '"' ) ) {
-        return nextChar == QLatin1Char( '"' ) || nextChar == QLatin1Char( '\\' );
-    }
 
-    if ( quoteChar == QLatin1Char( '\'' ) ) {
-        return false;
-    }
-
-    return nextChar.isSpace() || nextChar == QLatin1Char( '"' )
-           || nextChar == QLatin1Char( '\'' ) || nextChar == QLatin1Char( '\\' );
-}
-
-QStringList splitCommandArguments( const QString& arguments )
-{
-    QStringList tokens;
-    QString currentToken;
-    QChar quoteChar;
-    bool tokenStarted = false;
-
-    for ( int i = 0; i < arguments.size(); ++i ) {
-        const auto ch = arguments.at( i );
-        if ( ch == QLatin1Char( '\\' ) ) {
-            const auto nextIndex = i + 1;
-            if ( nextIndex < arguments.size() ) {
-                const auto nextChar = arguments.at( nextIndex );
-                if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
-                    tokenStarted = true;
-                    currentToken.append( nextChar );
-                    ++i;
-                    continue;
-                }
-            }
-
-            tokenStarted = true;
-            currentToken.append( ch );
-            continue;
-        }
-
-        if ( !quoteChar.isNull() ) {
-            if ( ch == quoteChar ) {
-                quoteChar = QChar{};
-            }
-            else {
-                tokenStarted = true;
-                currentToken.append( ch );
-            }
-            continue;
-        }
-
-        if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
-            tokenStarted = true;
-            quoteChar = ch;
-            continue;
-        }
-
-        if ( ch.isSpace() ) {
-            if ( tokenStarted ) {
-                tokens.push_back( currentToken );
-                currentToken.clear();
-                tokenStarted = false;
-            }
-            continue;
-        }
-
-        tokenStarted = true;
-        currentToken.append( ch );
-    }
-
-    if ( tokenStarted ) {
-        tokens.push_back( currentToken );
-    }
-
-    return tokens;
-}
+using ui::internal::splitCommandArguments;
 
 QString findExecutableAtKnownLocation( const QString& executable )
 {

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -89,17 +89,6 @@ QStringList splitCommandArguments( const QString& arguments )
     return tokens;
 }
 
-bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
-{
-    if ( process.waitForFinished( timeoutMs ) ) {
-        return true;
-    }
-
-    process.kill();
-    process.waitForFinished( 1500 );
-    return false;
-}
-
 QString findExecutableAtKnownLocation( const QString& executable )
 {
 #ifdef Q_OS_MAC
@@ -139,6 +128,18 @@ QString normalizedIosSyslogExecutable( const QString& executable )
     }
 
     return QStringLiteral( "pymobiledevice3" );
+}
+
+#ifdef Q_OS_MAC
+bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
+{
+    if ( process.waitForFinished( timeoutMs ) ) {
+        return true;
+    }
+
+    process.kill();
+    process.waitForFinished( 1500 );
+    return false;
 }
 
 QString firstStringValue( const QJsonObject& object, std::initializer_list<const char*> keys )
@@ -243,10 +244,16 @@ bool runPymobiledeviceListCommand( const QString& executable, const QStringList&
     return true;
 }
 
-QStringList pymobiledeviceListArguments()
+QStringList pymobiledeviceSimpleListArguments()
 {
     return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ), QStringLiteral( "--simple" ) };
 }
+
+QStringList pymobiledeviceLegacyListArguments()
+{
+    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ) };
+}
+#endif
 
 QStringList pymobiledeviceStreamingArguments( const QString& deviceUdid )
 {
@@ -279,6 +286,7 @@ QList<IosDeviceInfo> IosLogProcessTransport::listDevices( const QString& executa
                                                           QString* error )
 {
 #ifndef Q_OS_MAC
+    Q_UNUSED( executable );
     if ( error ) {
         *error = QObject::tr( "iOS log streaming is supported only on macOS." );
     }
@@ -286,9 +294,21 @@ QList<IosDeviceInfo> IosLogProcessTransport::listDevices( const QString& executa
 #else
     QList<IosDeviceInfo> devices;
     const auto pymobiledeviceExecutable = normalizedIosSyslogExecutable( executable );
-    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceListArguments(),
+    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceSimpleListArguments(),
                                         &devices, error ) ) {
-        return {};
+        QString legacyError;
+        if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable,
+                                            pymobiledeviceLegacyListArguments(), &devices,
+                                            &legacyError ) ) {
+            if ( error && !legacyError.isEmpty() ) {
+                *error = legacyError;
+            }
+            return {};
+        }
+
+        if ( error ) {
+            error->clear();
+        }
     }
 
     if ( devices.isEmpty() && error ) {
@@ -318,7 +338,12 @@ ProcessLiveSourceTransport::Command IosLogProcessTransport::streamingCommand() c
 
 ProcessLiveSourceTransport::Command IosLogProcessTransport::clearCommand() const
 {
-    return Command{ normalizedExecutable(), {} };
+#ifdef Q_OS_WIN
+    return Command{ QStringLiteral( "cmd" ),
+                    { QStringLiteral( "/c" ), QStringLiteral( "exit" ), QStringLiteral( "0" ) } };
+#else
+    return Command{ QStringLiteral( "true" ), {} };
+#endif
 }
 
 QString IosLogProcessTransport::normalizedExecutable() const

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -31,6 +31,7 @@ QStringList splitCommandArguments( const QString& arguments )
     QStringList tokens;
     QString currentToken;
     QChar quoteChar;
+    bool tokenStarted = false;
 
     for ( int i = 0; i < arguments.size(); ++i ) {
         const auto ch = arguments.at( i );
@@ -39,12 +40,14 @@ QStringList splitCommandArguments( const QString& arguments )
             if ( nextIndex < arguments.size() ) {
                 const auto nextChar = arguments.at( nextIndex );
                 if ( canEscapeArgumentCharacter( nextChar, quoteChar ) ) {
+                    tokenStarted = true;
                     currentToken.append( nextChar );
                     ++i;
                     continue;
                 }
             }
 
+            tokenStarted = true;
             currentToken.append( ch );
             continue;
         }
@@ -54,28 +57,32 @@ QStringList splitCommandArguments( const QString& arguments )
                 quoteChar = QChar{};
             }
             else {
+                tokenStarted = true;
                 currentToken.append( ch );
             }
             continue;
         }
 
         if ( ch == QLatin1Char( '"' ) || ch == QLatin1Char( '\'' ) ) {
+            tokenStarted = true;
             quoteChar = ch;
             continue;
         }
 
         if ( ch.isSpace() ) {
-            if ( !currentToken.isEmpty() ) {
+            if ( tokenStarted ) {
                 tokens.push_back( currentToken );
                 currentToken.clear();
+                tokenStarted = false;
             }
             continue;
         }
 
+        tokenStarted = true;
         currentToken.append( ch );
     }
 
-    if ( !currentToken.isEmpty() ) {
+    if ( tokenStarted ) {
         tokens.push_back( currentToken );
     }
 
@@ -243,22 +250,28 @@ QStringList pymobiledeviceListArguments()
 
 QStringList pymobiledeviceStreamingArguments( const QString& deviceUdid )
 {
+    QStringList arguments;
+    arguments.append( QStringLiteral( "syslog" ) );
+    arguments.append( QStringLiteral( "live" ) );
+
     if ( deviceUdid.isEmpty() ) {
-        return { QStringLiteral( "syslog" ), QStringLiteral( "live" ) };
+        return arguments;
     }
 
-    return { QStringLiteral( "syslog" ), QStringLiteral( "live" ), QStringLiteral( "--udid" ),
-             deviceUdid };
+    arguments.append( { QStringLiteral( "--udid" ), deviceUdid } );
+    return arguments;
 }
 
 } // namespace
 
 IosLogProcessTransport::IosLogProcessTransport( QString executable, QString deviceUdid,
-                                                QString extraArgs, QObject* parent )
+                                                QString extraArgs, bool ansiOutputEnabled,
+                                                QObject* parent )
     : ProcessLiveSourceTransport( parent )
     , executable_( std::move( executable ) )
     , deviceUdid_( std::move( deviceUdid ) )
     , extraArgs_( std::move( extraArgs ) )
+    , ansiOutputEnabled_( ansiOutputEnabled )
 {
 }
 
@@ -315,7 +328,9 @@ QString IosLogProcessTransport::normalizedExecutable() const
 
 QStringList IosLogProcessTransport::streamArguments() const
 {
-    QStringList arguments = pymobiledeviceStreamingArguments( deviceUdid_ );
+    QStringList arguments{ ansiOutputEnabled_ ? QStringLiteral( "--color" )
+                                              : QStringLiteral( "--no-color" ) };
+    arguments.append( pymobiledeviceStreamingArguments( deviceUdid_ ) );
     const auto trimmedExtraArgs = extraArgs_.trimmed();
     if ( !trimmedExtraArgs.isEmpty() ) {
         arguments.append( splitCommandArguments( trimmedExtraArgs ) );

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1252,18 +1252,32 @@ void MainWindow::clearLog()
     }
 
     if ( session_.getDocumentKind( crawler ) == DocumentKind::AdbLogcat ) {
+        auto* adbSource = session_.getAdbLogcatSource( crawler );
+        if ( !adbSource ) {
+            return;
+        }
+
         const auto displayName = session_.getDisplayName( crawler );
+        const auto isIosLogStream
+            = adbSource->sessionData().sourceType == LiveLogSourceType::IosLogStream;
         const auto userAction = QMessageBox::question(
-            this, tr( "klogg - clear logcat buffer" ),
-            tr( "Clear device log buffer for %1? Local cached log will also be removed." )
-                .arg( displayName ),
+            this,
+            isIosLogStream ? tr( "klogg - clear iOS log stream" )
+                           : tr( "klogg - clear logcat buffer" ),
+            isIosLogStream
+                ? tr( "Clear local iOS log stream capture for %1? The live stream will be "
+                      "restarted." )
+                      .arg( displayName )
+                : tr( "Clear device log buffer for %1? Local cached log will also be removed." )
+                      .arg( displayName ),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
 
         if ( userAction == QMessageBox::Yes ) {
-            if ( auto* adbSource = session_.getAdbLogcatSource( crawler );
-                 adbSource != nullptr && !adbSource->clearAndRestart() ) {
+            if ( !adbSource->clearAndRestart() ) {
                 QMessageBox::critical(
-                    this, tr( "klogg - clear logcat buffer" ),
+                    this,
+                    isIosLogStream ? tr( "klogg - clear iOS log stream" )
+                                   : tr( "klogg - clear logcat buffer" ),
                     adbSource->lastError().isEmpty() ? tr( "Failed to clear logcat buffer" )
                                                      : adbSource->lastError() );
             }

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -100,6 +100,7 @@
 #include "highlightersdialog.h"
 #include "highlightersmenu.h"
 #include "issuereporter.h"
+#include "ioslogdialog.h"
 #include "klogg_version.h"
 #include "logger.h"
 #include "mainwindowtext.h"
@@ -349,6 +350,8 @@ void MainWindow::reTranslateUI()
     openAction->setStatusTip( transAction( action::openStatusTip ) );
     openAdbLogcatAction->setText( tr( "Open ADB Logcat..." ) );
     openAdbLogcatAction->setStatusTip( tr( "Open Android logcat as a live source" ) );
+    openIosLogStreamAction->setText( tr( "Open iOS Log Stream..." ) );
+    openIosLogStreamAction->setStatusTip( tr( "Open iOS device logs as a live source" ) );
 
     recentFilesCleanup->setText( transAction( action::recentFilesCleanupText ) );
 
@@ -519,6 +522,14 @@ void MainWindow::createActions()
     openAdbLogcatAction->setStatusTip( tr( "Open Android logcat as a live source" ) );
     connect( openAdbLogcatAction, &QAction::triggered, this,
              [ this ]( auto ) { this->openAdbLogcat(); } );
+
+    openIosLogStreamAction = new QAction( tr( "Open iOS Log Stream..." ), this );
+    openIosLogStreamAction->setStatusTip( tr( "Open iOS device logs as a live source" ) );
+#ifndef Q_OS_MAC
+    openIosLogStreamAction->setVisible( false );
+#endif
+    connect( openIosLogStreamAction, &QAction::triggered, this,
+             [ this ]( auto ) { this->openIosLogStream(); } );
 
     recentFilesCleanup = new QAction( tr( action::recentFilesCleanupText ), this );
     connect( recentFilesCleanup, &QAction::triggered, this,
@@ -838,6 +849,7 @@ void MainWindow::createMenus()
     fileMenu->addAction( newWindowAction );
     fileMenu->addAction( openAction );
     fileMenu->addAction( openAdbLogcatAction );
+    fileMenu->addAction( openIosLogStreamAction );
     fileMenu->addAction( openClipboardAction );
     fileMenu->addAction( openUrlAction );
     recentFilesMenu = fileMenu->addMenu( tr( "Open Recent" ) );
@@ -1065,6 +1077,19 @@ void MainWindow::openAdbLogcat()
     if ( dialog.exec() == QDialog::Accepted ) {
         openAdbLogcatSource( dialog.sessionData(), true );
     }
+}
+
+void MainWindow::openIosLogStream()
+{
+#ifdef Q_OS_MAC
+    IosLogDialog dialog( this );
+    if ( dialog.exec() == QDialog::Accepted ) {
+        openAdbLogcatSource( dialog.sessionData(), true );
+    }
+#else
+    QMessageBox::information( this, tr( "Open iOS Log Stream" ),
+                              tr( "iOS log streaming is supported only on macOS." ) );
+#endif
 }
 
 void MainWindow::openRemoteFile( const QUrl& url )

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1266,7 +1266,7 @@ void MainWindow::clearLog()
                            : tr( "klogg - clear logcat buffer" ),
             isIosLogStream
                 ? tr( "Clear local iOS log stream capture for %1? The live stream will be "
-                      "restarted." )
+                      "restarted if the source was connected." )
                       .arg( displayName )
                 : tr( "Clear device log buffer for %1? Local cached log will also be removed." )
                       .arg( displayName ),
@@ -1278,8 +1278,10 @@ void MainWindow::clearLog()
                     this,
                     isIosLogStream ? tr( "klogg - clear iOS log stream" )
                                    : tr( "klogg - clear logcat buffer" ),
-                    adbSource->lastError().isEmpty() ? tr( "Failed to clear logcat buffer" )
-                                                     : adbSource->lastError() );
+                    adbSource->lastError().isEmpty()
+                        ? ( isIosLogStream ? tr( "Failed to clear iOS log stream" )
+                                           : tr( "Failed to clear logcat buffer" ) )
+                        : adbSource->lastError() );
             }
         }
         return;

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -37,15 +37,20 @@
  */
 
 #include <QColorDialog>
+#include <QFormLayout>
+#include <QGroupBox>
 #include <QKeySequenceEdit>
 #include <QMessageBox>
 #include <QToolButton>
 #include <QtGui>
 
+#include <algorithm>
+
 #include "adbprocesstransport.h"
 #include "encodings.h"
 #include "fontutils.h"
 #include "highlighteredit.h"
+#include "ioslogprocesstransport.h"
 #include "log.h"
 #include "logger.h"
 #include "mainwindow.h"
@@ -74,6 +79,8 @@ OptionsDialog::OptionsDialog( QWidget* parent )
     setupStyles();
     setupEncodings();
     setupLanguageList();
+    setupIosLogSettings();
+    setupPanelResetButtons();
 
     // Validators
     QValidator* pollingIntervalValidator = new QIntValidator( PollIntervalMin, PollIntervalMax );
@@ -115,13 +122,9 @@ OptionsDialog::OptionsDialog( QWidget* parent )
         adbExecutableLineEdit->setText( resolved );
     } );
 
-    connect( restoreShortcutsDefaults, &QPushButton::clicked, this, [ this ]() {
-        auto ret = QMessageBox::question(
-            this, "Restore Default Shortcuts", "Do you want to restore default shortcuts?",
-            QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel );
-        if ( ret == QMessageBox::Yes )
-            buildShortcutsTable( true );
-    } );
+    restoreShortcutsDefaults->setText( tr( "Reset to defaults" ) );
+    connect( restoreShortcutsDefaults, &QPushButton::clicked, this,
+             &OptionsDialog::resetShortcutsDefaults );
 
     updateDialogFromConfig();
 
@@ -229,6 +232,102 @@ void OptionsDialog::setupLanguageList()
                                        attributes.value( "ietfCode" ).toString() );
         }
     }
+}
+
+void OptionsDialog::setupIosLogSettings()
+{
+    iosLogGroupBox_ = new QGroupBox( tr( "iOS Log Stream" ), file_watch_tab );
+    iosLogGroupBox_->setObjectName( QStringLiteral( "iosLogGroupBox" ) );
+
+    auto* layout = new QVBoxLayout( iosLogGroupBox_ );
+
+    auto* executableRow = new QHBoxLayout();
+    auto* executableLabel = new QLabel( tr( "pymobiledevice3 executable" ), iosLogGroupBox_ );
+    iosLogExecutableLineEdit_ = new QLineEdit( iosLogGroupBox_ );
+    iosLogExecutableLineEdit_->setObjectName( QStringLiteral( "iosLogExecutableLineEdit" ) );
+    iosLogExecutableLineEdit_->setPlaceholderText( QStringLiteral( "pymobiledevice3" ) );
+    auto* detectButton = new QPushButton( tr( "Detect" ), iosLogGroupBox_ );
+    detectButton->setObjectName( QStringLiteral( "iosLogDetectButton" ) );
+    detectButton->setToolTip(
+        tr( "Probe well-known Homebrew install locations and fill the path automatically." ) );
+    executableRow->addWidget( executableLabel );
+    executableRow->addWidget( iosLogExecutableLineEdit_ );
+    executableRow->addWidget( detectButton );
+
+    auto* argsRow = new QHBoxLayout();
+    auto* argsLabel = new QLabel( tr( "Extra iOS log args" ), iosLogGroupBox_ );
+    iosLogArgsLineEdit_ = new QLineEdit( iosLogGroupBox_ );
+    iosLogArgsLineEdit_->setObjectName( QStringLiteral( "iosLogArgsLineEdit" ) );
+    argsRow->addWidget( argsLabel );
+    argsRow->addWidget( iosLogArgsLineEdit_ );
+
+    auto* helpLabel = new QLabel( iosLogGroupBox_ );
+    helpLabel->setWordWrap( true );
+    helpLabel->setText( tr( "Extra arguments are appended after "
+                            "'pymobiledevice3 syslog live --udid <udid>'. This feature is "
+                            "available only on macOS." ) );
+
+    layout->addLayout( executableRow );
+    layout->addLayout( argsRow );
+    layout->addWidget( helpLabel );
+
+    const auto insertIndex = std::max( 0, verticalLayout_9->count() - 1 );
+    verticalLayout_9->insertWidget( insertIndex, iosLogGroupBox_ );
+
+    connect( detectButton, &QPushButton::clicked, this, [ this ] {
+        const auto resolved = IosLogProcessTransport::detectIosSyslogExecutable();
+        if ( resolved.isEmpty() ) {
+            QMessageBox::information(
+                this, tr( "Detect iOS log executable" ),
+                tr( "No pymobiledevice3 found at well-known install locations. Set the path "
+                    "manually or install pymobiledevice3." ) );
+            return;
+        }
+
+        const auto current = iosLogExecutableLineEdit_->text().trimmed();
+        if ( !current.isEmpty() && current != resolved ) {
+            const auto answer = QMessageBox::question(
+                this, tr( "Detect iOS log executable" ),
+                tr( "Replace the configured path\n\n    %1\n\nwith the auto-detected path?\n\n    %2" )
+                    .arg( current, resolved ),
+                QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel );
+            if ( answer != QMessageBox::Yes ) {
+                return;
+            }
+        }
+        iosLogExecutableLineEdit_->setText( resolved );
+    } );
+
+#ifndef Q_OS_MAC
+    iosLogGroupBox_->setVisible( false );
+#endif
+}
+
+void OptionsDialog::setupPanelResetButtons()
+{
+    auto addResetButton = [ this ]( QWidget* tab, const QString& objectName, auto slot ) {
+        auto* button = new QPushButton( tr( "Reset to defaults" ), tab );
+        button->setObjectName( objectName );
+
+        auto* row = new QHBoxLayout();
+        row->addStretch();
+        row->addWidget( button );
+
+        if ( auto* layout = qobject_cast<QVBoxLayout*>( tab->layout() ) ) {
+            layout->addLayout( row );
+        }
+
+        connect( button, &QPushButton::clicked, this, slot );
+    };
+
+    addResetButton( general_tab, QStringLiteral( "resetGeneralDefaultsButton" ),
+                    &OptionsDialog::resetGeneralDefaults );
+    addResetButton( viewTab, QStringLiteral( "resetViewDefaultsButton" ),
+                    &OptionsDialog::resetViewDefaults );
+    addResetButton( file_watch_tab, QStringLiteral( "resetFileDefaultsButton" ),
+                    &OptionsDialog::resetFileDefaults );
+    addResetButton( advanced_tab, QStringLiteral( "resetAdvancedDefaultsButton" ),
+                    &OptionsDialog::resetAdvancedDefaults );
 }
 
 void OptionsDialog::setupPolling()
@@ -348,20 +447,26 @@ RegexpEngine OptionsDialog::getRegexpEngineFromIndex( int index ) const
 // Updates the dialog box using values in global Config()
 void OptionsDialog::updateDialogFromConfig()
 {
-    const auto& config = Configuration::get();
+    updateDialogFromConfiguration( Configuration::get() );
+}
 
+void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
+{
     // Main font
-    QFontInfo fontInfo = QFontInfo( config.mainFont() );
+    const auto configuredFont = config.mainFont();
+    const auto configuredFamily = configuredFont.family();
+    const auto configuredPointSize = configuredFont.pointSize();
 
-    int familyIndex = fontFamilyBox->findText( fontInfo.family() );
-    if ( familyIndex != -1 )
+    int familyIndex = fontFamilyBox->findText( configuredFamily );
+    if ( familyIndex == -1 && !configuredFamily.isEmpty() ) {
+        fontFamilyBox->addItem( configuredFamily );
+        familyIndex = fontFamilyBox->findText( configuredFamily );
+    }
+    if ( familyIndex != -1 ) {
         fontFamilyBox->setCurrentIndex( familyIndex );
+    }
 
-    updateFontSize( fontInfo.family() );
-
-    int sizeIndex = fontSizeBox->findText( QString::number( fontInfo.pointSize() ) );
-    if ( sizeIndex != -1 )
-        fontSizeBox->setCurrentIndex( sizeIndex );
+    updateFontSizePreservingSelection( fontFamilyBox->currentText(), configuredPointSize );
 
     lineSpacingSpinBox->setValue( config.lineSpacingPercent() );
     fontSmoothCheckBox->setChecked( config.forceFontAntialiasing() );
@@ -454,6 +559,12 @@ void OptionsDialog::updateDialogFromConfig()
     verifySslCheckBox->setChecked( config.verifySslPeers() );
     adbExecutableLineEdit->setText( config.adbExecutable() );
     adbLogcatArgsLineEdit->setText( config.adbLogcatExtraArgs() );
+    if ( iosLogExecutableLineEdit_ ) {
+        iosLogExecutableLineEdit_->setText( config.iosLogExecutable() );
+    }
+    if ( iosLogArgsLineEdit_ ) {
+        iosLogArgsLineEdit_->setText( config.iosLogExtraArgs() );
+    }
 
     const auto encodingIndex = encodingComboBox->findData( config.defaultEncodingMib() );
     encodingComboBox->setCurrentIndex( encodingIndex < 0 ? 0 : encodingIndex );
@@ -475,17 +586,36 @@ void OptionsDialog::updateDialogFromConfig()
 
 void OptionsDialog::updateFontSize( const QString& fontFamily )
 {
-    QString oldFontSize = fontSizeBox->currentText();
+    bool ok = false;
+    const auto oldFontSize = fontSizeBox->currentText().toInt( &ok );
+    updateFontSizePreservingSelection( fontFamily, ok ? oldFontSize : -1 );
+}
+
+void OptionsDialog::updateFontSizePreservingSelection( const QString& fontFamily,
+                                                       int preferredPointSize )
+{
     const auto sizes = FontUtils::availableFontSizes( fontFamily );
 
     fontSizeBox->clear();
     for ( int size : sizes ) {
         fontSizeBox->addItem( QString::number( size ) );
     }
+
+    if ( preferredPointSize > 0
+         && fontSizeBox->findText( QString::number( preferredPointSize ) ) == -1 ) {
+        auto insertIndex = 0;
+        while ( insertIndex < fontSizeBox->count()
+                && fontSizeBox->itemText( insertIndex ).toInt() < preferredPointSize ) {
+            ++insertIndex;
+        }
+        fontSizeBox->insertItem( insertIndex, QString::number( preferredPointSize ) );
+    }
+
     // Now restore the size we had before
-    int i = fontSizeBox->findText( oldFontSize );
-    if ( i != -1 )
+    int i = fontSizeBox->findText( QString::number( preferredPointSize ) );
+    if ( i != -1 ) {
         fontSizeBox->setCurrentIndex( i );
+    }
 }
 
 void OptionsDialog::changeMainColor()
@@ -504,6 +634,125 @@ void OptionsDialog::changeQfColor()
         qfSearchColor_ = newColor;
         HighlighterEdit::updateIcon( quickFindColorButton, qfSearchColor_ );
     }
+}
+
+void OptionsDialog::resetGeneralDefaults()
+{
+    const Configuration defaults;
+    const SavedSearches defaultSavedSearches;
+
+    mainSearchBox->setCurrentIndex( getRegexpTypeIndex( defaults.mainRegexpType() ) );
+    mainSearchColor_ = defaults.mainSearchBackColor();
+    HighlighterEdit::updateIcon( mainSearchColorButton, mainSearchColor_ );
+    quickFindSearchBox->setCurrentIndex( getRegexpTypeIndex( defaults.quickfindRegexpType() ) );
+    qfSearchColor_ = defaults.qfBackColor();
+    HighlighterEdit::updateIcon( quickFindColorButton, qfSearchColor_ );
+
+    highlightMainSearchCheckBox->setChecked( defaults.mainSearchHighlight() );
+    variateHighlightCheckBox->setChecked( defaults.variateMainSearchHighlight() );
+    incrementalCheckBox->setChecked( defaults.isQuickfindIncremental() );
+    caseSensitiveCheckBox->setChecked( !defaults.isSearchIgnoreCaseDefault() );
+    logicalCombiningCheckBox->setChecked( defaults.isSearchLogicalCombiningDefault() );
+    autoRefreshCheckBox->setChecked( defaults.isSearchAutoRefreshDefault() );
+    autoRunSearchOnAddCheckBox->setChecked( defaults.autoRunSearchOnPatternChange() );
+    searchHistorySpinBox->setValue( defaultSavedSearches.historySize() );
+
+    loadLastSessionCheckBox->setChecked( defaults.loadLastSession() );
+    followFileOnLoadCheckBox->setChecked( defaults.followFileOnLoad() );
+    minimizeToTrayCheckBox->setChecked( defaults.minimizeToTray() );
+    multipleWindowsCheckBox->setChecked( defaults.allowMultipleWindows() );
+    confirmTabCloseCheckBox->setChecked( defaults.confirmTabClose() );
+
+    checkForNewVersionCheckBox->setChecked( defaults.versionCheckingEnabled() );
+}
+
+void OptionsDialog::resetViewDefaults()
+{
+    const Configuration defaults;
+
+    const auto defaultFont = defaults.mainFont();
+    auto familyIndex = fontFamilyBox->findText( defaultFont.family() );
+    if ( familyIndex == -1 ) {
+        fontFamilyBox->addItem( defaultFont.family() );
+        familyIndex = fontFamilyBox->findText( defaultFont.family() );
+    }
+    if ( familyIndex != -1 ) {
+        fontFamilyBox->setCurrentIndex( familyIndex );
+    }
+    updateFontSizePreservingSelection( fontFamilyBox->currentText(), defaultFont.pointSize() );
+    lineSpacingSpinBox->setValue( defaults.lineSpacingPercent() );
+    fontSmoothCheckBox->setChecked( defaults.forceFontAntialiasing() );
+    boldFontCheckBox->setChecked( defaults.useBoldFont() );
+    wrapTextCheckBox->setChecked( defaults.useTextWrap() );
+
+    auto langIdx = languageComboBox->findData( defaults.language() );
+    languageComboBox->setCurrentIndex( langIdx == -1 ? 0 : langIdx );
+
+    const auto styleIndex = styleComboBox->findData( defaults.style() );
+    styleComboBox->setCurrentIndex( styleIndex == -1 ? 0 : styleIndex );
+    const auto themeModeIndex
+        = themeModeComboBox->findData( static_cast<int>( defaults.themeMode() ) );
+    themeModeComboBox->setCurrentIndex( themeModeIndex == -1 ? 0 : themeModeIndex );
+
+    enableQtHiDpiCheckBox->setChecked( defaults.enableQtHighDpi() );
+    scaleRoundingComboBox->setCurrentIndex( defaults.scaleFactorRounding() - 1 );
+    hideAnsiColorsCheckBox->setChecked( defaults.hideAnsiColorSequences() );
+}
+
+void OptionsDialog::resetFileDefaults()
+{
+    const Configuration defaults;
+    const RecentFiles defaultRecentFiles;
+
+    nativeFileWatchCheckBox->setChecked( defaults.nativeFileWatchEnabled() );
+    fastModificationDetectionCheckBox->setChecked( defaults.fastModificationDetection() );
+    pollingCheckBox->setChecked( defaults.pollingEnabled() );
+    pollIntervalLineEdit->setText( QString::number( defaults.pollIntervalMs() ) );
+    allowFollowOnScrollCheckBox->setChecked( defaults.allowFollowOnScroll() );
+    setupPolling();
+
+    const auto encodingIndex = encodingComboBox->findData( defaults.defaultEncodingMib() );
+    encodingComboBox->setCurrentIndex( encodingIndex < 0 ? 0 : encodingIndex );
+    filesHistoryMaxItemsSpinBox->setValue( defaultRecentFiles.filesHistoryMaxItems() );
+
+    extractArchivesCheckBox->setChecked( defaults.extractArchives() );
+    extractArchivesAlwaysCheckBox->setChecked( defaults.extractArchivesAlways() );
+    setupArchives();
+
+    verifySslCheckBox->setChecked( defaults.verifySslPeers() );
+    adbExecutableLineEdit->setText( defaults.adbExecutable() );
+    adbLogcatArgsLineEdit->setText( defaults.adbLogcatExtraArgs() );
+    if ( iosLogExecutableLineEdit_ ) {
+        iosLogExecutableLineEdit_->setText( defaults.iosLogExecutable() );
+    }
+    if ( iosLogArgsLineEdit_ ) {
+        iosLogArgsLineEdit_->setText( defaults.iosLogExtraArgs() );
+    }
+}
+
+void OptionsDialog::resetShortcutsDefaults()
+{
+    buildShortcutsTable( true );
+}
+
+void OptionsDialog::resetAdvancedDefaults()
+{
+    const Configuration defaults;
+
+    regexpEngineComboBox->setCurrentIndex( getRegexpEngineIndex( defaults.regexpEngine() ) );
+    parallelSearchCheckBox->setChecked( defaults.useParallelSearch() );
+    searchResultsCacheCheckBox->setChecked( defaults.useSearchResultsCache() );
+    searchCacheSpinBox->setValue( static_cast<int>( defaults.searchResultsCacheLines() ) );
+    indexReadBufferSpinBox->setValue( defaults.indexReadBufferSizeMb() );
+    searchReadBufferSpinBox->setValue( defaults.searchReadBufferSizeLines() );
+    keepFileClosedCheckBox->setChecked( defaults.keepFileClosed() );
+    compressedIndexCheckBox->setChecked( defaults.useCompressedIndex() );
+    optimizeForNotLatinEncodingsCheckBox->setChecked( defaults.optimizeForNotLatinEncodings() );
+    setupSearchResultsCache();
+
+    loggingCheckBox->setChecked( defaults.enableLogging() );
+    verbositySpinBox->setValue( defaults.loggingLevel() );
+    setupLogging();
 }
 
 void OptionsDialog::checkShortcutsOnDuplicate() const
@@ -560,8 +809,7 @@ void OptionsDialog::checkShortcutsOnDuplicate() const
 
 int OptionsDialog::updateTranslate()
 {
-    auto mw = dynamic_cast<MainWindow*>( parent() );
-    return mw->installLanguage( languageComboBox->currentData().toString() );
+    return MainWindow::installLanguage( languageComboBox->currentData().toString() );
 }
 
 void OptionsDialog::updateConfigFromDialog()
@@ -569,7 +817,12 @@ void OptionsDialog::updateConfigFromDialog()
     bool restartAppMessage = false;
     auto& config = Configuration::get();
 
-    QFont font = QFont( fontFamilyBox->currentText(), ( fontSizeBox->currentText() ).toInt() );
+    bool fontSizeOk = false;
+    auto fontPointSize = fontSizeBox->currentText().toInt( &fontSizeOk );
+    if ( !fontSizeOk || fontPointSize <= 0 ) {
+        fontPointSize = Configuration{}.mainFont().pointSize();
+    }
+    QFont font = QFont( fontFamilyBox->currentText(), fontPointSize );
     config.setMainFont( font );
     config.setLineSpacingPercent( lineSpacingSpinBox->value() );
     config.setForceFontAntialiasing( fontSmoothCheckBox->isChecked() );
@@ -636,6 +889,12 @@ void OptionsDialog::updateConfigFromDialog()
     config.setVerifySslPeers( verifySslCheckBox->isChecked() );
     config.setAdbExecutable( adbExecutableLineEdit->text().trimmed() );
     config.setAdbLogcatExtraArgs( adbLogcatArgsLineEdit->text().trimmed() );
+    if ( iosLogExecutableLineEdit_ ) {
+        config.setIosLogExecutable( iosLogExecutableLineEdit_->text().trimmed() );
+    }
+    if ( iosLogArgsLineEdit_ ) {
+        config.setIosLogExtraArgs( iosLogArgsLineEdit_->text().trimmed() );
+    }
 
     const auto selectedStyle = styleComboBox->currentData().toString();
     restartAppMessage = config.style() != selectedStyle;
@@ -715,8 +974,8 @@ void OptionsDialog::onButtonBoxClicked( QAbstractButton* button )
 
 KeySequencePresenter::KeySequencePresenter( const QString& keySequence )
 {
-    keySequenceLabel_
-        = new QLabel( QKeySequence( keySequence ).toString( QKeySequence::NativeText ) );
+    keySequenceLabel_ = new QLabel();
+    setKeySequence( keySequence );
 
     auto editButton = new QPushButton();
     editButton->setText( "..." );
@@ -735,7 +994,13 @@ KeySequencePresenter::KeySequencePresenter( const QString& keySequence )
 
 QString KeySequencePresenter::keySequence() const
 {
-    return keySequenceLabel_->text();
+    return keySequence_;
+}
+
+void KeySequencePresenter::setKeySequence( const QString& keySequence )
+{
+    keySequence_ = QKeySequence( keySequence ).toString( QKeySequence::PortableText );
+    keySequenceLabel_->setText( QKeySequence( keySequence_ ).toString( QKeySequence::NativeText ) );
 }
 
 void KeySequencePresenter::showEditor()
@@ -743,7 +1008,7 @@ void KeySequencePresenter::showEditor()
     QDialog keyEditDialog;
 
     auto label = new QLabel( "Press new key combination" );
-    auto editor = new QKeySequenceEdit( QKeySequence( keySequenceLabel_->text() ) );
+    auto editor = new QKeySequenceEdit( QKeySequence( keySequence_ ) );
     auto clearButton = new QToolButton();
     clearButton->setText( "Clear" );
     auto dialogButtons = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel );
@@ -762,7 +1027,7 @@ void KeySequencePresenter::showEditor()
     connect( dialogButtons, &QDialogButtonBox::rejected, &keyEditDialog, &QDialog::reject );
 
     if ( keyEditDialog.exec() == QDialog::Accepted ) {
-        keySequenceLabel_->setText( editor->keySequence().toString() );
+        setKeySequence( editor->keySequence().toString( QKeySequence::PortableText ) );
         Q_EMIT edited(); // NOTE: it's important to emit this signal only after changing
                          // \keySequenceLabel_'s text
     }

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -37,6 +37,7 @@
  */
 
 #include <QColorDialog>
+#include <QCheckBox>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QKeySequenceEdit>
@@ -236,6 +237,12 @@ void OptionsDialog::setupLanguageList()
 
 void OptionsDialog::setupIosLogSettings()
 {
+    adbAnsiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), adbGroupBox );
+    adbAnsiOutputCheckBox_->setObjectName( QStringLiteral( "adbAnsiOutputCheckBox" ) );
+    if ( auto* adbLayout = qobject_cast<QVBoxLayout*>( adbGroupBox->layout() ) ) {
+        adbLayout->insertWidget( std::max( 0, adbLayout->count() - 1 ), adbAnsiOutputCheckBox_ );
+    }
+
     iosLogGroupBox_ = new QGroupBox( tr( "iOS Log Stream" ), file_watch_tab );
     iosLogGroupBox_->setObjectName( QStringLiteral( "iosLogGroupBox" ) );
 
@@ -261,6 +268,9 @@ void OptionsDialog::setupIosLogSettings()
     argsRow->addWidget( argsLabel );
     argsRow->addWidget( iosLogArgsLineEdit_ );
 
+    iosLogAnsiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), iosLogGroupBox_ );
+    iosLogAnsiOutputCheckBox_->setObjectName( QStringLiteral( "iosLogAnsiOutputCheckBox" ) );
+
     auto* helpLabel = new QLabel( iosLogGroupBox_ );
     helpLabel->setWordWrap( true );
     helpLabel->setText( tr( "Extra arguments are appended after "
@@ -269,6 +279,7 @@ void OptionsDialog::setupIosLogSettings()
 
     layout->addLayout( executableRow );
     layout->addLayout( argsRow );
+    layout->addWidget( iosLogAnsiOutputCheckBox_ );
     layout->addWidget( helpLabel );
 
     const auto insertIndex = std::max( 0, verticalLayout_9->count() - 1 );
@@ -559,11 +570,17 @@ void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
     verifySslCheckBox->setChecked( config.verifySslPeers() );
     adbExecutableLineEdit->setText( config.adbExecutable() );
     adbLogcatArgsLineEdit->setText( config.adbLogcatExtraArgs() );
+    if ( adbAnsiOutputCheckBox_ ) {
+        adbAnsiOutputCheckBox_->setChecked( config.adbLogcatAnsiOutputEnabled() );
+    }
     if ( iosLogExecutableLineEdit_ ) {
         iosLogExecutableLineEdit_->setText( config.iosLogExecutable() );
     }
     if ( iosLogArgsLineEdit_ ) {
         iosLogArgsLineEdit_->setText( config.iosLogExtraArgs() );
+    }
+    if ( iosLogAnsiOutputCheckBox_ ) {
+        iosLogAnsiOutputCheckBox_->setChecked( config.iosLogAnsiOutputEnabled() );
     }
 
     const auto encodingIndex = encodingComboBox->findData( config.defaultEncodingMib() );
@@ -722,11 +739,17 @@ void OptionsDialog::resetFileDefaults()
     verifySslCheckBox->setChecked( defaults.verifySslPeers() );
     adbExecutableLineEdit->setText( defaults.adbExecutable() );
     adbLogcatArgsLineEdit->setText( defaults.adbLogcatExtraArgs() );
+    if ( adbAnsiOutputCheckBox_ ) {
+        adbAnsiOutputCheckBox_->setChecked( defaults.adbLogcatAnsiOutputEnabled() );
+    }
     if ( iosLogExecutableLineEdit_ ) {
         iosLogExecutableLineEdit_->setText( defaults.iosLogExecutable() );
     }
     if ( iosLogArgsLineEdit_ ) {
         iosLogArgsLineEdit_->setText( defaults.iosLogExtraArgs() );
+    }
+    if ( iosLogAnsiOutputCheckBox_ ) {
+        iosLogAnsiOutputCheckBox_->setChecked( defaults.iosLogAnsiOutputEnabled() );
     }
 }
 
@@ -889,11 +912,17 @@ void OptionsDialog::updateConfigFromDialog()
     config.setVerifySslPeers( verifySslCheckBox->isChecked() );
     config.setAdbExecutable( adbExecutableLineEdit->text().trimmed() );
     config.setAdbLogcatExtraArgs( adbLogcatArgsLineEdit->text().trimmed() );
+    if ( adbAnsiOutputCheckBox_ ) {
+        config.setAdbLogcatAnsiOutputEnabled( adbAnsiOutputCheckBox_->isChecked() );
+    }
     if ( iosLogExecutableLineEdit_ ) {
         config.setIosLogExecutable( iosLogExecutableLineEdit_->text().trimmed() );
     }
     if ( iosLogArgsLineEdit_ ) {
         config.setIosLogExtraArgs( iosLogArgsLineEdit_->text().trimmed() );
+    }
+    if ( iosLogAnsiOutputCheckBox_ ) {
+        config.setIosLogAnsiOutputEnabled( iosLogAnsiOutputCheckBox_->isChecked() );
     }
 
     const auto selectedStyle = styleComboBox->currentData().toString();

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -97,6 +97,16 @@ OptionsDialog::OptionsDialog( QWidget* parent )
 
     connect( extractArchivesCheckBox, &QCheckBox::toggled,
              [ this ]( auto ) { this->setupArchives(); } );
+    connect( hideAnsiColorsCheckBox, &QCheckBox::toggled, this, [ this ]( bool checked ) {
+        if ( checked ) {
+            renderAnsiColorsCheckBox->setChecked( false );
+        }
+    } );
+    connect( renderAnsiColorsCheckBox, &QCheckBox::toggled, this, [ this ]( bool checked ) {
+        if ( checked ) {
+            hideAnsiColorsCheckBox->setChecked( false );
+        }
+    } );
 
     connect( mainSearchColorButton, &QPushButton::clicked, this, &OptionsDialog::changeMainColor );
     connect( quickFindColorButton, &QPushButton::clicked, this, &OptionsDialog::changeQfColor );
@@ -508,6 +518,8 @@ void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
     }
 
     hideAnsiColorsCheckBox->setChecked( config.hideAnsiColorSequences() );
+    renderAnsiColorsCheckBox->setChecked( !config.hideAnsiColorSequences()
+                                          && config.renderAnsiColorSequences() );
 
     // Regexp types
     mainSearchBox->setCurrentIndex( getRegexpTypeIndex( config.mainRegexpType() ) );
@@ -714,6 +726,8 @@ void OptionsDialog::resetViewDefaults()
     enableQtHiDpiCheckBox->setChecked( defaults.enableQtHighDpi() );
     scaleRoundingComboBox->setCurrentIndex( defaults.scaleFactorRounding() - 1 );
     hideAnsiColorsCheckBox->setChecked( defaults.hideAnsiColorSequences() );
+    renderAnsiColorsCheckBox->setChecked( !defaults.hideAnsiColorSequences()
+                                          && defaults.renderAnsiColorSequences() );
 }
 
 void OptionsDialog::resetFileDefaults()
@@ -941,6 +955,8 @@ void OptionsDialog::updateConfigFromDialog()
     }
     
     config.setHideAnsiColorSequences( hideAnsiColorsCheckBox->isChecked() );
+    config.setRenderAnsiColorSequences( !hideAnsiColorsCheckBox->isChecked()
+                                        && renderAnsiColorsCheckBox->isChecked() );
 
     config.setDefaultEncodingMib( encodingComboBox->currentData().toInt() );
 

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -397,13 +397,19 @@ WindowSession::restore( const std::function<ViewInterface*()>& view_factory,
     for ( const auto& file : session_files ) {
         LOG_DEBUG << "Create view for " << file.fileName;
         ViewInterface* view = nullptr;
-        if ( file.sourceType == QStringLiteral( "adb_logcat" )
-             || file.sourceType == QStringLiteral( "ios_log_stream" ) ) {
-            view = appSession_->openAdbAlways( AdbLogcatSessionData::fromJson( file.sourceSpec ),
-                                               view_factory, false, file.viewContext );
+        if ( AdbLogcatSessionData::isPersistedSourceType( file.sourceType ) ) {
+            const auto sessionData = AdbLogcatSessionData::fromJson( file.sourceSpec );
+            if ( sessionData.isValid() ) {
+                view = appSession_->openAdbAlways( sessionData, view_factory, false,
+                                                   file.viewContext );
+            }
         }
         else {
             view = appSession_->openAlways( file.fileName, view_factory, file.viewContext );
+        }
+
+        if ( !view ) {
+            continue;
         }
 
         const auto info = appSession_->openedDocumentInfo( view );

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -365,8 +365,8 @@ void WindowSession::save(
 
         LOG_DEBUG << "Saving " << file->fileName.toLocal8Bit().data() << " in session.";
         session_files.emplace_back( file->documentId, top_line, view_context->toString(),
-                                    file->kind == DocumentKind::AdbLogcat
-                                        ? QStringLiteral( "adb_logcat" )
+                                    file->kind == DocumentKind::AdbLogcat && file->adbLogcatSource
+                                        ? file->adbLogcatSource->sessionData().persistedSourceType()
                                         : QString{},
                                     file->displayName,
                                     file->adbLogcatSource
@@ -397,7 +397,8 @@ WindowSession::restore( const std::function<ViewInterface*()>& view_factory,
     for ( const auto& file : session_files ) {
         LOG_DEBUG << "Create view for " << file.fileName;
         ViewInterface* view = nullptr;
-        if ( file.sourceType == QStringLiteral( "adb_logcat" ) ) {
+        if ( file.sourceType == QStringLiteral( "adb_logcat" )
+             || file.sourceType == QStringLiteral( "ios_log_stream" ) ) {
             view = appSession_->openAdbAlways( AdbLogcatSessionData::fromJson( file.sourceSpec ),
                                                view_factory, false, file.viewContext );
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add test cpp file
 add_executable(klogg_tests
     adb_ui_transport_test.cpp
+    ansicolorprocessor_test.cpp
     capturestore_test.cpp
     cli_test.cpp
     colorlabelsmanager_test.cpp

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -19,6 +19,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QCoreApplication>
 #include <QDialogButtonBox>
@@ -64,6 +65,7 @@ class ScopedAdbConfigurationGuard {
         : config_( Configuration::getSynced() )
         , executable_( config_.adbExecutable() )
         , extraArgs_( config_.adbLogcatExtraArgs() )
+        , ansiOutput_( config_.adbLogcatAnsiOutputEnabled() )
     {
     }
 
@@ -71,6 +73,7 @@ class ScopedAdbConfigurationGuard {
     {
         config_.setAdbExecutable( executable_ );
         config_.setAdbLogcatExtraArgs( extraArgs_ );
+        config_.setAdbLogcatAnsiOutputEnabled( ansiOutput_ );
         config_.save();
     }
 
@@ -78,6 +81,7 @@ class ScopedAdbConfigurationGuard {
     Configuration& config_;
     QString executable_;
     QString extraArgs_;
+    bool ansiOutput_;
 };
 
 class ScopedOptionsDialogConfigurationGuard {
@@ -90,8 +94,10 @@ class ScopedOptionsDialogConfigurationGuard {
         , pollIntervalMs_( config_.pollIntervalMs() )
         , adbExecutable_( config_.adbExecutable() )
         , adbExtraArgs_( config_.adbLogcatExtraArgs() )
+        , adbAnsiOutput_( config_.adbLogcatAnsiOutputEnabled() )
         , iosLogExecutable_( config_.iosLogExecutable() )
         , iosLogExtraArgs_( config_.iosLogExtraArgs() )
+        , iosLogAnsiOutput_( config_.iosLogAnsiOutputEnabled() )
         , useSearchResultsCache_( config_.useSearchResultsCache() )
         , shortcuts_( config_.shortcuts() )
         , savedSearches_( SavedSearches::getSynced() )
@@ -109,8 +115,10 @@ class ScopedOptionsDialogConfigurationGuard {
         config_.setPollIntervalMs( pollIntervalMs_ );
         config_.setAdbExecutable( adbExecutable_ );
         config_.setAdbLogcatExtraArgs( adbExtraArgs_ );
+        config_.setAdbLogcatAnsiOutputEnabled( adbAnsiOutput_ );
         config_.setIosLogExecutable( iosLogExecutable_ );
         config_.setIosLogExtraArgs( iosLogExtraArgs_ );
+        config_.setIosLogAnsiOutputEnabled( iosLogAnsiOutput_ );
         config_.setUseSearchResultsCache( useSearchResultsCache_ );
         config_.setShortcuts( shortcuts_ );
         config_.save();
@@ -129,8 +137,10 @@ class ScopedOptionsDialogConfigurationGuard {
     int pollIntervalMs_;
     QString adbExecutable_;
     QString adbExtraArgs_;
+    bool adbAnsiOutput_;
     QString iosLogExecutable_;
     QString iosLogExtraArgs_;
+    bool iosLogAnsiOutput_;
     bool useSearchResultsCache_;
     std::map<std::string, QStringList> shortcuts_;
     SavedSearches& savedSearches_;
@@ -236,22 +246,82 @@ TEST_CASE( "AdbProcessTransport preserves literal backslashes in extra args" )
                              QStringLiteral( "--title" ), QStringLiteral( "hello world" ) } );
 }
 
+TEST_CASE( "AdbProcessTransport preserves empty quoted extra args" )
+{
+    TestAdbProcessTransport transport( QString{}, QStringLiteral( "serial-123" ),
+                                       QStringLiteral( "--empty '' --quoted \"\"" ) );
+
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                             QStringLiteral( "logcat" ), QStringLiteral( "--empty" ),
+                             QString{}, QStringLiteral( "--quoted" ), QString{} } );
+}
+
+TEST_CASE( "AdbProcessTransport adds logcat color modifier when ANSI output is enabled" )
+{
+    TestAdbProcessTransport transport( QString{}, QStringLiteral( "serial-123" ),
+                                       QStringLiteral( "-v threadtime *:I" ), true );
+
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "color" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "threadtime" ), QStringLiteral( "*:I" ) } );
+}
+
 TEST_CASE( "IosLogProcessTransport builds normalized streaming commands" )
 {
     TestIosLogProcessTransport transport(
         QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
         QStringLiteral( "00008030-001C195E36D8802E" ),
-        QStringLiteral( "--no-color --match \"process name\"" ) );
+        QStringLiteral( "--match \"process name\"" ) );
 
     const auto streaming = transport.streamingCommandForTest();
     REQUIRE( streaming.program == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
     REQUIRE( streaming.arguments
-             == QStringList{ QStringLiteral( "syslog" ), QStringLiteral( "live" ),
+             == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ),
                              QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ),
-                             QStringLiteral( "--no-color" ),
                              QStringLiteral( "--match" ),
                              QStringLiteral( "process name" ) } );
+}
+
+TEST_CASE( "IosLogProcessTransport preserves empty quoted extra args" )
+{
+    TestIosLogProcessTransport transport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ),
+        QStringLiteral( "--tunnel '' --match \"\"" ) );
+
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ),
+                             QStringLiteral( "--tunnel" ), QString{}, QStringLiteral( "--match" ),
+                             QString{} } );
+}
+
+TEST_CASE( "IosLogProcessTransport controls pymobiledevice3 ANSI color output" )
+{
+    TestIosLogProcessTransport colorTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, true );
+    TestIosLogProcessTransport plainTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, false );
+
+    REQUIRE( colorTransport.streamingCommandForTest().arguments
+             == QStringList{ QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
+    REQUIRE( plainTransport.streamingCommandForTest().arguments
+             == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
 }
 
 TEST_CASE( "IosLogProcessTransport reports unsupported device listing off macOS" )
@@ -399,7 +469,9 @@ TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
     config.setLineSpacingPercent( Configuration::MaxLineSpacingPercent );
     config.setPollIntervalMs( 12345 );
     config.setAdbExecutable( QStringLiteral( "/custom/adb" ) );
+    config.setAdbLogcatAnsiOutputEnabled( true );
     config.setIosLogExecutable( QStringLiteral( "/custom/pymobiledevice3" ) );
+    config.setIosLogAnsiOutputEnabled( true );
     config.setUseSearchResultsCache( false );
     config.setShortcuts( { { ShortcutAction::MainWindowOpenFile,
                              QStringList{ QStringLiteral( "Ctrl+Shift+P" ) } } } );
@@ -439,7 +511,10 @@ TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
     CHECK( restoredConfig.lineSpacingPercent() == defaults.lineSpacingPercent() );
     CHECK( restoredConfig.pollIntervalMs() == defaults.pollIntervalMs() );
     CHECK( restoredConfig.adbExecutable() == defaults.adbExecutable() );
+    CHECK( restoredConfig.adbLogcatAnsiOutputEnabled()
+           == defaults.adbLogcatAnsiOutputEnabled() );
     CHECK( restoredConfig.iosLogExecutable() == defaults.iosLogExecutable() );
+    CHECK( restoredConfig.iosLogAnsiOutputEnabled() == defaults.iosLogAnsiOutputEnabled() );
     CHECK( restoredConfig.useSearchResultsCache() == defaults.useSearchResultsCache() );
     CHECK( SavedSearches::getSynced().historySize() == defaultSavedSearches.historySize() );
     CHECK( RecentFiles::getSynced().filesHistoryMaxItems()
@@ -603,23 +678,29 @@ TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edit
     auto& config = Configuration::getSynced();
     config.setAdbExecutable( QStringLiteral( "/configured/adb" ) );
     config.setAdbLogcatExtraArgs( QStringLiteral( "-v color" ) );
+    config.setAdbLogcatAnsiOutputEnabled( true );
     config.save();
 
     AdbLogcatDialog dialog;
     auto* adbExecutableEdit = dialog.findChild<QLineEdit*>( QStringLiteral( "adbExecutableEdit" ) );
     auto* extraArgsEdit = dialog.findChild<QLineEdit*>( QStringLiteral( "extraArgsEdit" ) );
+    auto* ansiOutputCheckBox
+        = dialog.findChild<QCheckBox*>( QStringLiteral( "ansiOutputCheckBox" ) );
     auto* deviceCombo = dialog.findChild<QComboBox*>( QStringLiteral( "deviceCombo" ) );
     auto* buttonBox = dialog.findChild<QDialogButtonBox*>( QStringLiteral( "buttonBox" ) );
 
     REQUIRE( adbExecutableEdit != nullptr );
     REQUIRE( extraArgsEdit != nullptr );
     REQUIRE( deviceCombo != nullptr );
+    REQUIRE( ansiOutputCheckBox != nullptr );
     REQUIRE( buttonBox != nullptr );
     REQUIRE( adbExecutableEdit->text() == QStringLiteral( "/configured/adb" ) );
     REQUIRE( extraArgsEdit->text() == QStringLiteral( "-v color" ) );
+    REQUIRE( ansiOutputCheckBox->isChecked() );
 
     adbExecutableEdit->setText( QStringLiteral( "/saved/adb" ) );
     extraArgsEdit->setText( QStringLiteral( "-v threadtime *:I" ) );
+    ansiOutputCheckBox->setChecked( false );
     deviceCombo->addItem( QStringLiteral( "Pixel 8 (ABC123)" ), QStringLiteral( "ABC123" ) );
     deviceCombo->setCurrentIndex( 0 );
     QCoreApplication::processEvents();
@@ -629,6 +710,7 @@ TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edit
     REQUIRE( sessionData.deviceSerial == QStringLiteral( "ABC123" ) );
     REQUIRE( sessionData.deviceDescription == QStringLiteral( "Pixel 8 (ABC123)" ) );
     REQUIRE( sessionData.extraArgs == QStringLiteral( "-v threadtime *:I" ) );
+    REQUIRE_FALSE( sessionData.ansiOutputEnabled );
     REQUIRE_FALSE( sessionData.captureId.isEmpty() );
 
     auto* okButton = buttonBox->button( QDialogButtonBox::Ok );
@@ -639,6 +721,7 @@ TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edit
     auto& restoredConfig = Configuration::getSynced();
     REQUIRE( restoredConfig.adbExecutable() == QStringLiteral( "/saved/adb" ) );
     REQUIRE( restoredConfig.adbLogcatExtraArgs() == QStringLiteral( "-v threadtime *:I" ) );
+    REQUIRE_FALSE( restoredConfig.adbLogcatAnsiOutputEnabled() );
 }
 
 TEST_CASE( "iOS log stream session data serializes its source type" )
@@ -651,6 +734,7 @@ TEST_CASE( "iOS log stream session data serializes its source type" )
         QStringLiteral( "ios-capture" ),
         QStringLiteral( "/tmp/ios.log" ),
         LiveLogSourceType::IosLogStream,
+        true,
     };
 
     const auto json = QString::fromUtf8(
@@ -662,6 +746,7 @@ TEST_CASE( "iOS log stream session data serializes its source type" )
     REQUIRE( restored.persistedSourceType() == QStringLiteral( "ios_log_stream" ) );
     REQUIRE( restored.deviceSerial == QStringLiteral( "00008030-001C195E36D8802E" ) );
     REQUIRE( restored.extraArgs == QStringLiteral( "--network" ) );
+    REQUIRE( restored.ansiOutputEnabled );
 }
 
 TEST_CASE( "AdbLogcatSource clears and restarts iOS log streams without remote clear" )

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -31,10 +31,13 @@
 #include <QJsonDocument>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QTemporaryDir>
+#include <QUuid>
 
 #include <map>
 
 #include "adbprocesstransport.h"
+#include "adblogcatsource.h"
 #include "adblogcatdialog.h"
 #include "configuration.h"
 #include "ioslogprocesstransport.h"
@@ -42,6 +45,7 @@
 #include "optionsdialog.h"
 #include "recentfiles.h"
 #include "savedsearches.h"
+#include "streaminglogdata.h"
 #include "shortcuts.h"
 #include "test_utils.h"
 
@@ -161,6 +165,22 @@ class TestIosLogProcessTransport : public IosLogProcessTransport {
         return streamingCommand();
     }
 };
+
+QString makeCaptureId()
+{
+    return QUuid::createUuid().toString( QUuid::WithoutBraces );
+}
+
+bool waitForLineCount( const std::shared_ptr<StreamingLogData>& logData, unsigned long long lineCount )
+{
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( logData->getNbLine().get() < lineCount && deadline.elapsed() < 5000 ) {
+        QCoreApplication::processEvents();
+        QTest::qWait( 50 );
+    }
+    return logData->getNbLine().get() >= lineCount;
+}
 } // namespace
 
 TEST_CASE( "AdbProcessTransport builds normalized streaming and clear commands" )
@@ -642,6 +662,58 @@ TEST_CASE( "iOS log stream session data serializes its source type" )
     REQUIRE( restored.persistedSourceType() == QStringLiteral( "ios_log_stream" ) );
     REQUIRE( restored.deviceSerial == QStringLiteral( "00008030-001C195E36D8802E" ) );
     REQUIRE( restored.extraArgs == QStringLiteral( "--network" ) );
+}
+
+TEST_CASE( "AdbLogcatSource clears and restarts iOS log streams without remote clear" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based iOS stream restart test on Windows." );
+    return;
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "pymobiledevice3" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    script.write( "#!/bin/sh\n"
+                  "i=1\n"
+                  "while :; do\n"
+                  "  echo ios-live-line-$i\n"
+                  "  i=$((i + 1))\n"
+                  "  sleep 0.05\n"
+                  "done\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+    const AdbLogcatSessionData sessionData{
+        scriptPath,
+        QStringLiteral( "00008030-001C195E36D8802E" ),
+        QStringLiteral( "iPhone Test" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::IosLogStream,
+    };
+
+    AdbLogcatSource source( sessionData, logData );
+
+    REQUIRE( source.connectSource() );
+    REQUIRE( source.state() == AdbLogcatSource::State::Connected );
+    REQUIRE( waitForLineCount( logData, 1 ) );
+
+    REQUIRE( source.clearAndRestart() );
+    REQUIRE( source.state() == AdbLogcatSource::State::Connected );
+    REQUIRE( source.lastError().isEmpty() );
+    REQUIRE( waitForLineCount( logData, 1 ) );
+
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -26,17 +26,23 @@
 #include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
+#include <QFont>
 #include <QGuiApplication>
+#include <QJsonDocument>
 #include <QLineEdit>
 #include <QPushButton>
+
+#include <map>
 
 #include "adbprocesstransport.h"
 #include "adblogcatdialog.h"
 #include "configuration.h"
+#include "ioslogprocesstransport.h"
 #include "livesourcetransport.h"
 #include "optionsdialog.h"
 #include "recentfiles.h"
 #include "savedsearches.h"
+#include "shortcuts.h"
 #include "test_utils.h"
 
 namespace {
@@ -70,6 +76,65 @@ class ScopedAdbConfigurationGuard {
     QString extraArgs_;
 };
 
+class ScopedOptionsDialogConfigurationGuard {
+  public:
+    ScopedOptionsDialogConfigurationGuard()
+        : config_( Configuration::getSynced() )
+        , mainFont_( config_.mainFont() )
+        , lineSpacingPercent_( config_.lineSpacingPercent() )
+        , versionCheckingEnabled_( config_.versionCheckingEnabled() )
+        , pollIntervalMs_( config_.pollIntervalMs() )
+        , adbExecutable_( config_.adbExecutable() )
+        , adbExtraArgs_( config_.adbLogcatExtraArgs() )
+        , iosLogExecutable_( config_.iosLogExecutable() )
+        , iosLogExtraArgs_( config_.iosLogExtraArgs() )
+        , useSearchResultsCache_( config_.useSearchResultsCache() )
+        , shortcuts_( config_.shortcuts() )
+        , savedSearches_( SavedSearches::getSynced() )
+        , searchHistorySize_( savedSearches_.historySize() )
+        , recentFiles_( RecentFiles::getSynced() )
+        , recentFilesMaxItems_( recentFiles_.filesHistoryMaxItems() )
+    {
+    }
+
+    ~ScopedOptionsDialogConfigurationGuard()
+    {
+        config_.setMainFont( mainFont_ );
+        config_.setLineSpacingPercent( lineSpacingPercent_ );
+        config_.setVersionCheckingEnabled( versionCheckingEnabled_ );
+        config_.setPollIntervalMs( pollIntervalMs_ );
+        config_.setAdbExecutable( adbExecutable_ );
+        config_.setAdbLogcatExtraArgs( adbExtraArgs_ );
+        config_.setIosLogExecutable( iosLogExecutable_ );
+        config_.setIosLogExtraArgs( iosLogExtraArgs_ );
+        config_.setUseSearchResultsCache( useSearchResultsCache_ );
+        config_.setShortcuts( shortcuts_ );
+        config_.save();
+
+        savedSearches_.setHistorySize( searchHistorySize_ );
+        savedSearches_.save();
+        recentFiles_.setFilesHistoryMaxItems( recentFilesMaxItems_ );
+        recentFiles_.save();
+    }
+
+  private:
+    Configuration& config_;
+    QFont mainFont_;
+    int lineSpacingPercent_;
+    bool versionCheckingEnabled_;
+    int pollIntervalMs_;
+    QString adbExecutable_;
+    QString adbExtraArgs_;
+    QString iosLogExecutable_;
+    QString iosLogExtraArgs_;
+    bool useSearchResultsCache_;
+    std::map<std::string, QStringList> shortcuts_;
+    SavedSearches& savedSearches_;
+    int searchHistorySize_;
+    RecentFiles& recentFiles_;
+    int recentFilesMaxItems_;
+};
+
 class TestAdbProcessTransport : public AdbProcessTransport {
   public:
     using AdbProcessTransport::AdbProcessTransport;
@@ -83,6 +148,17 @@ class TestAdbProcessTransport : public AdbProcessTransport {
     Command clearCommandForTest() const
     {
         return clearCommand();
+    }
+};
+
+class TestIosLogProcessTransport : public IosLogProcessTransport {
+  public:
+    using IosLogProcessTransport::IosLogProcessTransport;
+    using Command = ProcessLiveSourceTransport::Command;
+
+    Command streamingCommandForTest() const
+    {
+        return streamingCommand();
     }
 };
 } // namespace
@@ -138,6 +214,36 @@ TEST_CASE( "AdbProcessTransport preserves literal backslashes in extra args" )
                              QStringLiteral( "C:\\temp\\log.txt" ),
                              QStringLiteral( "--pattern" ), QStringLiteral( "regex\\d+" ),
                              QStringLiteral( "--title" ), QStringLiteral( "hello world" ) } );
+}
+
+TEST_CASE( "IosLogProcessTransport builds normalized streaming commands" )
+{
+    TestIosLogProcessTransport transport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ),
+        QStringLiteral( "--no-color --match \"process name\"" ) );
+
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE( streaming.program == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "syslog" ), QStringLiteral( "live" ),
+                             QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ),
+                             QStringLiteral( "--no-color" ),
+                             QStringLiteral( "--match" ),
+                             QStringLiteral( "process name" ) } );
+}
+
+TEST_CASE( "IosLogProcessTransport reports unsupported device listing off macOS" )
+{
+#ifndef Q_OS_MAC
+    QString error;
+    const auto devices = IosLogProcessTransport::listDevices( QString{}, &error );
+    REQUIRE( devices.isEmpty() );
+    REQUIRE_FALSE( error.isEmpty() );
+#else
+    SUCCEED( "iOS device listing is macOS-only and covered by command construction here." );
+#endif
 }
 
 TEST_CASE( "AdbProcessTransport reports startup failures through the transport interface" )
@@ -215,6 +321,119 @@ TEST_CASE( "OptionsDialog loads and persists adb settings" )
     REQUIRE( restoredConfig.adbExecutable() == QStringLiteral( "/updated/adb" ) );
     REQUIRE( restoredConfig.adbLogcatExtraArgs()
              == QStringLiteral( "-v threadtime ActivityManager:I *:S" ) );
+}
+
+TEST_CASE( "OptionsDialog default shortcut table keeps Apply and OK enabled" )
+{
+    ScopedOptionsDialogConfigurationGuard configGuard;
+    auto& config = Configuration::getSynced();
+    config.setShortcuts( {} );
+    config.save();
+
+    OptionsDialog dialog;
+    auto* buttonBox = dialog.findChild<QDialogButtonBox*>( QStringLiteral( "buttonBox" ) );
+    REQUIRE( buttonBox != nullptr );
+
+    auto* okButton = buttonBox->button( QDialogButtonBox::Ok );
+    auto* applyButton = buttonBox->button( QDialogButtonBox::Apply );
+    REQUIRE( okButton != nullptr );
+    REQUIRE( applyButton != nullptr );
+    CHECK( okButton->isEnabled() );
+    CHECK( applyButton->isEnabled() );
+}
+
+TEST_CASE( "OptionsDialog persists changed font size from preferences" )
+{
+    ScopedOptionsDialogConfigurationGuard configGuard;
+    auto& config = Configuration::getSynced();
+    const auto originalFont = config.mainFont();
+    const auto baseSize = originalFont.pointSize() > 0 ? originalFont.pointSize() : 10;
+    config.setMainFont( QFont{ originalFont.family(), baseSize } );
+    config.save();
+
+    OptionsDialog dialog;
+    auto* fontSizeBox = dialog.findChild<QComboBox*>( QStringLiteral( "fontSizeBox" ) );
+    REQUIRE( fontSizeBox != nullptr );
+
+    const auto requestedSize = baseSize == 13 ? 14 : 13;
+    auto sizeIndex = fontSizeBox->findText( QString::number( requestedSize ) );
+    if ( sizeIndex == -1 ) {
+        fontSizeBox->addItem( QString::number( requestedSize ) );
+        sizeIndex = fontSizeBox->findText( QString::number( requestedSize ) );
+    }
+    REQUIRE( sizeIndex != -1 );
+    fontSizeBox->setCurrentIndex( sizeIndex );
+
+    REQUIRE( QMetaObject::invokeMethod( &dialog, "updateConfigFromDialog", Qt::DirectConnection ) );
+
+    const auto restoredFont = Configuration::getSynced().mainFont();
+    CHECK( restoredFont.pointSize() == requestedSize );
+}
+
+TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
+{
+    ScopedOptionsDialogConfigurationGuard configGuard;
+
+    auto& config = Configuration::getSynced();
+    config.setVersionCheckingEnabled( false );
+    config.setLineSpacingPercent( Configuration::MaxLineSpacingPercent );
+    config.setPollIntervalMs( 12345 );
+    config.setAdbExecutable( QStringLiteral( "/custom/adb" ) );
+    config.setIosLogExecutable( QStringLiteral( "/custom/pymobiledevice3" ) );
+    config.setUseSearchResultsCache( false );
+    config.setShortcuts( { { ShortcutAction::MainWindowOpenFile,
+                             QStringList{ QStringLiteral( "Ctrl+Shift+P" ) } } } );
+    config.save();
+
+    auto& savedSearches = SavedSearches::getSynced();
+    savedSearches.setHistorySize( 7 );
+    savedSearches.save();
+    auto& recentFiles = RecentFiles::getSynced();
+    recentFiles.setFilesHistoryMaxItems( 9 );
+    recentFiles.save();
+
+    OptionsDialog dialog;
+    const QStringList resetButtons{
+        QStringLiteral( "resetGeneralDefaultsButton" ),
+        QStringLiteral( "resetViewDefaultsButton" ),
+        QStringLiteral( "resetFileDefaultsButton" ),
+        QStringLiteral( "restoreShortcutsDefaults" ),
+        QStringLiteral( "resetAdvancedDefaultsButton" ),
+    };
+
+    for ( const auto& objectName : resetButtons ) {
+        auto* button = dialog.findChild<QPushButton*>( objectName );
+        REQUIRE( button != nullptr );
+        button->click();
+        QCoreApplication::processEvents();
+    }
+
+    REQUIRE( QMetaObject::invokeMethod( &dialog, "updateConfigFromDialog", Qt::DirectConnection ) );
+
+    const Configuration defaults;
+    const SavedSearches defaultSavedSearches;
+    const RecentFiles defaultRecentFiles;
+    const auto& restoredConfig = Configuration::getSynced();
+
+    CHECK( restoredConfig.versionCheckingEnabled() == defaults.versionCheckingEnabled() );
+    CHECK( restoredConfig.lineSpacingPercent() == defaults.lineSpacingPercent() );
+    CHECK( restoredConfig.pollIntervalMs() == defaults.pollIntervalMs() );
+    CHECK( restoredConfig.adbExecutable() == defaults.adbExecutable() );
+    CHECK( restoredConfig.iosLogExecutable() == defaults.iosLogExecutable() );
+    CHECK( restoredConfig.useSearchResultsCache() == defaults.useSearchResultsCache() );
+    CHECK( SavedSearches::getSynced().historySize() == defaultSavedSearches.historySize() );
+    CHECK( RecentFiles::getSynced().filesHistoryMaxItems()
+           == defaultRecentFiles.filesHistoryMaxItems() );
+
+    const auto restoredOpenFileShortcuts
+        = ShortcutAction::shortcutKeys( ShortcutAction::MainWindowOpenFile,
+                                        restoredConfig.shortcuts() );
+    const auto defaultOpenFileShortcuts
+        = ShortcutAction::shortcutKeys( ShortcutAction::MainWindowOpenFile, {} );
+    CHECK_FALSE( restoredOpenFileShortcuts.contains( QKeySequence( QStringLiteral( "Ctrl+Shift+P" ) ) ) );
+    for ( const auto& defaultShortcut : defaultOpenFileShortcuts ) {
+        CHECK( restoredOpenFileShortcuts.contains( defaultShortcut ) );
+    }
 }
 
 TEST_CASE( "OptionsDialog adb detect button fills the executable field with the resolved adb path" )
@@ -400,6 +619,29 @@ TEST_CASE( "AdbLogcatDialog reads adb defaults from configuration and saves edit
     auto& restoredConfig = Configuration::getSynced();
     REQUIRE( restoredConfig.adbExecutable() == QStringLiteral( "/saved/adb" ) );
     REQUIRE( restoredConfig.adbLogcatExtraArgs() == QStringLiteral( "-v threadtime *:I" ) );
+}
+
+TEST_CASE( "iOS log stream session data serializes its source type" )
+{
+    const AdbLogcatSessionData iosSessionData{
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ),
+        QStringLiteral( "iPhone Test" ),
+        QStringLiteral( "--network" ),
+        QStringLiteral( "ios-capture" ),
+        QStringLiteral( "/tmp/ios.log" ),
+        LiveLogSourceType::IosLogStream,
+    };
+
+    const auto json = QString::fromUtf8(
+        QJsonDocument( iosSessionData.toJson() ).toJson( QJsonDocument::Compact ) );
+    const auto restored = AdbLogcatSessionData::fromJson( json );
+
+    REQUIRE( restored.sourceType == LiveLogSourceType::IosLogStream );
+    REQUIRE( restored.documentId() == QStringLiteral( "ios-log://ios-capture" ) );
+    REQUIRE( restored.persistedSourceType() == QStringLiteral( "ios_log_stream" ) );
+    REQUIRE( restored.deviceSerial == QStringLiteral( "00008030-001C195E36D8802E" ) );
+    REQUIRE( restored.extraArgs == QStringLiteral( "--network" ) );
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -60,6 +60,16 @@ bool isHeadlessDialogTestEnvironment()
                   == 0;
 }
 
+bool skipHeadlessOptionsDialogTest()
+{
+    if ( isHeadlessDialogTestEnvironment() ) {
+        WARN( "OptionsDialog UI coverage is skipped on headless/offscreen platforms" );
+        return true;
+    }
+
+    return false;
+}
+
 class ScopedAdbConfigurationGuard {
   public:
     ScopedAdbConfigurationGuard()
@@ -402,8 +412,7 @@ TEST_CASE( "AdbProcessTransport surfaces immediate post-start failures as transp
 
 TEST_CASE( "OptionsDialog loads and persists adb settings" )
 {
-    if ( isHeadlessDialogTestEnvironment() ) {
-        WARN( "OptionsDialog UI coverage is skipped on headless/offscreen platforms" );
+    if ( skipHeadlessOptionsDialogTest() ) {
         return;
     }
 
@@ -439,6 +448,10 @@ TEST_CASE( "OptionsDialog loads and persists adb settings" )
 
 TEST_CASE( "OptionsDialog default shortcut table keeps Apply and OK enabled" )
 {
+    if ( skipHeadlessOptionsDialogTest() ) {
+        return;
+    }
+
     ScopedOptionsDialogConfigurationGuard configGuard;
     auto& config = Configuration::getSynced();
     config.setShortcuts( {} );
@@ -458,6 +471,10 @@ TEST_CASE( "OptionsDialog default shortcut table keeps Apply and OK enabled" )
 
 TEST_CASE( "OptionsDialog persists changed font size from preferences" )
 {
+    if ( skipHeadlessOptionsDialogTest() ) {
+        return;
+    }
+
     ScopedOptionsDialogConfigurationGuard configGuard;
     auto& config = Configuration::getSynced();
     const auto originalFont = config.mainFont();
@@ -486,6 +503,10 @@ TEST_CASE( "OptionsDialog persists changed font size from preferences" )
 
 TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
 {
+    if ( skipHeadlessOptionsDialogTest() ) {
+        return;
+    }
+
     ScopedOptionsDialogConfigurationGuard configGuard;
 
     auto& config = Configuration::getSynced();
@@ -557,8 +578,7 @@ TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
 
 TEST_CASE( "OptionsDialog adb detect button fills the executable field with the resolved adb path" )
 {
-    if ( isHeadlessDialogTestEnvironment() ) {
-        WARN( "OptionsDialog UI coverage is skipped on headless/offscreen platforms" );
+    if ( skipHeadlessOptionsDialogTest() ) {
         return;
     }
 

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -32,6 +32,7 @@
 #include <QJsonDocument>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSettings>
 #include <QTemporaryDir>
 #include <QUuid>
 
@@ -88,65 +89,38 @@ class ScopedOptionsDialogConfigurationGuard {
   public:
     ScopedOptionsDialogConfigurationGuard()
         : config_( Configuration::getSynced() )
-        , mainFont_( config_.mainFont() )
-        , lineSpacingPercent_( config_.lineSpacingPercent() )
-        , versionCheckingEnabled_( config_.versionCheckingEnabled() )
-        , pollIntervalMs_( config_.pollIntervalMs() )
-        , adbExecutable_( config_.adbExecutable() )
-        , adbExtraArgs_( config_.adbLogcatExtraArgs() )
-        , adbAnsiOutput_( config_.adbLogcatAnsiOutputEnabled() )
-        , iosLogExecutable_( config_.iosLogExecutable() )
-        , iosLogExtraArgs_( config_.iosLogExtraArgs() )
-        , iosLogAnsiOutput_( config_.iosLogAnsiOutputEnabled() )
-        , useSearchResultsCache_( config_.useSearchResultsCache() )
-        , shortcuts_( config_.shortcuts() )
         , savedSearches_( SavedSearches::getSynced() )
-        , searchHistorySize_( savedSearches_.historySize() )
         , recentFiles_( RecentFiles::getSynced() )
-        , recentFilesMaxItems_( recentFiles_.filesHistoryMaxItems() )
     {
+        REQUIRE( snapshotDir_.isValid() );
+        snapshotPath_ = snapshotDir_.filePath( QStringLiteral( "settings.ini" ) );
+
+        QSettings snapshot( snapshotPath_, QSettings::IniFormat );
+        config_.saveToStorage( snapshot );
+        savedSearches_.saveToStorage( snapshot );
+        recentFiles_.saveToStorage( snapshot );
+        snapshot.sync();
     }
 
     ~ScopedOptionsDialogConfigurationGuard()
     {
-        config_.setMainFont( mainFont_ );
-        config_.setLineSpacingPercent( lineSpacingPercent_ );
-        config_.setVersionCheckingEnabled( versionCheckingEnabled_ );
-        config_.setPollIntervalMs( pollIntervalMs_ );
-        config_.setAdbExecutable( adbExecutable_ );
-        config_.setAdbLogcatExtraArgs( adbExtraArgs_ );
-        config_.setAdbLogcatAnsiOutputEnabled( adbAnsiOutput_ );
-        config_.setIosLogExecutable( iosLogExecutable_ );
-        config_.setIosLogExtraArgs( iosLogExtraArgs_ );
-        config_.setIosLogAnsiOutputEnabled( iosLogAnsiOutput_ );
-        config_.setUseSearchResultsCache( useSearchResultsCache_ );
-        config_.setShortcuts( shortcuts_ );
+        QSettings snapshot( snapshotPath_, QSettings::IniFormat );
+        config_.retrieveFromStorage( snapshot );
         config_.save();
 
-        savedSearches_.setHistorySize( searchHistorySize_ );
+        savedSearches_.retrieveFromStorage( snapshot );
         savedSearches_.save();
-        recentFiles_.setFilesHistoryMaxItems( recentFilesMaxItems_ );
+
+        recentFiles_.retrieveFromStorage( snapshot );
         recentFiles_.save();
     }
 
   private:
     Configuration& config_;
-    QFont mainFont_;
-    int lineSpacingPercent_;
-    bool versionCheckingEnabled_;
-    int pollIntervalMs_;
-    QString adbExecutable_;
-    QString adbExtraArgs_;
-    bool adbAnsiOutput_;
-    QString iosLogExecutable_;
-    QString iosLogExtraArgs_;
-    bool iosLogAnsiOutput_;
-    bool useSearchResultsCache_;
-    std::map<std::string, QStringList> shortcuts_;
     SavedSearches& savedSearches_;
-    int searchHistorySize_;
     RecentFiles& recentFiles_;
-    int recentFilesMaxItems_;
+    QTemporaryDir snapshotDir_;
+    QString snapshotPath_;
 };
 
 class TestAdbProcessTransport : public AdbProcessTransport {
@@ -173,6 +147,11 @@ class TestIosLogProcessTransport : public IosLogProcessTransport {
     Command streamingCommandForTest() const
     {
         return streamingCommand();
+    }
+
+    Command clearCommandForTest() const
+    {
+        return clearCommand();
     }
 };
 
@@ -322,6 +301,51 @@ TEST_CASE( "IosLogProcessTransport controls pymobiledevice3 ANSI color output" )
              == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
                              QStringLiteral( "live" ), QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ) } );
+}
+
+TEST_CASE( "IosLogProcessTransport clear command is an inert no-op" )
+{
+    TestIosLogProcessTransport transport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{} );
+
+    const auto clear = transport.clearCommandForTest();
+#ifdef Q_OS_WIN
+    REQUIRE( clear.program == QStringLiteral( "cmd" ) );
+    REQUIRE( clear.arguments == QStringList{ QStringLiteral( "/c" ), QStringLiteral( "exit" ),
+                                             QStringLiteral( "0" ) } );
+#else
+    REQUIRE( clear.program == QStringLiteral( "true" ) );
+    REQUIRE( clear.arguments.isEmpty() );
+#endif
+}
+
+TEST_CASE( "IosLogProcessTransport falls back to legacy pymobiledevice3 device listing" )
+{
+#ifdef Q_OS_MAC
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "pymobiledevice3" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    script.write( "#!/bin/sh\n"
+                  "case \"$*\" in\n"
+                  "  *--simple*) echo 'No such option: --simple' >&2; exit 2 ;;\n"
+                  "esac\n"
+                  "printf '[{\"Identifier\":\"00008030\",\"DeviceName\":\"Test iPhone\"}]\\n'\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    QString error;
+    const auto devices = IosLogProcessTransport::listDevices( scriptPath, &error );
+    REQUIRE( error.isEmpty() );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices.front().udid == QStringLiteral( "00008030" ) );
+    CHECK( devices.front().description == QStringLiteral( "Test iPhone" ) );
+#else
+    SUCCEED( "pymobiledevice3 device listing is macOS-only." );
+#endif
 }
 
 TEST_CASE( "IosLogProcessTransport reports unsupported device listing off macOS" )

--- a/tests/unit/ansicolorprocessor_test.cpp
+++ b/tests/unit/ansicolorprocessor_test.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch.hpp>
+
+#include "ansicolorprocessor.h"
+
+TEST_CASE( "ANSI processor strips CSI sequences without rendering colors" )
+{
+    const auto processed = processAnsiSequences(
+        QStringLiteral( "plain \x1b[31mred\x1b[0m tail\x1b[K" ), AnsiProcessingMode::Strip );
+
+    REQUIRE( processed.text == QStringLiteral( "plain red tail" ) );
+    REQUIRE( processed.colorSpans.empty() );
+}
+
+TEST_CASE( "ANSI processor renders SGR color ranges on stripped text" )
+{
+    const auto processed = processAnsiSequences(
+        QStringLiteral( "a\x1b[31mred\x1b[0m b\x1b[38;2;1;2;3mtrue\x1b[39m" ),
+        AnsiProcessingMode::Render );
+
+    REQUIRE( processed.text == QStringLiteral( "ared btrue" ) );
+    REQUIRE( processed.colorSpans.size() == 2 );
+
+    REQUIRE( processed.colorSpans[ 0 ].startColumn == 1_lcol );
+    REQUIRE( processed.colorSpans[ 0 ].length == 3_length );
+    REQUIRE( processed.colorSpans[ 0 ].foreground == 0xde382b );
+
+    REQUIRE( processed.colorSpans[ 1 ].startColumn == 6_lcol );
+    REQUIRE( processed.colorSpans[ 1 ].length == 4_length );
+    REQUIRE( processed.colorSpans[ 1 ].foreground == 0x010203 );
+}
+
+TEST_CASE( "ANSI processor leaves escape text untouched in plain mode" )
+{
+    const auto source = QStringLiteral( "\x1b[32mgreen" );
+    const auto processed = processAnsiSequences( source, AnsiProcessingMode::Plain );
+
+    REQUIRE( processed.text == source );
+    REQUIRE( processed.colorSpans.empty() );
+}

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -130,6 +130,8 @@ TEST_CASE( "Configuration stores and restores iOS log defaults" )
         Configuration config;
         config.setIosLogExecutable( QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
         config.setIosLogExtraArgs( QStringLiteral( "--no-color --match SpringBoard" ) );
+        config.setIosLogAnsiOutputEnabled( true );
+        config.setAdbLogcatAnsiOutputEnabled( true );
         config.saveToStorage( settings );
         settings.sync();
         REQUIRE( settings.status() == QSettings::NoError );
@@ -143,4 +145,6 @@ TEST_CASE( "Configuration stores and restores iOS log defaults" )
              == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
     REQUIRE( restoredConfig.iosLogExtraArgs()
              == QStringLiteral( "--no-color --match SpringBoard" ) );
+    REQUIRE( restoredConfig.iosLogAnsiOutputEnabled() );
+    REQUIRE( restoredConfig.adbLogcatAnsiOutputEnabled() );
 }

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -117,3 +117,30 @@ TEST_CASE( "Configuration stores and restores adb defaults" )
              == QStringLiteral( "/opt/android/platform-tools/adb" ) );
     REQUIRE( restoredConfig.adbLogcatExtraArgs() == QStringLiteral( "-v threadtime *:I" ) );
 }
+
+TEST_CASE( "Configuration stores and restores iOS log defaults" )
+{
+    const auto dirPath = makeTestDir( "configuration_ios_log" );
+    REQUIRE( QDir{ dirPath }.exists() );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration-ios-log.ini" );
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+
+        Configuration config;
+        config.setIosLogExecutable( QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
+        config.setIosLogExtraArgs( QStringLiteral( "--no-color --match SpringBoard" ) );
+        config.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+    }
+
+    QSettings restoredSettings( settingsPath, QSettings::IniFormat );
+    Configuration restoredConfig;
+    restoredConfig.retrieveFromStorage( restoredSettings );
+
+    REQUIRE( restoredConfig.iosLogExecutable()
+             == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
+    REQUIRE( restoredConfig.iosLogExtraArgs()
+             == QStringLiteral( "--no-color --match SpringBoard" ) );
+}

--- a/tests/unit/shortcut_bindings_test.cpp
+++ b/tests/unit/shortcut_bindings_test.cpp
@@ -194,7 +194,7 @@ TEST_CASE( "Shortcut bindings: editable defaults have no duplicate displayed key
 
     std::map<QString, std::vector<std::string>> keyToActions;
     for ( const auto& [ action, shortcut ] : shortcuts ) {
-        const auto visibleShortcutCount = std::min( 2, shortcut.keySequence.size() );
+        const auto visibleShortcutCount = std::min<qsizetype>( 2, shortcut.keySequence.size() );
         for ( auto shortcutIndex = 0; shortcutIndex < visibleShortcutCount; ++shortcutIndex ) {
             const auto key = QKeySequence( shortcut.keySequence.at( shortcutIndex ) )
                                  .toString( QKeySequence::NativeText );

--- a/tests/unit/shortcut_bindings_test.cpp
+++ b/tests/unit/shortcut_bindings_test.cpp
@@ -22,6 +22,8 @@
 #include <QKeySequence>
 #include <QString>
 
+#include <algorithm>
+
 #include "shortcuts.h"
 
 TEST_CASE( "Shortcut bindings: disconnect and reconnect source have defaults" )
@@ -134,6 +136,22 @@ TEST_CASE( "Shortcut bindings: crawler visibility and filter options use Ctrl+Sh
     }
 }
 
+TEST_CASE( "Shortcut bindings: open from clipboard does not steal text paste" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+    const auto it = shortcuts.find( ShortcutAction::MainWindowOpenFromClipboard );
+    REQUIRE( it != shortcuts.end() );
+
+    const auto pasteKeys = QKeySequence::keyBindings( QKeySequence::Paste );
+    for ( const auto& configuredKey : it->second.keySequence ) {
+        const auto configuredSequence = QKeySequence( configuredKey );
+        for ( const auto& pasteKey : pasteKeys ) {
+            CHECK( configuredSequence.matches( pasteKey ) != QKeySequence::ExactMatch );
+            CHECK( pasteKey.matches( configuredSequence ) != QKeySequence::ExactMatch );
+        }
+    }
+}
+
 TEST_CASE( "Shortcut bindings: no duplicate key bindings across all default shortcuts" )
 {
     const auto& shortcuts = ShortcutAction::defaultShortcutList();
@@ -166,6 +184,34 @@ TEST_CASE( "Shortcut bindings: no duplicate key bindings across all default shor
                 }
                 CHECK( it->second.size() <= 1 );
             }
+        }
+    }
+}
+
+TEST_CASE( "Shortcut bindings: editable defaults have no duplicate displayed keys" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    std::map<QString, std::vector<std::string>> keyToActions;
+    for ( const auto& [ action, shortcut ] : shortcuts ) {
+        const auto visibleShortcutCount = std::min( 2, shortcut.keySequence.size() );
+        for ( auto shortcutIndex = 0; shortcutIndex < visibleShortcutCount; ++shortcutIndex ) {
+            const auto key = QKeySequence( shortcut.keySequence.at( shortcutIndex ) )
+                                 .toString( QKeySequence::NativeText );
+            if ( !key.isEmpty() ) {
+                keyToActions[ key ].push_back( action );
+            }
+        }
+    }
+
+    for ( const auto& [ key, actions ] : keyToActions ) {
+        DYNAMIC_SECTION( "Displayed key " << key.toStdString() << " is unique" )
+        {
+            INFO( "Actions using displayed key:" );
+            for ( const auto& action : actions ) {
+                INFO( "  " << action );
+            }
+            CHECK( actions.size() <= 1 );
         }
     }
 }

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -23,6 +23,8 @@
 #include <QTemporaryDir>
 #include <QUuid>
 
+#include <string_view>
+
 #include "capturestore.h"
 #include "streaminglogdata.h"
 #include "test_utils.h"
@@ -122,6 +124,41 @@ TEST_CASE( "StreamingLogData getLinesRaw returns correct RawLines for search wor
     REQUIRE( decoded[ 1 ] == QStringLiteral( "second" ) );
     REQUIRE( decoded[ 2 ] == QStringLiteral( "third" ) );
     REQUIRE( decoded[ 3 ] == QStringLiteral( "fourth" ) );
+}
+
+TEST_CASE( "StreamingLogData strips ANSI before display and search views" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+
+    REQUIRE( loadingSpy.safeWait() );
+    loadingSpy.clear();
+
+    logData.appendUtf8( QByteArrayLiteral( "plain \x1b[31mred\x1b[0m text\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    REQUIRE( logData.getNbLine().get() == 1 );
+
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Plain );
+    REQUIRE( logData.getLineString( 0_lnum ) == QStringLiteral( "plain \x1b[31mred\x1b[0m text" ) );
+
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Strip );
+    REQUIRE( logData.getLineString( 0_lnum ) == QStringLiteral( "plain red text" ) );
+    const auto strippedRawLines = logData.getLinesRaw( 0_lnum, 1_lcount );
+    REQUIRE( strippedRawLines.decodeLines()[ 0 ] == QStringLiteral( "plain red text" ) );
+    REQUIRE( strippedRawLines.buildUtf8View()[ 0 ] == std::string_view{ "plain red text" } );
+
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Render );
+    REQUIRE( logData.getLineString( 0_lnum ) == QStringLiteral( "plain red text" ) );
+    const auto colors = logData.getLineAnsiColors( 0_lnum );
+    REQUIRE( colors.size() == 1 );
+    REQUIRE( colors[ 0 ].startColumn == 6_lcol );
+    REQUIRE( colors[ 0 ].length == 3_length );
+    REQUIRE( colors[ 0 ].foreground == 0xde382b );
+    REQUIRE( logData.getLinesRaw( 0_lnum, 1_lcount ).buildUtf8View()[ 0 ]
+             == std::string_view{ "plain red text" } );
 }
 
 TEST_CASE( "StreamingLogData reports accurate fileSize and lastModifiedDate" )


### PR DESCRIPTION
## Summary
- Add iOS live log streaming via `pymobiledevice3 syslog live`, with device enumeration, ANSI color toggle, and session persistence
- Add ANSI escape sequence processing (strip and render modes) across all log data views, with a configuration toggle to hide ANSI colors
- Add per-panel Reset buttons in OptionsDialog, normalize shortcut key bindings, and add iOS log settings panel
- Extract duplicated command-line tokenizer into shared header, fix `qsizetype`→`int` narrowing that broke CI on macOS/Linux with `-Werror`

## Background
- Introduced by: Extending the ADB logcat live-source architecture to also support iOS syslog streaming via pymobiledevice3
- Use case: macOS users need to stream iOS device logs without Xcode; all platforms benefit from ANSI color rendering in live log streams
- Root cause (CI failures): `ansicolorprocessor.cpp` passed `QString::size()` (qsizetype/long long) to `int` parameters, triggering `-Werror=conversion` on GCC and `-Werror,-Wshorten-64-to-32` on Clang. Additionally, `canEscapeArgumentCharacter`/`splitCommandArguments` were copy-pasted into two TUs
- How to fix: Use `qsizetype` for `colorSpanStart` and `static_cast<int>` at call sites; extract tokenizer into `ui::internal` namespace in a shared header

## Changes by area

**iOS log streaming**
- `IosLogProcessTransport` — pymobiledevice3 executable detection, device listing (usbmux/simple + legacy fallback), streaming command with `--color`/`--no-color`, inert no-op `clearCommand()`
- `IosLogDialog` — modal dialog for executable, device selection, extra args, ANSI toggle; async device refresh via `QTimer::singleShot(0, …)`
- `AdbLogcatSource` / `AdbLogcatSessionData` — `LiveLogSourceType` enum (AdbLogcat / IosLogStream), `persistedSourceType()` / `isPersistedSourceType()` / `isValid()` helpers, JSON round-trip with source type
- `session.cpp` — restore validates `isValid()` before opening live-source tabs
- `mainwindow.cpp` — "Open iOS Log Stream" action (macOS-visible), context-sensitive clear/restart messaging

**ANSI color processing**
- `AnsiColorProcessor` — strip and render modes for CSI/SGR sequences; `static_cast<int>` at `appendColorSpan` calls to satisfy `-Wconversion`
- `StreamingLogData`, `SearchableLogData`, `AbstractLogView` — wire ANSI stripping/rendering into display, search, and filtered views
- Configuration option `hideAnsiColorSequences` to disable rendering

**OptionsDialog & shortcuts**
- iOS log settings panel (executable, extra args, detect, ANSI toggle)
- Per-panel Reset buttons that restore defaults and apply
- `ShortcutAction::uniqueKeyBindings()` normalization, `QKeySequence::PortableText` for binding strings

**Code quality**
- `commandargumenttokenizer.h` — shared `ui::internal::splitCommandArguments` / `canEscapeArgumentCharacter`, replacing identical copies in `adbprocesstransport.cpp` and `ioslogprocesstransport.cpp`
- Headless CI guard applied to all `OptionsDialog` UI tests

## Tests
- `cmake --build build -j4` — clean build on macOS Qt 5.15 (local)
- `./build/output/klogg_tests` — all 97 test cases pass (4765 assertions)
- CI-targeted tests verified: AdbProcessTransport (5), IosLogProcessTransport (6), ANSI processor (3), iOS stream serialization (1), iOS stream clear/restart (1), OptionsDialog reset buttons (1), configuration iOS persistence (1)
- CI builds not yet verified (pending push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS log streaming support (macOS only) with configurable executable path and device selection
  * Added ANSI color output configuration for both iOS and Android logs
  * New ANSI color processing modes: Plain, Strip, and Render for customized color display

* **Improvements**
  * Enhanced session persistence to support multiple log source types
  * Added "Render ANSI Colors" display option in preferences
  * Improved keyboard shortcut management and duplicate detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->