### PR TITLE
Fix iOS device display, search UI freeze, and prefetch CI deps

### DIFF
--- a/.github/actions/agent-setup/action.yml
+++ b/.github/actions/agent-setup/action.yml
@@ -6,20 +6,13 @@ runs:
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master
 
-    - name: Cache Qt
-      id: cache-qt
-      uses: actions/cache@v4
-      with:
-        path: ../Qt
-        key: ${{ matrix.config.os }}-${{ matrix.config.arch }}-${{ matrix.config.qt_version }}-QtCache
-
     - name: Install Qt
       if: ${{ matrix.config.qt_arch }}
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: ${{ matrix.config.qt_version }}
         arch: ${{ matrix.config.qt_arch }}
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+        cache: true
         modules: ${{ matrix.config.qt_modules }}
         archives: ${{ matrix.config.qt_archives || 'qtbase icu' }}
 

--- a/.github/actions/prepare-workspace-env/action.yml
+++ b/.github/actions/prepare-workspace-env/action.yml
@@ -16,12 +16,12 @@ runs:
       if: "startsWith(matrix.config.qt_version, '5')"
       shell: sh
       run: |
-        echo "KLOGG_QT=Qt5" >> $GITHUB_ENV 
-        echo "KLOGG_QT_DIR=${{ env.Qt5_Dir }}" >> $GITHUB_ENV
-    
+        echo "KLOGG_QT=Qt5" >> $GITHUB_ENV
+        echo "KLOGG_QT_DIR=${{ env.Qt5_DIR }}" >> $GITHUB_ENV
+
     - name: Set qt env var
       if: "startsWith(matrix.config.qt_version, '6')"
       shell: sh
       run: |
-        echo "KLOGG_QT=Qt6" >> $GITHUB_ENV 
-        echo "KLOGG_QT_DIR=${{ env.Qt6_Dir }}" >> $GITHUB_ENV
+        echo "KLOGG_QT=Qt6" >> $GITHUB_ENV
+        echo "KLOGG_QT_DIR=${{ env.Qt6_DIR }}" >> $GITHUB_ENV

--- a/.github/actions/prepare-workspace-env/action.yml
+++ b/.github/actions/prepare-workspace-env/action.yml
@@ -17,11 +17,13 @@ runs:
       shell: sh
       run: |
         echo "KLOGG_QT=Qt5" >> $GITHUB_ENV
-        echo "KLOGG_QT_DIR=${{ env.Qt5_DIR }}" >> $GITHUB_ENV
+        # install-qt-action sets QT_ROOT_DIR to the Qt root (where bin/
+        # and plugins/ live), which is exactly what KLOGG_QT_DIR needs.
+        echo "KLOGG_QT_DIR=${{ env.QT_ROOT_DIR }}" >> $GITHUB_ENV
 
     - name: Set qt env var
       if: "startsWith(matrix.config.qt_version, '6')"
       shell: sh
       run: |
         echo "KLOGG_QT=Qt6" >> $GITHUB_ENV
-        echo "KLOGG_QT_DIR=${{ env.Qt6_DIR }}" >> $GITHUB_ENV
+        echo "KLOGG_QT_DIR=${{ env.QT_ROOT_DIR }}" >> $GITHUB_ENV

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -141,6 +141,40 @@ jobs:
             sleep $((attempt * 10))
           done
 
+      - name: Prefetch linuxdeployqt artifact
+        shell: sh
+        run: |
+          PREFETCH_ROOT="$KLOGG_WORKSPACE/prefetch_artifacts"
+          LINUXDEPLOYQT="$PREFETCH_ROOT/linuxdeployqt-continuous-x86_64.AppImage"
+          LINUXDEPLOYQT_URL="https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+
+          mkdir -p "$PREFETCH_ROOT"
+
+          attempt=1
+          max_attempts=3
+          while [ $attempt -le $max_attempts ]; do
+            rm -f "$LINUXDEPLOYQT"
+
+            if curl --fail --retry 3 --retry-delay 10 --progress-bar --location \
+              --output "$LINUXDEPLOYQT" "$LINUXDEPLOYQT_URL"; then
+              if file "$LINUXDEPLOYQT" | grep -q "ELF"; then
+                chmod +x "$LINUXDEPLOYQT"
+                exit 0
+              fi
+              echo "Downloaded file is not a valid ELF/AppImage binary, retrying..."
+              rm -f "$LINUXDEPLOYQT"
+            fi
+
+            if [ $attempt -eq $max_attempts ]; then
+              echo "::error::Failed to download linuxdeployqt after $max_attempts attempts"
+              exit 1
+            fi
+
+            echo "linuxdeployqt prefetch attempt $attempt failed, retrying after backoff..."
+            attempt=$((attempt + 1))
+            sleep $((attempt * 10))
+          done
+
       - uses: actions/upload-artifact@v4
         with:
           name: cpm-cache
@@ -158,6 +192,12 @@ jobs:
         with:
           name: openssl-archive
           path: prefetch_artifacts/openssl.zip
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linuxdeployqt
+          path: prefetch_artifacts/linuxdeployqt-continuous-x86_64.AppImage
           if-no-files-found: error
 
   Linux:
@@ -218,6 +258,11 @@ jobs:
         with:
           name: cpm-cache
           path: ${{ github.workspace }}/cpm_cache
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: linuxdeployqt
+          path: ${{ github.workspace }}/tools
 
       #- uses: satackey/action-docker-layer-caching@v0.0.11
       #  # Ignore the failure of a step and avoid terminating the job.

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -55,6 +55,7 @@ jobs:
       KLOGG_WORKSPACE: ${{ github.workspace }}
       BOOST_URL: https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2/download
       OPENSSL_URL: https://www.firedaemon.com/download-firedaemon-openssl-1.1.1-zip
