### PR TITLE
Fix Linux package CPU compatibility

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -379,28 +379,28 @@ jobs:
             arch: x64
             label: ubuntu-22.04-deb
             package_tag: vs-gen
-            check_command: apt-get update && apt install --dry-run /usr/local/klogg*.deb
             cpack_gen: DEB
             artifacts_id: jammy
             package_suffix: deb
             check_container: ubuntu:22.04
             container_root: docker/ubuntu22.04
             container: variar/klogg_ubuntu22.04
-            cmake_opts: ""
+            cmake_opts: -DKLOGG_GENERIC_CPU=ON
+            check_command: apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y /usr/local/klogg*.deb && QT_QPA_PLATFORM=offscreen klogg -v
 
           - os: ubuntu_noble
             os_version: 24.04
             arch: x64
             label: ubuntu-24.04-deb
             package_tag: vs-gen
-            check_command: apt-get update && apt install --dry-run /usr/local/klogg*.deb
+            check_command: apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y /usr/local/klogg*.deb && QT_QPA_PLATFORM=offscreen klogg -v
             cpack_gen: DEB
             artifacts_id: noble
             package_suffix: deb
             check_container: ubuntu:24.04
             container_root: docker/ubuntu24.04
             container: variar/klogg_ubuntu24.04
-            cmake_opts: -DENABLE_CPPCHECK=ON
+            cmake_opts: -DENABLE_CPPCHECK=ON -DKLOGG_GENERIC_CPU=ON
 
           - os: ubuntu_appimage
             os_version: 20.04
@@ -411,7 +411,7 @@ jobs:
             package_suffix: AppImage
             container_root: docker/ubuntu20.04
             container: variar/klogg_ubuntu20.04
-            cmake_opts: ""
+            cmake_opts: -DKLOGG_GENERIC_CPU=ON
 
 
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   SaveVersion:
-    needs: [PrefetchDeps]
+    needs: [PrefetchDeps, PrefetchWindowsTools]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-22.04
     outputs:
@@ -562,7 +562,7 @@ jobs:
           if-no-files-found: warn
 
   Windows:
-    needs: [SaveVersion, PrefetchWindowsTools]
+    needs: [SaveVersion]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   SaveVersion:
-    needs: [PrefetchDeps, PrefetchWindowsTools]
+    needs: [PrefetchDeps]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-22.04
     outputs:
@@ -562,7 +562,7 @@ jobs:
           if-no-files-found: warn
 
   Windows:
-    needs: [SaveVersion]
+    needs: [SaveVersion, PrefetchWindowsTools]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run lint
-        run: python3 scripts/lint_platform_fragile.py
+        run: |
+          python3 scripts/lint_platform_fragile.py
+          python3 scripts/lint_linux_package_runtime.py

--- a/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
+++ b/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
@@ -6,7 +6,6 @@ index 1db128ba..969206a0 100644
  
 +if (KLOGG_GENERIC_CPU AND (ARCH_IA32 OR ARCH_X86_64))
 +    set(GNUCC_ARCH x86-64)
-+    set(TUNE_FLAG generic)
 +    set(GNUCC_TUNE "")
 +endif ()
 +

--- a/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
+++ b/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1db128ba..969206a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -137,7 +137,13 @@ include (${CMAKE_MODULE_PATH}/archdetect.cmake)
+@@ -137,7 +137,12 @@ include (${CMAKE_MODULE_PATH}/archdetect.cmake)
  
 +if (KLOGG_GENERIC_CPU AND (ARCH_IA32 OR ARCH_X86_64))
 +    set(GNUCC_ARCH x86-64)

--- a/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
+++ b/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch
@@ -2,8 +2,14 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1db128ba..969206a0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -137,7 +137,7 @@ include (${CMAKE_MODULE_PATH}/archdetect.cmake)
+@@ -137,7 +137,13 @@ include (${CMAKE_MODULE_PATH}/archdetect.cmake)
  
