### PR TITLE
Fix search UI freeze, Ln:1 reset in follow mode, and iOS device display

### DIFF
--- a/src/logdata/src/logfiltereddataworker.cpp
+++ b/src/logdata/src/logfiltereddataworker.cpp
@@ -280,7 +280,8 @@ void LogFilteredDataWorker::dispatchLoop()
         {
             std::unique_lock<std::mutex> lock( requestMutex_ );
             requestCv_.wait( lock, [ this ] { return pendingRequest_.has_value() || dispatchShutdown_; } );
-            if ( dispatchShutdown_ && !pendingRequest_.has_value() ) {
+            if ( dispatchShutdown_ ) {
+                pendingRequest_.reset();
                 return;
             }
             if ( !pendingRequest_.has_value() ) {
@@ -290,12 +291,10 @@ void LogFilteredDataWorker::dispatchLoop()
             pendingRequest_.reset();
         }
 
-        // Acquire the operations mutex — this may block if a previous
-        // search is still running, but that's OK because we're on the
-        // dispatch thread, not the UI thread.
-        ScopedLock locker( operationsMutex_ );
-
-        // Check if this request has been superseded by a newer one.
+        // Check if this request has been superseded by a newer one before
+        // doing any work. Serialization with the previous operation is
+        // provided by joining opThread_ below; the worker itself acquires
+        // operationsMutex_ for the duration of its run.
         if ( request.generation != operationGeneration_.load() ) {
             continue;
         }
@@ -353,6 +352,18 @@ void LogFilteredDataWorker::interrupt()
 
 void LogFilteredDataWorker::waitForDone()
 {
+    // Cancel any queued request and shut down the dispatch thread so that
+    // no new opThread_ can be spawned after this point.
+    {
+        std::lock_guard<std::mutex> lock( requestMutex_ );
+        dispatchShutdown_ = true;
+        pendingRequest_.reset();
+    }
+    requestCv_.notify_one();
+    if ( dispatchThread_.joinable() ) {
+        dispatchThread_.join();
+    }
+
     if ( opThread_.joinable() ) {
         opThread_.join();
     }

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -111,6 +111,9 @@ class CrawlerWidget : public QSplitter,
     // Returns whether follow is enabled in this crawler
     bool isFollowEnabled() const;
 
+    // Returns whether the initial file load has completed
+    bool isFirstLoadDone() const;
+
     bool isTextWrapEnabled() const;
 
     qint64 searchPendingLines() const { return searchPendingLines_; }

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -17,10 +17,12 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     static QString detectIosSyslogExecutable();
 
     bool clearRemote( QString* error ) override;
+    bool connectTransport() override;
 
   protected:
     Command streamingCommand() const override;
     Command clearCommand() const override;
+    void filterReceivedBytes( QByteArray& data ) override;
 
   private:
     QString normalizedExecutable() const;
@@ -30,6 +32,7 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     QString deviceUdid_;
     QString extraArgs_;
     bool ansiOutputEnabled_;
+    bool ptyPrefixStripped_ = false;
 };
 
 #endif

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -52,6 +52,7 @@ class ProcessLiveSourceTransport : public LiveSourceTransport {
   protected:
     virtual Command streamingCommand() const = 0;
     virtual Command clearCommand() const = 0;
+    virtual void filterReceivedBytes( QByteArray& data );
     bool runBlockingCommand( const Command& command, QByteArray* stdErr ) const;
 
   private:

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -280,6 +280,10 @@ void CrawlerWidget::reload()
 {
     searchUpdateThrottleTimer_.stop();
     searchUpdatePending_ = false;
+    if ( searchPendingLines_ != 0 ) {
+        searchPendingLines_ = 0;
+        Q_EMIT searchPendingLinesChanged();
+    }
     searchState_.resetState();
     constexpr auto DropCache = true;
     logFilteredData_->clearSearch( DropCache );
@@ -448,6 +452,10 @@ void CrawlerWidget::stopSearch()
 {
     searchUpdateThrottleTimer_.stop();
     searchUpdatePending_ = false;
+    if ( searchPendingLines_ != 0 ) {
+        searchPendingLines_ = 0;
+        Q_EMIT searchPendingLinesChanged();
+    }
     logFilteredData_->interruptSearch();
     searchState_.stopSearch();
     printSearchInfoMessage();

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -932,7 +932,6 @@ void CrawlerWidget::loadingFinishedHandler( LoadingStatus status )
         changeDataStatus( DataStatus::NEW_DATA );
     }
     else {
-        firstLoadDone_ = true;
         for ( const auto& m : savedMarkedLines_ ) {
             logFilteredData_->addMark( m );
         }
@@ -941,6 +940,11 @@ void CrawlerWidget::loadingFinishedHandler( LoadingStatus status )
 
     loadingInProgress_ = false;
     Q_EMIT loadingFinished( status );
+
+    // Set firstLoadDone_ AFTER emitting loadingFinished so that
+    // MainWindow::handleLoadingFinished can distinguish the initial load
+    // from incremental updates via isFirstLoadDone().
+    firstLoadDone_ = true;
 }
 
 void CrawlerWidget::fireThrottledSearchUpdate()
@@ -963,6 +967,10 @@ void CrawlerWidget::fileChangedHandler( MonitoredFileStatus status )
         logFilteredData_->clearMarks();
         searchUpdateThrottleTimer_.stop();
         searchUpdatePending_ = false;
+        if ( searchPendingLines_ != 0 ) {
+            searchPendingLines_ = 0;
+            Q_EMIT searchPendingLinesChanged();
+        }
         if ( !searchInfoLine_->text().isEmpty() ) {
             // Invalidate the search
             constexpr auto DropCache = true;

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -956,6 +956,8 @@ void CrawlerWidget::fileChangedHandler( MonitoredFileStatus status )
     if ( status == MonitoredFileStatus::Truncated ) {
         // Clear all marks (TODO offer the option to keep them)
         logFilteredData_->clearMarks();
+        searchUpdateThrottleTimer_.stop();
+        searchUpdatePending_ = false;
         if ( !searchInfoLine_->text().isEmpty() ) {
             // Invalidate the search
             constexpr auto DropCache = true;

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -212,6 +212,11 @@ bool CrawlerWidget::isFollowEnabled() const
     return logMainView_->isFollowEnabled();
 }
 
+bool CrawlerWidget::isFirstLoadDone() const
+{
+    return firstLoadDone_;
+}
+
 bool CrawlerWidget::isTextWrapEnabled() const
 {
     return logMainView_->isTextWrapEnabled();

--- a/src/ui/src/iosdeviceparser.cpp
+++ b/src/ui/src/iosdeviceparser.cpp
@@ -88,7 +88,11 @@ QString stripAnsiSequences( const QString& text )
 
 QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output )
 {
-    const auto document = QJsonDocument::fromJson( output );
+    // Strip ANSI escape sequences from the raw output before JSON parsing,
+    // in case pymobiledevice3 emits colored output that corrupts the JSON
+    // structure (e.g. \x1b[32m[{...}]\x1b[0m).
+    const auto cleanedOutput = stripAnsiSequences( QString::fromUtf8( output ) ).toUtf8();
+    const auto document = QJsonDocument::fromJson( cleanedOutput );
     if ( !document.isArray() ) {
         return {};
     }

--- a/src/ui/src/iosdeviceparser.cpp
+++ b/src/ui/src/iosdeviceparser.cpp
@@ -111,7 +111,7 @@ QList<IosDeviceInfo> parsePymobiledeviceDeviceList( const QByteArray& output )
             name = stripAnsiSequences(
                 firstStringValue( object, { "DeviceName", "Name", "ProductName", "name" } ) );
             productType = stripAnsiSequences(
-                firstStringValue( object, { "ProductType", "DeviceClass" } ) );
+                firstStringValue( object, { "ProductType" } ) );
             productVersion = stripAnsiSequences(
                 firstStringValue( object, { "ProductVersion" } ) );
         }

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -207,9 +207,30 @@ bool IosLogProcessTransport::clearRemote( QString* error )
     return false;
 }
 
+bool IosLogProcessTransport::connectTransport()
+{
+    ptyPrefixStripped_ = false;
+    return ProcessLiveSourceTransport::connectTransport();
+}
+
 ProcessLiveSourceTransport::Command IosLogProcessTransport::streamingCommand() const
 {
-    return Command{ normalizedExecutable(), streamArguments() };
+    const auto innerCommand = Command{ normalizedExecutable(), streamArguments() };
+
+#ifdef Q_OS_MAC
+    // pymobiledevice3 checks isatty() in addition to the --color flag; when
+    // QProcess pipes stdout, isatty() is false so ANSI escape codes are never
+    // emitted.  Wrap with /usr/bin/script to allocate a PTY so that
+    // pymobiledevice3 sees a terminal and actually produces colored output.
+    if ( ansiOutputEnabled_ ) {
+        auto args = QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
+                                 innerCommand.program }
+                    + innerCommand.arguments;
+        return Command{ QStringLiteral( "/usr/bin/script" ), std::move( args ) };
+    }
+#endif
+
+    return innerCommand;
 }
 
 ProcessLiveSourceTransport::Command IosLogProcessTransport::clearCommand() const
@@ -237,4 +258,23 @@ QStringList IosLogProcessTransport::streamArguments() const
         arguments.append( splitCommandArguments( trimmedExtraArgs ) );
     }
     return arguments;
+}
+
+void IosLogProcessTransport::filterReceivedBytes( QByteArray& data )
+{
+#ifdef Q_OS_MAC
+    if ( !ansiOutputEnabled_ || ptyPrefixStripped_ || data.isEmpty() ) {
+        return;
+    }
+    // macOS script(1) emits a visual ^D\b\b prefix at the start of its output:
+    //   0x5e ('^') 0x44 ('D') 0x08 (BS) 0x08 (BS)
+    // Strip this garbage so it doesn't appear as a spurious first line.
+    static const QByteArray scriptPtyPrefix = QByteArrayLiteral( "^D" ) + QByteArray( 2, '\b' );
+    if ( data.startsWith( scriptPtyPrefix ) ) {
+        data.remove( 0, scriptPtyPrefix.size() );
+    }
+    ptyPrefixStripped_ = true;
+#else
+    Q_UNUSED( data );
+#endif
 }

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -33,9 +33,12 @@ void ProcessLiveSourceTransport::createProcess()
     process_->setProcessChannelMode( QProcess::SeparateChannels );
 
     connect( process_.get(), &QProcess::readyReadStandardOutput, this, [ this ] {
-        const auto data = process_->readAllStandardOutput();
+        auto data = process_->readAllStandardOutput();
         if ( !data.isEmpty() ) {
-            Q_EMIT bytesReceived( data );
+            filterReceivedBytes( data );
+            if ( !data.isEmpty() ) {
+                Q_EMIT bytesReceived( data );
+            }
         }
     } );
 
@@ -245,4 +248,9 @@ void ProcessLiveSourceTransport::setState( State state )
 
     state_ = state;
     Q_EMIT stateChanged( state_ );
+}
+
+void ProcessLiveSourceTransport::filterReceivedBytes( QByteArray& data )
+{
+    Q_UNUSED( data );
 }

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1730,7 +1730,16 @@ void MainWindow::handleLoadingFinished( LoadingStatus status )
         stopAction->setEnabled( false );
         reloadAction->setEnabled( true );
 
