### PR TITLE
Fix pymobiledevice3 discovery and tilde expansion for iOS/ADB live sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,10 @@
-![media_small](https://user-images.githubusercontent.com/1620716/119145300-2d98b800-ba52-11eb-8d87-abe72cf65dd1.png)
-
 [![GitHub license](https://img.shields.io/github/license/ZEACENT/klogg.svg?style=flat)](https://github.com/ZEACENT/klogg/blob/master/COPYING)
 [![C++](https://img.shields.io/github/languages/top/ZEACENT/klogg?style=flat)]()
 [![GitHub contributors](https://img.shields.io/github/contributors/ZEACENT/klogg.svg?style=flat)](https://github.com/ZEACENT/klogg/graphs/contributors/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/f6db6ef0be3a4a5abff94111a5291c45)](https://www.codacy.com/manual/ZEACENT/klogg?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ZEACENT/klogg&amp;utm_campaign=Badge_Grade)
-
-
 [![Github all releases](https://img.shields.io/github/downloads/ZEACENT/klogg/total?style=flat)](https://github.com/ZEACENT/klogg/releases/)
-[ ![Github](https://img.shields.io/github/v/release/ZEACENT/klogg?style=flat&label=Stable%20release&)](https://github.com/ZEACENT/klogg/releases/latest)
-
-[![Packaging status](https://repology.org/badge/vertical-allrepos/klogg.svg)](https://repology.org/project/klogg/versions)
-
-Check [GitHub releases](https://github.com/ZEACENT/klogg/releases/latest) for Windows installers and Linux/Mac packages.
-
-Development status
-
-[![Next milestone](https://img.shields.io/github/milestones/progress-percent/ZEACENT/klogg/4?style=flat&)](https://github.com/ZEACENT/klogg/milestone/4)
-[![Ready for testing](https://img.shields.io/github/issues-raw/ZEACENT/klogg/status:%20ready%20for%20testing?color=green&label=issues%20ready%20for%20testing&style=flat)](https://github.com/ZEACENT/klogg/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+ready+for+testing%22)
-[![Need documentation](https://img.shields.io/github/issues-search/ZEACENT/klogg?color=yellow&label=features%20need%20documentation&query=is%3Aissue%20label%3A%22status%3A%20need%20documentation%22&style=flat)](https://github.com/ZEACENT/klogg/issues?q=is%3Aissue+label%3A%22status%3A+need+documentation%22)
-[![GitHub commits](https://img.shields.io/github/commits-since/ZEACENT/klogg/v22.06.svg?style=flat)](https://github.com/ZEACENT/klogg/commits/)
-[![CI Build and Release](https://github.com/ZEACENT/klogg/actions/workflows/ci-build.yml/badge.svg)](https://github.com/ZEACENT/klogg/actions/workflows/ci-build.yml)
-
-[![Chat on Discord](https://img.shields.io/discord/838452586944266260?label=Discord&style=flat)](https://discord.gg/DruNyQftzB) [![Join the chat at https://gitter.im/klogg_log_viewer/community](https://badges.gitter.im/klogg_log_viewer/community.svg)](https://gitter.im/klogg_log_viewer/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Github](https://img.shields.io/github/v/release/ZEACENT/klogg?style=flat&label=Stable%20release)](https://github.com/ZEACENT/klogg/releases/latest)
+[![CI Build](https://github.com/ZEACENT/klogg/actions/workflows/ci-build.yml/badge.svg)](https://github.com/ZEACENT/klogg/actions/workflows/ci-build.yml)
 
 ## Overview
 
@@ -31,19 +13,11 @@ through long and complex log files. It is designed with programmers and
 system administrators in mind and can be seen as a graphical, interactive
 combination of grep, less, and tail.
 
-![Klogg main window](website/static/screenshots/mainwindow.png)
-
 Please refer to the
 [technical documentation](docs/TECHNICAL_DOCUMENTATION.md)
 page for how to use Klogg.
 
-### Latest testing builds
-
-| Windows | Linux | Mac |
-| ------------- |------------- | ------------- |
-| [continuous-win](https://github.com/ZEACENT/klogg/releases/tag/continuous-win) | [continuous-linux](https://github.com/ZEACENT/klogg/releases/tag/continuous-linux) | [continuous-osx](https://github.com/ZEACENT/klogg/releases/tag/continuous-osx) |
-
-I try to keep a [changelog](CHANGELOG.md) with monthly changes. 
+A [changelog](CHANGELOG.md) tracks monthly changes.
 
 ## Table of Contents
 
@@ -55,24 +29,20 @@ I try to keep a [changelog](CHANGELOG.md) with monthly changes.
 1. [Contributing](#contributing)
 1. [License](#license)
 1. [Authors](#authors)
+1. [Backlog](#backlog)
 
 ## About the Project
 
 Klogg started as a fork of [glogg](https://github.com/nickbnf/glogg) - the fast, smart log explorer in 2016.
 
 Since then it has evolved from fixing small annoying bugs to rewriting core components to
-make it faster and smarter that predecessor.
-
-Development of klogg is driven by features my colleagues and I need
-to stay productive as well as feature requests from users on Github and in glogg mailing list.
-
-Latest news about klogg development can be found at https://klogg.filimonov.dev.
+make it faster and smarter than its predecessor.
 
 ### Comparing with glogg
 
-Klogg has all best features of glogg:
+Klogg has all the best features of glogg:
 
-* Runs on Unix-like systems, Windows and Mac thanks to Qt5
+* Runs on Unix-like systems, Windows and Mac thanks to Qt5/Qt6
 * Is fast and reads the file directly from disk, without loading it into memory
 * Can operate on huge text files (10+ Gb is not a problem)
 * Search results are displayed separately from original file
@@ -89,9 +59,9 @@ And on top of that klogg:
 * Includes optimized regular expressions search; benchmark details live in [docs/REGEX_BENCHMARKS.md](docs/REGEX_BENCHMARKS.md)
 * Allows combining regular expressions with boolean operators (AND, OR, NOT)
 * Supports many common text encodings
-* Detects file encoding automatically using [uchardet](https://www.freedesktop.org/wiki/Software/uchardet/) library (supports utf8, utf16, cp1251 and more) 
+* Detects file encoding automatically using [uchardet](https://www.freedesktop.org/wiki/Software/uchardet/) library (supports utf8, utf16, cp1251 and more)
 * Can limit search operations to some part of huge file
-* Allows to configure several highlighters sets and switch between them
+* Allows configuring several highlighter sets and switching between them
 * Has a list of configurable predefined regular expression patterns
 * Includes a dark mode
 * Has configurable shortcuts
@@ -102,80 +72,37 @@ List of glogg issues that have been fixed/implemented in klogg can be found [her
 
 List of all changes can be found [here](https://github.com/ZEACENT/klogg/milestone/8?closed=1).
 
-**[Back to top](#table-of-contents)**
+### Comparing with variar/klogg
+
+This fork builds on [variar/klogg](https://github.com/variar/klogg) and adds:
+
+* **iOS live log streaming** — device discovery and log capture via pymobiledevice3
+* **Android logcat live streaming** — ADB-based logcat with persistent-file save mode
+* **ANSI color rendering** — configurable output modes (strip / render / plain) for live streams
+* **Live-source search throttling** — smooth UI during streaming without blocking the event loop
+* **Search generation IDs** — monotonic counter prevents stale search results after interrupting a search (see [PORTABILITY.md](docs/PORTABILITY.md))
+* **Batched flush** — triple-threshold output flushing (64 KB / 100 lines / 1 s) for live log captures
+* **Highlighter coexistence** — selection highlighting preserves keyword highlighter colors
+* **Status bar pending indicator** — shows pending search lines as `Ln:X/Y (+N pending)`
+* **Platform-aware tool resolution** — robust external-tool discovery across macOS launchd, Windows, and Linux (see [PORTABILITY.md](docs/PORTABILITY.md))
 
 ## Installation
 
 This project uses [Calendar Versioning](https://calver.org/). For a list of available versions, see the [repository tag list](https://github.com/ZEACENT/klogg/tags).
 
-### Current stable release builds
+Binaries for all platforms are available from [GitHub Releases](https://github.com/ZEACENT/klogg/releases/latest).
 
-Binaries for all platforms can be downloaded from GitHub releases.
-
-[ ![Release](https://img.shields.io/github/v/release/ZEACENT/klogg?style=flat)](https://github.com/ZEACENT/klogg/releases/latest)
-
-#### Windows
-Windows installer is also available from:
-
-* [ ![Chocolatey](https://img.shields.io/chocolatey/v/klogg?style=flat)](https://chocolatey.org/packages/klogg)
-* [ ![Scoop Extras bucket](https://img.shields.io/scoop/v/klogg?bucket=extras)](https://scoopsearch.github.io/#/apps?q=klogg)
-* [Winget package](https://winget.run/pkg/ZEACENT/klogg) 
-
-#### Mac OS
-Package for Mac can be installed from Homebrew
-
-[ ![homebrew cask](https://img.shields.io/homebrew/cask/v/klogg?style=flat)](https://formulae.brew.sh/cask/klogg)
-
-#### Linux
-It is recommended to use klogg package from distribution-specific [repositories](https://repology.org/project/klogg/versions).
-
-Generic packages are available from the klogg DEB repository hosted at GitHub Pages.
-They are built to run on Ubuntu 22.04/24.04 (x86-64 only).
-
-For DEB packages first download the gpg key:
-```
-curl -sS https://klogg.filimonov.dev/klogg.gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/klogg.gpg
-```
-
-You might need to manually create `/etc/apt/keyrings` directory.
-
-Then download the repository list file for your distribution (replace `<ubuntu_release>` with `jammy` or `noble`):
-```
-curl -sS https://klogg.filimonov.dev/deb/klogg.<ubuntu_release>.list | sudo tee /etc/apt/sources.list.d/klogg.list
-```
-
-Finally, install using apt
-```
-sudo apt-get update
-sudo apt install klogg
-```
-
-If there is already an entry for JFrogg hosted klogg repository in `/etc/apt/sources.list`, then remove this line from it:
-```
-deb [trusted=yes] https://favpackage.jfrog.io/artifactory/klogg_deb/ <ubuntu_release> utils
-```
-
-There is also an AppImage package that can be used without installation. To run klogg from AppImage, download the package and make in executable with either a file manager or terminal command `chmod +x <path_to_klogg_AppImage>` and then run the AppImage file.
-
-AppImage uses FUSE2 and Ubuntu 22.04 has moved away from FUSE2 into FUSE3 and therefore you need to install the necessary package to enable compatibility with FUSE2 `sudo apt install libfuse2`.
-
-As indicated by this link from the official appimage documentation: https://docs.appimage.org/user-guide/troubleshooting/fuse.html#setting-up-fuse-2-x-alongside-of-fuse-3-x-on-recent-ubuntu-22-04-debian-and-their-derivatives
-
-### Testing builds
-
-![CI Build and Release](https://github.com/ZEACENT/klogg/workflows/CI%20Build%20and%20Release/badge.svg)
+### Continuous builds
 
 | Windows | Linux | Mac |
 | ------------- |------------- | ------------- |
 | [continuous-win](https://github.com/ZEACENT/klogg/releases/tag/continuous-win) | [continuous-linux](https://github.com/ZEACENT/klogg/releases/tag/continuous-linux) | [continuous-osx](https://github.com/ZEACENT/klogg/releases/tag/continuous-osx) |
 
-**[Back to top](#table-of-contents)**
-
 ## Building
 
 Please review
 [docs/BUILD.md](docs/BUILD.md)
-for how to setup Klogg on your local machine for development and testing purposes.
+for how to set up Klogg on your local machine for development and testing purposes.
 
 ### Regex Benchmark Snapshot
 
@@ -223,110 +150,27 @@ All C++ dependencies are managed via [CPM](https://github.com/cpm-cmake/CPM.cmak
 
 ## How to Get Help
 
-First, please refer to the
+Please refer to the
 [technical documentation](docs/TECHNICAL_DOCUMENTATION.md)
 page.
 
-You can open issues using [klogg issues page](https://github.com/ZEACENT/klogg/issues)
-or post questions to glogg development [mailing list](http://groups.google.co.uk/group/glogg-devel).
+You can open issues on the [klogg issues page](https://github.com/ZEACENT/klogg/issues).
 
 ## Contributing
 
-We encourage public contributions! Please review [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct and development process.
+Contributions are welcome! Please review [CONTRIBUTING.md](CONTRIBUTING.md) for details on the code of conduct and development process.
 
 ## License
 
-This project is licensed under the GPLv3 or later - see [COPYING](COPYING) file for details.
+This project is licensed under the GPLv3 or later — see [COPYING](COPYING) file for details.
 
 ## Authors
 
 * **[Anton Filimonov](https://github.com/variar)**
-* *Initial work* - **[Nicolas Bonnefon](https://github.com/nickbnf)**
+* *Initial work* — **[Nicolas Bonnefon](https://github.com/nickbnf)**
 
-See also the list of [contributors](https://klogg.filimonov.dev/docs/getting_involved/#contributors) who participated in this project.
+See also the list of [contributors](https://github.com/ZEACENT/klogg/graphs/contributors) who participated in this project.
 
 ## Backlog
 
-| ID | Task | Priority | Status | Related |
-|----|------|----------|--------|---------|
-| TASK-001 | [Search generation ID refactoring](#task-001-search-generation-id-refactoring) | Low | Done | [PR #11](https://github.com/ZEACENT/klogg/pull/11) |
-| TASK-002 | [Chart Panel — regex match → time series](#task-002-chart-panel) | Medium | Planned | [SPEC](docs/SPEC_CHART_AND_FILTERS_PANEL.md) |
-| TASK-003 | [Filters Panel — persistent dock with groups & pinning](#task-003-filters-panel) | Medium | Planned | [SPEC](docs/SPEC_CHART_AND_FILTERS_PANEL.md) |
-
-### TASK-001: Search generation ID refactoring
-
-**Scenario:**
-`CrawlerWidget::replaceCurrentSearch()` needs to discard stale `searchProgressed`
-signals from an interrupted search before starting a new one. The current approach
-temporarily disconnects and reconnects the
-`LogFilteredData::searchProgressed` / `CrawlerWidget::updateFilteredView` slot.
-
-**Problem:**
-With `Qt::QueuedConnection`, `disconnect()` does not remove already-posted
-`QMetaCallEvent`s from the receiver's event queue — they will still be delivered
-after reconnect. Currently the window between disconnect and reconnect is very
-small (a few synchronous calls in `replaceCurrentSearch()`), so the practical
-impact is negligible. However, the pattern is fragile and could become a real bug
-if the window widens in future refactors.
-
-**Code context:**
-- Signal: `LogFilteredData::searchProgressed(LinesCount, int, LineNumber)` — `src/logdata/include/logfiltereddata.h:149`
-- Emit sites (6+): `src/logdata/src/logfiltereddata.cpp` (lines 164, 634, 646, 666), `src/logdata/src/logfiltereddataworker.cpp` (lines 319, 456, 485, 623, 708)
-- Disconnect/reconnect: `src/ui/src/crawlerwidget.cpp` (lines 1830–1831, 1904–1905)
-- Slot: `CrawlerWidget::updateFilteredView()` — `src/ui/src/crawlerwidget.cpp:630`
-
-**Proposed fix:**
-1. Add a monotonic `uint64_t` generation counter to `LogFilteredData`, incremented by `runSearch()` / `updateSearch()`
-2. Extend `searchProgressed` signal to carry the generation ID
-3. In `CrawlerWidget::updateFilteredView()`, ignore signals where `generation != activeSearchGeneration_`
-4. Remove the disconnect/reconnect calls in `replaceCurrentSearch()`
-
-**Trade-offs:**
-Cross-cutting change touching signal signature, all emit sites, and all connected slots.
-Should be done in a dedicated PR with thorough regression testing.
-
-**Resolution:**
-Implemented in branch `docs/backlog-generation-id`.  The wire type for the
-generation argument is plain `quint64` rather than the
-`LogFilteredDataWorker::OperationGeneration` typedef, because moc treats
-typedefs of non-builtin types as unregistered metatypes and `QSignalSpy`
-decodes the `QVariant` back to 0; the typedef alias is kept for
-code-readability but does not appear in any `Q_SIGNAL` signature.  Two
-new SCENARIOs in `tests/ui/logfiltereddata_test.cpp` cover generation
-increment and signal payload.  Receiver-side staleness gate is factored
-into `klogg::isStaleSearchGeneration` (`src/logdata/include/searchgeneration.h`)
-with its own unit test.  Cache-hit path bumps the generation via
-`LogFilteredDataWorker::bumpGeneration()` so prior-search progress
-signals are correctly dropped.
-
-### TASK-002: Chart Panel
-
-**Scenario:**
-Render a time-series chart of regex-matched events inside klogg so that
-post-mortem analysis goes beyond "search & scroll" into "see when things
-happen and how often".
-
-**Spec:** [`docs/SPEC_CHART_AND_FILTERS_PANEL.md`](docs/SPEC_CHART_AND_FILTERS_PANEL.md)
-covers goals / non-goals, UX, data model, three phased iterations
-(Phase 1: filter-frequency on a line-number axis; Phase 2: capture-group
-numeric aggregation; Phase 3: optional timestamp axis), files affected,
-testing strategy, and effort estimate (~5 weeks for Phase 1 + 2).
-
-**Recommended order:** ship after TASK-003.
-
-### TASK-003: Filters Panel
-
-**Scenario:**
-Surface the existing Predefined Filters feature as a persistent
-left-side dock with grouping and pinning, so users can toggle filter
-sets in one click instead of opening a multi-step dialog.
-
-**Spec:** [`docs/SPEC_CHART_AND_FILTERS_PANEL.md`](docs/SPEC_CHART_AND_FILTERS_PANEL.md)
-covers goals / non-goals, UX (tree view + drag-drop + per-group pin),
-data-model migration (legacy flat list → grouped collection), three
-phased iterations, testing strategy, and effort estimate (~1.5 weeks
-to feature-complete).
-
-**Recommended order:** ship before TASK-002.
-
-**[Back to top](#table-of-contents)**
+See [docs/BACKLOG.md](docs/BACKLOG.md) for the task backlog and planned features.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,83 @@
+# Klogg Task Backlog
+
+| ID | Task | Priority | Status | Related |
+|----|------|----------|--------|---------|
+| TASK-001 | [Search generation ID refactoring](#task-001-search-generation-id-refactoring) | Low | Done | [PR #11](https://github.com/ZEACENT/klogg/pull/11) |
+| TASK-002 | [Chart Panel — regex match → time series](#task-002-chart-panel) | Medium | Planned | [SPEC](SPEC_CHART_AND_FILTERS_PANEL.md) |
+| TASK-003 | [Filters Panel — persistent dock with groups & pinning](#task-003-filters-panel) | Medium | Planned | [SPEC](SPEC_CHART_AND_FILTERS_PANEL.md) |
+
+### TASK-001: Search generation ID refactoring
+
+**Scenario:**
+`CrawlerWidget::replaceCurrentSearch()` needs to discard stale `searchProgressed`
+signals from an interrupted search before starting a new one. The current approach
+temporarily disconnects and reconnects the
+`LogFilteredData::searchProgressed` / `CrawlerWidget::updateFilteredView` slot.
+
+**Problem:**
+With `Qt::QueuedConnection`, `disconnect()` does not remove already-posted
+`QMetaCallEvent`s from the receiver's event queue — they will still be delivered
+after reconnect. Currently the window between disconnect and reconnect is very
+small (a few synchronous calls in `replaceCurrentSearch()`), so the practical
+impact is negligible. However, the pattern is fragile and could become a real bug
+if the window widens in future refactors.
+
+**Code context:**
+- Signal: `LogFilteredData::searchProgressed(LinesCount, int, LineNumber)` — `src/logdata/include/logfiltereddata.h:149`
+- Emit sites (6+): `src/logdata/src/logfiltereddata.cpp` (lines 164, 634, 646, 666), `src/logdata/src/logfiltereddataworker.cpp` (lines 319, 456, 485, 623, 708)
+- Disconnect/reconnect: `src/ui/src/crawlerwidget.cpp` (lines 1830–1831, 1904–1905)
+- Slot: `CrawlerWidget::updateFilteredView()` — `src/ui/src/crawlerwidget.cpp:630`
+
+**Proposed fix:**
+1. Add a monotonic `uint64_t` generation counter to `LogFilteredData`, incremented by `runSearch()` / `updateSearch()`
+2. Extend `searchProgressed` signal to carry the generation ID
+3. In `CrawlerWidget::updateFilteredView()`, ignore signals where `generation != activeSearchGeneration_`
+4. Remove the disconnect/reconnect calls in `replaceCurrentSearch()`
+
+**Trade-offs:**
+Cross-cutting change touching signal signature, all emit sites, and all connected slots.
+Should be done in a dedicated PR with thorough regression testing.
+
+**Resolution:**
+Implemented in branch `docs/backlog-generation-id`.  The wire type for the
+generation argument is plain `quint64` rather than the
+`LogFilteredDataWorker::OperationGeneration` typedef, because moc treats
+typedefs of non-builtin types as unregistered metatypes and `QSignalSpy`
+decodes the `QVariant` back to 0; the typedef alias is kept for
+code-readability but does not appear in any `Q_SIGNAL` signature.  Two
+new SCENARIOs in `tests/ui/logfiltereddata_test.cpp` cover generation
+increment and signal payload.  Receiver-side staleness gate is factored
+into `klogg::isStaleSearchGeneration` (`src/logdata/include/searchgeneration.h`)
+with its own unit test.  Cache-hit path bumps the generation via
+`LogFilteredDataWorker::bumpGeneration()` so prior-search progress
+signals are correctly dropped.
+
+### TASK-002: Chart Panel
+
+**Scenario:**
+Render a time-series chart of regex-matched events inside klogg so that
+post-mortem analysis goes beyond "search & scroll" into "see when things
+happen and how often".
+
+**Spec:** [`SPEC_CHART_AND_FILTERS_PANEL.md`](SPEC_CHART_AND_FILTERS_PANEL.md)
+covers goals / non-goals, UX, data model, three phased iterations
+(Phase 1: filter-frequency on a line-number axis; Phase 2: capture-group
+numeric aggregation; Phase 3: optional timestamp axis), files affected,
+testing strategy, and effort estimate (~5 weeks for Phase 1 + 2).
+
+**Recommended order:** ship after TASK-003.
+
+### TASK-003: Filters Panel
+
+**Scenario:**
+Surface the existing Predefined Filters feature as a persistent
+left-side dock with grouping and pinning, so users can toggle filter
+sets in one click instead of opening a multi-step dialog.
+
+**Spec:** [`SPEC_CHART_AND_FILTERS_PANEL.md`](SPEC_CHART_AND_FILTERS_PANEL.md)
+covers goals / non-goals, UX (tree view + drag-drop + per-group pin),
+data-model migration (legacy flat list → grouped collection), three
+phased iterations, testing strategy, and effort estimate (~1.5 weeks
+to feature-complete).
+
+**Recommended order:** ship before TASK-002.

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -73,6 +73,134 @@ PATTERNS: list[dict] = [
     },
 ]
 
+# Multi-line patterns: checked separately via whole-file analysis.
+# Each entry has a name, a description, and a check function that
+# receives the file text and path, returning a list of
+# (line_number, message) tuples.
+
+def _check_unguarded_platform_helper(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag namespace-scope function definitions that appear *before* an
+    #ifdef Q_OS_* but whose *only* call sites are inside that #ifdef.
+
+    This catches the pattern that broke Linux CI in PR #14: a helper
+    function defined outside any platform guard but only called inside
+    #ifdef Q_OS_MAC, which triggers -Werror=unused-function on other
+    platforms.
+
+    The check is heuristic-based (regex, not a real preprocessor) and
+    focuses on anonymous-namespace and static free functions.
+    """
+    if ALLOW_MARKER in text:
+        return []
+
+    findings: list[tuple[int, str]] = []
+
+    # Collect top-level function definitions (anonymous-namespace or static).
+    # Matches lines like:  QStringList functionName( ... )  or  static void foo()
+    func_def_re = re.compile(
+        r"^(?:static\s+)?[\w:<>]+\s+\*?\s*(\w+)\s*\([^)]*\)\s*$"
+    )
+    # Collect #ifdef Q_OS_* guards.
+    ifdef_re = re.compile(r"^\s*#\s*if(?:def|n?def)?\s+(Q_OS_\w+)")
+    endif_re = re.compile(r"^\s*#\s*endif")
+
+    lines = text.splitlines()
+    # Build a map: function_name -> definition_line_number
+    func_defs: dict[str, int] = {}
+    for i, line in enumerate(lines, start=1):
+        m = func_def_re.match(line)
+        if m:
+            func_defs[m.group(1)] = i
+
+    if not func_defs:
+        return findings
+
+    # For each function, check whether all call sites are inside the same
+    # #ifdef Q_OS_* block, and the definition is NOT.
+    for func_name, def_line in func_defs.items():
+        call_re = re.compile(rf"\b{re.escape(func_name)}\s*\(")
+        # Find all call-site lines.
+        call_lines = [
+            (i, line)
+            for i, line in enumerate(lines, start=1)
+            if i != def_line and call_re.search(line) and not line.strip().startswith("#")
+        ]
+        if not call_lines:
+            # Unused function — that's a different problem (-Wunused),
+            # not a platform-guard mismatch. Skip.
+            continue
+
+        # Determine the #ifdef context of the definition line.
+        def_guard = _guard_at_line(lines, def_line)
+        # Determine the #ifdef context of each call site.
+        call_guards = {_guard_at_line(lines, cl[0]) for cl in call_lines}
+
+        # If *all* call sites share a guard that the definition does NOT have,
+        # the definition is unguarded and will cause -Werror=unused-function
+        # on other platforms.  If any call site is outside any guard (None),
+        # the function IS used on all platforms and this is not a problem.
+        if None in call_guards:
+            continue
+        common_guards = call_guards - {None}
+        if common_guards and def_guard not in common_guards:
+            for guard in common_guards:
+                findings.append(
+                    (
+                        def_line,
+                        f"Function '{func_name}' is defined outside #ifdef {guard} "
+                        f"but all call sites are inside it. This will cause "
+                        f"-Werror=unused-function on other platforms. "
+                        f"Move the definition inside the same #ifdef {guard} guard.",
+                    )
+                )
+                break  # one report per function is enough
+
+    return findings
+
+
+_GUARD_RE = re.compile(r"^\s*#\s*if(?:def|n?def)?\s+(Q_OS_\w+)")
+_ELSE_RE = re.compile(r"^\s*#\s*else")
+_ENDIF_RE = re.compile(r"^\s*#\s*endif")
+
+
+def _guard_at_line(lines: list[str], target: int) -> str | None:
+    """Return the innermost active #ifdef Q_OS_* guard at the given
+    1-based line number, or None if the line is not inside any such guard.
+
+    Returns None for lines inside #else branches (they run on the
+    complementary platform set, so a function used there IS used on
+    other platforms).
+    """
+    # Each entry is (guard_name, in_else: bool)
+    guard_stack: list[tuple[str, bool]] = []
+    for i, line in enumerate(lines, start=1):
+        if i > target:
+            break
+        m = _GUARD_RE.match(line)
+        if m:
+            guard_stack.append((m.group(1), False))
+        elif _ELSE_RE.match(line):
+            if guard_stack:
+                name, _ = guard_stack[-1]
+                guard_stack[-1] = (name, True)
+        elif _ENDIF_RE.match(line):
+            if guard_stack:
+                guard_stack.pop()
+    if guard_stack:
+        name, in_else = guard_stack[-1]
+        # If we're in the #else branch, the code runs on all platforms
+        # EXCEPT the guarded one — treat as unguarded (None).
+        return None if in_else else name
+    return None
+
+
+MULTI_LINE_CHECKS: list[dict] = [
+    {
+        "name": "unguarded-platform-helper",
+        "check": _check_unguarded_platform_helper,
+    },
+]
+
 
 def iter_target_files(paths: Iterable[Path]) -> Iterable[Path]:
     for root in paths:
@@ -102,6 +230,8 @@ def lint_file(path: Path) -> int:
     except OSError:
         return 0
     issues = 0
+
+    # Single-line patterns.
     for line_num, raw in enumerate(text.splitlines(), start=1):
         if ALLOW_MARKER in raw:
             continue
@@ -113,6 +243,17 @@ def lint_file(path: Path) -> int:
                 print(f"  fix: {pat['fix']}")
                 print()
                 issues += 1
+
+    # Multi-line checks.
+    for check in MULTI_LINE_CHECKS:
+        findings = check["check"](text, path)
+        for line_num, message in findings:
+            print(f"[platform-fragile] {check['name']}")
+            print(f"  at {path}:{line_num}")
+            print(f"  {message}")
+            print()
+            issues += len(findings)
+
     return issues
 
 

--- a/src/ui/include/commandargumenttokenizer.h
+++ b/src/ui/include/commandargumenttokenizer.h
@@ -3,8 +3,27 @@
 
 #include <QString>
 #include <QStringList>
+#include <QStandardPaths>
 
 namespace ui::internal {
+
+inline QString expandTildePath( const QString& path )
+{
+    if ( !path.startsWith( QLatin1Char( '~' ) ) ) {
+        return path;
+    }
+
+    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
+    if ( homeDir.isEmpty() ) {
+        return path;
+    }
+
+    if ( path.length() == 1 || path[ 1 ] == QLatin1Char( '/' ) ) {
+        return homeDir + path.mid( 1 );
+    }
+
+    return path;
+}
 
 inline bool canEscapeArgumentCharacter( const QChar nextChar, const QChar quoteChar )
 {

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -8,6 +8,8 @@
 #include <QProcessEnvironment>
 
 namespace {
+
+using ui::internal::expandTildePath;
 // See AdbProcessTransport::detectAdbExecutable for rationale and probe order.
 QString findAdbAtKnownLocation()
 {
@@ -60,9 +62,9 @@ QString findAdbAtKnownLocation()
 
 QString normalizedExecutable( const QString& adbExecutable )
 {
-    const auto trimmed = adbExecutable.trimmed();
-    if ( !trimmed.isEmpty() ) {
-        return trimmed;
+    const auto expanded = expandTildePath( adbExecutable.trimmed() );
+    if ( !expanded.isEmpty() ) {
+        return expanded;
     }
 
     const auto resolved = findAdbAtKnownLocation();

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -15,15 +15,34 @@
 namespace {
 
 using ui::internal::splitCommandArguments;
+using ui::internal::expandTildePath;
 
-QString findExecutableAtKnownLocation( const QString& executable )
+QStringList knownExecutableCandidatePaths( const QString& executable )
 {
-#ifdef Q_OS_MAC
-    const QStringList candidates{
+    QStringList candidates{
         QDir::cleanPath( QStringLiteral( "/opt/homebrew/bin/" ) + executable ),
         QDir::cleanPath( QStringLiteral( "/usr/local/bin/" ) + executable ),
     };
 
+#ifdef Q_OS_MAC
+    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
+    if ( !homeDir.isEmpty() ) {
+        const auto pythonRoot = QDir( homeDir + QStringLiteral( "/Library/Python" ) );
+        const auto versionDirs = pythonRoot.entryList( QDir::Dirs | QDir::NoDotAndDotDot );
+        for ( const auto& version : versionDirs ) {
+            candidates.append(
+                QDir::cleanPath( pythonRoot.absoluteFilePath( version + QStringLiteral( "/bin/" ) + executable ) ) );
+        }
+    }
+#endif
+
+    return candidates;
+}
+
+QString findExecutableAtKnownLocation( const QString& executable )
+{
+#ifdef Q_OS_MAC
+    const auto candidates = knownExecutableCandidatePaths( executable );
     for ( const auto& candidate : candidates ) {
         const QFileInfo info( candidate );
         if ( info.exists() && info.isFile() && info.isExecutable() ) {
@@ -44,9 +63,9 @@ QString findExecutableAtKnownLocation( const QString& executable )
 
 QString normalizedIosSyslogExecutable( const QString& executable )
 {
-    const auto trimmed = executable.trimmed();
-    if ( !trimmed.isEmpty() ) {
-        return trimmed;
+    const auto expanded = expandTildePath( executable.trimmed() );
+    if ( !expanded.isEmpty() ) {
+        return expanded;
     }
 
     const auto detected = findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -17,6 +17,7 @@ namespace {
 using ui::internal::splitCommandArguments;
 using ui::internal::expandTildePath;
 
+#ifdef Q_OS_MAC
 QStringList knownExecutableCandidatePaths( const QString& executable )
 {
     QStringList candidates{
@@ -24,7 +25,6 @@ QStringList knownExecutableCandidatePaths( const QString& executable )
         QDir::cleanPath( QStringLiteral( "/usr/local/bin/" ) + executable ),
     };
 
-#ifdef Q_OS_MAC
     const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
     if ( !homeDir.isEmpty() ) {
         const auto pythonRoot = QDir( homeDir + QStringLiteral( "/Library/Python" ) );
@@ -34,10 +34,10 @@ QStringList knownExecutableCandidatePaths( const QString& executable )
                 QDir::cleanPath( pythonRoot.absoluteFilePath( version + QStringLiteral( "/bin/" ) + executable ) ) );
         }
     }
-#endif
 
     return candidates;
 }
+#endif
 
 QString findExecutableAtKnownLocation( const QString& executable )
 {

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -41,6 +41,7 @@
 #include "adbprocesstransport.h"
 #include "adblogcatsource.h"
 #include "adblogcatdialog.h"
+#include "commandargumenttokenizer.h"
 #include "configuration.h"
 #include "ioslogprocesstransport.h"
 #include "livesourcetransport.h"
@@ -969,4 +970,48 @@ TEST_CASE( "ProcessLiveSourceTransport delivers every line of a slow streaming p
     QCoreApplication::processEvents();
     QTest::qWait( 1500 );
     QCoreApplication::processEvents();
+}
+
+TEST_CASE( "expandTildePath expands bare tilde to home directory" )
+{
+    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
+    REQUIRE( ui::internal::expandTildePath( QStringLiteral( "~" ) ) == homeDir );
+}
+
+TEST_CASE( "expandTildePath expands tilde-slash paths" )
+{
+    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
+    REQUIRE( ui::internal::expandTildePath( QStringLiteral( "~/bin/tool" ) )
+             == homeDir + QStringLiteral( "/bin/tool" ) );
+}
+
+TEST_CASE( "expandTildePath does not expand tilde-user syntax" )
+{
+    const auto input = QStringLiteral( "~otheruser/bin" );
+    REQUIRE( ui::internal::expandTildePath( input ) == input );
+}
+
+TEST_CASE( "expandTildePath leaves non-tilde paths unchanged" )
+{
+    REQUIRE( ui::internal::expandTildePath( QStringLiteral( "/opt/homebrew/bin/tool" ) )
+             == QStringLiteral( "/opt/homebrew/bin/tool" ) );
+    REQUIRE( ui::internal::expandTildePath( QString{} ) == QString{} );
+}
+
+TEST_CASE( "IosLogProcessTransport expands tilde in user-configured executable" )
+{
+    TestIosLogProcessTransport transport( QStringLiteral( "~/Library/Python/3.9/bin/pymobiledevice3" ),
+                                          QStringLiteral( "DEVICE_UDID" ), {} );
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE_FALSE( streaming.program.startsWith( QLatin1Char( '~' ) ) );
+    REQUIRE( streaming.program.contains( QStringLiteral( "Library/Python/3.9/bin/pymobiledevice3" ) ) );
+}
+
+TEST_CASE( "AdbProcessTransport expands tilde in user-configured executable" )
+{
+    TestAdbProcessTransport transport( QStringLiteral( "~/android/sdk/platform-tools/adb" ),
+                                       QStringLiteral( "emulator-5554" ), {} );
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE_FALSE( streaming.program.startsWith( QLatin1Char( '~' ) ) );
+    REQUIRE( streaming.program.contains( QStringLiteral( "android/sdk/platform-tools/adb" ) ) );
 }


### PR DESCRIPTION
## Summary
- Add `~/Library/Python/X.Y/bin/` to the executable search path so `pymobiledevice3` installed via `pip install --user` is found automatically on macOS.
- Add `expandTildePath()` to expand `~` and `~/` in user-configured executable paths before passing them to QProcess, which does not perform tilde expansion.
- Apply tilde expansion in both iOS and ADB transport normalized-executable paths.
- Add 6 unit tests covering `expandTildePath` edge cases and tilde expansion in both transport types.

## Background
- Introduced by: PR #13 added iOS live log streaming but only searched `/opt/homebrew/bin` and `/usr/local/bin` for `pymobiledevice3`, and passed user-configured paths to `QProcess` without expanding `~`.
- Use case: A user installs `pymobiledevice3` via `pip install --user` (lands in `~/Library/Python/3.X/bin/`) or types a `~/...` path in the iOS/ADB dialog executable field, then opens a live log stream.
- How to reproduce:
  1. Install `pymobiledevice3` only at `~/Library/Python/3.9/bin/`.
  2. Launch klogg from Finder (does not inherit shell PATH).
  3. Click **File → Open iOS Log Stream** → "Child process set up failed: execute: No such file or directory".
  4. Or: enter `~/Library/Python/3.9/bin/pymobiledevice3` in the executable field → same error.
- Root cause: Two issues:
  1. `findExecutableAtKnownLocation()` only probed `/opt/homebrew/bin` and `/usr/local/bin`, missing `~/Library/Python/X.Y/bin/`.
  2. `QProcess` does not expand `~`; user-typed paths like `~/Library/Python/3.9/bin/pymobiledevice3` were treated as literal directory names.
- How to fix:
  - `knownExecutableCandidatePaths()` dynamically scans `~/Library/Python/` subdirectories for versioned `bin/` folders.
  - `expandTildePath()` in `commandargumenttokenizer.h` (shared between iOS and ADB transports) replaces leading `~` or `~/` with the home directory, preserving `~user` syntax.
  - Applied in both `normalizedIosSyslogExecutable()` and `normalizedExecutable()`.

## Tests
- `./build/output/klogg_tests "expandTildePath*"` — 4 test cases, 5 assertions
- `./build/output/klogg_tests "*tilde in user-configured executable*"` — 2 test cases, 4 assertions
- `./build/output/klogg_tests "IosLogProcessTransport*"` — 6 test cases, 15 assertions
- `./build/output/klogg_tests "AdbProcessTransport*"` — 9 test cases, 22 assertions
- `./build/output/klogg_tests` — full suite: 103 test cases, 4764 assertions, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tilde (`~`) path expansion in executable path configuration for ADB and iOS logging processes. Users can now specify paths like `~/tools/adb` which will automatically expand to their home directory.

* **Tests**
  * Added unit tests verifying tilde path expansion and executable path normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/14)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->