### PR TITLE
Fix startup cleanup and live log state handling

### DIFF
--- a/.github/actions/docker-package/action.yml
+++ b/.github/actions/docker-package/action.yml
@@ -13,8 +13,10 @@ runs:
     - name: Check package
       if: ${{ matrix.config.check_command }}
       shell: sh
+      env:
+        KLOGG_CHECK_COMMAND: ${{ matrix.config.check_command }}
       run: |
-        docker run --rm -v "$KLOGG_WORKSPACE/$KLOGG_BUILD_ROOT/packages":/usr/local ${{ matrix.config.check_container }} /bin/bash -c "${{ matrix.config.check_command }}"
+        docker run --rm -v "$KLOGG_WORKSPACE/$KLOGG_BUILD_ROOT/packages":/usr/local ${{ matrix.config.check_container }} /bin/bash -c "$KLOGG_CHECK_COMMAND"
     
     - name: Linux AppImage 
       if: ${{ matrix.config.os == 'ubuntu_appimage' }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -386,14 +386,14 @@ jobs:
             container_root: docker/ubuntu22.04
             container: variar/klogg_ubuntu22.04
             cmake_opts: -DKLOGG_GENERIC_CPU=ON
-            check_command: apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y /usr/local/klogg*.deb && QT_QPA_PLATFORM=offscreen klogg -v
+            check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
 
           - os: ubuntu_noble
             os_version: 24.04
             arch: x64
             label: ubuntu-24.04-deb
             package_tag: vs-gen
-            check_command: apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y /usr/local/klogg*.deb && QT_QPA_PLATFORM=offscreen klogg -v
+            check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
             cpack_gen: DEB
             artifacts_id: noble
             package_suffix: deb

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -208,7 +208,7 @@ int main( int argc, char* argv[] )
               || ( !parameters.new_session
                    && ( previousRunCrashed
                         || ( parameters.filenames.empty() && config.loadLastSession() ) ) );
-        CaptureStore::cleanupUnusedCaptures( retainedAdbCaptureIds( sessionInfo ) );
+        CaptureStore::cleanupUnusedCapturesAsync( retainedAdbCaptureIds( sessionInfo ) );
 
         // Apply theme based on theme mode
         StyleManager::applyStyle( config.style() );

--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -54,7 +54,8 @@ class CaptureStore {
 
     static QString defaultRootPath();
     static void cleanupUnusedCaptures( const QSet<QString>& retainCaptureIds,
-                                       const QString& rootPath = {} );
+                                       const QString& rootPath = {},
+                                       const QDateTime& preserveModifiedAfter = {} );
     static void cleanupUnusedCapturesAsync( const QSet<QString>& retainCaptureIds,
                                             const QString& rootPath = {} );
 

--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -55,6 +55,8 @@ class CaptureStore {
     static QString defaultRootPath();
     static void cleanupUnusedCaptures( const QSet<QString>& retainCaptureIds,
                                        const QString& rootPath = {} );
+    static void cleanupUnusedCapturesAsync( const QSet<QString>& retainCaptureIds,
+                                            const QString& rootPath = {} );
 
     CaptureStore( const CaptureStore& ) = delete;
     CaptureStore& operator=( const CaptureStore& ) = delete;

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <limits>
 #include <stdexcept>
+#include <thread>
 
 #include <QDir>
 #include <QFileInfo>
@@ -62,6 +63,14 @@ void CaptureStore::cleanupUnusedCaptures( const QSet<QString>& retainCaptureIds,
         QDir orphanCaptureDir( entry.absoluteFilePath() );
         orphanCaptureDir.removeRecursively();
     }
+}
+
+void CaptureStore::cleanupUnusedCapturesAsync( const QSet<QString>& retainCaptureIds,
+                                               const QString& rootPath )
+{
+    std::thread( [ retainCaptureIds, rootPath ] {
+        CaptureStore::cleanupUnusedCaptures( retainCaptureIds, rootPath );
+    } ).detach();
 }
 
 CaptureStore::CaptureStore( QString captureId, QString rootPath )

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -8,6 +8,7 @@
 #include <thread>
 
 #include <QDir>
+#include <QDirIterator>
 #include <QFileInfo>
 
 #include "log.h"
@@ -39,6 +40,26 @@ void reserveSegmentMemory( QByteArray& data, qint64 targetBytes, qint64 budgetBy
     const auto cappedTarget = std::min<qint64>( reserveTarget, std::numeric_limits<int>::max() );
     data.reserve( type_safe::narrow_cast<int>( cappedTarget ) );
 }
+
+QDateTime latestModificationTime( const QFileInfo& entry )
+{
+    auto latestModification = entry.lastModified().toUTC();
+    if ( !entry.isDir() ) {
+        return latestModification;
+    }
+
+    QDirIterator iterator( entry.absoluteFilePath(), QDir::AllEntries | QDir::NoDotAndDotDot,
+                           QDirIterator::Subdirectories );
+    while ( iterator.hasNext() ) {
+        iterator.next();
+        const auto modified = iterator.fileInfo().lastModified().toUTC();
+        if ( !latestModification.isValid() || modified > latestModification ) {
+            latestModification = modified;
+        }
+    }
+
+    return latestModification;
+}
 } // namespace
 
 QString CaptureStore::defaultRootPath()