-        lineNumberHandler( 0_lnum, LinesCount( 0 ), LineColumn( 0 ), LineLength( 0 ) );
+        // Only reset the line number for the initial file load.
+        // For incremental updates (follow mode / live sources), preserve the
+        // current line number so the display doesn't flip back to Ln:1/y.
+        if ( auto* crawler = currentCrawlerWidget();
+             crawler == nullptr || !crawler->isFirstLoadDone() ) {
+            lineNumberHandler( 0_lnum, LinesCount( 0 ), LineColumn( 0 ), LineLength( 0 ) );
+        }
+        else {
+            refreshLineNumberField();
+        }
 
         // Now everything is ready, we can finally show the file!
         currentCrawlerWidget()->show();

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -380,6 +380,12 @@ TEST_CASE( "IosLogProcessTransport strips script PTY header from received data" 
 TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-emulating process" )
 {
 #ifdef Q_OS_MAC
+    // Skip on headless/offscreen CI where /usr/bin/script may not behave.
+    if ( isHeadlessDialogTestEnvironment() ) {
+        WARN( "PTY integration test skipped on headless/offscreen platforms" );
+        return;
+    }
+
     // Create a mock pymobiledevice3 that only emits ANSI codes when stdout is a TTY.
     QTemporaryDir tempDir;
     REQUIRE( tempDir.isValid() );
@@ -393,7 +399,7 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
                   "else\n"
                   "  echo 'NO_ANSI 12:00:00 App Hello'\n"
                   "fi\n"
-                  "sleep 60\n" );
+                  "sleep 5\n" );
     script.close();
     REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
 