+      CMAKE_INSTALLER_URL: https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh
     steps:
       - uses: actions/checkout@v4
 
@@ -175,6 +176,39 @@ jobs:
             sleep $((attempt * 10))
           done
 
+      - name: Prefetch CMake installer
+        shell: sh
+        run: |
+          PREFETCH_ROOT="$KLOGG_WORKSPACE/prefetch_artifacts"
+          CMAKE_INSTALLER="$PREFETCH_ROOT/cmake-3.20.2-linux-x86_64.sh"
+
+          mkdir -p "$PREFETCH_ROOT"
+
+          attempt=1
+          max_attempts=3
+          while [ $attempt -le $max_attempts ]; do
+            rm -f "$CMAKE_INSTALLER"
+
+            if curl --fail --retry 3 --retry-delay 10 --progress-bar --location \
+              --output "$CMAKE_INSTALLER" "$CMAKE_INSTALLER_URL"; then
+              if head -1 "$CMAKE_INSTALLER" | grep -q '#!/'; then
+                chmod +x "$CMAKE_INSTALLER"
+                exit 0
+              fi
+              echo "Downloaded file is not a valid shell script, retrying..."
+              rm -f "$CMAKE_INSTALLER"
+            fi
+
+            if [ $attempt -eq $max_attempts ]; then
+              echo "::error::Failed to download CMake installer after $max_attempts attempts"
+              exit 1
+            fi
+
+            echo "CMake installer prefetch attempt $attempt failed, retrying after backoff..."
+            attempt=$((attempt + 1))
+            sleep $((attempt * 10))
+          done
+
       - uses: actions/upload-artifact@v4
         with:
           name: cpm-cache
@@ -198,6 +232,12 @@ jobs:
         with:
           name: linuxdeployqt
           path: prefetch_artifacts/linuxdeployqt-continuous-x86_64.AppImage
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cmake-installer
+          path: prefetch_artifacts/cmake-3.20.2-linux-x86_64.sh
           if-no-files-found: error
 
   Linux:
@@ -264,11 +304,21 @@ jobs:
           name: linuxdeployqt
           path: ${{ github.workspace }}/tools
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: cmake-installer
+          path: ${{ github.workspace }}/tools
+
+      - name: Copy CMake installer to Docker context
+        shell: sh
+        run: |
+          cp "${{ github.workspace }}/tools/cmake-3.20.2-linux-x86_64.sh" "${{ matrix.config.container_root }}/"
+
       #- uses: satackey/action-docker-layer-caching@v0.0.11
       #  # Ignore the failure of a step and avoid terminating the job.
       #  continue-on-error: true
-      
-      - name: Build container 
+
+      - name: Build container
         run: |
           cd ${{ matrix.config.container_root }}
           docker build -t ${{ matrix.config.container }} .

