### PR TITLE
Add ANSI-preserve save mode for live logs and fix follow-mode alignment

### DIFF
--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -92,8 +92,8 @@ class CaptureStore {
     void flushOutputIfNeeded();
     void resetOutputFlushCounters();
 
-    static constexpr qint64 OutputFlushBytesThreshold = 64 * 1024;
-    static constexpr int OutputFlushLinesThreshold = 100;
+    static constexpr qint64 OutputFlushBytesThreshold = 1024 * 1024;
+    static constexpr int OutputFlushLinesThreshold = 1000;
 
   private:
     QString captureId_;

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -10,6 +10,11 @@
 #include "capturestore.h"
 #include "searchablelogdata.h"
 
+enum class LiveLogSaveAnsiMode {
+    Strip,
+    Preserve,
+};
+
 class StreamingLogData : public SearchableLogData {
     Q_OBJECT
 
@@ -21,6 +26,7 @@ class StreamingLogData : public SearchableLogData {
     void finishInput();
     void clearCapture();
     bool bindOutputFile( const QString& outputPath );
+    bool bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode );
     QString boundOutputFile() const;
     QString captureId() const;
     QString capturePath() const;
@@ -70,6 +76,7 @@ class StreamingLogData : public SearchableLogData {
     QTimer outputFlushTimer_;
     QString boundOutputFile_;
     QFile boundOutputHandle_;
+    LiveLogSaveAnsiMode outputSaveAnsiMode_ = LiveLogSaveAnsiMode::Strip;
 };
 
 #endif

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include <QFile>
 #include <QRegularExpression>
 #include <QTimer>
 
@@ -55,6 +56,9 @@ class StreamingLogData : public SearchableLogData {
     void scheduleLoadingFinished();
     void startOutputFlushTimer();
     void stopOutputFlushTimer();
+    bool openDisplayOutputFile( const QString& outputPath );
+    void closeDisplayOutputFile();
+    bool writeDisplayLinesToOutput( LineNumber first, LinesCount count );
     klogg::vector<QString> getLines( LineNumber first, LinesCount number ) const;
 
   private:
@@ -64,6 +68,8 @@ class StreamingLogData : public SearchableLogData {
     AnsiProcessingMode ansiProcessingMode_ = AnsiProcessingMode::Plain;
     bool loadingFinishedQueued_ = false;
     QTimer outputFlushTimer_;
+    QString boundOutputFile_;
+    QFile boundOutputHandle_;
 };
 
 #endif

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -24,6 +24,9 @@ StreamingLogData::StreamingLogData( QString captureId, QString captureRoot )
         if ( boundOutputHandle_.isOpen() ) {
             boundOutputHandle_.flush();
         }
+        if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Preserve ) {
+            captureStore_.flush();
+        }
     } );
 
 }
@@ -44,7 +47,8 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     const auto previousLineCount = captureStore_.lineCount();
     captureStore_.appendUtf8( data );
     const auto currentLineCount = captureStore_.lineCount();
-    if ( currentLineCount != previousLineCount ) {
+    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip
+         && currentLineCount != previousLineCount ) {
         writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
                                    currentLineCount - previousLineCount );
     }
@@ -60,9 +64,12 @@ void StreamingLogData::finishInput()
     const auto previousLineCount = captureStore_.lineCount();
     captureStore_.finishInput();
     const auto currentLineCount = captureStore_.lineCount();
-    if ( currentLineCount != previousLineCount ) {
+    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip
+         && currentLineCount != previousLineCount ) {
         writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
                                    currentLineCount - previousLineCount );
+    }
+    if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
     }
@@ -76,7 +83,7 @@ void StreamingLogData::clearCapture()
     const auto timerWasActive = outputFlushTimer_.isActive();
     stopOutputFlushTimer();
     captureStore_.clear();
-    if ( !boundOutputFile_.isEmpty() ) {
+    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip && !boundOutputFile_.isEmpty() ) {
         openDisplayOutputFile( boundOutputFile_ );
     }
 
@@ -93,8 +100,31 @@ void StreamingLogData::clearCapture()
 
 bool StreamingLogData::bindOutputFile( const QString& outputPath )
 {
+    return bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip );
+}
+
+bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode )
+{
     stopOutputFlushTimer();
-    const auto result = openDisplayOutputFile( outputPath );
+    outputSaveAnsiMode_ = ansiMode;
+
+    if ( outputPath.isEmpty() ) {
+        closeDisplayOutputFile();
+        captureStore_.bindOutputFile( QString{} );
+        return true;
+    }
+
+    bool result = false;
+    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Preserve ) {
+        closeDisplayOutputFile();
+        result = captureStore_.bindOutputFile( outputPath );
+        boundOutputFile_ = result ? outputPath : QString{};
+    }
+    else {
+        captureStore_.bindOutputFile( QString{} );
+        result = openDisplayOutputFile( outputPath );
+    }
+
     if ( !outputPath.isEmpty() && result ) {
         startOutputFlushTimer();
     }
@@ -119,6 +149,7 @@ QString StreamingLogData::capturePath() const
 void StreamingLogData::deleteCaptureFiles()
 {
     closeDisplayOutputFile();
+    captureStore_.bindOutputFile( QString{} );
     captureStore_.deleteCaptureFiles();
 }
 