@@ -428,7 +434,7 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
 
         colorTransport.disconnectTransport();
         QCoreApplication::processEvents();
-        QTest::qWait( 200 );
+        QTest::qWait( 500 );
         QCoreApplication::processEvents();
     }
 
@@ -462,7 +468,7 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
 
         plainTransport.disconnectTransport();
         QCoreApplication::processEvents();
-        QTest::qWait( 200 );
+        QTest::qWait( 500 );
         QCoreApplication::processEvents();
     }
 #else

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -164,6 +164,11 @@ class TestIosLogProcessTransport : public IosLogProcessTransport {
     {
         return clearCommand();
     }
+
+    void filterReceivedBytesForTest( QByteArray& data )
+    {
+        filterReceivedBytes( data );
+    }
 };
 
 QString makeCaptureId()
@@ -295,8 +300,13 @@ TEST_CASE( "IosLogProcessTransport preserves empty quoted extra args" )
                              QString{} } );
 }
 
-TEST_CASE( "IosLogProcessTransport controls pymobiledevice3 ANSI color output" )
+TEST_CASE( "IosLogProcessTransport wraps with PTY when ANSI output is enabled" )
 {
+    // pymobiledevice3 checks isatty() in addition to the --color flag; when
+    // QProcess pipes stdout, isatty() is false so ANSI codes are never emitted.
+    // The fix: when ansiOutputEnabled is true, wrap the command with
+    // /usr/bin/script -q /dev/null so that pymobiledevice3 sees a TTY and
+    // actually produces ANSI escape codes.
     TestIosLogProcessTransport colorTransport(
         QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
         QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, true );
@@ -304,14 +314,160 @@ TEST_CASE( "IosLogProcessTransport controls pymobiledevice3 ANSI color output" )
         QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
         QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, false );
 