--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ Binaries for all platforms are available from [GitHub Releases](https://github.c
 
 ### Continuous builds
 
-| Windows | Linux | Mac |
-| ------------- |------------- | ------------- |
-| [continuous-win](https://github.com/ZEACENT/klogg/releases/tag/continuous-win) | [continuous-linux](https://github.com/ZEACENT/klogg/releases/tag/continuous-linux) | [continuous-osx](https://github.com/ZEACENT/klogg/releases/tag/continuous-osx) |
+Automated pre-release builds for all platforms are available from the [continuous release](https://github.com/ZEACENT/klogg/releases/tag/continuous).
 
 ## Building
 

--- a/docker/oracle7/Dockerfile
+++ b/docker/oracle7/Dockerfile
@@ -10,9 +10,9 @@ RUN yum update -y && \
     devtoolset-7-gcc devtoolset-7-gcc-c++ ninja-build && \
     yum clean all
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:/opt/bin:$PATH

--- a/docker/oracle8/Dockerfile
+++ b/docker/oracle8/Dockerfile
@@ -10,10 +10,10 @@ RUN yum update -y && \
     gcc gcc-c++ elfutils-devel && \
     yum clean all
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 RUN wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip && \
     unzip ninja-linux.zip && chmod 755 ninja && mv ninja /opt/bin && rm ninja-linux.zip

--- a/docker/ubuntu20.04/Dockerfile
+++ b/docker/ubuntu20.04/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update -y && \
                     fuse file -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 ENV PATH=/opt/bin:$PATH
 ENV CC=/usr/bin/gcc-13

--- a/docker/ubuntu20.04_qt5.15/Dockerfile
+++ b/docker/ubuntu20.04_qt5.15/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update -y && \
                     wget ca-certificates fuse file -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 ENV PATH=/opt/bin:/opt/qt515/bin:$PATH

--- a/docker/ubuntu22.04/Dockerfile
+++ b/docker/ubuntu22.04/Dockerfile
@@ -11,9 +11,9 @@ RUN apt update -y && \
                     wget ca-certificates fuse file -y && \
     apt clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 ENV PATH=/opt/bin:$PATH

--- a/docker/ubuntu24.04/Dockerfile
+++ b/docker/ubuntu24.04/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update -y && \
                     wget ca-certificates fuse file -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2-linux-x86_64.sh && \
-    chmod 755 cmake-3.20.2-linux-x86_64.sh && \
-    ./cmake-3.20.2-linux-x86_64.sh --prefix=/opt/ --exclude-subdir --skip-license && \
-    rm cmake-3.20.2-linux-x86_64.sh
+COPY cmake-3.20.2-linux-x86_64.sh /tmp/cmake-installer.sh
+RUN chmod 755 /tmp/cmake-installer.sh && \
+    /tmp/cmake-installer.sh --prefix=/opt/ --exclude-subdir --skip-license && \
+    rm /tmp/cmake-installer.sh
 
 ENV PATH=/opt/bin:$PATH

--- a/packaging/linux/appimage/generate_appimage.sh
+++ b/packaging/linux/appimage/generate_appimage.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
+set -euo pipefail
 
 DESTDIR=$(readlink -f appdir) ninja install
-wget -c -q "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+
+LINUXDEPLOYQT_SRC="/usr/local/tools/linuxdeployqt-continuous-x86_64.AppImage"
+if [ ! -f "$LINUXDEPLOYQT_SRC" ]; then
+  echo "ERROR: linuxdeployqt not found at $LINUXDEPLOYQT_SRC"
+  exit 1
+fi
+
+cp "$LINUXDEPLOYQT_SRC" ./linuxdeployqt-continuous-x86_64.AppImage
 chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 
 VERSION=$KLOGG_VERSION ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -bundle-non-qt-libs

--- a/src/logdata/include/logfiltereddataworker.h
+++ b/src/logdata/include/logfiltereddataworker.h
@@ -42,7 +42,10 @@
 #include <QObject>
 
 #include <atomic>
+#include <condition_variable>
 #include <cstdint>
+#include <mutex>
+#include <optional>
 #include <thread>
 
 #ifndef Q_MOC_RUN
@@ -206,10 +209,13 @@ public:
     LogFilteredDataWorker( LogFilteredDataWorker&& ) = delete;
     LogFilteredDataWorker& operator=( LogFilteredDataWorker&& ) = delete;
 
-    // Start the search with the passed regexp
+    // Start the search with the passed regexp (non-blocking).
+    // The actual search is started on an internal dispatch thread,
+    // so the caller (typically the main/UI thread) is never blocked
+    // waiting for a previous search to release the operations mutex.
     void search( const RegularExpressionPattern& regExp, LineNumber startLine, LineNumber endLine );
     // Continue the previous search starting at the passed position
-    // in the source file (line number)
+    // in the source file (line number).  Also non-blocking.
     void updateSearch( const RegularExpressionPattern& regExp, LineNumber startLine,
                        LineNumber endLine, LineNumber position );
 
@@ -264,6 +270,30 @@ private:
                                             LineNumber initialLine,
                                             OperationGeneration generation );
     void emitSearchFinishedOnOwnerThread( OperationGeneration generation );
+
+    // Async dispatch ----------------------------------------------------------
+    // search() / updateSearch() enqueue a SearchRequest and return immediately.
+    // A dedicated dispatch thread waits for the operations mutex, joins the
+    // previous search thread, and starts the new one — so the caller (UI
+    // thread) never blocks on the mutex.
+    struct SearchRequest {
+        enum class Type { Full, Update } type;
+        RegularExpressionPattern regExp;
+        LineNumber startLine;
+        LineNumber endLine;
+        LineNumber position; // only for Update
+        OperationGeneration generation;
+        std::shared_ptr<RegularExpression> compiled;
+    };
+
+    void dispatchLoop();
+    void enqueueRequest( SearchRequest request );
+
+    std::thread dispatchThread_;
+    std::mutex requestMutex_;
+    std::condition_variable requestCv_;
+    std::optional<SearchRequest> pendingRequest_;
+    bool dispatchShutdown_ = false;
 
 private:
     // sourceLogData_, interruptRequested_, operationsMutex_, and searchData_ must all

--- a/src/logdata/src/logfiltereddataworker.cpp
+++ b/src/logdata/src/logfiltereddataworker.cpp
@@ -190,10 +190,21 @@ void SearchData::clear()
 LogFilteredDataWorker::LogFilteredDataWorker( const SearchableLogData& sourceLogData )
     : sourceLogData_( sourceLogData )
 {
+    dispatchThread_ = std::thread( [ this ] { dispatchLoop(); } );
 }
 
 LogFilteredDataWorker::~LogFilteredDataWorker() noexcept
 {
+    // Shut down the dispatch thread first.
+    {
+        std::lock_guard<std::mutex> lock( requestMutex_ );
+        dispatchShutdown_ = true;
+    }
+    requestCv_.notify_one();
+    if ( dispatchThread_.joinable() ) {
+        dispatchThread_.join();
+    }
+
     // Signal any running task to stop, then wait for the thread to fully exit
     // before any other members are destroyed.  std::thread::join() guarantees
     // the OS thread has completely exited -- no race with internal Qt thread-pool
@@ -228,29 +239,12 @@ void LogFilteredDataWorker::connectSignalsAndRun( SearchOperation* operationRequ
 void LogFilteredDataWorker::search( const RegularExpressionPattern& regExp, LineNumber startLine,
                                     LineNumber endLine )
 {
-    ScopedLock locker( operationsMutex_ ); // to protect operationRequested_
-    // ScopedLock blocks until the previous task releases operationsMutex_, so by
-    // the time we get here the previous task function has returned.  join() then
-    // waits for the OS thread to fully exit before we start a new one.
-    if ( opThread_.joinable() ) {
-        opThread_.join();
-    }
-    interruptRequested_.clear();
     const auto generation = operationGeneration_.fetch_add( 1 ) + 1;
-
-    LOG_INFO << "Search requested";
+    LOG_INFO << "Search requested (async dispatch, gen " << generation << ")";
     compiledExpression_ = std::make_shared<RegularExpression>( regExp );
-    QSemaphore operationStarted;
-    auto compiled = compiledExpression_;
-    opThread_ = std::thread( [ this, &operationStarted, regExp, startLine, endLine, generation,
-                               compiled ] {
-        operationStarted.release();
-        ScopedLock operationLock( operationsMutex_ );
-        auto operationRequested = std::make_unique<FullSearchOperation>(
-            sourceLogData_, interruptRequested_, regExp, startLine, endLine, compiled );
-        connectSignalsAndRun( operationRequested.get(), generation );
-    } );
-    operationStarted.acquire();
+
+    enqueueRequest( SearchRequest{ SearchRequest::Type::Full, regExp, startLine, endLine, {},
+                                   generation, compiledExpression_ } );
 }
 
 void LogFilteredDataWorker::updateSearch( const RegularExpressionPattern& regExp,
@@ -258,32 +252,90 @@ void LogFilteredDataWorker::updateSearch( const RegularExpressionPattern& regExp
                                           LineNumber position )
 {
     // Signal any running search to stop at the next chunk boundary so that
-    // operationsMutex_ is released quickly.  Without this, the main thread
-    // blocks here until the entire previous search finishes -- the root cause
-    // of UI freezes during live-source streaming (ADB logcat, etc.).
+    // operationsMutex_ is released quickly.
     interruptRequested_.set();
 
-    ScopedLock locker( operationsMutex_ ); // to protect operationRequested_
-    if ( opThread_.joinable() ) {
-        opThread_.join();
-    }
-    interruptRequested_.clear();
     const auto generation = operationGeneration_.fetch_add( 1 ) + 1;
+    LOG_INFO << "Search update requested from " << position.get()
+             << " (async dispatch, gen " << generation << ")";
 
-    LOG_INFO << "Search update requested from " << position.get();
+    enqueueRequest( SearchRequest{ SearchRequest::Type::Update, regExp, startLine, endLine, position,
+                                   generation, compiledExpression_ } );
+}
 
-    QSemaphore operationStarted;
-    auto compiled = compiledExpression_; // reuse compiled expression from previous search/update
-    opThread_ = std::thread( [ this, &operationStarted, regExp, startLine, endLine, position,
-                               generation, compiled ] {
-        operationStarted.release();
-        ScopedLock operationLock( operationsMutex_ );
-        auto operationRequested = std::make_unique<UpdateSearchOperation>(
-            sourceLogData_, interruptRequested_, regExp, startLine, endLine, position, compiled );
-        connectSignalsAndRun( operationRequested.get(), generation );
-    } );
+void LogFilteredDataWorker::enqueueRequest( SearchRequest request )
+{
+    interruptRequested_.set();
+    {
+        std::lock_guard<std::mutex> lock( requestMutex_ );
+        pendingRequest_.emplace( std::move( request ) );
+    }
+    requestCv_.notify_one();
+}
 
-    operationStarted.acquire();
+void LogFilteredDataWorker::dispatchLoop()
+{
+    while ( true ) {
+        SearchRequest request;
+        {
+            std::unique_lock<std::mutex> lock( requestMutex_ );
+            requestCv_.wait( lock, [ this ] { return pendingRequest_.has_value() || dispatchShutdown_; } );
+            if ( dispatchShutdown_ && !pendingRequest_.has_value() ) {
+                return;
+            }
+            if ( !pendingRequest_.has_value() ) {
+                continue;
+            }
+            request = std::move( *pendingRequest_ );
+            pendingRequest_.reset();
+        }
+
+        // Acquire the operations mutex — this may block if a previous
+        // search is still running, but that's OK because we're on the
+        // dispatch thread, not the UI thread.
+        ScopedLock locker( operationsMutex_ );
+
+        // Check if this request has been superseded by a newer one.
+        if ( request.generation != operationGeneration_.load() ) {
+            continue;
+        }
+
+        if ( opThread_.joinable() ) {
+            opThread_.join();
+        }
+        interruptRequested_.clear();
+
+        QSemaphore operationStarted;
+        if ( request.type == SearchRequest::Type::Full ) {
+            opThread_ = std::thread(
+                [ this, &operationStarted, request ] {
+                    operationStarted.release();
+                    ScopedLock operationLock( operationsMutex_ );
+                    if ( request.generation != operationGeneration_.load() ) {
+                        return;
+                    }
+                    auto operationRequested = std::make_unique<FullSearchOperation>(
+                        sourceLogData_, interruptRequested_, request.regExp, request.startLine,
+                        request.endLine, request.compiled );
+                    connectSignalsAndRun( operationRequested.get(), request.generation );
+                } );
+        }
+        else {
+            opThread_ = std::thread(
+                [ this, &operationStarted, request ] {
+                    operationStarted.release();
+                    ScopedLock operationLock( operationsMutex_ );
+                    if ( request.generation != operationGeneration_.load() ) {
+                        return;
+                    }
+                    auto operationRequested = std::make_unique<UpdateSearchOperation>(
+                        sourceLogData_, interruptRequested_, request.regExp, request.startLine,
+                        request.endLine, request.position, request.compiled );
+                    connectSignalsAndRun( operationRequested.get(), request.generation );
+                } );
+        }
+        operationStarted.acquire();
+    }
 }
 
 void LogFilteredDataWorker::interrupt()

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/infoline.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogprocesstransport.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosdeviceparser.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathline.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/livesourcetransport.h
@@ -82,6 +83,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/infoline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogprocesstransport.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosdeviceparser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pathline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/livesourcetransport.cpp

--- a/src/ui/include/iosdeviceparser.h
+++ b/src/ui/include/iosdeviceparser.h
@@ -1,0 +1,20 @@
+#ifndef IOSDEVICEPARSER_H
+#define IOSDEVICEPARSER_H
+
+#include <QByteArray>
+#include <QList>
+#include <QString>
+
+struct IosDeviceInfo {
+    QString udid;
+    QString displayName;
+    QString description;
+    QString productType;
+    QString productVersion;
+};
+
+QString stripAnsiSequences( const QString& text );
+QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output );
+QList<IosDeviceInfo> parsePymobiledeviceSimpleDeviceList( const QByteArray& output );
+
+#endif // IOSDEVICEPARSER_H

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -3,13 +3,8 @@
 
 #include <QList>
 
+#include "iosdeviceparser.h"
 #include "livesourcetransport.h"
-
-struct IosDeviceInfo {
-    QString udid;
-    QString displayName;
-    QString description;
-};
 
 class IosLogProcessTransport : public ProcessLiveSourceTransport {
     Q_OBJECT

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -906,7 +906,14 @@ void CrawlerWidget::loadingFinishedHandler( LoadingStatus status )
             }
         }
         else {
-            logFilteredData_->updateSearch( searchStartLine_, searchEndLine_ );
+            // For static files, also defer through the throttle timer to
+            // prevent the main thread from blocking on operationsMutex_ while
+            // a previous search is still running.
+            pendingSearchEndLine_ = searchEndLine_;
+            searchUpdatePending_ = true;
+            if ( !searchUpdateThrottleTimer_.isActive() ) {
+                searchUpdateThrottleTimer_.start( kSearchThrottleActiveMs );
+            }
         }
     }
 

--- a/src/ui/src/iosdeviceparser.cpp
+++ b/src/ui/src/iosdeviceparser.cpp
@@ -1,0 +1,151 @@
+#include "iosdeviceparser.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+namespace {
+
+constexpr ushort Escape = 0x1B;
+constexpr ushort Csi = '[';
+
+bool isCsiFinalByte( const QChar ch )
+{
+    const auto value = ch.unicode();
+    return value >= 0x40 && value <= 0x7e;
+}
+
+QString firstStringValue( const QJsonObject& object, std::initializer_list<const char*> keys )
+{
+    for ( const auto* key : keys ) {
+        const auto value = object.value( QLatin1String( key ) );
+        if ( value.isString() ) {
+            const auto text = value.toString().trimmed();
+            if ( !text.isEmpty() ) {
+                return text;
+            }
+        }
+    }
+
+    return {};
+}
+
+QString buildDisplayName( const QString& name, const QString& udid, const QString& productType,
+                          const QString& productVersion )
+{
+    QStringList parts;
+    if ( !name.isEmpty() ) {
+        parts.append( name );
+    }
+    if ( !udid.isEmpty() ) {
+        parts.append( udid );
+    }
+    if ( !productType.isEmpty() ) {
+        parts.append( productType );
+    }
+    if ( !productVersion.isEmpty() ) {
+        parts.append( productVersion );
+    }
+    return parts.join( QStringLiteral( " " ) );
+}
+
+} // namespace
+
+QString stripAnsiSequences( const QString& text )
+{
+    if ( text.isEmpty() ) {
+        return text;
+    }
+
+    QString result;
+    result.reserve( text.size() );
+
+    for ( int i = 0; i < text.size(); ) {
+        const auto ch = text[ i ];
+        if ( ch.unicode() != Escape || i + 1 >= text.size() || text[ i + 1 ].unicode() != Csi ) {
+            result.append( ch );
+            ++i;
+            continue;
+        }
+
+        int end = i + 2;
+        while ( end < text.size() && !isCsiFinalByte( text[ end ] ) ) {
+            ++end;
+        }
+
+        if ( end >= text.size() ) {
+            result.append( ch );
+            ++i;
+            continue;
+        }
+
+        i = end + 1;
+    }
+
+    return result;
+}
+
+QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output )
+{
+    const auto document = QJsonDocument::fromJson( output );
+    if ( !document.isArray() ) {
+        return {};
+    }
+
+    QList<IosDeviceInfo> devices;
+    for ( const auto& value : document.array() ) {
+        QString udid;
+        QString name;
+        QString productType;
+        QString productVersion;
+
+        if ( value.isString() ) {
+            udid = stripAnsiSequences( value.toString().trimmed() );
+        }
+        else if ( value.isObject() ) {
+            const auto object = value.toObject();
+            udid = stripAnsiSequences(
+                firstStringValue( object, { "Identifier", "UDID", "UniqueDeviceID",
+                                            "SerialNumber", "serial", "udid" } ) );
+            name = stripAnsiSequences(
+                firstStringValue( object, { "DeviceName", "Name", "ProductName", "name" } ) );
+            productType = stripAnsiSequences(
+                firstStringValue( object, { "ProductType", "DeviceClass" } ) );
+            productVersion = stripAnsiSequences(
+                firstStringValue( object, { "ProductVersion" } ) );
+        }
+
+        if ( udid.isEmpty() ) {
+            continue;
+        }
+
+        const auto displayName = buildDisplayName( name, udid, productType, productVersion );
+        const auto description = name.isEmpty() ? udid : name;
+        devices.push_back( IosDeviceInfo{ udid, displayName, description, productType, productVersion } );
+    }
+
+    return devices;
+}
+
+QList<IosDeviceInfo> parsePymobiledeviceSimpleDeviceList( const QByteArray& output )
+{
+    const auto parsed = parsePymobiledeviceDeviceList( output );
+    if ( !parsed.isEmpty() ) {
+        return parsed;
+    }
+
+    QList<IosDeviceInfo> devices;
+    const auto lines = QString::fromUtf8( output ).split( '\n' );
+    for ( auto& line : lines ) {
+        auto cleaned = stripAnsiSequences( line.trimmed() );
+        if ( cleaned.isEmpty() || cleaned.startsWith( QLatin1Char( '[' ) )
+             || cleaned.startsWith( QLatin1Char( ']' ) ) ) {
+            continue;
+        }
+
+        devices.push_back( IosDeviceInfo{ cleaned, cleaned, cleaned, {}, {} } );
+    }
+
+    return devices;
+}

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -1,12 +1,9 @@
 #include "ioslogprocesstransport.h"
 #include "commandargumenttokenizer.h"