@@ -47,16 +68,22 @@ QString CaptureStore::defaultRootPath()
 }
 
 void CaptureStore::cleanupUnusedCaptures( const QSet<QString>& retainCaptureIds,
-                                          const QString& rootPath )
+                                          const QString& rootPath,
+                                          const QDateTime& preserveModifiedAfter )
 {
     QDir capturesRoot( rootPath.isEmpty() ? defaultRootPath() : rootPath );
     if ( !capturesRoot.exists() ) {
         return;
     }
 
+    const auto cutoff = preserveModifiedAfter.toUTC();
     const auto entries = capturesRoot.entryInfoList( QDir::Dirs | QDir::NoDotAndDotDot );
     for ( const auto& entry : entries ) {
         if ( retainCaptureIds.contains( entry.fileName() ) ) {
+            continue;
+        }
+
+        if ( cutoff.isValid() && latestModificationTime( entry ) > cutoff ) {
             continue;
         }
 
@@ -68,8 +95,9 @@ void CaptureStore::cleanupUnusedCaptures( const QSet<QString>& retainCaptureIds,
 void CaptureStore::cleanupUnusedCapturesAsync( const QSet<QString>& retainCaptureIds,
                                                const QString& rootPath )
 {
-    std::thread( [ retainCaptureIds, rootPath ] {
-        CaptureStore::cleanupUnusedCaptures( retainCaptureIds, rootPath );
+    const auto cleanupScheduledAt = QDateTime::currentDateTimeUtc();
+    std::thread( [ retainCaptureIds, rootPath, cleanupScheduledAt ] {
+        CaptureStore::cleanupUnusedCaptures( retainCaptureIds, rootPath, cleanupScheduledAt );
     } ).detach();
 }
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2009,18 +2009,26 @@ int AbstractLogView::textViewportHeight() const
 
 int AbstractLogView::horizontalScrollBarOverlayHeight() const
 {
-    if ( horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff
-         || horizontalScrollBar()->maximum() <= 0 ) {
+    if ( horizontalScrollBarPolicy() == Qt::ScrollBarAlwaysOff ) {
+        return 0;
+    }
+
+    const auto scrollBarHeight = horizontalScrollBar()->sizeHint().height();
+    if ( scrollBarHeight <= 0 ) {
         return 0;
     }
 
     const auto transientScrollBar
         = style()->styleHint( QStyle::SH_ScrollBar_Transient, nullptr, horizontalScrollBar() ) != 0;
-    if ( !transientScrollBar ) {
+    if ( transientScrollBar ) {
+        return scrollBarHeight;
+    }
+
+    if ( horizontalScrollBar()->isVisible() ) {
         return 0;
     }
 
-    return horizontalScrollBar()->sizeHint().height();
+    return scrollBarHeight;
 }
 
 // Returns the number of columns visible in the viewport

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2024,11 +2024,7 @@ int AbstractLogView::horizontalScrollBarOverlayHeight() const
         return scrollBarHeight;
     }
 
-    if ( horizontalScrollBar()->isVisible() ) {
-        return 0;
-    }
-
-    return scrollBarHeight;
+    return 0;
 }
 
 // Returns the number of columns visible in the viewport

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -75,16 +75,13 @@ void ProcessLiveSourceTransport::createProcess()
                  }
 
                  if ( state_ == State::Connected || state_ == State::Connecting ) {
-                     if ( exitStatus != QProcess::NormalExit || exitCode != 0 || !lastError_.isEmpty() ) {
-                         if ( lastError_.isEmpty() ) {
-                             lastError_ = tr( "Live source exited unexpectedly (%1)" ).arg( exitCode );
-                         }
-                         setState( State::Error );
-                         Q_EMIT errorOccurred( lastError_ );
+                     if ( lastError_.isEmpty() ) {
+                         lastError_ = exitStatus == QProcess::NormalExit
+                                          ? tr( "Live source exited unexpectedly (%1)" ).arg( exitCode )
+                                          : tr( "Live source crashed" );
                      }
-                     else {
-                         setState( State::Disconnected );
-                     }
+                     setState( State::Error );
+                     Q_EMIT errorOccurred( lastError_ );
                  }
              } );
 }

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -1436,6 +1436,41 @@ SCENARIO( "Log view reserves space for transient horizontal scrollbars",
              == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
 }
 
+SCENARIO( "Log view keeps the bottom text gutter stable without horizontal overflow",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_short_lines_XXXXXX" };
+    REQUIRE( file.open() );
+    for ( int i = 0; i < SL_NB_LINES; ++i ) {
+        file.write( QStringLiteral( "short line %1\n" ).arg( i ).toUtf8() );
+    }
+    file.flush();
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    static TransientScrollBarStyle transientStyle;
+    crawlerVisitor.mainView()->setStyle( &transientStyle );
+    crawlerVisitor.resizeViews( 1600, 120 );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() == 0 );
+
+    const auto scrollbarHeight = crawlerVisitor.mainView()->horizontalScrollBar()->sizeHint().height();
+    REQUIRE( scrollbarHeight > 0 );
+    REQUIRE( crawlerVisitor.mainTextViewportHeight()
+             == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
+}
+
 SCENARIO( "Selection drag performance", "[ui][selection][regression]" )
 {
     QTemporaryFile file{ "crawler_selection_perf_XXXXXX" };

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -66,6 +66,20 @@ class TransientScrollBarStyle : public QProxyStyle {
     }
 };
 
+class ClassicScrollBarStyle : public QProxyStyle {
+  public:
+    int styleHint( StyleHint hint, const QStyleOption* option = nullptr,
+                   const QWidget* widget = nullptr,
+                   QStyleHintReturn* returnData = nullptr ) const override
+    {
+        if ( hint == QStyle::SH_ScrollBar_Transient ) {
+            return 0;
+        }
+
+        return QProxyStyle::styleHint( hint, option, widget, returnData );
+    }
+};
+
 bool generateDataFiles( QTemporaryFile& file )
 {
     char newLine[ 90 ];
@@ -1469,6 +1483,38 @@ SCENARIO( "Log view keeps the bottom text gutter stable without horizontal overf
     REQUIRE( scrollbarHeight > 0 );
     REQUIRE( crawlerVisitor.mainTextViewportHeight()
              == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
+}
+
+SCENARIO( "Log view does not reserve hidden classic horizontal scrollbar gutter",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_short_lines_XXXXXX" };
+    REQUIRE( file.open() );
+    for ( int i = 0; i < SL_NB_LINES; ++i ) {
+        file.write( QStringLiteral( "short line %1\n" ).arg( i ).toUtf8() );
+    }
+    file.flush();
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    static ClassicScrollBarStyle classicStyle;
+    crawlerVisitor.mainView()->setStyle( &classicStyle );
+    crawlerVisitor.resizeViews( 1600, 120 );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() == 0 );
+    REQUIRE_FALSE( crawlerVisitor.mainView()->horizontalScrollBar()->isVisible() );
+    REQUIRE( crawlerVisitor.mainTextViewportHeight() == crawlerVisitor.mainViewportSize().height() );
 }
 
 SCENARIO( "Selection drag performance", "[ui][selection][regression]" )

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -665,6 +665,66 @@ SCENARIO( "MainWindow close preserves restored ADB capture files", "[ui][session
     config.save();
 }
 
+SCENARIO( "MainWindow restored iOS live log tabs show disconnected state",
+          "[ui][session][ios]" )
+{
+    auto appSession = std::make_shared<Session>();
+    auto& sessionInfo = SessionInfo::getSynced();
+    auto windowIds = sessionInfo.windows();
+    const auto windowId = QString( "restore-ios-session-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+
+    for ( const auto& existingWindowId : windowIds ) {
+        sessionInfo.remove( existingWindowId );
+    }
+    sessionInfo.add( windowId );
+
+    const AdbLogcatSessionData iosSessionData{
+        QStringLiteral( "pymobiledevice3" ),
+        QStringLiteral( "00008030-001C195E36D8802E" ),
+        QStringLiteral( "iPhone Test" ),
+        QString{},
+        QString( "ios_capture_%1" ).arg( QUuid::createUuid().toString( QUuid::WithoutBraces ) ),
+        QString{},
+        LiveLogSourceType::IosLogStream,
+    };
+    const auto sourceSpec = QString::fromUtf8(
+        QJsonDocument( iosSessionData.toJson() ).toJson( QJsonDocument::Compact ) );
+
+    sessionInfo.setOpenFiles(
+        windowId, { SessionInfo::OpenFile( iosSessionData.documentId(), 0, {},
+                                           iosSessionData.persistedSourceType(),
+                                           iosSessionData.displayName(), sourceSpec ) } );
+    sessionInfo.setCurrentFileIndex( windowId, 0 );
+    sessionInfo.save();
+
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+
+    QTest::qWait( 100 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    auto tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+
+    runInUiThread( [&mainWindow] { mainWindow->reloadSession(); } );
+    REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+    REQUIRE( tabArea->tabText( 0 ) == QStringLiteral( "iPhone Test [disconnected]" ) );
+
+    mainWindow->close();
+    sessionInfo.remove( windowId );
+    sessionInfo.save();
+}
+
 SCENARIO( "Session restore clears unavailable ADB output bindings", "[ui][session][adb]" )
 {
     auto appSession = std::make_shared<Session>();

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -78,6 +78,58 @@ struct TabGroupCleanupGuard {
     }
 };
 
+struct SessionInfoWindowSnapshot {
+    QString id;
+    QByteArray geometry;
+    int currentFileIndex = -1;
+    std::vector<SessionInfo::OpenFile> openFiles;
+};
+
+class SessionInfoRestoreGuard {
+  public:
+    explicit SessionInfoRestoreGuard( SessionInfo& sessionInfo )
+        : sessionInfo_{ sessionInfo }
+    {
+        for ( const auto& windowId : sessionInfo_.windows() ) {
+            snapshots_.push_back( { windowId, sessionInfo_.geometry( windowId ),
+                                    sessionInfo_.currentFileIndex( windowId ),
+                                    sessionInfo_.openFiles( windowId ) } );
+        }
+    }
+
+    ~SessionInfoRestoreGuard()
+    {
+        QStringList originalWindowIds;
+        for ( const auto& snapshot : snapshots_ ) {
+            originalWindowIds.push_back( snapshot.id );
+            sessionInfo_.add( snapshot.id );
+            sessionInfo_.setGeometry( snapshot.id, snapshot.geometry );
+            sessionInfo_.setCurrentFileIndex( snapshot.id, snapshot.currentFileIndex );
+            sessionInfo_.setOpenFiles( snapshot.id, snapshot.openFiles );
+        }
+
+        for ( const auto& windowId : sessionInfo_.windows() ) {
+            if ( !originalWindowIds.contains( windowId ) ) {
+                sessionInfo_.remove( windowId );
+            }
+        }
+
+        if ( snapshots_.empty() ) {
+            for ( const auto& windowId : sessionInfo_.windows() ) {
+                sessionInfo_.setGeometry( windowId, {} );
+                sessionInfo_.setCurrentFileIndex( windowId, -1 );
+                sessionInfo_.setOpenFiles( windowId, {} );
+            }
+        }
+
+        sessionInfo_.save();
+    }
+
+  private:
+    SessionInfo& sessionInfo_;
+    std::vector<SessionInfoWindowSnapshot> snapshots_;
+};
+
 QToolButton* findGroupChipButton( QTabBar* tabBar, int tabIndex )
 {
     if ( tabBar == nullptr || tabIndex < 0 || tabIndex >= tabBar->count() ) {
@@ -670,14 +722,15 @@ SCENARIO( "MainWindow restored iOS live log tabs show disconnected state",
 {
     auto appSession = std::make_shared<Session>();
     auto& sessionInfo = SessionInfo::getSynced();
-    auto windowIds = sessionInfo.windows();
+    SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
+    const auto windowIds = sessionInfo.windows();
     const auto windowId = QString( "restore-ios-session-%1" ).arg(
         QUuid::createUuid().toString( QUuid::WithoutBraces ) );
 
+    sessionInfo.add( windowId );
     for ( const auto& existingWindowId : windowIds ) {
         sessionInfo.remove( existingWindowId );
     }
-    sessionInfo.add( windowId );
 
     const AdbLogcatSessionData iosSessionData{
         QStringLiteral( "pymobiledevice3" ),

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -909,6 +909,30 @@ class LongRunningTestTransport : public ProcessLiveSourceTransport {
 #endif
     }
 };
+
+class FiniteSuccessfulTestTransport : public ProcessLiveSourceTransport {
+  public:
+    Command streamingCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "cmd" ),
+                 { QStringLiteral( "/c" ),
+                   QStringLiteral( "ping -n 2 127.0.0.1 > nul & exit /b 0" ) } };
+#else
+        return { QStringLiteral( "/bin/sh" ),
+                 { QStringLiteral( "-c" ), QStringLiteral( "sleep 0.5; exit 0" ) } };
+#endif
+    }
+
+    Command clearCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "cmd" ), { QStringLiteral( "/c" ), QStringLiteral( "echo" ) } };
+#else
+        return { QStringLiteral( "true" ), {} };
+#endif
+    }
+};
 } // namespace
 
 TEST_CASE( "ProcessLiveSourceTransport suppresses errorOccurred during intentional disconnect" )
@@ -938,6 +962,24 @@ TEST_CASE( "ProcessLiveSourceTransport suppresses errorOccurred during intention
     const auto lastState
         = stateSpy.at( stateSpy.count() - 1 ).at( 0 ).value<LiveSourceTransport::State>();
     CHECK( lastState == LiveSourceTransport::State::Disconnected );
+}
+
+TEST_CASE( "ProcessLiveSourceTransport treats unexpected clean process exit as error" )
+{
+    FiniteSuccessfulTestTransport transport;
+
+    SafeQSignalSpy errorSpy( &transport, SIGNAL( errorOccurred( QString ) ) );
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+
+    REQUIRE( transport.connectTransport() );
+
+    REQUIRE( errorSpy.safeWait( 3000 ) );
+    REQUIRE_FALSE( transport.lastError().isEmpty() );
+
+    REQUIRE( stateSpy.count() >= 1 );
+    const auto lastState
+        = stateSpy.at( stateSpy.count() - 1 ).at( 0 ).value<LiveSourceTransport::State>();
+    CHECK( lastState == LiveSourceTransport::State::Error );
 }
 
 TEST_CASE( "ProcessLiveSourceTransport async disconnect returns immediately" )

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -164,7 +164,7 @@ TEST_CASE( "CaptureStore cleanupUnusedCapturesAsync removes orphan captures off 
     const auto elapsedMs = timer.elapsed();
 
     INFO( "cleanup scheduling elapsed ms: " << elapsedMs );
-    REQUIRE( elapsedMs < 50 );
+    CHECK( elapsedMs < 200 );
     REQUIRE( QDir{ retainedPath }.exists() );
 
     QElapsedTimer deadline;
@@ -175,6 +175,35 @@ TEST_CASE( "CaptureStore cleanupUnusedCapturesAsync removes orphan captures off 
 
     REQUIRE_FALSE( QDir{ orphanPath }.exists() );
     REQUIRE( QDir{ retainedPath }.exists() );
+}
+
+TEST_CASE( "CaptureStore cleanupUnusedCaptures preserves captures modified after cutoff" )
+{
+    const auto rootPath = makeTestDir( "capturestore_cleanup_cutoff" );
+    const auto orphanCaptureId = makeCaptureId();
+    const auto activeCaptureId = makeCaptureId();
+    const auto orphanPath = QDir( rootPath ).filePath( orphanCaptureId );
+    const auto activePath = QDir( rootPath ).filePath( activeCaptureId );
+
+    REQUIRE( QDir{}.mkpath( orphanPath ) );
+    QFile orphanSegment( QDir( orphanPath ).filePath( QStringLiteral( "segment_000000.log" ) ) );
+    REQUIRE( orphanSegment.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    orphanSegment.write( QByteArrayLiteral( "old\n" ) );
+    orphanSegment.close();
+
+    const auto cleanupCutoff = QDateTime::currentDateTimeUtc();
+    std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+
+    REQUIRE( QDir{}.mkpath( activePath ) );
+    QFile activeSegment( QDir( activePath ).filePath( QStringLiteral( "segment_000000.log" ) ) );
+    REQUIRE( activeSegment.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    activeSegment.write( QByteArrayLiteral( "new\n" ) );
+    activeSegment.close();
+
+    CaptureStore::cleanupUnusedCaptures( {}, rootPath, cleanupCutoff );
+
+    REQUIRE_FALSE( QDir{ orphanPath }.exists() );
+    REQUIRE( QDir{ activePath }.exists() );
 }
 
 TEST_CASE( "CaptureStore bindOutputFile overwrites existing files and replays spilled segments" )

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -20,6 +20,7 @@
 #include <catch2/catch.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <thread>
 #include <QDir>
 #include <QElapsedTimer>
@@ -139,6 +140,41 @@ TEST_CASE( "CaptureStore deleteCaptureFiles suppresses destructor persistence" )
     }
 
     REQUIRE_FALSE( QFileInfo::exists( capturePath ) );
+}
+
+TEST_CASE( "CaptureStore cleanupUnusedCapturesAsync removes orphan captures off the startup path" )
+{
+    const auto rootPath = makeTestDir( "capturestore_async_cleanup" );
+    const auto retainedCaptureId = makeCaptureId();
+    const auto orphanCaptureId = makeCaptureId();
+    const auto retainedPath = QDir( rootPath ).filePath( retainedCaptureId );
+    const auto orphanPath = QDir( rootPath ).filePath( orphanCaptureId );
+
+    REQUIRE( QDir{}.mkpath( retainedPath ) );
+    REQUIRE( QDir{}.mkpath( orphanPath ) );
+
+    QFile orphanSegment( QDir( orphanPath ).filePath( QStringLiteral( "segment_000000.log" ) ) );
+    REQUIRE( orphanSegment.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    orphanSegment.write( QByteArray( 1024 * 1024, 'x' ) );
+    orphanSegment.close();
+
+    QElapsedTimer timer;
+    timer.start();
+    CaptureStore::cleanupUnusedCapturesAsync( QSet<QString>{ retainedCaptureId }, rootPath );
+    const auto elapsedMs = timer.elapsed();
+
+    INFO( "cleanup scheduling elapsed ms: " << elapsedMs );
+    REQUIRE( elapsedMs < 50 );
+    REQUIRE( QDir{ retainedPath }.exists() );
+
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( QDir{ orphanPath }.exists() && deadline.elapsed() < 5000 ) {
+        std::this_thread::sleep_for( std::chrono::milliseconds( 20 ) );
+    }
+
+    REQUIRE_FALSE( QDir{ orphanPath }.exists() );
+    REQUIRE( QDir{ retainedPath }.exists() );
 }
 
 TEST_CASE( "CaptureStore bindOutputFile overwrites existing files and replays spilled segments" )


### PR DESCRIPTION
## Summary
- Move unused capture cleanup off the startup path so stale live capture directories do not block startup.
- Prevent async capture cleanup from deleting live captures created or modified after cleanup was scheduled.
- Keep iOS restored live log tabs visibly disconnected and treat unexpected live-source process exits as errors.
- Fix horizontal scrollbar gutter handling so only transient overlay scrollbars reserve hidden gutter height; classic scrollbars no longer shrink the text viewport when hidden.
- Harden Debian package verification so transient apt/DNS failures are retried and apt index warnings cannot fall through as misleading dependency failures.
- Add regression coverage for async cleanup cutoff behavior, iOS restored tabs, live-source clean exits, transient/classic scrollbar behavior, and the CI repaint scenario.

## Background
- Introduced by: PR #24 moved cleanup into a detached startup worker and changed bottom scrollbar spacing logic.
- Use case: Users launching with stale captures, restoring iOS live log sessions, losing live-source processes unexpectedly, or viewing logs under different platform scrollbar styles.
- How to reproduce: On the previous revision, run the PR CI matrix or run `klogg_itests -platform offscreen "Scenario: Log view repaints after deferred horizontal scrollbar initialization"`; Linux/Windows failed while macOS passed. The macOS miss happened because the local style path used transient/overlay scrollbar behavior, while CI exercised classic non-transient scrollbar behavior where hidden scrollbars should not reserve gutter height.
- Root cause: `AbstractLogView::horizontalScrollBarOverlayHeight()` reserved scrollbar height for any hidden horizontal scrollbar, not only transient overlay scrollbars. Async cleanup also only knew startup retained IDs, so a capture created after scheduling could be considered orphaned.
- How to fix: Limit hidden gutter reservation to transient scrollbars, add a macOS-runnable classic-scrollbar regression style to catch the CI class locally, pass a scheduled-at cutoff into `CaptureStore` cleanup and skip captures modified after that cutoff, relax the flaky scheduling assertion, and restore `SessionInfo` state after the iOS restore test.
- CI rerun note: The original Linux/Windows `klogg_itests` failures passed after the scrollbar fix. The next rerun exposed a separate Debian package verification failure caused by temporary DNS resolution failures for Ubuntu apt mirrors inside the check container; the package check now retries apt updates and treats update warnings as failures before install.

## Tests
- `cmake --build build_root --target klogg_tests klogg_itests -j2`
- `build_root/output/klogg_itests -platform offscreen "Scenario: Log view does not reserve hidden classic horizontal scrollbar gutter"`
- `build_root/output/klogg_itests -platform offscreen "Scenario: Log view repaints after deferred horizontal scrollbar initialization"`
- `build_root/output/klogg_itests -platform offscreen "[scrollbar]"`
- `build_root/output/klogg_tests -platform offscreen "CaptureStore cleanupUnusedCaptures*"`
- `build_root/output/klogg_itests -platform offscreen "Scenario: MainWindow restored iOS live log tabs show disconnected state"`
- `python3 scripts/lint_platform_fragile.py`
- `python3 scripts/lint_linux_package_runtime.py`
- `ctest --test-dir build_root --output-on-failure`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci-build.yml"); YAML.load_file(".github/actions/docker-package/action.yml"); puts "yaml ok"'`
- `bash -n /tmp/klogg-check-jammy.sh && bash -n /tmp/klogg-check-noble.sh`
- `git diff --check`

## CI Prevention
- Added a dedicated classic/non-transient scrollbar test style in `tests/ui/crawlerwidget_test.cpp`, so macOS local/offscreen tests now cover the Linux/Windows scrollbar branch that failed in CI.
- Kept the existing `platform-fragile patterns` lint green; CI is already running it as a fast gate before the full matrix.
- Added apt retry logic to Debian package verification and enabled `APT::Update::Error-Mode=any`, so transient apt mirror or DNS failures do not immediately fail a PR and cannot masquerade as package dependency issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Startup now performs capture cleanup asynchronously and preserves captures modified recently, improving startup responsiveness and data safety.

* **Bug Fixes**
  * Fixed horizontal scrollbar overlay height calculation for more stable layout.
  * Live-source transport now consistently reports error state when streaming processes exit unexpectedly.

* **Tests**
  * Added tests for session restoration, scrollbar behaviors, async cleanup, and transport error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->