### PR TITLE
Fix log view Home/End shortcuts and pull-to-follow clipping

### DIFF
--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -158,6 +158,7 @@ class CrawlerWidget : public QSplitter,
     void doSendAllStateSignals() override;
 
     void changeEvent( QEvent* event ) override;
+    bool eventFilter( QObject* watched, QEvent* event ) override;
 
   Q_SIGNALS:
     // Sent to signal the client load has progressed,

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1234,15 +1234,18 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         const int heightForPullToFollow = ( useTextWrap_ && textAreaCache_.actual_height_ > 0 )
             ? textAreaCache_.actual_height_
             : effectiveHeight;
+        const int maxPullToFollowTop
+            = std::max( 0, viewport()->height() - pullToFollowHeight );
         drawingPullToFollowTopPosition
-            = std::min( drawingTopPosition + heightForPullToFollow, viewport()->height() );
+            = std::min( drawingTopPosition + heightForPullToFollow, maxPullToFollowTop );
     }
     else {
         drawingTopOffset_ = -pullToFollowHeight;
         drawingTopPosition = drawingTopOffset_;
-        // Update pull-to-follow position using effective height
+        const int maxPullToFollowTop
+            = std::max( 0, viewport()->height() - pullToFollowHeight );
         drawingPullToFollowTopPosition
-            = std::min( drawingTopPosition + effectiveHeight, viewport()->height() );
+            = std::min( drawingTopPosition + effectiveHeight, maxPullToFollowTop );
     }
 
     devicePainter.drawPixmap( 0, drawingTopPosition, textAreaCache_.pixmap_ );

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -845,8 +845,18 @@ void AbstractLogView::registerShortcut( const std::string& action, std::function
     const auto& config = Configuration::get();
     const auto& configuredShortcuts = config.shortcuts();
 
-    ShortcutAction::registerShortcut( configuredShortcuts, shortcuts_, this, Qt::WidgetShortcut,
-                                      action, func );
+    ShortcutAction::registerShortcut( configuredShortcuts, shortcuts_, this,
+                                      Qt::WidgetWithChildrenShortcut, action,
+                                      [ this, func = std::move( func ) ] {
+                                          const auto* focusWidget = QApplication::focusWidget();
+                                          if ( focusWidget == nullptr
+                                               || ( focusWidget != this && focusWidget != viewport()
+                                                    && !isAncestorOf( focusWidget ) ) ) {
+                                              return;
+                                          }
+
+                                          func();
+                                      } );
 }
 
 void AbstractLogView::registerShortcuts()

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -53,9 +53,11 @@
 #include <QAction>
 #include <QApplication>
 #include <QCompleter>
+#include <QEvent>
 #include <QFontMetrics>
 #include <QInputDialog>
 #include <QJsonDocument>
+#include <QKeyEvent>
 #include <QKeySequence>
 #include <QLineEdit>
 #include <QListView>
@@ -308,7 +310,45 @@ void CrawlerWidget::setEncoding( std::optional<int> mib )
 
 void CrawlerWidget::focusSearchEdit()
 {
-    searchLineEdit_->setFocus( Qt::ShortcutFocusReason );
+    searchLineEdit_->lineEdit()->setFocus( Qt::ShortcutFocusReason );
+}
+
+bool CrawlerWidget::eventFilter( QObject* watched, QEvent* event )
+{
+    const auto* searchEdit = searchLineEdit_ != nullptr ? searchLineEdit_->lineEdit() : nullptr;
+    const auto isSearchInput = watched == searchLineEdit_ || watched == searchEdit;
+    if ( !isSearchInput ) {
+        return QSplitter::eventFilter( watched, event );
+    }
+
+    if ( event->type() != QEvent::ShortcutOverride && event->type() != QEvent::KeyPress ) {
+        return QSplitter::eventFilter( watched, event );
+    }
+
+    auto* keyEvent = static_cast<QKeyEvent*>( event );
+    const auto key = keyEvent->key();
+    if ( key != Qt::Key_Home && key != Qt::Key_End ) {
+        return QSplitter::eventFilter( watched, event );
+    }
+
+    const auto modifiers = keyEvent->modifiers() & ~Qt::KeypadModifier;
+    if ( modifiers != Qt::NoModifier ) {
+        return QSplitter::eventFilter( watched, event );
+    }
+
+    if ( event->type() == QEvent::ShortcutOverride ) {
+        event->accept();
+        return false;
+    }
+
+    if ( key == Qt::Key_Home ) {
+        searchLineEdit_->lineEdit()->setCursorPosition( 0 );
+    }
+    else {
+        searchLineEdit_->lineEdit()->end( false );
+    }
+    event->accept();
+    return true;
 }
 
 void CrawlerWidget::jumpToTop()