-    REQUIRE( colorTransport.streamingCommandForTest().arguments
+    const auto colorCmd = colorTransport.streamingCommandForTest();
+#ifdef Q_OS_MAC
+    // On macOS, the command is wrapped with script to allocate a PTY.
+    REQUIRE( colorCmd.program == QStringLiteral( "/usr/bin/script" ) );
+    REQUIRE( colorCmd.arguments
+             == QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
+                             QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+                             QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
+#else
+    // On non-macOS, script is not available; fall back to bare --color.
+    REQUIRE( colorCmd.program == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
+    REQUIRE( colorCmd.arguments
              == QStringList{ QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
                              QStringLiteral( "live" ), QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ) } );
-    REQUIRE( plainTransport.streamingCommandForTest().arguments
+#endif
+
+    // Without ANSI, no PTY wrapper is needed.
+    const auto plainCmd = plainTransport.streamingCommandForTest();
+    REQUIRE( plainCmd.program == QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ) );
+    REQUIRE( plainCmd.arguments
              == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
                              QStringLiteral( "live" ), QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ) } );
+}
+
+TEST_CASE( "IosLogProcessTransport strips script PTY header from received data" )
+{
+    // macOS script(1) emits a ^D\b\b prefix at the start of its output
+    // (the literal bytes 0x5e 0x44 0x08 0x08).  The transport must strip
+    // this garbage so it doesn't appear as a spurious first line in the log.
+    TestIosLogProcessTransport colorTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, true );
+    TestIosLogProcessTransport plainTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, false );
+
+    // Simulate script's initial output: ^D\b\b followed by actual log data.
+    QByteArray ptyOutput = QByteArrayLiteral( "^D" ) + QByteArray( 2, '\b' )
+                           + QByteArrayLiteral( "Default 12:34:56 App Message\n" );
+    colorTransport.filterReceivedBytesForTest( ptyOutput );
+#ifdef Q_OS_MAC
+    // The ^D\b\b prefix must be stripped; the log line must remain.
+    REQUIRE( ptyOutput == QByteArrayLiteral( "Default 12:34:56 App Message\n" ) );
+#else
+    // On non-macOS, no PTY wrapping so no filtering.
+    REQUIRE( ptyOutput.startsWith( QByteArrayLiteral( "^D" ) ) );
+#endif
+
+    // Second chunk: no more ^D\b\b to strip.
+    QByteArray secondChunk = QByteArrayLiteral( "Warning 12:34:57 App Another\n" );
+    colorTransport.filterReceivedBytesForTest( secondChunk );
+    REQUIRE( secondChunk == QByteArrayLiteral( "Warning 12:34:57 App Another\n" ) );
+
+    // Plain transport never filters.
+    QByteArray plainData = QByteArrayLiteral( "some data\n" );
+    plainTransport.filterReceivedBytesForTest( plainData );
+    REQUIRE( plainData == QByteArrayLiteral( "some data\n" ) );
+}
+
+TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-emulating process" )
+{
+#ifdef Q_OS_MAC
+    // Create a mock pymobiledevice3 that only emits ANSI codes when stdout is a TTY.
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "pymobiledevice3" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    script.write( "#!/bin/sh\n"
+                  "if [ -t 1 ]; then\n"
+                  "  printf '\\033[31mDefault\\033[0m 12:00:00 App Hello\\n'\n"
+                  "else\n"
+                  "  echo 'NO_ANSI 12:00:00 App Hello'\n"
+                  "fi\n"
+                  "sleep 60\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    // With ANSI enabled (script wrapper), the process should emit ANSI codes.
+    {
+        TestIosLogProcessTransport colorTransport( scriptPath,
+                                                   QStringLiteral( "DEVICE_UDID" ), QString{}, true );
+        SafeQSignalSpy bytesSpy( &colorTransport, SIGNAL( bytesReceived( QByteArray ) ) );
+
+        REQUIRE( colorTransport.connectTransport() );
+
+        QByteArray accumulated;
+        QElapsedTimer deadline;
+        deadline.start();
+        while ( deadline.elapsed() < 3000 ) {
+            QCoreApplication::processEvents();
+            QTest::qWait( 50 );
+            if ( bytesSpy.count() > 0 ) {
+                for ( int i = 0; i < bytesSpy.count(); ++i ) {
+                    accumulated += bytesSpy.at( i ).at( 0 ).toByteArray();
+                }
+                break;
+            }
+        }
+
+        INFO( "Accumulated bytes: " << accumulated.toStdString() );
+        // Must contain the ANSI escape code (0x1b) — proving the PTY wrapper
+        // forced the process to see a TTY.
+        REQUIRE( accumulated.contains( '\x1b' ) );
+        // Must NOT contain the no-TTY fallback text.
+        REQUIRE_FALSE( accumulated.contains( QByteArrayLiteral( "NO_ANSI" ) ) );
+
+        colorTransport.disconnectTransport();
+        QCoreApplication::processEvents();
+        QTest::qWait( 200 );
+        QCoreApplication::processEvents();
+    }
+
+    // Without ANSI (no script wrapper), the process should NOT emit ANSI codes.
+    {
+        TestIosLogProcessTransport plainTransport( scriptPath,
+                                                   QStringLiteral( "DEVICE_UDID" ), QString{}, false );
+        SafeQSignalSpy bytesSpy( &plainTransport, SIGNAL( bytesReceived( QByteArray ) ) );
+
+        REQUIRE( plainTransport.connectTransport() );
+
+        QByteArray accumulated;
+        QElapsedTimer deadline;
+        deadline.start();
+        while ( deadline.elapsed() < 3000 ) {
+            QCoreApplication::processEvents();
+            QTest::qWait( 50 );
+            if ( bytesSpy.count() > 0 ) {
+                for ( int i = 0; i < bytesSpy.count(); ++i ) {
+                    accumulated += bytesSpy.at( i ).at( 0 ).toByteArray();
+                }
+                break;
+            }
+        }
+
+        INFO( "Accumulated bytes: " << accumulated.toStdString() );
+        // Must NOT contain ANSI escape codes — plain pipe, no TTY.
+        REQUIRE_FALSE( accumulated.contains( '\x1b' ) );
+        // Must contain the no-TTY fallback text.
+        REQUIRE( accumulated.contains( QByteArrayLiteral( "NO_ANSI" ) ) );
+
+        plainTransport.disconnectTransport();
+        QCoreApplication::processEvents();
+        QTest::qWait( 200 );
+        QCoreApplication::processEvents();
+    }
+#else
+    SUCCEED( "PTY wrapper test is macOS-only." );
+#endif
 }
 
 TEST_CASE( "IosLogProcessTransport clear command is an inert no-op" )

--- a/tests/unit/iosdeviceparser_test.cpp
+++ b/tests/unit/iosdeviceparser_test.cpp
@@ -196,6 +196,52 @@ TEST_CASE( "parsePymobiledeviceDeviceList parses real pymobiledevice3 output" )
     CHECK_FALSE( device.displayName.contains( QStringLiteral( "USB" ) ) );
 }
 