++if (KLOGG_GENERIC_CPU AND (ARCH_IA32 OR ARCH_X86_64))
++    set(GNUCC_ARCH x86-64)
++    set(TUNE_FLAG generic)
++    set(GNUCC_TUNE "")
++endif ()
++
  include (${CMAKE_MODULE_PATH}/sanitize.cmake)
  
 -if (NOT FAT_RUNTIME)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -5,6 +5,8 @@
 | TASK-001 | [Search generation ID refactoring](#task-001-search-generation-id-refactoring) | Low | Done | [PR #11](https://github.com/ZEACENT/klogg/pull/11) |
 | TASK-002 | [Chart Panel — regex match → time series](#task-002-chart-panel) | Medium | Planned | [SPEC](SPEC_CHART_AND_FILTERS_PANEL.md) |
 | TASK-003 | [Filters Panel — persistent dock with groups & pinning](#task-003-filters-panel) | Medium | Planned | [SPEC](SPEC_CHART_AND_FILTERS_PANEL.md) |
+| TASK-004 | [macOS code signing and notarization hardening](#task-004-macos-code-signing-and-notarization-hardening) | Medium | Planned | CI Release |
+| TASK-005 | [Continuous and Release tag Changes automation](#task-005-continuous-and-release-tag-changes-automation) | Medium | Planned | Releases |
 
 ### TASK-001: Search generation ID refactoring
 
@@ -81,3 +83,48 @@ phased iterations, testing strategy, and effort estimate (~1.5 weeks
 to feature-complete).
 
 **Recommended order:** ship before TASK-002.
+
+### TASK-004: macOS Code Signing And Notarization Hardening
+
+**Scenario:**
+Release macOS artifacts should be signed and notarized consistently so users can
+open downloaded DMGs without Gatekeeper warnings or manual override steps.
+
+**Problem:**
+The packaging action contains signing and notarization hooks, but the backlog
+needs a dedicated plan to verify identity setup, entitlement requirements,
+secret handling, and artifact validation for both Intel and Apple Silicon
+packages.
+
+**Proposed plan:**
+1. Document required Apple Developer certificates, installer identities, App
+   Store Connect issuer/key material, and GitHub secret names.
+2. Add CI preflight checks that fail early when signing secrets are missing on a
+   release run.
+3. Sign the `.app` bundle before DMG creation, sign the DMG, submit for
+   notarization, staple the result, and verify with `codesign`, `spctl`, and
+   `stapler`.
+4. Keep unsigned local/PR builds possible while making release signing behavior
+   explicit in logs and artifact metadata.
+
+### TASK-005: Continuous And Release Tag Changes Automation
+
+**Scenario:**
+The `continuous` prerelease and versioned release tags should publish useful
+Changes text so users can understand what changed without digging through CI
+runs or commit history.
+
+**Problem:**
+Release assets are uploaded automatically, but the release notes need a clear
+plan covering the moving `continuous` tag and immutable version tags.
+
+**Proposed plan:**
+1. Generate Continuous Changes from commits merged since the previous
+   successful Continuous build, grouped by change type using
+   `scripts/gen_changelog.py`.
+2. Generate Release Changes from the previous version tag to the new version
+   tag, including highlights, fixed issues, and artifact notes.
+3. Update the release workflow to write the generated text into the GitHub
+   Release body after assets are uploaded.
+4. Add a dry-run mode that prints the planned release notes in CI logs for PR
+   validation before changing any GitHub Release.

--- a/scripts/lint_linux_package_runtime.py
+++ b/scripts/lint_linux_package_runtime.py
@@ -57,7 +57,8 @@ def main() -> int:
 
         if package_suffix == "deb":
             check_command = entry.get("check_command", "")
-            if "apt install" not in check_command or "--dry-run" in check_command:
+            has_real_install = ("apt install" in check_command) or ("apt-get install" in check_command)
+            if not has_real_install or "--dry-run" in check_command:
                 failures.append(f"{os_name}: deb package check must perform a real install")
             if "klogg -v" not in check_command:
                 failures.append(f"{os_name}: deb package check must execute klogg -v")

--- a/scripts/lint_linux_package_runtime.py
+++ b/scripts/lint_linux_package_runtime.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Check Linux release-package CI keeps runtime CPU compatibility covered."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci-build.yml"
+THIRDPARTY_CMAKE = ROOT / "3rdparty" / "CMakeLists.txt"
+VECTORSCAN_FLAGS_PATCH = ROOT / "3rdparty" / "patches" / "fix_vectorscan_msvc_warning_flags.patch"
+
+
+def linux_matrix_entries(workflow_text: str) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+
+    for raw_line in workflow_text.splitlines():
+        stripped = raw_line.strip()
+
+        if stripped.startswith("- os: "):
+            if current and current.get("os", "").startswith("ubuntu_"):
+                entries.append(current)
+            current = {"os": stripped.split(":", 1)[1].strip()}
+            continue
+
+        if current is None:
+            continue
+
+        if stripped and not stripped.startswith("#") and ":" in stripped:
+            key, value = stripped.split(":", 1)
+            current[key.strip()] = value.strip().strip('"')
+
+    if current and current.get("os", "").startswith("ubuntu_"):
+        entries.append(current)
+
+    return entries
+
+
+def main() -> int:
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    thirdparty_cmake = THIRDPARTY_CMAKE.read_text(encoding="utf-8")
+    vectorscan_patch = VECTORSCAN_FLAGS_PATCH.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    for entry in linux_matrix_entries(workflow_text):
+        package_suffix = entry.get("package_suffix")
+        if package_suffix not in {"deb", "AppImage"}:
+            continue
+
+        os_name = entry.get("os", "<unknown>")
+        cmake_opts = entry.get("cmake_opts", "")
+        if "-DKLOGG_GENERIC_CPU=ON" not in cmake_opts:
+            failures.append(f"{os_name}: release packages must set -DKLOGG_GENERIC_CPU=ON")
+
+        if package_suffix == "deb":
+            check_command = entry.get("check_command", "")
+            if "apt install" not in check_command or "--dry-run" in check_command:
+                failures.append(f"{os_name}: deb package check must perform a real install")
+            if "klogg -v" not in check_command:
+                failures.append(f"{os_name}: deb package check must execute klogg -v")
+
+    if "if(KLOGG_GENERIC_CPU)" not in thirdparty_cmake:
+        failures.append("Vectorscan build must branch on KLOGG_GENERIC_CPU")
+    if "set(VECTORSCAN_BUILD_AVX2 OFF)" not in thirdparty_cmake:
+        failures.append("KLOGG_GENERIC_CPU must disable Vectorscan AVX2")
+    if "set(VECTORSCAN_BUILD_AVX512 OFF)" not in thirdparty_cmake:
+        failures.append("KLOGG_GENERIC_CPU must disable Vectorscan AVX512")
+    if "KLOGG_GENERIC_CPU" not in vectorscan_patch or "GNUCC_ARCH x86-64" not in vectorscan_patch:
+        failures.append("Vectorscan patch must force x86-64 architecture for KLOGG_GENERIC_CPU")
+
+    if failures:
+        print("Linux package runtime lint failed:")
+        for failure in failures:
+            print(f" - {failure}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -81,6 +81,17 @@ PATTERNS: list[dict] = [
             "exits with a non-zero status instead."
         ),
     },
+    {
+        "name": "private macro access override",
+        "regex": re.compile(r"^\s*#\s*define\s+private\s+public\b"),
+        "fix": (
+            "Do not rewrite C++ access specifiers with a macro in tests. MSVC "
+            "encodes access level in decorated symbols, so a test translation "
+            "unit that sees a private method as public can fail to link against "
+            "the implementation object. Add a narrow access_by<T> test adapter "
+            "to the class instead."
+        ),
+    },
 ]
 
 # Multi-line patterns: checked separately via whole-file analysis.

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -69,8 +69,6 @@ class KloggApp : public QApplication {
     {
         QFontDatabase::addApplicationFont( ":/fonts/DejaVuSansMono.ttf" );
 
-        QNetworkProxyFactory::setUseSystemConfiguration( true );
-
         qRegisterMetaType<LoadingStatus>( "LoadingStatus" );
         qRegisterMetaType<LinesCount>( "LinesCount" );
         qRegisterMetaType<LineNumber>( "LineNumber" );
@@ -215,7 +213,10 @@ class KloggApp : public QApplication {
     void startBackgroundTasks()
     {
         LOG_DEBUG << "startBackgroundTasks";
-        versionChecker_.startCheck();
+        QTimer::singleShot( 0, this, [ this ] {
+            QNetworkProxyFactory::setUseSystemConfiguration( true );
+            versionChecker_.startCheck();
+        } );
     }
 
 #ifdef Q_OS_MAC

--- a/src/logdata/include/logfiltereddataworker.h
+++ b/src/logdata/include/logfiltereddataworker.h
@@ -221,6 +221,9 @@ class LogFilteredDataWorker : public QObject {
     Q_OBJECT
 
 public:
+    template <class T>
+    struct access_by;
+
     explicit LogFilteredDataWorker( const SearchableLogData& sourceLogData );
     ~LogFilteredDataWorker() noexcept override;
 

--- a/src/logdata/src/logfiltereddataworker.cpp
+++ b/src/logdata/src/logfiltereddataworker.cpp
@@ -326,6 +326,9 @@ void LogFilteredDataWorker::enqueueRequest( SearchRequest request, bool interrup
     }
     {
         std::lock_guard<std::mutex> lock( requestMutex_ );
+        if ( request.type == SearchRequest::Type::LiveUpdate ) {
+            deferredLiveRequest_.reset();
+        }
         pendingRequest_.emplace( std::move( request ) );
     }
     requestCv_.notify_one();

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -477,6 +477,8 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     LinesCount getNbVisibleLines() const;
     LinesCount getNbBottomWrappedVisibleLines() const;
     LineLength getNbVisibleCols() const;
+    int textViewportHeight() const;
+    int horizontalScrollBarOverlayHeight() const;
 
     FilePosition convertCoordToFilePos( const QPoint& pos ) const;
     OptionalLineNumber convertCoordToLine( int yPos ) const;

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -76,6 +76,7 @@
 #include <QScrollBar>
 #include <QShortcut>
 #include <QStringView>
+#include <QStyle>
 #include <QtCore>
 
 #include <tbb/flow_graph.h>
@@ -1223,6 +1224,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     QPainter devicePainter( viewport() );
 
     // Calculate effective height for text wrapping and pull-to-follow bar positioning
+    const int availableTextHeight = textViewportHeight();
     const int effectiveHeight
         = ( useTextWrap_ && textAreaCache_.actual_height_ > 0 ) ? textAreaCache_.actual_height_
                                                                  : wholeHeight;
@@ -1231,10 +1233,10 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     int drawingTopPosition = drawingTopOffset_;
     // Keep pull-to-follow within viewport to avoid blank/gray regions.
     int drawingPullToFollowTopPosition
-        = std::min( drawingTopPosition + effectiveHeight, viewport()->height() );
+        = std::min( drawingTopPosition + effectiveHeight, availableTextHeight );
 
     if ( shouldBottomAlignFrame() ) {
-        int hiddenHeightPx = std::max( 0, effectiveHeight - viewport()->height() );
+        int hiddenHeightPx = std::max( 0, effectiveHeight - availableTextHeight );
         if ( !useTextWrap_ ) {
             hiddenHeightPx = alignHiddenHeightToLineGrid( hiddenHeightPx );
         }
@@ -1245,7 +1247,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
             ? textAreaCache_.actual_height_
             : effectiveHeight;
         const int maxPullToFollowTop
-            = std::max( 0, viewport()->height() - pullToFollowHeight );
+            = std::max( 0, availableTextHeight - pullToFollowHeight );
         drawingPullToFollowTopPosition
             = std::min( drawingTopPosition + heightForPullToFollow, maxPullToFollowTop );
     }
@@ -1253,7 +1255,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
         drawingTopOffset_ = -pullToFollowHeight;
         drawingTopPosition = drawingTopOffset_;
         const int maxPullToFollowTop
-            = std::max( 0, viewport()->height() - pullToFollowHeight );
+            = std::max( 0, availableTextHeight - pullToFollowHeight );
         drawingPullToFollowTopPosition
             = std::min( drawingTopPosition + effectiveHeight, maxPullToFollowTop );
     }
@@ -1997,7 +1999,28 @@ void AbstractLogView::setSearchLimits( LineNumber startLine, LineNumber endLine 
 LinesCount AbstractLogView::getNbVisibleLines() const
 {
     return LinesCount(
-        static_cast<LinesCount::UnderlyingType>( viewport()->height() / charHeight_ + 1 ) );
+        static_cast<LinesCount::UnderlyingType>( textViewportHeight() / charHeight_ + 1 ) );
+}
+
+int AbstractLogView::textViewportHeight() const
+{
+    return std::max( 0, viewport()->height() - horizontalScrollBarOverlayHeight() );
+}
+
+int AbstractLogView::horizontalScrollBarOverlayHeight() const
+{
+    if ( horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
+         || horizontalScrollBar()->maximum() <= 0 ) {
+        return 0;
+    }
+
+    const auto transientScrollBar
+        = style()->styleHint( QStyle::SH_ScrollBar_Transient, nullptr, horizontalScrollBar() ) != 0;
+    if ( !transientScrollBar ) {
+        return 0;
+    }
+
+    return horizontalScrollBar()->sizeHint().height();
 }
 
 // Returns the number of columns visible in the viewport

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -22,7 +22,9 @@
 #include <QShortcut>
 #include <QSignalSpy>
 #include <QLineEdit>
+#include <QProxyStyle>
 #include <QScrollBar>
+#include <QStyle>
 #include <QTemporaryFile>
 #include <QTest>
 #include <QTimer>
@@ -50,6 +52,20 @@
 static const qint64 SL_NB_LINES = 100LL;
 
 namespace {
+class TransientScrollBarStyle : public QProxyStyle {
+  public:
+    int styleHint( StyleHint hint, const QStyleOption* option = nullptr,
+                   const QWidget* widget = nullptr,
+                   QStyleHintReturn* returnData = nullptr ) const override
+    {
+        if ( hint == QStyle::SH_ScrollBar_Transient ) {
+            return 1;
+        }
+
+        return QProxyStyle::styleHint( hint, option, widget, returnData );
+    }
+};
+
 bool generateDataFiles( QTemporaryFile& file )
 {
     char newLine[ 90 ];
@@ -189,6 +205,11 @@ struct AbstractLogView::access_by<AbstractLogViewPrivate> {
     static LineLength visibleColumns( const AbstractLogView* view )
     {
         return view->getNbVisibleCols();
+    }
+
+    static int textViewportHeight( const AbstractLogView* view )
+    {
+        return view->textViewportHeight();
     }
 
     static QShortcut* shortcutFor( const AbstractLogView* view, const QString& key )
@@ -500,6 +521,12 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
     int mainCharHeight() const
     {
         return AbstractLogView::access_by<AbstractLogViewPrivate>::charHeight( crawler->logMainView_ );
+    }
+
+    int mainTextViewportHeight() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::textViewportHeight(
+            crawler->logMainView_ );
     }
 
     int mainGetSelectedTextCallCount() const
@@ -1376,6 +1403,36 @@ SCENARIO( "Log view repaints after deferred horizontal scrollbar initialization"
              >= crawlerVisitor.mainViewportSize().width() );
     REQUIRE( crawlerVisitor.mainTextAreaCachePixmapSize().height()
              >= crawlerVisitor.mainViewportSize().height() );
+}
+
+SCENARIO( "Log view reserves space for transient horizontal scrollbars",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
+    REQUIRE( generateLongLineDataFile( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.mainView()->setStyle( new TransientScrollBarStyle );
+    crawlerVisitor.resizeViews( 260, 120 );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() > 0 );
+
+    const auto scrollbarHeight = crawlerVisitor.mainView()->horizontalScrollBar()->sizeHint().height();
+    REQUIRE( scrollbarHeight > 0 );
+    REQUIRE( crawlerVisitor.mainTextViewportHeight()
+             == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
 }
 
 SCENARIO( "Selection drag performance", "[ui][selection][regression]" )

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -1421,7 +1421,8 @@ SCENARIO( "Log view reserves space for transient horizontal scrollbars",
     REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
 
     crawlerVisitor.setTextWrap( false );
-    crawlerVisitor.mainView()->setStyle( new TransientScrollBarStyle );
+    static TransientScrollBarStyle transientStyle;
+    crawlerVisitor.mainView()->setStyle( &transientStyle );
     crawlerVisitor.resizeViews( 260, 120 );
     crawlerVisitor.render();
     QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(klogg_tests
     patternmatcher_test.cpp
     quicklabelpattern_test.cpp
     searchgeneration_test.cpp
+    logfiltereddataworker_test.cpp
     sessioninfo_test.cpp
     shortcut_bindings_test.cpp
     streaminglogdata_test.cpp

--- a/tests/unit/logfiltereddataworker_test.cpp
+++ b/tests/unit/logfiltereddataworker_test.cpp
@@ -44,17 +44,7 @@
 #include "regularexpression.h"
 #include "searchablelogdata.h"
 #include "synchronization.h"
-
-#if defined( __clang__ )
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wkeyword-macro"
-#endif
-#define private public
 #include "logfiltereddataworker.h"
-#undef private
-#if defined( __clang__ )
-#pragma clang diagnostic pop
-#endif
 #include "logfiltereddata.h"
 
 namespace {
@@ -89,30 +79,58 @@ class TestSearchableLogData : public SearchableLogData {
     void doDetachReader() const override {}
 };
 
-LogFilteredDataWorker::SearchRequest makeLiveRequest( quint64 operationId, LineNumber endLine )
-{
-    return LogFilteredDataWorker::SearchRequest{ LogFilteredDataWorker::SearchRequest::Type::LiveUpdate,
-                                                 RegularExpressionPattern{ QStringLiteral( "ERROR" ) },
-                                                 0_lnum,
-                                                 endLine,
-                                                 0_lnum,
-                                                 0,
-                                                 operationId,
-                                                 nullptr };
-}
 } // namespace
+
+struct LogFilteredDataWorkerPrivate {
+};
+
+template <>
+struct LogFilteredDataWorker::access_by<LogFilteredDataWorkerPrivate> {
+    static void enqueueOrDeferLiveRequest( LogFilteredDataWorker* worker, quint64 operationId,
+                                           LineNumber endLine )
+    {
+        worker->enqueueOrDeferLiveRequest( makeLiveRequest( operationId, endLine ) );
+    }
+
+    static void enqueueImmediateLiveRequest( LogFilteredDataWorker* worker, quint64 operationId,
+                                             LineNumber endLine )
+    {
+        worker->enqueueRequest( makeLiveRequest( operationId, endLine ), false );
+    }
+
+    static bool hasDeferredLiveRequest( LogFilteredDataWorker* worker )
+    {
+        std::lock_guard<std::mutex> lock( worker->requestMutex_ );
+        return worker->deferredLiveRequest_.has_value();
+    }
+
+  private:
+    static SearchRequest makeLiveRequest( quint64 operationId, LineNumber endLine )
+    {
+        return SearchRequest{ SearchRequest::Type::LiveUpdate,
+                              RegularExpressionPattern{ QStringLiteral( "ERROR" ) },
+                              0_lnum,
+                              endLine,
+                              0_lnum,
+                              0,
+                              operationId,
+                              nullptr };
+    }
+};
 
 TEST_CASE( "LogFilteredDataWorker clears deferred live update when immediate live dispatch supersedes it" )
 {
+    using WorkerVisitor = LogFilteredDataWorker::access_by<LogFilteredDataWorkerPrivate>;
+
     TestSearchableLogData sourceLogData;
     LogFilteredDataWorker worker( sourceLogData );
 
-    worker.enqueueOrDeferLiveRequest( makeLiveRequest( 1, 10_lnum ) );
-    REQUIRE( worker.deferredLiveRequest_.has_value() );
+    WorkerVisitor::enqueueOrDeferLiveRequest( &worker, 1, 10_lnum );
+    REQUIRE( WorkerVisitor::hasDeferredLiveRequest( &worker ) );
 
-    worker.enqueueRequest( makeLiveRequest( 2, 100_lnum ), false );
+    WorkerVisitor::enqueueImmediateLiveRequest( &worker, 2, 100_lnum );
 
-    CHECK_FALSE( worker.deferredLiveRequest_.has_value() );
+    CHECK_FALSE( WorkerVisitor::hasDeferredLiveRequest( &worker ) );
 
     worker.shutdownAndWait();
 }

--- a/tests/unit/logfiltereddataworker_test.cpp
+++ b/tests/unit/logfiltereddataworker_test.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QDateTime>
+#include <QTextCodec>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+#ifndef Q_MOC_RUN
+#include <roaring.hh>
+#include <roaring64map.hh>
+#include <tbb/task_group.h>
+#endif
+
+#include "abstractlogdata.h"
+#include "atomicflag.h"
+#include "linetypes.h"
+#include "matchercache.h"
+#include "regularexpression.h"
+#include "searchablelogdata.h"
+#include "synchronization.h"
+
+#if defined( __clang__ )
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
+#endif
+#define private public
+#include "logfiltereddataworker.h"
+#undef private
+#if defined( __clang__ )
+#pragma clang diagnostic pop
+#endif
+
+namespace {
+class TestSearchableLogData : public SearchableLogData {
+  public:
+    void interruptLoading() override {}
+    std::unique_ptr<LogFilteredData> getNewFilteredData() const override { return nullptr; }
+    qint64 getFileSize() const override { return 0; }
+    QDateTime getLastModifiedDate() const override { return {}; }
+    void reload( QTextCodec* = nullptr ) override {}
+    QTextCodec* getDetectedEncoding() const override { return QTextCodec::codecForName( "UTF-8" ); }
+    void setPrefilter( const QString& ) override {}
+    void setAnsiProcessingMode( AnsiProcessingMode ) override {}
+    RawLines getLinesRaw( LineNumber, LinesCount ) const override { return {}; }
+    bool isLiveSource() const override { return true; }
+
+  protected:
+    QString doGetLineString( LineNumber ) const override { return {}; }
+    QString doGetExpandedLineString( LineNumber ) const override { return {}; }
+    klogg::vector<QString> doGetLines( LineNumber, LinesCount ) const override { return {}; }
+    klogg::vector<QString> doGetExpandedLines( LineNumber, LinesCount ) const override
+    {
+        return {};
+    }
+    LineNumber doGetLineNumber( LineNumber index ) const override { return index; }
+    LinesCount doGetNbLine() const override { return 0_lcount; }
+    LineLength doGetMaxLength() const override { return 0_length; }
+    LineLength doGetLineLength( LineNumber ) const override { return 0_length; }
+    void doSetDisplayEncoding( const char* ) override {}
+    QTextCodec* doGetDisplayEncoding() const override { return QTextCodec::codecForName( "UTF-8" ); }
+    void doAttachReader() const override {}
+    void doDetachReader() const override {}
+};
+
+LogFilteredDataWorker::SearchRequest makeLiveRequest( quint64 operationId, LineNumber endLine )
+{
+    return LogFilteredDataWorker::SearchRequest{ LogFilteredDataWorker::SearchRequest::Type::LiveUpdate,
+                                                 RegularExpressionPattern{ QStringLiteral( "ERROR" ) },
+                                                 0_lnum,
+                                                 endLine,
+                                                 0_lnum,
+                                                 0,
+                                                 operationId,
+                                                 nullptr };
+}
+} // namespace
+
+TEST_CASE( "LogFilteredDataWorker clears deferred live update when immediate live dispatch supersedes it" )
+{
+    TestSearchableLogData sourceLogData;
+    LogFilteredDataWorker worker( sourceLogData );
+
+    worker.enqueueOrDeferLiveRequest( makeLiveRequest( 1, 10_lnum ) );
+    REQUIRE( worker.deferredLiveRequest_.has_value() );
+
+    worker.enqueueRequest( makeLiveRequest( 2, 100_lnum ), false );
+
+    CHECK_FALSE( worker.deferredLiveRequest_.has_value() );
+
+    worker.shutdownAndWait();
+}

--- a/tests/unit/logfiltereddataworker_test.cpp
+++ b/tests/unit/logfiltereddataworker_test.cpp
@@ -55,6 +55,7 @@
 #if defined( __clang__ )
 #pragma clang diagnostic pop
 #endif
+#include "logfiltereddata.h"
 
 namespace {
 class TestSearchableLogData : public SearchableLogData {


### PR DESCRIPTION
## Summary
- Fixes #22 by building Linux release artifacts with generic CPU flags and keeping Vectorscan from reintroducing `-march=native` in generic builds.
- Replaces deb dry-run checks with real package installation plus `QT_QPA_PLATFORM=offscreen klogg -v` for Jammy and Noble.
- Adds Linux package runtime lint plus a platform-fragile lint guard against `#define private public`, which caused the Windows-only test link failure.
- Fixes the LogFilteredDataWorker regression test to use the repo's `access_by<T>` test adapter and locked state reads instead of rewriting C++ access specifiers.
- Defers system proxy setup out of synchronous app startup, reserves space for transient horizontal scrollbars, and adds backlog plans for macOS signing plus release Changes automation.
- Fixes the Vectorscan patch hunk count after review cleanup so CI can apply the patch on every CMake-based platform job.

## Background
- Introduced by: Linux release packaging allowed builder-native CPU tuning; the new live-update regression test also used `#define private public` to inspect private state.
- Use case: Release artifacts must run on older x86-64 Linux systems, and PR CI must build the unit tests on Windows x64/x86.
- How to reproduce: Run PR 23 CI before the latest fixes; Windows x64/x86 fail linking `klogg_tests.exe` with unresolved `LogFilteredDataWorker::enqueueRequest` / `enqueueOrDeferLiveRequest` symbols. After the review cleanup, all CMake-based CI jobs failed earlier with `error: corrupt patch at line 19` while applying `fix_vectorscan_msvc_warning_flags.patch`.
- Root cause: Vectorscan selected native CPU flags inside its own CMake configuration; MSVC decorated test-call symbols as public because the test translation unit saw private members through a macro; and the patch hunk header still declared `+137,13` after one added line was removed.
- How to fix: Force Vectorscan x86-64/generic tuning under `KLOGG_GENERIC_CPU`, run real deb install checks, replace private macro access with an `access_by<T>` adapter, add lint coverage for package-runtime and platform-fragile patterns, and update the Vectorscan patch header to `+137,12`.

## Verification
- `python3 scripts/lint_linux_package_runtime.py`
- `python3 scripts/lint_platform_fragile.py`
- `python3 scripts/lint_platform_fragile.py --check-staged`
- `git diff --check`
- `git -C /tmp/vectorscan-patch-check apply --check /Users/johnsonv/ws/klogg/3rdparty/patches/fix_vectorscan_msvc_warning_flags.patch` against clean Vectorscan `d29730e1`
- `cmake --build build_root --target klogg_tests -j2`
- `QT_QPA_PLATFORM=offscreen build_root/output/klogg_tests "LogFilteredDataWorker clears deferred live update when immediate live dispatch supersedes it"`
- `QT_QPA_PLATFORM=offscreen build_root/output/klogg_tests`
- `cmake --build build_root --target klogg_itests -j2`
- `QT_QPA_PLATFORM=offscreen build_root/output/klogg_itests "Scenario: Log view reserves space for transient horizontal scrollbars"`
- Earlier in this PR: `cmake --build build_root --target klogg_tests klogg_itests klogg -j2`, scrollbar repaint UI regression, `klogg -v`, Docker Jammy clean configure showing Vectorscan `ARCH_C_FLAGS: -march=x86-64 -mtune=generic -msse4.2`, Docker Jammy `ci_build`/`ctest`/`cpack`, and real Jammy runtime deb install plus `klogg -v`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Better horizontal-scrollbar handling so text view reserves correct space.
  * Live-update behavior improved: immediate updates now supersede deferred ones.
  * Background startup tasks (proxy/version checks) moved to run after initialization to reduce startup work.

* **Tests**
  * New unit and UI tests covering live-update logic and transient scrollbar layout.

* **Chores**
  * CI and linting workflows enhanced to validate Linux package/runtime and platform lint rules.

* **Documentation**
  * Added backlog items for macOS signing/notarization and automated release notes generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