+#include "iosdeviceparser.h"
 
 #include <QDir>
 #include <QFileInfo>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonValue>
 #include <QProcess>
 #include <QStandardPaths>
 
@@ -86,76 +83,6 @@ bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
     process.kill();
     process.waitForFinished( 1500 );
     return false;
-}
-
-QString firstStringValue( const QJsonObject& object, std::initializer_list<const char*> keys )
-{
-    for ( const auto* key : keys ) {
-        const auto value = object.value( QLatin1String( key ) );
-        if ( value.isString() ) {
-            const auto text = value.toString().trimmed();
-            if ( !text.isEmpty() ) {
-                return text;
-            }
-        }
-    }
-
-    return {};
-}
-
-QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output )
-{
-    const auto document = QJsonDocument::fromJson( output );
-    if ( !document.isArray() ) {
-        return {};
-    }
-
-    QList<IosDeviceInfo> devices;
-    for ( const auto& value : document.array() ) {
-        QString udid;
-        QString name;
-
-        if ( value.isString() ) {
-            udid = value.toString().trimmed();
-        }
-        else if ( value.isObject() ) {
-            const auto object = value.toObject();
-            udid = firstStringValue( object, { "Identifier", "UDID", "UniqueDeviceID",
-                                               "SerialNumber", "serial", "udid" } );
-            name = firstStringValue( object, { "DeviceName", "Name", "ProductName", "name" } );
-        }
-
-        if ( udid.isEmpty() ) {
-            continue;
-        }
-
-        const auto displayName = name.isEmpty() ? udid : QStringLiteral( "%1 (%2)" ).arg( name, udid );
-        devices.push_back( IosDeviceInfo{ udid, displayName, name.isEmpty() ? udid : name } );
-    }
-
-    return devices;
-}
-
-QList<IosDeviceInfo> parsePymobiledeviceSimpleDeviceList( const QByteArray& output )
-{
-    const auto parsed = parsePymobiledeviceDeviceList( output );
-    if ( !parsed.isEmpty() ) {
-        return parsed;
-    }
-
-    QList<IosDeviceInfo> devices;
-    const auto lines = QString::fromUtf8( output ).split( '\n' );
-    for ( auto line : lines ) {
-        const auto udid = line.trimmed();
-        if ( udid.isEmpty() || udid.startsWith( QLatin1Char( '[' ) )
-             || udid.startsWith( QLatin1Char( ']' ) ) ) {
-            continue;
-        }
-
-        devices.push_back( IosDeviceInfo{ udid, udid, udid } );
-    }
-
-    return devices;
 }
 
 bool runPymobiledeviceListCommand( const QString& executable, const QStringList& arguments,
@@ -240,14 +167,17 @@ QList<IosDeviceInfo> IosLogProcessTransport::listDevices( const QString& executa
 #else
     QList<IosDeviceInfo> devices;
     const auto pymobiledeviceExecutable = normalizedIosSyslogExecutable( executable );
-    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceSimpleListArguments(),
+    // Try the full JSON output first — it includes DeviceName, ProductType,
+    // ProductVersion, etc.  Fall back to --simple (UDID-only) only if the
+    // full listing is not supported by the installed pymobiledevice3 version.
+    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceLegacyListArguments(),
                                         &devices, error ) ) {
-        QString legacyError;
+        QString simpleError;
         if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable,
-                                            pymobiledeviceLegacyListArguments(), &devices,
-                                            &legacyError ) ) {
-            if ( error && !legacyError.isEmpty() ) {
-                *error = legacyError;
+                                            pymobiledeviceSimpleListArguments(), &devices,
+                                            &simpleError ) ) {
+            if ( error && !simpleError.isEmpty() ) {
+                *error = simpleError;
             }
             return {};
         }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(klogg_tests
     adb_ui_transport_test.cpp
     ansicolorprocessor_test.cpp
+    iosdeviceparser_test.cpp
     capturestore_test.cpp
     cli_test.cpp
     colorlabelsmanager_test.cpp

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -331,7 +331,7 @@ TEST_CASE( "IosLogProcessTransport clear command is an inert no-op" )
 #endif
 }
 