@@ -1327,6 +1367,8 @@ void CrawlerWidget::setup()
     searchLineEdit_->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
     searchLineEdit_->lineEdit()->setMaxLength( std::numeric_limits<int>::max() / 1024 );
     searchLineEdit_->setContentsMargins( 2, 2, 2, 2 );
+    searchLineEdit_->installEventFilter( this );
+    searchLineEdit_->lineEdit()->installEventFilter( this );
 
     QAction* clearSearchHistoryAction = new QAction( tr( "Clear search history" ), this );
     QAction* editSearchHistoryAction = new QAction( tr( "Edit search history" ), this );

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -19,7 +19,9 @@
 
 #include <catch2/catch.hpp>
 
+#include <QShortcut>
 #include <QSignalSpy>
+#include <QLineEdit>
 #include <QScrollBar>
 #include <QTemporaryFile>
 #include <QTest>
@@ -188,6 +190,12 @@ struct AbstractLogView::access_by<AbstractLogViewPrivate> {
     {
         return view->getNbVisibleCols();
     }
+
+    static QShortcut* shortcutFor( const AbstractLogView* view, const QString& key )
+    {
+        const auto shortcut = view->shortcuts_.find( key );
+        return shortcut != view->shortcuts_.end() ? shortcut->second : nullptr;
+    }
 };
 
 template <>
@@ -244,6 +252,36 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         QTest::keyClicks( crawler->searchLineEdit_, pattern );
     }
 