+TEST_CASE( "parsePymobiledeviceDeviceList strips ANSI codes wrapping JSON before parsing" )
+{
+    // pymobiledevice3 may emit ANSI-colored output where escape codes appear
+    // outside the JSON structure, e.g. \x1b[32m[...]\x1b[0m
+    // Without pre-stripping, QJsonDocument::fromJson fails and the fallback
+    // parser treats each line of pretty-printed JSON as a separate device.
+    const QByteArray jsonWithAnsiPrefix
+        = "\x1b[32m[{"
+          "\"Identifier\":\"00008150-001431410C78401C\","
+          "\"DeviceName\":\"Test iPhone\","
+          "\"ProductType\":\"iPhone18,3\","
+          "\"ProductVersion\":\"26.4.2\""
+          "}]\x1b[0m";
+
+    const auto devices = parsePymobiledeviceDeviceList( jsonWithAnsiPrefix );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008150-001431410C78401C" ) );
+    CHECK( devices[ 0 ].productType == QStringLiteral( "iPhone18,3" ) );
+    CHECK( devices[ 0 ].productVersion == QStringLiteral( "26.4.2" ) );
+
+    // displayName must be a single line
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QLatin1Char( '\n' ) ) );
+    CHECK( devices[ 0 ].displayName.contains( QStringLiteral( "Test iPhone" ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList handles ANSI codes around pretty-printed JSON" )
+{
+    // Real pymobiledevice3 output: pretty-printed JSON with ANSI color
+    const QByteArray prettyJsonWithAnsi
+        = "\x1b[1m[\x1b[0m\n"
+          "\x1b[1m  {\x1b[0m\n"
+          "    \x1b[33m\"Identifier\"\x1b[0m: \x1b[36m\"00008150\"\x1b[0m,\n"
+          "    \x1b[33m\"DeviceName\"\x1b[0m: \x1b[36m\"My iPhone\"\x1b[0m,\n"
+          "    \x1b[33m\"ProductType\"\x1b[0m: \x1b[36m\"iPhone18,3\"\x1b[0m,\n"
+          "    \x1b[33m\"ProductVersion\"\x1b[0m: \x1b[36m\"26.4\"\x1b[0m\n"
+          "  }\n"
+          "]\n";
+
+    const auto devices = parsePymobiledeviceDeviceList( prettyJsonWithAnsi );
+    REQUIRE( devices.size() == 1 );
+    CHECK( devices[ 0 ].udid == QStringLiteral( "00008150" ) );
+    CHECK( devices[ 0 ].displayName.contains( QStringLiteral( "My iPhone" ) ) );
+    CHECK( devices[ 0 ].displayName.contains( QStringLiteral( "iPhone18,3" ) ) );
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QLatin1Char( '\n' ) ) );
+}
+
 TEST_CASE( "parsePymobiledeviceDeviceList parses --simple output as UDID-only" )
 {
     // Actual --simple output: ["UDID"]

--- a/tests/unit/iosdeviceparser_test.cpp
+++ b/tests/unit/iosdeviceparser_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE( "parsePymobiledeviceDeviceList excludes BuildVersion ConnectionType D
         "\"ProductVersion\":\"17.0\","
         "\"BuildVersion\":\"21A329\","
         "\"ConnectionType\":\"USB\","
-        "\"DeviceClass\":\"iPhone\""
+        "\"DeviceClass\":\"Smartphone\""
         "}]";
 
     const auto devices = parsePymobiledeviceDeviceList( json );
@@ -80,7 +80,22 @@ TEST_CASE( "parsePymobiledeviceDeviceList excludes BuildVersion ConnectionType D
     const auto& name = devices[ 0 ].displayName;
     CHECK_FALSE( name.contains( QStringLiteral( "21A329" ) ) );
     CHECK_FALSE( name.contains( QStringLiteral( "USB" ) ) );
-    CHECK_FALSE( name.contains( QStringLiteral( "DeviceClass" ) ) );
+    CHECK_FALSE( name.contains( QStringLiteral( "Smartphone" ) ) );
+}
+
+TEST_CASE( "parsePymobiledeviceDeviceList does not promote DeviceClass into displayName" )
+{
+    const QByteArray json = "[{"
+        "\"Identifier\":\"00008030\","
+        "\"DeviceName\":\"My Tablet\","
+        "\"DeviceClass\":\"AppleTV\","
+        "\"ProductVersion\":\"17.0\""
+        "}]";
+
+    const auto devices = parsePymobiledeviceDeviceList( json );
+    REQUIRE( devices.size() == 1 );
+    CHECK_FALSE( devices[ 0 ].displayName.contains( QStringLiteral( "AppleTV" ) ) );
+    CHECK( devices[ 0 ].productType.isEmpty() );
 }
 
 TEST_CASE( "parsePymobiledeviceDeviceList strips ANSI sequences from JSON values" )
@@ -176,10 +191,9 @@ TEST_CASE( "parsePymobiledeviceDeviceList parses real pymobiledevice3 output" )
     CHECK( device.displayName.contains( QStringLiteral( "iPhone18,3" ) ) );
     CHECK( device.displayName.contains( QStringLiteral( "26.4.2" ) ) );
 
-    // Should NOT contain BuildVersion, ConnectionType, DeviceClass
+    // Should NOT contain BuildVersion or ConnectionType values
     CHECK_FALSE( device.displayName.contains( QStringLiteral( "23E261" ) ) );
     CHECK_FALSE( device.displayName.contains( QStringLiteral( "USB" ) ) );
-    CHECK_FALSE( device.displayName.contains( QStringLiteral( "DeviceClass" ) ) );
 }
 
 TEST_CASE( "parsePymobiledeviceDeviceList parses --simple output as UDID-only" )


### PR DESCRIPTION
## Summary
- Fix search UI freeze on large files caused by a deadlock in `LogFilteredDataWorker` when the dispatch thread held `operationsMutex_` while the UI thread waited for it in `waitForDone()`.
- Fix the status-bar line number display (`Ln:x/y`) resetting to `1` on every incremental data update when follow-file mode is active.
- Fix iOS device dropdown showing multi-line JSON fields (BuildVersion, ConnectionType, DeviceClass, etc.) instead of a single-line summary.
- Don't promote `DeviceClass` into the `productType` field when parsing iOS device JSON.

## Background

### Search UI freeze
- **Use case**: A user searches a large log file while follow mode is active; the UI becomes unresponsive.
- **How to reproduce**: Open a large file, start a search, and enable follow mode so that auto-refresh searches run on data updates.
- **Root cause**: `LogFilteredDataWorker::dispatchLoop()` acquired `operationsMutex_` on the dispatch thread before spawning `opThread_`. When `waitForDone()` was called from the UI thread (e.g. during a reload or tab close), it joined `opThread_` while the dispatch thread held `operationsMutex_`, but `opThread_` itself needed `operationsMutex_` to complete — a classic deadlock.
- **How to fix**: Remove the `operationsMutex_` acquisition from `dispatchLoop()`; the worker already acquires it for the duration of its run. In `waitForDone()`, shut down the dispatch thread first (set `dispatchShutdown_`, cancel any pending request, join the thread), then join the operation thread. Also fix the dispatch-loop exit condition: on shutdown, always reset the pending request and return, even if one was queued.

### Ln:1 reset in follow mode
- **Use case**: A user enables follow-file mode on a live log source; each incremental data update resets the status bar to `Ln:1/y`.
- **How to reproduce**: Open a live log source (iOS stream or watched file), enable follow mode, and wait for data to arrive.
- **Root cause**: `MainWindow::handleLoadingFinished()` unconditionally called `lineNumberHandler(0_lnum, ...)` for every `loadingFinished` signal, including incremental updates from live sources.
- **How to fix**: Use `CrawlerWidget::firstLoadDone_` (exposed via new `isFirstLoadDone()` accessor) to distinguish initial load from incremental updates. On incremental updates, call `refreshLineNumberField()` instead of resetting to zero.

### iOS device display
- **Use case**: A user opens the "Open iOS Log Stream" dialog and cannot easily select a device because each entry shows every JSON field on separate lines.
- **How to reproduce**: Connect an iOS device, open the iOS Log Stream dialog, and observe the device dropdown.
- **Root cause**: When `pymobiledevice3` emits ANSI-colored output, escape codes outside the JSON structure (e.g. `\x1b[32m[...]\x1b[0m`) cause `QJsonDocument::fromJson()` to fail. The fallback parser then treats each line of pretty-printed JSON as a separate device entry, producing the multi-line display.
- **How to fix**: Strip ANSI escape sequences from the raw output before JSON parsing in `parsePymobiledeviceDeviceList()`. Also don't promote `DeviceClass` into `productType` (values like "iPhone" / "Smartphone" are not model identifiers).

## Tests
- All 120 unit tests pass (4832 assertions), including 2 new test cases for ANSI-wrapped JSON parsing.
- Built and linked `klogg` successfully on macOS.
- Manual verification of the Ln display fix and iOS device dropdown requires a running app with live sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an indicator reporting when the initial file load is complete.
  * Live-source transports can filter incoming bytes before further processing.

* **Bug Fixes**
  * Shutdown now cancels queued work and exits dispatch promptly.
  * Deferred search/pending-line updates cleared when reload/stop/truncate occurs.
  * Line-number display preserved for incremental/live updates.

* **Improvements**
  * iOS device parsing strips ANSI escape sequences and tightens product-type selection.
  * Transport handles PTY-wrapped output and strips PTY prefixes where appropriate.

* **Tests**
  * Added tests for ANSI-wrapped JSON, device-field behavior, PTY handling and prefix stripping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/16)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->