@@ -315,13 +346,9 @@ bool StreamingLogData::writeDisplayLinesToOutput( LineNumber first, LinesCount c
 
     qint64 unflushedBytes = 0;
     LinesCount::UnderlyingType unflushedLines = 0;
-    const auto displayMode = ansiProcessingMode_ == AnsiProcessingMode::Plain
-        ? AnsiProcessingMode::Plain
-        : AnsiProcessingMode::Strip;
-
     const auto lines = getLines( first, count );
     for ( const auto& line : lines ) {
-        const auto outputLine = processAnsiSequences( line, displayMode ).text.toUtf8();
+        const auto outputLine = processAnsiSequences( line, AnsiProcessingMode::Strip ).text.toUtf8();
         if ( boundOutputHandle_.write( outputLine ) != outputLine.size()
              || boundOutputHandle_.write( "\n", 1 ) != 1 ) {
             closeDisplayOutputFile();

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -1,8 +1,15 @@
 #include "streaminglogdata.h"
 
+#include <QDir>
+#include <QFileInfo>
 #include <QMetaObject>
 
 #include "logfiltereddata.h"
+
+namespace {
+constexpr qint64 OutputFlushBytesThreshold = 1024 * 1024;
+constexpr LinesCount::UnderlyingType OutputFlushLinesThreshold = 1000;
+}
 
 StreamingLogData::StreamingLogData( QString captureId, QString captureRoot )
     : SearchableLogData()
@@ -14,40 +21,34 @@ StreamingLogData::StreamingLogData( QString captureId, QString captureRoot )
 
     outputFlushTimer_.setInterval( 1000 );
     connect( &outputFlushTimer_, &QTimer::timeout, this, [this] {
-        captureStore_.flush();
+        if ( boundOutputHandle_.isOpen() ) {
+            boundOutputHandle_.flush();
+        }
     } );
 
-    captureStore_.setOutputFlushedCallback( [this] {
-        // Restart timer so the 1-second countdown begins after each threshold flush.
-        // Use QMetaObject::invokeMethod to ensure QTimer is accessed from its owning thread.
-        QMetaObject::invokeMethod( &outputFlushTimer_, [this] {
-            if ( outputFlushTimer_.isActive() ) {
-                outputFlushTimer_.start();
-            }
-        }, Qt::QueuedConnection );
-    } );
 }
 
 StreamingLogData::~StreamingLogData()
 {
-    // Clear callback before members are destroyed to prevent use-after-free.
-    // captureStore_ is declared before outputFlushTimer_, so the timer is
-    // destroyed first; without this, CaptureStore's destructor could fire
-    // the callback against a dead timer.
-    captureStore_.setOutputFlushedCallback( nullptr );
+    closeDisplayOutputFile();
 }
 
 void StreamingLogData::appendUtf8( const QByteArray& data )
 {
     // Restart the flush timer if new data arrives while an output file is bound
     // but the timer is stopped (e.g. after finishInput from a reconnect cycle).
-    if ( !outputFlushTimer_.isActive() && !captureStore_.boundOutputFile().isEmpty() ) {
+    if ( !outputFlushTimer_.isActive() && !boundOutputFile_.isEmpty() ) {
         startOutputFlushTimer();
     }
 
     const auto previousLineCount = captureStore_.lineCount();
     captureStore_.appendUtf8( data );
-    if ( captureStore_.lineCount() != previousLineCount ) {
+    const auto currentLineCount = captureStore_.lineCount();
+    if ( currentLineCount != previousLineCount ) {
+        writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
+                                   currentLineCount - previousLineCount );
+    }
+    if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
     }
@@ -58,9 +59,15 @@ void StreamingLogData::finishInput()
     stopOutputFlushTimer();
     const auto previousLineCount = captureStore_.lineCount();
     captureStore_.finishInput();
-    if ( captureStore_.lineCount() != previousLineCount ) {
+    const auto currentLineCount = captureStore_.lineCount();
+    if ( currentLineCount != previousLineCount ) {
+        writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
+                                   currentLineCount - previousLineCount );
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
+    }
+    if ( boundOutputHandle_.isOpen() ) {
+        boundOutputHandle_.flush();
     }
 }
 
@@ -69,11 +76,14 @@ void StreamingLogData::clearCapture()
     const auto timerWasActive = outputFlushTimer_.isActive();
     stopOutputFlushTimer();
     captureStore_.clear();
+    if ( !boundOutputFile_.isEmpty() ) {
+        openDisplayOutputFile( boundOutputFile_ );
+    }
 
     // clear() internally rebinds the output file if one was bound.
     // Only restart the timer if it was running before the clear,
     // so a clearCapture after finishInput does not revive the timer.
-    if ( timerWasActive && !captureStore_.boundOutputFile().isEmpty() ) {
+    if ( timerWasActive && !boundOutputFile_.isEmpty() ) {
         startOutputFlushTimer();
     }
 
@@ -84,7 +94,7 @@ void StreamingLogData::clearCapture()
 bool StreamingLogData::bindOutputFile( const QString& outputPath )
 {
     stopOutputFlushTimer();
-    const auto result = captureStore_.bindOutputFile( outputPath );
+    const auto result = openDisplayOutputFile( outputPath );
     if ( !outputPath.isEmpty() && result ) {
         startOutputFlushTimer();
     }
@@ -93,7 +103,7 @@ bool StreamingLogData::bindOutputFile( const QString& outputPath )
 
 QString StreamingLogData::boundOutputFile() const
 {
-    return captureStore_.boundOutputFile();
+    return boundOutputFile_;
 }
 
 QString StreamingLogData::captureId() const
@@ -108,6 +118,7 @@ QString StreamingLogData::capturePath() const
 
 void StreamingLogData::deleteCaptureFiles()
 {
+    closeDisplayOutputFile();
     captureStore_.deleteCaptureFiles();
 }
 
@@ -259,6 +270,78 @@ void StreamingLogData::startOutputFlushTimer()
 void StreamingLogData::stopOutputFlushTimer()
 {
     outputFlushTimer_.stop();
+}
+
+bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
+{
+    const auto outputPathCopy = outputPath;
+    closeDisplayOutputFile();
+    boundOutputFile_ = outputPathCopy;
+
+    if ( boundOutputFile_.isEmpty() ) {
+        return true;
+    }
+
+    QDir().mkpath( QFileInfo( boundOutputFile_ ).absolutePath() );
+    boundOutputHandle_.setFileName( boundOutputFile_ );
+    if ( !boundOutputHandle_.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
+        boundOutputFile_.clear();
+        return false;
+    }
+
+    if ( !writeDisplayLinesToOutput( 0_lnum, captureStore_.lineCount() ) ) {
+        closeDisplayOutputFile();
+        return false;
+    }
+
+    boundOutputHandle_.flush();
+    return true;
+}
+
+void StreamingLogData::closeDisplayOutputFile()
+{
+    if ( boundOutputHandle_.isOpen() ) {
+        boundOutputHandle_.flush();
+        boundOutputHandle_.close();
+    }
+    boundOutputFile_.clear();
+}
+
+bool StreamingLogData::writeDisplayLinesToOutput( LineNumber first, LinesCount count )
+{
+    if ( !boundOutputHandle_.isOpen() || count <= 0_lcount ) {
+        return true;
+    }
+
+    qint64 unflushedBytes = 0;
+    LinesCount::UnderlyingType unflushedLines = 0;
+    const auto displayMode = ansiProcessingMode_ == AnsiProcessingMode::Plain
+        ? AnsiProcessingMode::Plain
+        : AnsiProcessingMode::Strip;
+
+    const auto lines = getLines( first, count );
+    for ( const auto& line : lines ) {
+        const auto outputLine = processAnsiSequences( line, displayMode ).text.toUtf8();
+        if ( boundOutputHandle_.write( outputLine ) != outputLine.size()
+             || boundOutputHandle_.write( "\n", 1 ) != 1 ) {
+            closeDisplayOutputFile();
+            return false;
+        }
+
+        unflushedBytes += outputLine.size() + 1;
+        ++unflushedLines;
+        if ( unflushedBytes >= OutputFlushBytesThreshold
+             || unflushedLines >= OutputFlushLinesThreshold ) {
+            if ( !boundOutputHandle_.flush() ) {
+                closeDisplayOutputFile();
+                return false;
+            }
+            unflushedBytes = 0;
+            unflushedLines = 0;
+        }
+    }
+
+    return true;
 }
 
 klogg::vector<QString> StreamingLogData::getLines( LineNumber first, LinesCount number ) const

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -7,6 +7,7 @@
 #include <QObject>
 
 #include "livesourcetransport.h"
+#include "streaminglogdata.h"
 
 class StreamingLogData;
 
@@ -53,6 +54,7 @@ class AdbLogcatSource : public QObject {
     bool reconnectSource();
     bool clearAndRestart();
     bool bindOutputFile( const QString& outputPath );
+    bool bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode );
     void deleteCaptureFiles();
 
     const AdbLogcatSessionData& sessionData() const;

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -66,6 +66,7 @@ class QActionGroup;
 class Session;
 class RecentFiles;
 class HighlightersMenu;
+enum class LiveLogSaveAnsiMode;
 
 // Main window of the application, creates menus, toolbar and
 // the CrawlerWidget
@@ -118,7 +119,6 @@ class MainWindow : public QMainWindow {
     void copy();
     void find();
     void clearLog();
-    void saveCurrentLiveLog();
     void disconnectCurrentSource();
     void reconnectCurrentSource();
     void copyFullPath();
@@ -231,6 +231,7 @@ class MainWindow : public QMainWindow {
     void persistSessionState();
     void registerAdbLogcatSource( CrawlerWidget* crawler );
     void updateLiveTabAppearance( CrawlerWidget* crawler );
+    void saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode );
 
     WindowSession session_;
     QString loadingFileName;
@@ -239,6 +240,7 @@ class MainWindow : public QMainWindow {
     QActionGroup* recentFilesGroup;
 
     QMenu* fileMenu;
+    QMenu* saveCurrentLiveLogMenu;
     QMenu* recentFilesMenu;
     QMenu* editMenu;
     QMenu* viewMenu;
@@ -275,7 +277,8 @@ class MainWindow : public QMainWindow {
     QAction* goToLineAction;
     QAction* findAction;
     QAction* clearLogAction;
-    QAction* saveCurrentLiveLogAction;
+    QAction* saveCurrentLiveLogStripAnsiAction;
+    QAction* saveCurrentLiveLogPreserveAnsiAction;
     QAction* disconnectSourceAction;
     QAction* reconnectSourceAction;
     QAction* copyPathToClipboardAction;

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1224,10 +1224,10 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         = std::min( drawingTopPosition + effectiveHeight, viewport()->height() );
 
     if ( shouldBottomAlignFrame() ) {
-        const int hiddenHeightPx
-            = std::max( 0, effectiveHeight - viewport()->height() );
-        // Use exact pixel offset instead of line-grid snapping so the last line
-        // is never cut off and no gap appears between content bottom and viewport bottom.
+        int hiddenHeightPx = std::max( 0, effectiveHeight - viewport()->height() );
+        if ( !useTextWrap_ ) {
+            hiddenHeightPx = alignHiddenHeightToLineGrid( hiddenHeightPx );
+        }
         drawingTopOffset_ = -hiddenHeightPx;
         drawingTopPosition = drawingTopOffset_;
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1201,11 +1201,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     // Height including the potentially invisible last line
     const auto wholeHeight = static_cast<int>( getNbVisibleLines().get() ) * charHeight_;
     // Height in pixels of the "pull to follow" bottom bar.
-    const auto pullToFollowHeight
-        = mapPullToFollowLength( followElasticHook_.size() )
-          + ( followElasticHook_.isHooked()
-                  ? ( wholeHeight - viewport()->height() ) + PullToFollowHookedHeight
-                  : 0 );
+    const auto pullToFollowHeight = mapPullToFollowLength( followElasticHook_.size() );
 
     if ( pullToFollowHeight && ( pullToFollowCache_.nb_columns_ != getNbVisibleCols() ) ) {
         LOG_DEBUG << "Drawing pull to follow bar";
@@ -1227,18 +1223,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     int drawingPullToFollowTopPosition
         = std::min( drawingTopPosition + effectiveHeight, viewport()->height() );
 
-    // This is to cover the special case where there is less than a screenful
-    // worth of data, we want to see the document from the top, rather than
-    // pushing the first couple of lines above the viewport.
-    if ( followElasticHook_.isHooked()
-         && ( logData_->getNbLine() + LinesCount( 1 ) < getNbVisibleLines() ) ) {
-        drawingTopOffset_ = 0;
-        drawingTopPosition = ( wholeHeight - viewport()->height() ) + PullToFollowHookedHeight;
-        drawingPullToFollowTopPosition
-            = std::min( drawingTopPosition + viewport()->height() - PullToFollowHookedHeight,
-                        viewport()->height() );
-    }
-    else if ( shouldBottomAlignFrame() && !followElasticHook_.isHooked() ) {
+    if ( shouldBottomAlignFrame() ) {
         const int hiddenHeightPx
             = std::max( 0, effectiveHeight - viewport()->height() );
         // Use exact pixel offset instead of line-grid snapping so the last line

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -209,11 +209,16 @@ bool AdbLogcatSource::clearAndRestart()
 
 bool AdbLogcatSource::bindOutputFile( const QString& outputPath )
 {
+    return bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip );
+}
+
+bool AdbLogcatSource::bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode )
+{
     if ( !logData_ ) {
         return false;
     }
 
-    if ( !logData_->bindOutputFile( outputPath ) ) {
+    if ( !logData_->bindOutputFile( outputPath, ansiMode ) ) {
         return false;
     }
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -126,6 +126,57 @@ void signalCrawlerToFollowFile( CrawlerWidget* crawler_widget )
 
 static constexpr auto ClipboardMaxTry = 5;
 
+class ScopedMainWindowShortcutSuspender {
+  public:
+    explicit ScopedMainWindowShortcutSuspender( QWidget* window )
+    {
+        if ( !window ) {
+            return;
+        }
+
+        for ( auto* action : window->findChildren<QAction*>() ) {
+            const auto shortcuts = action->shortcuts();
+            if ( shortcuts.isEmpty() ) {
+                continue;
+            }
+            actionShortcuts_.push_back( { action, shortcuts } );
+            action->setShortcuts( {} );
+        }
+
+        for ( auto* shortcut : window->findChildren<QShortcut*>() ) {
+            if ( !shortcut->isEnabled() ) {
+                continue;
+            }
+            disabledShortcuts_.push_back( shortcut );
+            shortcut->setEnabled( false );
+        }
+    }
+
+    ~ScopedMainWindowShortcutSuspender()
+    {
+        for ( const auto& actionShortcut : actionShortcuts_ ) {
+            if ( actionShortcut.action ) {
+                actionShortcut.action->setShortcuts( actionShortcut.shortcuts );
+            }
+        }
+
+        for ( auto* shortcut : disabledShortcuts_ ) {
+            if ( shortcut ) {
+                shortcut->setEnabled( true );
+            }
+        }
+    }
+
+  private:
+    struct ActionShortcuts {
+        QAction* action;
+        QList<QKeySequence> shortcuts;
+    };
+
+    std::vector<ActionShortcuts> actionShortcuts_;
+    std::vector<QShortcut*> disabledShortcuts_;
+};
+
 } // namespace
 
 QTranslator MainWindow::mTranslator;
@@ -378,8 +429,13 @@ void MainWindow::reTranslateUI()
 
     clearLogAction->setText( transAction( action::clearLogText ) );
     clearLogAction->setStatusTip( transAction( action::clearLogStatusTip ) );
-    saveCurrentLiveLogAction->setText( tr( "Save Live Log As..." ) );
-    saveCurrentLiveLogAction->setStatusTip( tr( "Persist the current live capture to a file" ) );
+    saveCurrentLiveLogMenu->setTitle( tr( "Save Live Log As" ) );
+    saveCurrentLiveLogStripAnsiAction->setText( tr( "Without ANSI Sequences..." ) );
+    saveCurrentLiveLogStripAnsiAction->setStatusTip(
+        tr( "Persist the current live capture to a file after removing ANSI sequences" ) );
+    saveCurrentLiveLogPreserveAnsiAction->setText( tr( "With ANSI Sequences..." ) );
+    saveCurrentLiveLogPreserveAnsiAction->setStatusTip(
+        tr( "Persist the current live capture to a file without modifying ANSI sequences" ) );
     disconnectSourceAction->setText( tr( "Disconnect Source" ) );
     disconnectSourceAction->setStatusTip( tr( "Stop streaming from the current live source" ) );
     reconnectSourceAction->setText( tr( "Reconnect Source" ) );
@@ -580,11 +636,26 @@ void MainWindow::createActions()
     clearLogAction->setStatusTip( tr( action::clearLogStatusTip ) );
     connect( clearLogAction, &QAction::triggered, this, [ this ]( auto ) { this->clearLog(); } );
 
-    saveCurrentLiveLogAction = new QAction( tr( "Save Live Log As..." ), this );
-    saveCurrentLiveLogAction->setStatusTip(
-        tr( "Persist the current live capture to a file" ) );
-    connect( saveCurrentLiveLogAction, &QAction::triggered, this,
-             [ this ]( auto ) { this->saveCurrentLiveLog(); } );
+    saveCurrentLiveLogMenu = new QMenu( tr( "Save Live Log As" ), this );
+    saveCurrentLiveLogMenu->setObjectName( QStringLiteral( "saveCurrentLiveLogMenu" ) );
+    saveCurrentLiveLogStripAnsiAction = new QAction( tr( "Without ANSI Sequences..." ), this );
+    saveCurrentLiveLogStripAnsiAction->setObjectName(
+        QStringLiteral( "saveCurrentLiveLogStripAnsiAction" ) );
+    saveCurrentLiveLogStripAnsiAction->setStatusTip(
+        tr( "Persist the current live capture to a file after removing ANSI sequences" ) );
+    connect( saveCurrentLiveLogStripAnsiAction, &QAction::triggered, this,
+             [ this ]( auto ) { this->saveCurrentLiveLog( LiveLogSaveAnsiMode::Strip ); } );
+
+    saveCurrentLiveLogPreserveAnsiAction = new QAction( tr( "With ANSI Sequences..." ), this );
+    saveCurrentLiveLogPreserveAnsiAction->setObjectName(
+        QStringLiteral( "saveCurrentLiveLogPreserveAnsiAction" ) );
+    saveCurrentLiveLogPreserveAnsiAction->setStatusTip(
+        tr( "Persist the current live capture to a file without modifying ANSI sequences" ) );
+    connect( saveCurrentLiveLogPreserveAnsiAction, &QAction::triggered, this,
+             [ this ]( auto ) { this->saveCurrentLiveLog( LiveLogSaveAnsiMode::Preserve ); } );
+    saveCurrentLiveLogMenu->addAction( saveCurrentLiveLogStripAnsiAction );
+    saveCurrentLiveLogMenu->addAction( saveCurrentLiveLogPreserveAnsiAction );
+    saveCurrentLiveLogMenu->setEnabled( false );
 
     disconnectSourceAction = new QAction( tr( "Disconnect Source" ), this );
     disconnectSourceAction->setStatusTip(
@@ -867,7 +938,7 @@ void MainWindow::createMenus()
 
     fileMenu->addAction( optionsAction );
     fileMenu->addSeparator();
-
+    fileMenu->addMenu( saveCurrentLiveLogMenu );
     fileMenu->addSeparator();
     fileMenu->addAction( exitAction );
 
@@ -883,7 +954,7 @@ void MainWindow::createMenus()
     editMenu->addAction( openContainingFolderAction );
     editMenu->addSeparator();
     editMenu->addAction( openInEditorAction );
-    editMenu->addAction( saveCurrentLiveLogAction );
+    editMenu->addMenu( saveCurrentLiveLogMenu );
     editMenu->addAction( clearLogAction );
     editMenu->addAction( disconnectSourceAction );
     editMenu->addAction( reconnectSourceAction );
@@ -1299,7 +1370,7 @@ void MainWindow::clearLog()
     }
 }
 
-void MainWindow::saveCurrentLiveLog()
+void MainWindow::saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode )
 {
     auto* crawler = currentCrawlerWidget();
     if ( !crawler || session_.getDocumentKind( crawler ) != DocumentKind::AdbLogcat ) {
@@ -1317,14 +1388,18 @@ void MainWindow::saveCurrentLiveLog()
             = QDir::home().filePath( session_.getDisplayName( crawler ) + QStringLiteral( ".log" ) );
     }
 
-    const auto outputPath
-        = QFileDialog::getSaveFileName( this, tr( "Save live log" ), suggestedPath,
-                                        tr( "Log files (*.log *.txt);;All files (*)" ) );
+    QString outputPath;
+    {
+        ScopedMainWindowShortcutSuspender shortcutSuspender( this );
+        outputPath = QFileDialog::getSaveFileName(
+            this, tr( "Save live log" ), suggestedPath,
+            tr( "Log files (*.log *.txt);;All files (*)" ) );
+    }
     if ( outputPath.isEmpty() ) {
         return;
     }
 
-    if ( !adbSource->bindOutputFile( outputPath ) ) {
+    if ( !adbSource->bindOutputFile( outputPath, ansiMode ) ) {
         QMessageBox::critical( this, tr( "Save live log" ),
                                tr( "Failed to bind live capture to %1" ).arg( outputPath ) );
         return;
@@ -1872,7 +1947,7 @@ void MainWindow::currentTabChanged( int index )
         followAction->setEnabled( Configuration::get().anyFileWatchEnabled() );
         addToFavoritesAction->setEnabled( false );
         addToFavoritesMenuAction->setEnabled( false );
-        saveCurrentLiveLogAction->setEnabled( false );
+        saveCurrentLiveLogMenu->setEnabled( false );
         disconnectSourceAction->setEnabled( false );
         reconnectSourceAction->setEnabled( false );
         openContainingFolderAction->setEnabled( false );
@@ -2437,7 +2512,7 @@ void MainWindow::updateMenuBarFromDocument( const CrawlerWidget* crawler )
     openInEditorAction->setEnabled( hasFilesystemPath );
     addToFavoritesAction->setEnabled( isFileDocument );
     addToFavoritesMenuAction->setEnabled( isFileDocument );
-    saveCurrentLiveLogAction->setEnabled( isLiveDocument );
+    saveCurrentLiveLogMenu->setEnabled( isLiveDocument );
 
     auto* adbSource = isLiveDocument ? session_.getAdbLogcatSource( crawler ) : nullptr;
     const auto sourceState

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -636,6 +636,19 @@ SCENARIO( "Crawler widget search", "[ui]" )
                         REQUIRE( offsetBefore >= 0 );
                     }
                 }
+
+                AND_WHEN( "follow mode is enabled at the filtered bottom" )
+                {
+                    const auto offsetBeforeFollow = crawlerVisitor.filteredDrawingTopOffset();
+                    crawlerVisitor.enableFollowMode( true );
+                    crawlerVisitor.render();
+
+                    THEN( "follow mode does not reserve a bottom bar or move the text area" )
+                    {
+                        REQUIRE( crawlerVisitor.isFollowModeEnabled() );
+                        REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == offsetBeforeFollow );
+                    }
+                }
             }
         }
 

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -481,6 +481,27 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         return AbstractLogView::access_by<AbstractLogViewPrivate>::charHeight( crawler->filteredView_ );
     }
 
+    QSize filteredViewportSize() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::viewport( crawler->filteredView_ )
+            ->size();
+    }
+
+    void makeFilteredViewportHeightPartialLine()
+    {
+        for ( int height = 70; height < 130; ++height ) {
+            crawler->filteredView_->setFixedHeight( height );
+            QTest::qWait( 10 );
+            crawler->grab();
+
+            const auto charHeight = filteredCharHeight();
+            const auto viewportHeight = filteredViewportSize().height();
+            if ( charHeight > 0 && viewportHeight % charHeight != 0 ) {
+                return;
+            }
+        }
+    }
+
     void setFilteredLastLineAligned( bool value )
     {
         AbstractLogView::access_by<AbstractLogViewPrivate>::setLastLineAligned( crawler->filteredView_,
@@ -606,20 +627,19 @@ SCENARIO( "Crawler widget search", "[ui]" )
 
             AND_WHEN( "the filtered view is scrolled vertically and horizontally" )
             {
-                crawlerVisitor.resizeViews( 220, 95 );
+                crawlerVisitor.makeFilteredViewportHeightPartialLine();
                 crawlerVisitor.render();
                 crawlerVisitor.scrollFilteredVerticallyToBottom();
                 crawlerVisitor.render();
 
                 THEN( "vertical scrolling aligns content bottom to viewport bottom" )
                 {
-                    // With exact-pixel bottom alignment, the drawing top offset
-                    // may not be a multiple of charHeight — that is expected.
-                    // Instead, verify that content fills the viewport without
-                    // cutting off the last line or leaving a gap at the bottom.
                     const auto offset = qAbs( crawlerVisitor.filteredDrawingTopOffset() );
                     const auto charH = crawlerVisitor.filteredCharHeight();
+                    const auto viewportHeight = crawlerVisitor.filteredViewportSize().height();
+                    REQUIRE( viewportHeight % charH != 0 );
                     REQUIRE( offset >= 0 );
+                    REQUIRE( offset % charH == 0 );
                     // The offset should be at most one viewport's worth of content
                     REQUIRE( offset < charH * 50 );
                 }

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -25,6 +25,7 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QKeySequence>
+#include <QMenu>
 #include <QSignalSpy>
 #include <QTabBar>
 #include <QTemporaryDir>
@@ -130,6 +131,17 @@ SCENARIO( "Main window tests", "[ui]" )
 
         auto tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
         REQUIRE( tabArea != nullptr );
+
+        auto* saveLiveLogMenu = mainWindow->findChild<QMenu*>(
+            QStringLiteral( "saveCurrentLiveLogMenu" ) );
+        REQUIRE( saveLiveLogMenu != nullptr );
+        REQUIRE_FALSE( saveLiveLogMenu->isEnabled() );
+        REQUIRE( mainWindow->findChild<QAction*>(
+                     QStringLiteral( "saveCurrentLiveLogStripAnsiAction" ) )
+                 != nullptr );
+        REQUIRE( mainWindow->findChild<QAction*>(
+                     QStringLiteral( "saveCurrentLiveLogPreserveAnsiAction" ) )
+                 != nullptr );
 
         const auto tempDirPath = makeTestDir( "mainwindow" );
         REQUIRE( QDir{ tempDirPath }.exists() );

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -305,6 +305,38 @@ TEST_CASE( "IosLogProcessTransport builds normalized streaming commands" )
                              QStringLiteral( "process name" ) } );
 }
 
+TEST_CASE( "IosLogProcessTransport passes color flags as pymobiledevice3 top-level options" )
+{
+    TestIosLogProcessTransport colorTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, true );
+    TestIosLogProcessTransport plainTransport(
+        QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ), QString{}, false );
+
+    const auto colorCmd = colorTransport.streamingCommandForTest();
+    const auto plainCmd = plainTransport.streamingCommandForTest();
+
+#ifdef Q_OS_MAC
+    REQUIRE( colorCmd.arguments
+             == QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
+                             QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+                             QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
+#else
+    REQUIRE( colorCmd.arguments
+             == QStringList{ QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
+#endif
+
+    REQUIRE( plainCmd.arguments
+             == QStringList{ QStringLiteral( "--no-color" ), QStringLiteral( "syslog" ),
+                             QStringLiteral( "live" ), QStringLiteral( "--udid" ),
+                             QStringLiteral( "00008030-001C195E36D8802E" ) } );
+}
+
 TEST_CASE( "IosLogProcessTransport preserves empty quoted extra args" )
 {
     TestIosLogProcessTransport transport(

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -413,7 +413,7 @@ TEST_CASE( "CaptureStore batched output defers flush below threshold" )
     CaptureStore store( makeCaptureId(), rootPath );
     REQUIRE( store.bindOutputFile( outputPath ) );
 
-    // Append a small amount of data (well below 64KB and 100 lines)
+    // Append a small amount of data (well below 1MB and 1000 lines)
     for ( int i = 0; i < 10; ++i ) {
         store.appendUtf8( QStringLiteral( "short-line-%1\n" ).arg( i ).toUtf8() );
     }
@@ -442,16 +442,16 @@ TEST_CASE( "CaptureStore batched output auto-flushes after byte threshold" )
     CaptureStore store( makeCaptureId(), rootPath );
     REQUIRE( store.bindOutputFile( outputPath ) );
 
-    // Append more than 64KB of data to trigger auto-flush
+    // Append more than 1MB of data to trigger auto-flush
     const QByteArray bigLine = QByteArray( 1024, 'X' ) + "\n";
-    for ( int i = 0; i < 70; ++i ) {
+    for ( int i = 0; i < 1040; ++i ) {
         store.appendUtf8( bigLine );
     }
 
-    // Data should have been auto-flushed (70KB > 64KB threshold)
+    // Data should have been auto-flushed (1040KB > 1MB threshold)
     QFile output( outputPath );
     REQUIRE( output.open( QIODevice::ReadOnly ) );
-    REQUIRE( output.size() > 64 * 1024 );
+    REQUIRE( output.size() > 1024 * 1024 );
 }
 
 TEST_CASE( "CaptureStore batched output auto-flushes after line threshold" )
@@ -462,12 +462,12 @@ TEST_CASE( "CaptureStore batched output auto-flushes after line threshold" )
     CaptureStore store( makeCaptureId(), rootPath );
     REQUIRE( store.bindOutputFile( outputPath ) );
 
-    // Append more than 100 lines (each small enough to stay under 64KB total)
-    for ( int i = 0; i < 110; ++i ) {
+    // Append more than 1000 lines (each small enough to stay under 1MB total)
+    for ( int i = 0; i < 1010; ++i ) {
         store.appendUtf8( QStringLiteral( "ln-%1\n" ).arg( i ).toUtf8() );
     }
 
-    // Data should have been auto-flushed (110 lines > 100 line threshold)
+    // Data should have been auto-flushed (1010 lines > 1000 line threshold)
     const auto content = readUtf8File( outputPath );
     REQUIRE( content.contains( QStringLiteral( "ln-0" ) ) );
 }

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -20,6 +20,7 @@
 #include <catch2/catch.hpp>
 
 #include <QDir>
+#include <QFile>
 #include <QTemporaryDir>
 #include <QUuid>
 
@@ -159,6 +160,33 @@ TEST_CASE( "StreamingLogData strips ANSI before display and search views" )
     REQUIRE( colors[ 0 ].foreground == 0xde382b );
     REQUIRE( logData.getLinesRaw( 0_lnum, 1_lcount ).buildUtf8View()[ 0 ]
              == std::string_view{ "plain red text" } );
+}
+
+TEST_CASE( "StreamingLogData saves display text when ANSI rendering is enabled" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+
+    REQUIRE( loadingSpy.safeWait() );
+    loadingSpy.clear();
+
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[32mI/App\x1b[0m first\n" ) );
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[31mE/App\x1b[0m second\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    logData.finishInput();
+
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Render );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+    REQUIRE( logData.bindOutputFile( outputPath ) );
+    logData.bindOutputFile( QString{} );
+
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::ReadOnly ) );
+    REQUIRE( outputFile.readAll() == QByteArrayLiteral( "I/App first\nE/App second\n" ) );
 }
 
 TEST_CASE( "StreamingLogData reports accurate fileSize and lastModifiedDate" )

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -189,6 +189,64 @@ TEST_CASE( "StreamingLogData saves display text when ANSI rendering is enabled" 
     REQUIRE( outputFile.readAll() == QByteArrayLiteral( "I/App first\nE/App second\n" ) );
 }
 
+TEST_CASE( "StreamingLogData can strip ANSI while saving current and future live log lines" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+
+    REQUIRE( loadingSpy.safeWait() );
+    loadingSpy.clear();
+
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[32mI/App\x1b[0m first\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Render );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "strip.log" ) );
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+
+    loadingSpy.clear();
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[31mE/App\x1b[0m second\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    logData.bindOutputFile( QString{} );
+
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::ReadOnly ) );
+    REQUIRE( outputFile.readAll() == QByteArrayLiteral( "I/App first\nE/App second\n" ) );
+}
+
+TEST_CASE( "StreamingLogData can preserve ANSI while saving current and future live log lines" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+
+    REQUIRE( loadingSpy.safeWait() );
+    loadingSpy.clear();
+
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[32mI/App\x1b[0m first\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    logData.setAnsiProcessingMode( AnsiProcessingMode::Render );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "preserve.log" ) );
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Preserve ) );
+
+    loadingSpy.clear();
+    logData.appendUtf8( QByteArrayLiteral( "\x1b[31mE/App\x1b[0m second\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+    logData.bindOutputFile( QString{} );
+
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::ReadOnly ) );
+    REQUIRE( outputFile.readAll()
+             == QByteArrayLiteral( "\x1b[32mI/App\x1b[0m first\n"
+                                   "\x1b[31mE/App\x1b[0m second\n" ) );
+}
+
 TEST_CASE( "StreamingLogData reports accurate fileSize and lastModifiedDate" )
 {
     QTemporaryDir tempDir;


### PR DESCRIPTION
## Summary
- Add a **Save Live Log As** submenu with two modes: *Without ANSI Sequences* (strips escape codes from the saved file) and *With ANSI Sequences* (preserves raw output including color codes).
- Fix follow-mode bottom-bar rendering so that enabling follow no longer reserves space for a pull-to-follow bar or shifts the text area upward.
- Suspend all main-window keyboard shortcuts while the save-file dialog is open, preventing accidental shortcut activation.
- Raise CaptureStore output flush thresholds from 64 KB/100 lines to 1 MB/1000 lines to reduce unnecessary flushes during live-stream persistence.

## Background
- Introduced by: The original `saveCurrentLiveLog` action saved only the raw capture (with ANSI codes). Users viewing colorized iOS `syslog live` output wanted the option to save either the cleaned display text or the original colored stream.
- Use case: A user streams `adb logcat` or iOS `syslog live` with ANSI color rendering enabled, then saves the capture to a `.log` file.
- How to reproduce: Open a live log stream with ANSI colors, choose *File → Save Live Log As → With ANSI Sequences…* — the saved file would previously contain ANSI-stripped text only.
- Root cause: `StreamingLogData::bindOutputFile` always delegated to `CaptureStore`, which writes raw bytes before ANSI processing. There was no path to save the display-rendered (stripped) text or to explicitly preserve ANSI when the display mode was Render.
- How to fix: Introduce a `LiveLogSaveAnsiMode` enum. In Strip mode, `StreamingLogData` writes ANSI-stripped display lines through its own `QFile` handle. In Preserve mode, it delegates to `CaptureStore`'s existing raw-output path. The UI exposes both modes as a submenu. Follow-mode alignment was simplified by removing the extra `PullToFollowHookedHeight` offset that incorrectly expanded the pull-to-follow bar in hooked state.

## Tests
- `tests/unit/streaminglogdata_test.cpp` — new unit tests for Strip and Preserve save modes, verifying file contents after appending live data.
- `tests/unit/capturestore_test.cpp` — updated flush-threshold assertions (1 MB / 1000 lines).
- `tests/unit/adb_ui_transport_test.cpp` — new test for `--color` / `--no-color` iOS pymobiledevice3 flags.
- `tests/ui/mainwindow_test.cpp` — verifies the Save Live Log submenu and both ANSI-mode actions exist.
- `tests/ui/crawlerwidget_test.cpp` — verifies follow mode does not shift the text area and that bottom alignment snaps to the line grid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Save current live logs with options to either strip or preserve ANSI color codes.

* **Improvements**
  * Increased output flushing capacity thresholds for improved performance.
  * Refined log view rendering and bottom-alignment display behavior.

* **Tests**
  * Updated and expanded test coverage for ANSI handling and display output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/18)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->