+    void replaceSearchPattern( const QString& pattern )
+    {
+        crawler->searchLineEdit_->lineEdit()->setText( pattern );
+    }
+
+    void focusSearchPattern()
+    {
+        crawler->show();
+        const auto windowExposed = QTest::qWaitForWindowExposed( crawler.get() );
+        (void) windowExposed;
+        crawler->searchLineEdit_->setFocus();
+        QTest::qWait( 20 );
+    }
+
+    void setSearchPatternCursorPosition( int position )
+    {
+        crawler->searchLineEdit_->lineEdit()->setCursorPosition( position );
+    }
+
+    int searchPatternCursorPosition() const
+    {
+        return crawler->searchLineEdit_->lineEdit()->cursorPosition();
+    }
+
+    void pressSearchPatternKey( Qt::Key key )
+    {
+        QTest::keyClick( crawler->searchLineEdit_, key );
+        QTest::qWait( 20 );
+    }
+
     void enableCaseSensitiveSearch()
     {
         if ( !crawler->matchCaseButton_->isChecked() ) {
@@ -285,6 +323,72 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
     int mainHorizontalScrollMaximum() const
     {
         return crawler->logMainView_->horizontalScrollBar()->maximum();
+    }
+
+    int mainHorizontalScrollValue() const
+    {
+        return crawler->logMainView_->horizontalScrollBar()->value();
+    }
+
+    int filteredHorizontalScrollMaximum() const
+    {
+        return crawler->filteredView_->horizontalScrollBar()->maximum();
+    }
+
+    int filteredHorizontalScrollValue() const
+    {
+        return crawler->filteredView_->horizontalScrollBar()->value();
+    }
+
+    void setMainHorizontalScrollValue( int value )
+    {
+        crawler->logMainView_->horizontalScrollBar()->setValue( value );
+        QTest::qWait( 20 );
+    }
+
+    void setFilteredHorizontalScrollValue( int value )
+    {
+        crawler->filteredView_->horizontalScrollBar()->setValue( value );
+        QTest::qWait( 20 );
+    }
+
+    void focusMainView()
+    {
+        crawler->show();
+        const auto windowExposed = QTest::qWaitForWindowExposed( crawler.get() );
+        (void) windowExposed;
+        crawler->logMainView_->viewport()->setFocus();
+        QTest::qWait( 20 );
+    }
+
+    void focusFilteredView()
+    {
+        crawler->show();
+        const auto windowExposed = QTest::qWaitForWindowExposed( crawler.get() );
+        (void) windowExposed;
+        crawler->filteredView_->viewport()->setFocus();
+        QTest::qWait( 20 );
+    }
+
+    void pressMainViewKey( Qt::Key key )
+    {
+        QTest::keyClick( crawler->logMainView_->viewport(), key );
+        QTest::qWait( 20 );
+    }
+
+    void pressFilteredViewKey( Qt::Key key )
+    {
+        QTest::keyClick( crawler->filteredView_->viewport(), key );
+        QTest::qWait( 20 );
+    }
+
+    void activateMainViewShortcut( Qt::Key key )
+    {
+        auto* shortcut = AbstractLogView::access_by<AbstractLogViewPrivate>::shortcutFor(
+            crawler->logMainView_, QKeySequence( key ).toString() );
+        REQUIRE( shortcut != nullptr );
+        Q_EMIT shortcut->activated();
+        QTest::qWait( 20 );
     }
 
     bool mainTextAreaCacheInvalid() const
@@ -683,6 +787,136 @@ SCENARIO( "Crawler widget search", "[ui]" )
             THEN( "single line match" )
             {
                 REQUIRE( crawlerVisitor.getLogFilteredNbLines().get() == 1 );
+            }
+        }
+
+        WHEN( "Home and End are pressed in the filter input" )
+        {
+            const auto pattern = QStringLiteral( "this is line" );
+            const auto middlePosition = static_cast<int>( pattern.size() / 2 );
+            const auto endPosition = static_cast<int>( pattern.size() );
+            crawlerVisitor.replaceSearchPattern( pattern );
+            crawlerVisitor.focusSearchPattern();
+
+            crawlerVisitor.setSearchPatternCursorPosition( middlePosition );
+            crawlerVisitor.pressSearchPatternKey( Qt::Key_Home );
+
+            THEN( "Home moves the text cursor to the beginning of the input" )
+            {
+                REQUIRE( crawlerVisitor.searchPatternCursorPosition() == 0 );
+            }
+
+            AND_WHEN( "End is pressed" )
+            {
+                crawlerVisitor.setSearchPatternCursorPosition( middlePosition );
+                crawlerVisitor.pressSearchPatternKey( Qt::Key_End );
+
+                THEN( "End moves the text cursor to the end of the input" )
+                {
+                    REQUIRE( crawlerVisitor.searchPatternCursorPosition() == endPosition );
+                }
+            }
+        }
+
+        WHEN( "log view Home and End shortcuts are activated while the filter input has focus" )
+        {
+            crawlerVisitor.setTextWrap( false );
+            crawlerVisitor.resizeViews( 200, 120 );
+            crawlerVisitor.render();
+
+            REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() > 0 );
+
+            const auto middleScroll = crawlerVisitor.mainHorizontalScrollMaximum() / 2;
+            crawlerVisitor.replaceSearchPattern( QStringLiteral( "this is line" ) );
+            crawlerVisitor.focusSearchPattern();
+            crawlerVisitor.setMainHorizontalScrollValue( middleScroll );
+            const auto scrollBeforeShortcut = crawlerVisitor.mainHorizontalScrollValue();
+
+            crawlerVisitor.activateMainViewShortcut( Qt::Key_Home );
+
+            THEN( "the main view does not handle Home" )
+            {
+                REQUIRE( crawlerVisitor.mainHorizontalScrollValue() == scrollBeforeShortcut );
+            }
+
+            AND_WHEN( "End is activated" )
+            {
+                crawlerVisitor.activateMainViewShortcut( Qt::Key_End );
+
+                THEN( "the main view does not handle End" )
+                {
+                    REQUIRE( crawlerVisitor.mainHorizontalScrollValue() == scrollBeforeShortcut );
+                }
+            }
+        }
+
+        WHEN( "Home and End are pressed while the main log view has focus" )
+        {
+            crawlerVisitor.setTextWrap( false );
+            crawlerVisitor.resizeViews( 200, 120 );
+            crawlerVisitor.render();
+            crawlerVisitor.focusMainView();
+            crawlerVisitor.resizeViews( 200, 120 );
+            crawlerVisitor.render();
+
+            REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() > 0 );
+
+            const auto middleScroll = crawlerVisitor.mainHorizontalScrollMaximum() / 2;
+            crawlerVisitor.setMainHorizontalScrollValue( middleScroll );
+
+            crawlerVisitor.pressMainViewKey( Qt::Key_Home );
+
+            THEN( "Home jumps the main view to the left of the log line" )
+            {
+                REQUIRE( crawlerVisitor.mainHorizontalScrollValue() == 0 );
+            }
+
+            AND_WHEN( "End is activated" )
+            {
+                crawlerVisitor.setMainHorizontalScrollValue( middleScroll );
+                crawlerVisitor.pressMainViewKey( Qt::Key_End );
+
+                THEN( "End jumps the main view to the right of the log line" )
+                {
+                    REQUIRE( crawlerVisitor.mainHorizontalScrollValue() > middleScroll );
+                }
+            }
+        }
+
+        WHEN( "Home and End are pressed while the filtered log view has focus" )
+        {
+            crawlerVisitor.setSearchPattern( "10" );
+            crawlerVisitor.runSearch();
+            waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 1; } );
+
+            crawlerVisitor.setTextWrap( false );
+            crawlerVisitor.resizeViews( 200, 120 );
+            crawlerVisitor.render();
+            crawlerVisitor.focusFilteredView();
+            crawlerVisitor.resizeViews( 200, 120 );
+            crawlerVisitor.render();
+
+            REQUIRE( crawlerVisitor.filteredHorizontalScrollMaximum() > 0 );
+
+            const auto middleScroll = crawlerVisitor.filteredHorizontalScrollMaximum() / 2;
+            crawlerVisitor.setFilteredHorizontalScrollValue( middleScroll );
+
+            crawlerVisitor.pressFilteredViewKey( Qt::Key_Home );
+
+            THEN( "Home jumps the filtered view to the left of the log line" )
+            {
+                REQUIRE( crawlerVisitor.filteredHorizontalScrollValue() == 0 );
+            }
+
+            AND_WHEN( "End is pressed" )
+            {
+                crawlerVisitor.setFilteredHorizontalScrollValue( middleScroll );
+                crawlerVisitor.pressFilteredViewKey( Qt::Key_End );
+
+                THEN( "End jumps the filtered view to the right of the log line" )
+                {
+                    REQUIRE( crawlerVisitor.filteredHorizontalScrollValue() > middleScroll );
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Keep the pull-to-follow indicator visible when bottom-aligned frames are rendered at the viewport bottom.
- Fix Home/End focus handling so the filter input keeps normal text cursor navigation while the main and filtered log views still use Home/End for horizontal log-line navigation.
- Add UI regression coverage for filter-input Home/End behavior and real key delivery in both log views.

## Background
- Introduced by: PR #17 (`be4bc966`) for the pull-to-follow clipping regression; commit `154b8994584c` for the Home/End shortcut regression after log view navigation moved to configurable shortcuts.
- Use case: Users following a live log should see the pull-to-follow indicator, and users should be able to use Home/End naturally depending on whether focus is in the filter input or a log view.
- How to reproduce: In follow mode with bottom-aligned rendering, observe the pull-to-follow bar clipped below the viewport. For Home/End, focus the filter input and press Home/End, then focus the main or filtered log view after horizontal scrolling and press Home/End.
- Root cause: The pull-to-follow top position was clamped to `viewport()->height()` instead of leaving room for the indicator height. For Home/End, log view shortcuts used a focus scope that could steal keys from the filter input, and the intermediate viewport-only fix no longer triggered for real log-view key events.
- How to fix: Clamp the indicator top position against `viewport()->height() - pullToFollowHeight`. Handle Home/End on the filter input during shortcut override/key press, focus the embedded line edit for search focus, and register log view shortcuts on `AbstractLogView` with child-widget scope plus an active-focus guard.

## Tests
- `cmake --build build_root --target klogg_itests -j2`
- `QT_QPA_PLATFORM=offscreen build_root/output/klogg_itests "Scenario: Crawler widget search"`
- `QT_QPA_PLATFORM=offscreen build_root/output/klogg_itests`
- Built and opened `build_root/output/klogg.app` for manual verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the search input: Home and End keys now correctly move the cursor to the start and end of the search field.
  * Enhanced shortcut context awareness to prevent unintended shortcut triggers in different widget focus states.
  * Fixed "pull to follow" UI element positioning logic for improved visual accuracy.

* **Tests**
  * Added comprehensive test coverage for keyboard navigation behavior across different focus states in the search functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/19)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->