-TEST_CASE( "IosLogProcessTransport falls back to legacy pymobiledevice3 device listing" )
+TEST_CASE( "IosLogProcessTransport lists devices using full JSON output" )
 {
 #ifdef Q_OS_MAC
     QTemporaryDir tempDir;
@@ -341,10 +341,8 @@ TEST_CASE( "IosLogProcessTransport falls back to legacy pymobiledevice3 device l
     QFile script( scriptPath );
     REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
     script.write( "#!/bin/sh\n"
-                  "case \"$*\" in\n"
-                  "  *--simple*) echo 'No such option: --simple' >&2; exit 2 ;;\n"
-                  "esac\n"
-                  "printf '[{\"Identifier\":\"00008030\",\"DeviceName\":\"Test iPhone\"}]\\n'\n" );
+                  "printf '[{\"Identifier\":\"00008030\",\"DeviceName\":\"Test iPhone\","
+                  "\"ProductType\":\"iPhone14,2\",\"ProductVersion\":\"17.0\"}]\\n'\n" );
     script.close();
     REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
 
@@ -354,6 +352,36 @@ TEST_CASE( "IosLogProcessTransport falls back to legacy pymobiledevice3 device l
     REQUIRE( devices.size() == 1 );
     CHECK( devices.front().udid == QStringLiteral( "00008030" ) );
     CHECK( devices.front().description == QStringLiteral( "Test iPhone" ) );
+    CHECK( devices.front().productType == QStringLiteral( "iPhone14,2" ) );
+    CHECK( devices.front().productVersion == QStringLiteral( "17.0" ) );
+#else
+    SUCCEED( "pymobiledevice3 device listing is macOS-only." );
+#endif
+}
+
+TEST_CASE( "IosLogProcessTransport falls back to --simple when full listing fails" )
+{
+#ifdef Q_OS_MAC
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "pymobiledevice3" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    // Legacy (full) listing fails; --simple returns UDID-only JSON
+    script.write( "#!/bin/sh\n"
+                  "case \"$*\" in\n"
+                  "  *--simple*) printf '[\"00008030\"]\\n' ;;\n"
+                  "  *) echo 'Full listing not supported' >&2; exit 2 ;;\n"
+                  "esac\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    QString error;
+    const auto devices = IosLogProcessTransport::listDevices( scriptPath, &error );
+    REQUIRE( error.isEmpty() );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices.front().udid == QStringLiteral( "00008030" ) );
 #else
     SUCCEED( "pymobiledevice3 device listing is macOS-only." );
 #endif

--- a/tests/unit/iosdeviceparser_test.cpp
+++ b/tests/unit/iosdeviceparser_test.cpp
@@ -1,0 +1,195 @@
+#include <catch2/catch.hpp>
+
+#include "iosdeviceparser.h"
+
+TEST_CASE( "stripAnsiSequences removes CSI color sequences" )
+{
+    const auto input = QStringLiteral( "\x1b[31mRedText\x1b[0m normal" );
+    const auto result = stripAnsiSequences( input );
+    REQUIRE( result == QStringLiteral( "RedText normal" ) );
+}
+
+TEST_CASE( "stripAnsiSequences removes multi-param CSI sequences" )
+{
+    const auto input = QStringLiteral( "\x1b[38;2;255;0;0mTrueColor\x1b[39m tail\x1b[K" );
+    const auto result = stripAnsiSequences( input );
+    REQUIRE( result == QStringLiteral( "TrueColor tail" ) );
+}
+
+TEST_CASE( "stripAnsiSequences leaves plain text unchanged" )
+{
+    const auto input = QStringLiteral( "plain text no escapes" );
+    REQUIRE( stripAnsiSequences( input ) == input );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList extracts device info from JSON" )
+{
+    const QByteArray json = "[{"
+        "\"Identifier\":\"00008030-001C195E36D8802E\","
+        "\"DeviceName\":\"Test iPhone\","
+        "\"ProductType\":\"iPhone14,2\","
+        "\"ProductVersion\":\"17.0\","
+        "\"BuildVersion\":\"21A329\","
+        "\"ConnectionType\":\"USB\","
+        "\"DeviceClass\":\"iPhone\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008030-001C195E36D8802E" ) );
+    CHECK( devices[ 0 ].productType == QStringLiteral( "iPhone14,2" ) );
+    CHECK( devices[ 0 ].productVersion == QStringLiteral( "17.0" ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList formats displayName on a single line" )
+{
+    const QByteArray json = "[{"
+        "\"Identifier\":\"00008030-001C195E36D8802E\","
+        "\"DeviceName\":\"Test iPhone\","
+        "\"ProductType\":\"iPhone14,2\","
+        "\"ProductVersion\":\"17.0\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+
+    // displayName must be a single line with DeviceName, Identifier, ProductType, ProductVersion
+    const auto& name = devices[ 0 ].displayName;
+    CHECK_FALSE( name.contains( QLatin1Char( '\n' ) ) );
+    CHECK( name.contains( QStringLiteral( "Test iPhone" ) ) );
+    CHECK( name.contains( QStringLiteral( "00008030-001C195E36D8802E" ) ) );
+    CHECK( name.contains( QStringLiteral( "iPhone14,2" ) ) );
+    CHECK( name.contains( QStringLiteral( "17.0" ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList excludes BuildVersion ConnectionType DeviceClass from displayName" )
+{
+    const QByteArray json = "[{"
+        "\"Identifier\":\"00008030\","
+        "\"DeviceName\":\"Test iPhone\","
+        "\"ProductType\":\"iPhone14,2\","
+        "\"ProductVersion\":\"17.0\","
+        "\"BuildVersion\":\"21A329\","
+        "\"ConnectionType\":\"USB\","
+        "\"DeviceClass\":\"iPhone\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+
+    const auto& name = devices[ 0 ].displayName;
+    CHECK_FALSE( name.contains( QStringLiteral( "21A329" ) ) );
+    CHECK_FALSE( name.contains( QStringLiteral( "USB" ) ) );
+    CHECK_FALSE( name.contains( QStringLiteral( "DeviceClass" ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList strips ANSI sequences from JSON values" )
+{
+    // JSON uses  for the ESC character; pymobiledevice3 may emit
+    // ANSI-colored output that ends up embedded in JSON string values.
+    const QByteArray json = "[{"
+        "\"Identifier\":\"\\u001b[32m00008030\\u001b[0m\","
+        "\"DeviceName\":\"\\u001b[33mTest iPhone\\u001b[0m\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008030" ) );
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QChar( 0x1b ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList handles string-array output" )
+{
+    const QByteArray json = "[\"00008030-001C195E36D8802E\"]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008030-001C195E36D8802E" ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList returns empty for invalid JSON" )
+{
+    const QByteArray invalid = "not json at all";
+    REQUIRE( parsePymobiledeviceDeviceList( invalid ).isEmpty() );
+}
+
+TEST_CASE( "parsePymobiledeviceSimpleDeviceList falls back to line-by-line parsing with ANSI stripping" )
+{
+    // Simulates pymobiledevice3 usbmux list --simple output with ANSI codes
+    const QByteArray output =
+        "\x1b[32m00008030-001C195E36D8802E  Test iPhone  iPhone14,2  17.0\x1b[0m\n"
+        "\x1b[34m00008031-002D296F47E9903F  iPad Pro  iPad13,8  17.1\x1b[0m\n";
+
+    const auto devices = parsePymobiledeviceSimpleDeviceList( output );
+    REQUIRE( devices.size() == 2 );
+
+    // ANSI sequences must be stripped
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QStringLiteral( "\x1b" ) ) );
+    CHECK_FALSE( devices[ 1 ].displayName.contains( QStringLiteral( "\x1b" ) ) );
+
+    // displayName must be a single line
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QLatin1Char( '\n' ) ) );
+    CHECK_FALSE( devices[ 1 ].displayName.contains( QLatin1Char( '\n' ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceSimpleDeviceList tries JSON first" )
+{
+    const QByteArray json = "[{"
+        "\"Identifier\":\"00008030\","
+        "\"DeviceName\":\"Test iPhone\","
+        "\"ProductType\":\"iPhone14,2\","
+        "\"ProductVersion\":\"17.0\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceSimpleDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008030" ) );
+    CHECK( devices[ 0 ].productType == QStringLiteral( "iPhone14,2" ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList parses real pymobiledevice3 output" )
+{
+    // Actual output from pymobiledevice3 usbmux list on this machine
+    const QByteArray json = R"([{
+        "BuildVersion": "23E261",
+        "ConnectionType": "USB",
+        "DeviceClass": "iPhone",
+        "DeviceName": "ZEACENT’s iPhone",
+        "Identifier": "00008150-001431410C78401C",
+        "ProductType": "iPhone18,3",
+        "ProductVersion": "26.4.2",
+        "UniqueDeviceID": "00008150-001431410C78401C"
+    }])";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+
+    const auto& device = devices[ 0 ];
+    CHECK( device.udid == QStringLiteral( "00008150-001431410C78401C" ) );
+    CHECK( device.productType == QStringLiteral( "iPhone18,3" ) );
+    CHECK( device.productVersion == QStringLiteral( "26.4.2" ) );
+
+    // displayName must be a single line with DeviceName, Identifier, ProductType, ProductVersion
+    CHECK_FALSE( device.displayName.contains( QLatin1Char( '\n' ) ) );
+    CHECK( device.displayName.contains( QStringLiteral( "ZEACENT" ) ) );
+    CHECK( device.displayName.contains( QStringLiteral( "00008150-001431410C78401C" ) ) );
+    CHECK( device.displayName.contains( QStringLiteral( "iPhone18,3" ) ) );
+    CHECK( device.displayName.contains( QStringLiteral( "26.4.2" ) ) );
+
+    // Should NOT contain BuildVersion, ConnectionType, DeviceClass
+    CHECK_FALSE( device.displayName.contains( QStringLiteral( "23E261" ) ) );
+    CHECK_FALSE( device.displayName.contains( QStringLiteral( "USB" ) ) );
+    CHECK_FALSE( device.displayName.contains( QStringLiteral( "DeviceClass" ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList parses --simple output as UDID-only" )
+{
+    // Actual --simple output: ["UDID"]
+    const QByteArray json = R"(["00008150-001431410C78401C"])";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008150-001431410C78401C" ) );
+    CHECK( devices[ 0 ].productType.isEmpty() );
+    CHECK( devices[ 0 ].productVersion.isEmpty() );
+}


### PR DESCRIPTION
## Summary
- **iOS device display**: Strip ANSI escape sequences, display DeviceName/Identifier/ProductType/ProductVersion on a single line instead of showing all JSON fields (BuildVersion, ConnectionType, DeviceClass, etc.) as a paragraph
- **Search UI freeze**: Add async dispatch thread to `LogFilteredDataWorker` so `search()` and `updateSearch()` never block the main/UI thread on `operationsMutex_`; apply search throttle timer to static files (previously live-source-only)
- **CI prefetch**: Prefetch CMake and linuxdeployqt in CI to speed up builds; upgrade install-qt-action to v4

## Background

**iOS device display**
- Introduced by: The original iOS live source integration (#13) only extracted `Identifier` and `DeviceName` from JSON; the `--simple` flag was tried first, which returns only UDIDs and loses all device metadata
- Use case: User opens "Open iOS Log Stream" dialog with a connected iPhone
- How to reproduce: Connect an iPhone, open the iOS Log Stream dialog — the Device combo showed only the raw UDID or the entire JSON blob with all fields on multiple lines
- Root cause: (1) `--simple` was tried first and returns `["UDID"]` — no DeviceName/ProductType/ProductVersion; (2) no ANSI stripping in the parsing pipeline; (3) displayName was `name (udid)` instead of a single line with product info
- How to fix: Swap command order (full JSON first, `--simple` as fallback); extract ProductType/ProductVersion from JSON; add `stripAnsiSequences()` for CSI escape removal; format displayName as space-separated single line

**Search UI freeze**
- Introduced by: `LogFilteredDataWorker::search()` and `updateSearch()` acquired `operationsMutex_` on the calling (main) thread, blocking the UI until the previous search released the mutex at a chunk boundary
- Use case: User searches a large log file (100k+ lines), then changes the search term while a previous search is still running
- How to reproduce: Open a large log file, start a search, change the search term — the window becomes unresponsive for seconds
- Root cause: Main thread blocks on `operationsMutex_` while a background search thread holds it; for large files with 10k-line chunks this can take seconds per chunk
- How to fix: Offload mutex acquisition and thread joining to a dedicated dispatch thread so the UI thread never blocks; also apply the existing search throttle timer to static files in `loadingFinishedHandler()` (previously only live sources were throttled)

## Tests
- `cmake --build build --target klogg_tests` — 117 test cases, 4823 assertions, all pass
- 15 new unit tests for iOS device parsing including real `pymobiledevice3 usbmux list` output from a connected iPhone (ZEACENT's iPhone, iPhone18,3, iOS 26.4.2)
- Verified device combo shows `ZEACENT's iPhone 00008150-001431410C78401C iPhone18,3 26.4.2` on a single line with no ANSI sequences
- 2 updated integration tests for `IosLogProcessTransport` reflecting new command order (full JSON first, `--simple` as fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS device discovery and richer device info parsing.
  * Non-blocking search model for better responsiveness with large files.

* **Chores**
  * Improved build/tool provisioning and container build process to rely on pre-fetched tooling.
  * Packaging updated to use supplied tooling during AppImage and container builds.

* **Documentation**
  * README updated to document continuous pre-release builds.

* **Tests**
  * Added unit tests covering iOS device parsing and ANSI/JSON handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/15)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->