### PR TITLE
Fix filtered log defaults and release notes

### DIFF
--- a/.github/actions/agent-package-mac/action.yml
+++ b/.github/actions/agent-package-mac/action.yml
@@ -5,6 +5,10 @@ inputs:
     required: false
   p12-password:
     required: false
+  codesign-identity:
+    required: false
+  installer-sign-identity:
+    required: false
   notarization-username:
     required: false
   notarization-team:
@@ -15,13 +19,41 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Mac prepare codesign
-      id: prepare-codesign
-      if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
-      uses: apple-actions/import-codesign-certs@v1
-      with: 
-        p12-file-base64: ${{ inputs.p12-file-base64 }}
-        p12-password: ${{ inputs.p12-password }}
+    # macOS signing/notarization is disabled until the CI account has a paid
+    # Apple Developer Program membership and Developer ID certificates.
+    #
+    # - name: Mac signing preflight
+    #   if: ${{ github.event_name != 'pull_request' }}
+    #   shell: sh
+    #   run: |
+    #     missing=0
+    #     require_input() {
+    #       name="$1"
+    #       value="$2"
+    #       if [ -z "${value}" ]; then
+    #         echo "::error::Missing macOS signing input: ${name}"
+    #         missing=1
+    #       fi
+    #     }
+    #
+    #     require_input "p12-file-base64 (GitHub secret CODESIGN_BASE64)" "${{ inputs.p12-file-base64 }}"
+    #     require_input "p12-password (GitHub secret CODESIGN_PASSWORD)" "${{ inputs.p12-password }}"
+    #     require_input "codesign-identity (GitHub secret APPLE_DEVELOPER_ID_APPLICATION)" "${{ inputs.codesign-identity }}"
+    #     require_input "notarization-username (GitHub secret NOTARIZATION_USERNAME)" "${{ inputs.notarization-username }}"
+    #     require_input "notarization-team (GitHub secret NOTARIZATION_TEAM)" "${{ inputs.notarization-team }}"
+    #     require_input "notarization-password (GitHub secret NOTARIZATION_PASSWORD)" "${{ inputs.notarization-password }}"
+    #
+    #     if [ "${missing}" -ne 0 ]; then
+    #       exit 1
+    #     fi
+    #
+    # - name: Mac prepare codesign
+    #   id: prepare-codesign
+    #   if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
+    #   uses: apple-actions/import-codesign-certs@v1
+    #   with:
+    #     p12-file-base64: ${{ inputs.p12-file-base64 }}
+    #     p12-password: ${{ inputs.p12-password }}
      
     - name: Mac deploy Qt
       shell: sh
@@ -48,18 +80,19 @@ runs:
     - name: Set packaging env
       shell: sh
       run: |
-        echo "KLOGG_CODESIGN=Developer ID Application: Anton Filimonov (GAW773U324)" >> $GITHUB_ENV
-        echo "KLOGG_INSTALLERSIGN=Developer ID Installer: Anton Filimonov (GAW773U324)" >> $GITHUB_ENV
+        # echo "KLOGG_CODESIGN=${{ inputs.codesign-identity }}" >> $GITHUB_ENV
+        # echo "KLOGG_INSTALLERSIGN=${{ inputs.installer-sign-identity }}" >> $GITHUB_ENV
         echo "KLOGG_DMG=klogg-${{ env.KLOGG_VERSION }}-mac-${{ env.KLOGG_ARCH }}-${{ env.KLOGG_PACKAGE_TAG }}.dmg" >> $GITHUB_ENV
         echo "KLOGG_PKG=klogg-${{ env.KLOGG_VERSION }}-mac-${{ env.KLOGG_ARCH }}-${{ env.KLOGG_PACKAGE_TAG }}.pkg" >> $GITHUB_ENV
 
-    - name: Mac codesign binaries
-      if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
-      shell: sh
-      run: |
-        cd $KLOGG_BUILD_ROOT
-        codesign -v -f -o runtime --deep --timestamp -s "${{ env.KLOGG_CODESIGN }}" ./output/klogg.app;
-    
+    # - name: Mac codesign binaries
+    #   if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
+    #   shell: sh
+    #   run: |
+    #     cd $KLOGG_BUILD_ROOT
+    #     codesign -v -f -o runtime --deep --timestamp -s "${{ env.KLOGG_CODESIGN }}" ./output/klogg.app;
+    #     codesign --verify --deep --strict --verbose=2 ./output/klogg.app
+
     - name: Mac pack dmg
       shell: sh
       run: |
@@ -116,27 +149,30 @@ runs:
         mv ./packages/klogg-${{ env.KLOGG_VERSION }}-OSX.dmg ./packages/${{ env.KLOGG_DMG }}
         echo "Renamed DMG to: ${{ env.KLOGG_DMG }}"
 
-    - name: Mac codesign dmg
-      if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
-      shell: sh
-      run: |
-        cd $KLOGG_BUILD_ROOT
-        codesign -v -f -o runtime --timestamp -s "${{ env.KLOGG_CODESIGN }}" ./packages/${{ env.KLOGG_DMG }}
-    
-    - name: Mac notarize DMG 
-      if: ${{ github.event_name != 'pull_request' && inputs.notarization-username != '' }}
-      shell: sh
-      run: |
-        xcrun notarytool submit --wait --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}" | tee dmg_notary.log
-        dmg_notary_id=$(awk '$1=="id:"{id=$2} END{print id}' dmg_notary.log)
-        xcrun notarytool log --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "$dmg_notary_id" "dmg_notary.log.json"
-        cat "dmg_notary.log.json"
-
-    - name: Mac staple DMG 
-      if: ${{ github.event_name != 'pull_request' && inputs.notarization-username != '' }}
-      shell: sh
-      run: |
-        xcrun stapler staple "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}"
+    # - name: Mac codesign dmg
+    #   if: ${{ github.event_name != 'pull_request' && inputs.p12-file-base64 != '' }}
+    #   shell: sh
+    #   run: |
+    #     cd $KLOGG_BUILD_ROOT
+    #     codesign -v -f -o runtime --timestamp -s "${{ env.KLOGG_CODESIGN }}" ./packages/${{ env.KLOGG_DMG }}
+    #     codesign --verify --strict --verbose=2 ./packages/${{ env.KLOGG_DMG }}
+    #
+    # - name: Mac notarize DMG
+    #   if: ${{ github.event_name != 'pull_request' && inputs.notarization-username != '' }}
+    #   shell: sh
+    #   run: |
+    #     xcrun notarytool submit --wait --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}" | tee dmg_notary.log
+    #     dmg_notary_id=$(awk '$1=="id:"{id=$2} END{print id}' dmg_notary.log)
+    #     xcrun notarytool log --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "$dmg_notary_id" "dmg_notary.log.json"
+    #     cat "dmg_notary.log.json"
+    #
+    # - name: Mac staple DMG
+    #   if: ${{ github.event_name != 'pull_request' && inputs.notarization-username != '' }}
+    #   shell: sh
+    #   run: |
+    #     xcrun stapler staple "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}"
+    #     xcrun stapler validate "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}"
+    #     spctl --assess --type open --context context:primary-signature --verbose "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_DMG }}"
 
     #- name: "Mac build pkg"
     #  if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -548,12 +548,16 @@ jobs:
       - uses: ./.github/actions/agent-build
       - uses: ./.github/actions/agent-run-tests
       - uses: ./.github/actions/agent-package-mac
-        with:
-          p12-file-base64: ${{ secrets.CODESIGN_BASE64 }}
-          p12-password: ${{ secrets.CODESIGN_PASSWORD }}
-          notarization-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          notarization-team: ${{ secrets.NOTARIZATION_TEAM }}
-          notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+        # macOS signing/notarization is disabled until the CI account has a paid
+        # Apple Developer Program membership and Developer ID certificates.
+        # with:
+        #   p12-file-base64: ${{ secrets.CODESIGN_BASE64 }}
+        #   p12-password: ${{ secrets.CODESIGN_PASSWORD }}
+        #   codesign-identity: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+        #   installer-sign-identity: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}
+        #   notarization-username: ${{ secrets.NOTARIZATION_USERNAME }}
+        #   notarization-team: ${{ secrets.NOTARIZATION_TEAM }}
+        #   notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -845,15 +849,7 @@ jobs:
         id: changelog
         shell: bash
         run: |
-          # Find the last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            echo "No previous tag found. Generating log from start."
-            CHANGELOG=$(git log --pretty=format:"* %s (%h)")
-          else
-            echo "Generating changelog since $LAST_TAG"
-            CHANGELOG=$(git log --pretty=format:"* %s (%h)" ${LAST_TAG}..HEAD)
-          fi
+          CHANGELOG="$(python3 scripts/gen_changelog.py --mode prerelease --to-ref HEAD --print-range)"
           
           # Escape newlines for GITHUB_ENV
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   SaveVersion:
-    needs: [PrefetchDeps]
+    needs: [PrefetchDeps, PrefetchWindowsTools]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-22.04
     outputs:
@@ -566,7 +566,7 @@ jobs:
           if-no-files-found: warn
 
   Windows:
-    needs: [SaveVersion, PrefetchWindowsTools]
+    needs: [SaveVersion]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -19,26 +19,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Generate Changelog
-      id: changelog
-      shell: bash
-      run: |
-        # Find the last tag
-        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-        if [ -z "$LAST_TAG" ]; then
-          echo "No previous tag found. Generating log from start."
-          CHANGELOG=$(git log --pretty=format:"* %s (%h)")
-        else
-          echo "Generating changelog since $LAST_TAG"
-          CHANGELOG=$(git log --pretty=format:"* %s (%h)" ${LAST_TAG}..HEAD)
-        fi
-        
-        # Escape newlines for GITHUB_ENV
-        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-        echo "CHANGELOG<<$EOF" >> $GITHUB_ENV
-        echo "$CHANGELOG" >> $GITHUB_ENV
-        echo "$EOF" >> $GITHUB_ENV
-
     - name: Download artifacts for last successful CI workflow
       if: ${{ !github.event.inputs.ci-run-id }}
       uses: dawidd6/action-download-artifact@v2
@@ -56,6 +36,18 @@ jobs:
 
     - name: Initialize version
       run: echo "KLOGG_VERSION=`cat klogg_version/klogg_version.txt`" >> $GITHUB_ENV
+
+    - name: Generate Changelog
+      id: changelog
+      shell: bash
+      run: |
+        CHANGELOG="$(python3 scripts/gen_changelog.py --mode release --current-tag "v${KLOGG_VERSION}" --to-ref HEAD --print-range)"
+
+        # Escape newlines for GITHUB_ENV
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "CHANGELOG<<$EOF" >> $GITHUB_ENV
+        echo "$CHANGELOG" >> $GITHUB_ENV
+        echo "$EOF" >> $GITHUB_ENV
 
     - name: Display structure of downloaded files
       run: ls -R ./packages-*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,3 +22,4 @@ jobs:
         run: |
           python3 scripts/lint_platform_fragile.py
           python3 scripts/lint_linux_package_runtime.py
+          python3 -m unittest discover -s tests/scripts -p 'test_*.py'

--- a/scripts/gen_changelog.py
+++ b/scripts/gen_changelog.py
@@ -44,7 +44,7 @@ def git(args: List[str]) -> str:
 
 
 def version_tags() -> List[str]:
-    output = git(["tag", "--list", "v[0-9]*", "--sort=-v:refname"])
+    output = git(["tag", "--list", "v[0-9]*", "--sort=-v:refname", "--merged", "HEAD"])
     return [line.strip() for line in output.splitlines() if line.strip()]
 
 

--- a/scripts/gen_changelog.py
+++ b/scripts/gen_changelog.py
@@ -73,10 +73,12 @@ def normalize_group(group: str, message: str) -> str:
         return "docs"
     if group == "test":
         return "tests"
-    if group in {key for key, _ in GROUPS_MAPPING}:
+    if group in {key for key, _ in GROUPS_MAPPING} and group != "other":
         return group
     if "feature" in message.lower():
         return "feature"
+    if group == "other":
+        return group
     return "other"
 
 

--- a/scripts/gen_changelog.py
+++ b/scripts/gen_changelog.py
@@ -1,17 +1,16 @@
-import os
-import subprocess
+#!/usr/bin/env python3
+import argparse
 import re
-from datetime import date, datetime
-
-from dataclasses import dataclass
-from typing import Dict, List, Tuple
+import subprocess
 from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Dict, List, Optional, Tuple
 
-git_log_proc = subprocess.run(['git', '--no-pager', 'log', '--format=%as %h: %s (%an)', 'v20.12..'], capture_output=True)
-log = git_log_proc.stdout.decode("utf-8").splitlines()
 
-log_regex = re.compile("([0-9\-]{10}) ([a-z0-9]+){8}: ([a-z]+):(.*)")
-simple_log_regex = re.compile("([0-9\-]{10}) ([a-z0-9]{8}):(.*)")
+COMMIT_RE = re.compile(r"([0-9-]{10}) ([0-9a-f]+) (.*)")
+CONVENTIONAL_RE = re.compile(r"([a-zA-Z]+)(?:\([^)]+\))?!?:\s*(.*)")
+
 
 @dataclass
 class CommitMessage:
@@ -20,71 +19,143 @@ class CommitMessage:
     group: str
     message: str
 
-YearMonthKey = Tuple[int,int]
+
+YearMonthKey = Tuple[int, int]
 CommitsList = List[CommitMessage]
 CommitsGroup = Dict[str, CommitsList]
-commits: Dict[YearMonthKey, CommitsGroup] = defaultdict(lambda: defaultdict(lambda: []))
 
-for log_line in log:
-    if not log_line:
-        continue
 
-    simple_match = simple_log_regex.match(log_line)
-    if not simple_match:
-        continue
-
-    commit_date = datetime.strptime(simple_match.group(1), '%Y-%m-%d').date()
-    commit_sha = simple_match.group(2).strip()
-    commit_message = simple_match.group(3).strip()
-    commit_group = 'other'
-
-    match = log_regex.match(log_line)
-    if match and len(match.groups()) == 4:
-        commit_group = match.group(3).strip()
-        commit_message = match.group(4).strip()
-
-    if commit_group == 'feat':
-        commit_group = 'feature'
-
-    if commit_group == 'doc':
-        commit_group = 'docs'
-
-    if 'feature' in commit_message:
-        commit_group = 'feature'
-    if 'ump version' in commit_message:
-        commit_group = 'chore'
-    if 'ump latest version' in commit_message:
-        commit_group = 'chore'
-    if 'ix build' in commit_message:
-        commit_group = 'build'
-    if 'ix test' in commit_message:
-        commit_group = 'tests'
-
-    key: YearMonthKey = (commit_date.year, commit_date.month)
-    commits_this_month = commits[key]
-    commits_this_month[commit_group].append(CommitMessage(commit_date, commit_sha, commit_group, commit_message))
-
-groups_mapping = [ 
-    ('feature', 'New features'), 
-    ('fixes', 'Bug fixes'), 
-    ('docs', 'Documentation'),
-    ('perf', 'Performance'),
-    ('refactor', 'Code refactoring'), 
-    ('tests', 'Tests'), 
-    ('build', 'Build system'), 
-    ('ci', 'Continuous integration workflow'),
-    ('other', 'Other commits')
+GROUPS_MAPPING = [
+    ("feature", "New features"),
+    ("fixes", "Bug fixes"),
+    ("docs", "Documentation"),
+    ("perf", "Performance"),
+    ("refactor", "Code refactoring"),
+    ("tests", "Tests"),
+    ("build", "Build system"),
+    ("ci", "Continuous integration workflow"),
+    ("chore", "Maintenance"),
+    ("other", "Other commits"),
 ]
 
-months_keys = sorted(commits.keys())
-months_keys.reverse()
 
-for key in months_keys:
-    print(f'# {key[0]}-{key[1]:02}:')
-    for g, header in groups_mapping:
-        commits_in_g = commits[key][g]
-        if not commits_in_g:
+def git(args: List[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def version_tags() -> List[str]:
+    output = git(["tag", "--list", "v[0-9]*", "--sort=-v:refname"])
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def latest_version_tag(excluding: Optional[str] = None) -> Optional[str]:
+    for tag in version_tags():
+        if tag != excluding:
+            return tag
+    return None
+
+
+def resolve_from_ref(args: argparse.Namespace) -> Optional[str]:
+    if args.from_ref:
+        return args.from_ref
+    if args.mode == "release":
+        return latest_version_tag(args.current_tag)
+    return latest_version_tag()
+
+
+def normalize_group(group: str, message: str) -> str:
+    group = group.lower()
+    if group == "feat":
+        return "feature"
+    if group == "fix":
+        return "fixes"
+    if group == "doc":
+        return "docs"
+    if group == "test":
+        return "tests"
+    if group in {key for key, _ in GROUPS_MAPPING}:
+        return group
+    if "feature" in message.lower():
+        return "feature"
+    return "other"
+
+
+def commits_for_range(from_ref: Optional[str], to_ref: str) -> List[CommitMessage]:
+    revision_range = f"{from_ref}..{to_ref}" if from_ref else to_ref
+    log = git(["--no-pager", "log", "--format=%as %h %s (%an)", revision_range])
+    commits: List[CommitMessage] = []
+
+    for line in log.splitlines():
+        match = COMMIT_RE.match(line)
+        if not match:
             continue
-        print(f'## {header}:')
-        for c in commits_in_g:
-            print(f' - [{c.sha}](https://github.com/ZEACENT/klogg/commit/{c.sha}): {c.message}')
+
+        commit_date = datetime.strptime(match.group(1), "%Y-%m-%d").date()
+        commit_sha = match.group(2)
+        commit_message = match.group(3).strip()
+        commit_group = "other"
+
+        conventional = CONVENTIONAL_RE.match(commit_message)
+        if conventional:
+            commit_group = normalize_group(conventional.group(1), conventional.group(2))
+            commit_message = conventional.group(2).strip()
+        else:
+            commit_group = normalize_group(commit_group, commit_message)
+
+        commits.append(CommitMessage(commit_date, commit_sha, commit_group, commit_message))
+
+    return commits
+
+
+def render(commits: List[CommitMessage]) -> str:
+    grouped: Dict[YearMonthKey, CommitsGroup] = defaultdict(lambda: defaultdict(list))
+    for commit in commits:
+        grouped[(commit.date.year, commit.date.month)][commit.group].append(commit)
+
+    lines: List[str] = []
+    for key in sorted(grouped.keys(), reverse=True):
+        lines.append(f"# {key[0]}-{key[1]:02}:")
+        for group, header in GROUPS_MAPPING:
+            commits_in_group = grouped[key][group]
+            if not commits_in_group:
+                continue
+            lines.append(f"## {header}:")
+            for commit in commits_in_group:
+                lines.append(
+                    f" - [{commit.sha}](https://github.com/ZEACENT/klogg/commit/{commit.sha}): "
+                    f"{commit.message}"
+                )
+
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("prerelease", "release"),
+        default="release",
+        help="prerelease starts at the latest version release; release starts at the previous version release",
+    )
+    parser.add_argument("--from-ref", help="explicit changelog start ref")
+    parser.add_argument("--to-ref", default="HEAD", help="changelog end ref")
+    parser.add_argument("--current-tag", help="current release tag to exclude when mode=release")
+    parser.add_argument(
+        "--print-range",
+        action="store_true",
+        help="print the resolved git range before the changelog",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    from_ref = resolve_from_ref(args)
+    if args.print_range:
+        start = from_ref if from_ref else "repository start"
+        print(f"Changes from {start} to {args.to_ref}\n")
+    print(render(commits_for_range(from_ref, args.to_ref)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/logdata/include/logfiltereddata.h
+++ b/src/logdata/include/logfiltereddata.h
@@ -90,6 +90,8 @@ class LogFilteredData : public AbstractLogData {
     void interruptSearch();
     // Clear the search and the list of results.
     void clearSearch( bool dropCache = false );
+    void setAllLinesVisible( bool visible );
+    bool allLinesVisible() const { return allLinesVisible_; }
 
     // Returns the line number in the original LogData where the element
     // 'index' was found.
@@ -222,6 +224,7 @@ class LogFilteredData : public AbstractLogData {
     SearchResultArray matching_lines_;
     SearchResultArray marks_;
     SearchResultArray marks_and_matches_;
+    bool allLinesVisible_ = false;
 
     const SearchableLogData* sourceLogData_;
 

--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -145,6 +145,7 @@ void LogFilteredData::runSearch( const RegularExpressionPattern& regExp, LineNum
     const auto& config = Configuration::get();
 
     clearSearch();
+    setAllLinesVisible( false );
     currentRegExp_ = regExp;
     currentSearchKey_ = makeCacheKey( regExp, startLine, endLine );
     LOG_INFO << "Search cache key: " << regExp.pattern << "_" << startLine.get() << "_"
@@ -182,6 +183,7 @@ void LogFilteredData::updateSearch( LineNumber startLine, LineNumber endLine )
 {
     LOG_DEBUG << "Entering updateSearch";
 
+    setAllLinesVisible( false );
     currentSearchKey_ = {};
 
     attachReaderIfNeeded();
@@ -200,6 +202,7 @@ void LogFilteredData::clearSearch( bool dropCache )
 {
     interruptSearch();
 
+    allLinesVisible_ = false;
     currentRegExp_ = {};
     matching_lines_ = {};
     marks_and_matches_ = marks_;
@@ -212,8 +215,22 @@ void LogFilteredData::clearSearch( bool dropCache )
     }
 }
 
+void LogFilteredData::setAllLinesVisible( bool visible )
+{
+    if ( allLinesVisible_ == visible ) {
+        return;
+    }
+
+    allLinesVisible_ = visible;
+    contextLinesListValid_ = false;
+}
+
 LineNumber LogFilteredData::getMatchingLineNumber( LineNumber matchNum ) const
 {
+    if ( allLinesVisible_ ) {
+        return matchNum;
+    }
+
     // If context lines are enabled, get the line number from context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -261,6 +278,10 @@ LinesCount LogFilteredData::getNbMarks() const
 
 LogFilteredData::LineType LogFilteredData::lineTypeByIndex( LineNumber index ) const
 {
+    if ( allLinesVisible_ ) {
+        return lineTypeByLine( index );
+    }
+
     // If context lines are enabled, get the line number from context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -291,6 +312,14 @@ LogFilteredData::LineType LogFilteredData::lineTypeByLine( LineNumber lineNumber
 
 void LogFilteredData::iterateOverLines( const std::function<void( LineNumber )>& callback ) const
 {
+    if ( allLinesVisible_ ) {
+        const auto totalLines = sourceLogData_ ? sourceLogData_->getNbLine() : 0_lcount;
+        for ( auto line = 0_lnum; line < LineNumber( totalLines.get() ); ++line ) {
+            callback( line );
+        }
+        return;
+    }
+
     using CallbackFn = std::function<void( LineNumber )>;
     const auto& currentResults = currentResultArray();
     currentResults.iterate(
@@ -677,6 +706,10 @@ void LogFilteredData::handleSearchProgressedThrottled()
 
 LineNumber LogFilteredData::findLogDataLine( LineNumber index ) const
 {
+    if ( allLinesVisible_ ) {
+        return index;
+    }
+
     const auto& currentResults = currentResultArray();
 
     LineNumber::UnderlyingType line = {};
@@ -708,6 +741,10 @@ const SearchResultArray& LogFilteredData::currentResultArray() const
 
 LineNumber LogFilteredData::findFilteredLine( LineNumber lineNum ) const
 {
+    if ( allLinesVisible_ ) {
+        return lineNum;
+    }
+
     // If context lines are enabled, search in context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -740,6 +777,10 @@ QString LogFilteredData::doGetLineString( LineNumber index ) const
         return QString();
     }
 
+    if ( allLinesVisible_ ) {
+        return sourceLogData_->getLineString( index );
+    }
+
     // If context lines are enabled, use the context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -764,6 +805,10 @@ QString LogFilteredData::doGetExpandedLineString( LineNumber index ) const
         return QString();
     }
 
+    if ( allLinesVisible_ ) {
+        return sourceLogData_->getExpandedLineString( index );
+    }
+
     // If context lines are enabled, use the context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -784,6 +829,10 @@ klogg::vector<AnsiColorSpan> LogFilteredData::doGetLineAnsiColors( LineNumber in
 {
     if ( !sourceLogData_ ) {
         return {};
+    }
+
+    if ( allLinesVisible_ ) {
+        return sourceLogData_->getLineAnsiColors( index );
     }
 
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
@@ -831,6 +880,10 @@ LogFilteredData::doGetLines( LineNumber first_line, LinesCount number,
 
 LineNumber LogFilteredData::doGetLineNumber(LineNumber index) const
 {
+    if ( allLinesVisible_ ) {
+        return index;
+    }
+
     // If context lines are enabled, return the line number from context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -849,6 +902,10 @@ LineNumber LogFilteredData::doGetLineNumber(LineNumber index) const
 // Implementation of the virtual function.
 LinesCount LogFilteredData::doGetNbLine() const
 {
+    if ( allLinesVisible_ ) {
+        return sourceLogData_ ? sourceLogData_->getNbLine() : 0_lcount;
+    }
+
     // If context lines are enabled, return the size of context lines list
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -865,6 +922,10 @@ LinesCount LogFilteredData::doGetNbLine() const
 // Implementation of the virtual function.
 LineLength LogFilteredData::doGetMaxLength() const
 {
+    if ( allLinesVisible_ ) {
+        return sourceLogData_ ? sourceLogData_->getMaxLength() : 0_length;
+    }
+
     LineLength result = qMax( maxLength_, maxLengthMarks_ );
     if ( contextLinesBefore_ > 0 || contextLinesAfter_ > 0 ) {
         if ( !contextLinesListValid_ ) {
@@ -881,6 +942,10 @@ LineLength LogFilteredData::doGetLineLength( LineNumber lineNum ) const
     // Safety check: if sourceLogData_ is null (object being destroyed), return 0
     if ( !sourceLogData_ ) {
         return 0_length;
+    }
+
+    if ( allLinesVisible_ ) {
+        return sourceLogData_->getLineLength( lineNum );
     }
 
     // If context lines are enabled, use the context lines list

--- a/src/logdata/src/logfiltereddata.cpp
+++ b/src/logdata/src/logfiltereddata.cpp
@@ -227,7 +227,7 @@ void LogFilteredData::setAllLinesVisible( bool visible )
 
 LineNumber LogFilteredData::getMatchingLineNumber( LineNumber matchNum ) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return matchNum;
     }
 
@@ -278,7 +278,7 @@ LinesCount LogFilteredData::getNbMarks() const
 
 LogFilteredData::LineType LogFilteredData::lineTypeByIndex( LineNumber index ) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return lineTypeByLine( index );
     }
 
@@ -312,7 +312,7 @@ LogFilteredData::LineType LogFilteredData::lineTypeByLine( LineNumber lineNumber
 
 void LogFilteredData::iterateOverLines( const std::function<void( LineNumber )>& callback ) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         const auto totalLines = sourceLogData_ ? sourceLogData_->getNbLine() : 0_lcount;
         for ( auto line = 0_lnum; line < LineNumber( totalLines.get() ); ++line ) {
             callback( line );
@@ -706,7 +706,7 @@ void LogFilteredData::handleSearchProgressedThrottled()
 
 LineNumber LogFilteredData::findLogDataLine( LineNumber index ) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return index;
     }
 
@@ -741,7 +741,7 @@ const SearchResultArray& LogFilteredData::currentResultArray() const
 
 LineNumber LogFilteredData::findFilteredLine( LineNumber lineNum ) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return lineNum;
     }
 
@@ -777,7 +777,7 @@ QString LogFilteredData::doGetLineString( LineNumber index ) const
         return QString();
     }
 
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_->getLineString( index );
     }
 
@@ -805,7 +805,7 @@ QString LogFilteredData::doGetExpandedLineString( LineNumber index ) const
         return QString();
     }
 
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_->getExpandedLineString( index );
     }
 
@@ -831,7 +831,7 @@ klogg::vector<AnsiColorSpan> LogFilteredData::doGetLineAnsiColors( LineNumber in
         return {};
     }
 
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_->getLineAnsiColors( index );
     }
 
@@ -880,7 +880,7 @@ LogFilteredData::doGetLines( LineNumber first_line, LinesCount number,
 
 LineNumber LogFilteredData::doGetLineNumber(LineNumber index) const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return index;
     }
 
@@ -902,7 +902,7 @@ LineNumber LogFilteredData::doGetLineNumber(LineNumber index) const
 // Implementation of the virtual function.
 LinesCount LogFilteredData::doGetNbLine() const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_ ? sourceLogData_->getNbLine() : 0_lcount;
     }
 
@@ -922,7 +922,7 @@ LinesCount LogFilteredData::doGetNbLine() const
 // Implementation of the virtual function.
 LineLength LogFilteredData::doGetMaxLength() const
 {
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_ ? sourceLogData_->getMaxLength() : 0_length;
     }
 
@@ -944,7 +944,7 @@ LineLength LogFilteredData::doGetLineLength( LineNumber lineNum ) const
         return 0_length;
     }
 
-    if ( allLinesVisible_ ) {
+    if ( allLinesVisible_ && visibility_.testFlag( VisibilityFlags::Matches ) ) {
         return sourceLogData_->getLineLength( lineNum );
     }
 

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -587,6 +587,14 @@ class Configuration final : public Persistable<Configuration> {
     {
         autoRunSearchOnPatternChange_ = enable;
     }
+    bool showAllInFilteredViewWhenSearchEmpty() const
+    {
+        return showAllInFilteredViewWhenSearchEmpty_;
+    }
+    void setShowAllInFilteredViewWhenSearchEmpty( bool enable )
+    {
+        showAllInFilteredViewWhenSearchEmpty_ = enable;
+    }
 
     bool optimizeForNotLatinEncodings() const
     {
@@ -711,6 +719,7 @@ class Configuration final : public Persistable<Configuration> {
 
     bool allowFollowOnScroll_ = true;
     bool autoRunSearchOnPatternChange_ = false;
+    bool showAllInFilteredViewWhenSearchEmpty_ = true;
 
     bool optimizeForNotLatinEncodings_ = false;
 

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -186,6 +186,11 @@ void Configuration::retrieveFromStorage( QSettings& settings )
                                         .value( "regexpType.autoRunSearch",
                                                 DefaultConfiguration.autoRunSearchOnPatternChange_ )
                                         .toBool();
+    showAllInFilteredViewWhenSearchEmpty_
+        = settings
+              .value( "regexpType.showAllInFilteredViewWhenSearchEmpty",
+                      DefaultConfiguration.showAllInFilteredViewWhenSearchEmpty_ )
+              .toBool();
 
     // "Advanced" settings
     nativeFileWatchEnabled_
@@ -429,6 +434,8 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "regexpType.mainHighlight", enableMainSearchHighlight_ );
     settings.setValue( "regexpType.mainHighlightVariate", enableMainSearchHighlightVariance_ );
     settings.setValue( "regexpType.autoRunSearch", autoRunSearchOnPatternChange_ );
+    settings.setValue( "regexpType.showAllInFilteredViewWhenSearchEmpty",
+                       showAllInFilteredViewWhenSearchEmpty_ );
 
     settings.setValue( "regexpType.quickfind", static_cast<int>( quickfindRegexpType_ ) );
     settings.setValue( "regexpType.quickfindBackColor", qfBackColor_.name( QColor::HexArgb ) );

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -526,7 +526,6 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
 
     void selectAndDisplayRange( FilePosition pos );
     bool shouldBottomAlignFrame() const;
-    int alignHiddenHeightToLineGrid( int hiddenHeightPx ) const;
 };
 
 #endif

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -362,6 +362,7 @@ class CrawlerWidget : public QSplitter,
     void updateEncoding();
     void changeTopViewSize( int32_t delta );
     void updatePredefinedFiltersWidget();
+    void applyEmptyFilterBehavior();
 
     // Reload predefined filters after changing settings
     void reloadPredefinedFilters() const;

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -99,6 +99,13 @@
               </property>
              </widget>
             </item>
+            <item row="10" column="0" colspan="3">
+             <widget class="QCheckBox" name="showAllFilteredWhenEmptyCheckBox">
+              <property name="text">
+               <string>Show all lines in filtered window when filter is empty</string>
+              </property>
+             </widget>
+            </item>
             <item row="4" column="0">
              <widget class="QLabel" name="label_4">
               <property name="text">

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2018,13 +2018,7 @@ int AbstractLogView::horizontalScrollBarOverlayHeight() const
         return 0;
     }
 
-    const auto transientScrollBar
-        = style()->styleHint( QStyle::SH_ScrollBar_Transient, nullptr, horizontalScrollBar() ) != 0;
-    if ( transientScrollBar ) {
-        return scrollBarHeight;
-    }
-
-    return 0;
+    return scrollBarHeight;
 }
 
 // Returns the number of columns visible in the viewport

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1237,9 +1237,6 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
 
     if ( shouldBottomAlignFrame() ) {
         int hiddenHeightPx = std::max( 0, effectiveHeight - availableTextHeight );
-        if ( !useTextWrap_ ) {
-            hiddenHeightPx = alignHiddenHeightToLineGrid( hiddenHeightPx );
-        }
         drawingTopOffset_ = -hiddenHeightPx;
         drawingTopPosition = drawingTopOffset_;
 
@@ -1282,15 +1279,6 @@ bool AbstractLogView::shouldBottomAlignFrame() const
     const auto scrollValue = verticalScrollBar()->value();
     const auto scrollMax = verticalScrollBar()->maximum();
     return scrollMax > 0 && scrollValue >= scrollMax;
-}
-
-int AbstractLogView::alignHiddenHeightToLineGrid( int hiddenHeightPx ) const
-{
-    if ( hiddenHeightPx <= 0 || charHeight_ <= 0 ) {
-        return 0;
-    }
-
-    return ( hiddenHeightPx / charHeight_ ) * charHeight_;
 }
 
 // These two functions are virtual and this implementation is clearly

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1118,7 +1118,7 @@ void AbstractLogView::scrollContentsBy( int dx, int /*dy*/ )
     // Determine if we're at the bottom by checking if scroll value >= maximum.
     // This avoids the expensive getNbBottomWrappedVisibleLines() call on every scroll.
     // The scroll range is already calculated correctly by updateScrollBars().
-    const bool atBottom = ( scrollMax > 0 ) ? ( scrollValue >= scrollMax ) : true;
+    const bool atBottom = scrollMax > 0 && scrollValue >= scrollMax;
 
     if ( atBottom ) {
         // We're at or past the bottom, lock the last line at the bottom
@@ -1281,7 +1281,7 @@ bool AbstractLogView::shouldBottomAlignFrame() const
 
     const auto scrollValue = verticalScrollBar()->value();
     const auto scrollMax = verticalScrollBar()->maximum();
-    return scrollValue >= scrollMax;
+    return scrollMax > 0 && scrollValue >= scrollMax;
 }
 
 int AbstractLogView::alignHiddenHeightToLineGrid( int hiddenHeightPx ) const
@@ -1837,8 +1837,10 @@ void AbstractLogView::updateDisplaySize()
               << " lastLineAligned_=" << lastLineAligned_
               << " followMode_=" << followMode_;
 
-    // Remember if we were bottom-aligned before size change
-    const bool wasBottomAligned = lastLineAligned_;
+    // Remember if the user was looking at EOF before the size change.  The
+    // scrollbar maximum changes with the viewport height, so this must be
+    // captured before updateScrollBars() recalculates the range.
+    const bool wasBottomAligned = shouldBottomAlignFrame();
 
     // Update the scroll bars first - this recalculates range based on new viewport size
     updateScrollBars();

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -898,6 +898,21 @@ void CrawlerWidget::applyConfiguration()
     }
 
     reloadPredefinedFilters();
+    applyEmptyFilterBehavior();
+}
+
+void CrawlerWidget::applyEmptyFilterBehavior()
+{
+    if ( !logFilteredData_ || !filteredView_ || !searchLineEdit_ ) {
+        return;
+    }
+
+    const bool showAll = searchLineEdit_->currentText().isEmpty()
+        && Configuration::get().showAllInFilteredViewWhenSearchEmpty();
+    logFilteredData_->setAllLinesVisible( showAll );
+    if ( searchLineEdit_->currentText().isEmpty() ) {
+        filteredView_->updateData();
+    }
 }
 
 void CrawlerWidget::enteringQuickFind()
@@ -931,6 +946,7 @@ void CrawlerWidget::loadingFinishedHandler( LoadingStatus status )
     // FIXME, handle topLine
     // logMainView_->updateData( logData_, topLine );
     logMainView_->updateData();
+    applyEmptyFilterBehavior();
 
     // Shall we Forbid starting a search when loading in progress?
     // searchButton_->setEnabled( false );
@@ -1363,6 +1379,7 @@ void CrawlerWidget::setup()
     searchLineEdit_->setEditable( true );
     searchLineEdit_->setCompleter( searchLineCompleter_ );
     searchLineEdit_->addItems( savedSearches_->recentSearches() );
+    searchLineEdit_->lineEdit()->clear();
     searchLineEdit_->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
     searchLineEdit_->setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
     searchLineEdit_->lineEdit()->setMaxLength( std::numeric_limits<int>::max() / 1024 );
@@ -1937,6 +1954,9 @@ void CrawlerWidget::replaceCurrentSearch( const QString& searchText )
 
     // Clear and recompute the content of the filtered window.
     logFilteredData_->clearSearch();
+    if ( searchText.isEmpty() && Configuration::get().showAllInFilteredViewWhenSearchEmpty() ) {
+        logFilteredData_->setAllLinesVisible( true );
+    }
     filteredView_->updateData();
 
     // Update the match overview

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -10,7 +10,11 @@
 #include "log.h"
 
 namespace {
+#ifdef Q_OS_WIN
+constexpr int StartupFailureGracePeriodMs = 1000;
+#else
 constexpr int StartupFailureGracePeriodMs = 250;
+#endif
 constexpr int StartupFailurePollIntervalMs = 10;
 }
 

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -530,6 +530,8 @@ void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
     HighlighterEdit::updateIcon( quickFindColorButton, qfSearchColor_ );
     regexpEngineComboBox->setCurrentIndex( getRegexpEngineIndex( config.regexpEngine() ) );
     autoRunSearchOnAddCheckBox->setChecked( config.autoRunSearchOnPatternChange() );
+    showAllFilteredWhenEmptyCheckBox->setChecked(
+        config.showAllInFilteredViewWhenSearchEmpty() );
 
     highlightMainSearchCheckBox->setChecked( config.mainSearchHighlight() );
     variateHighlightCheckBox->setChecked( config.variateMainSearchHighlight() );
@@ -684,6 +686,8 @@ void OptionsDialog::resetGeneralDefaults()
     logicalCombiningCheckBox->setChecked( defaults.isSearchLogicalCombiningDefault() );
     autoRefreshCheckBox->setChecked( defaults.isSearchAutoRefreshDefault() );
     autoRunSearchOnAddCheckBox->setChecked( defaults.autoRunSearchOnPatternChange() );
+    showAllFilteredWhenEmptyCheckBox->setChecked(
+        defaults.showAllInFilteredViewWhenSearchEmpty() );
     searchHistorySpinBox->setValue( defaultSavedSearches.historySize() );
 
     loadLastSessionCheckBox->setChecked( defaults.loadLastSession() );
@@ -880,6 +884,8 @@ void OptionsDialog::updateConfigFromDialog()
     config.setQuickfindIncremental( incrementalCheckBox->isChecked() );
     config.setRegexpEnging( getRegexpEngineFromIndex( regexpEngineComboBox->currentIndex() ) );
     config.setAutoRunSearchOnPatternChange( autoRunSearchOnAddCheckBox->isChecked() );
+    config.setShowAllInFilteredViewWhenSearchEmpty(
+        showAllFilteredWhenEmptyCheckBox->isChecked() );
 
     config.setNativeFileWatchEnabled( nativeFileWatchCheckBox->isChecked() );
     config.setPollingEnabled( pollingCheckBox->isChecked() );

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -22,6 +22,7 @@
 #include <QApplication>
 #include <QClipboard>
 #include <QColorDialog>
+#include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
 #include <QHash>
@@ -84,13 +85,16 @@ QIcon makeGroupColorIcon( const QColor& color )
 
 QString liveStatusSuffix( const QString& title )
 {
-    static const QStringList suffixes{
+    QStringList suffixes{
+        QCoreApplication::translate( "MainWindow", " [disconnected]" ),
+        QCoreApplication::translate( "MainWindow", " [error]" ),
         QStringLiteral( " [disconnected]" ),
         QStringLiteral( " [error]" ),
     };
+    suffixes.removeDuplicates();
 
     for ( const auto& suffix : suffixes ) {
-        if ( title.endsWith( suffix ) ) {
+        if ( !suffix.isEmpty() && title.endsWith( suffix ) ) {
             return suffix;
         }
     }
@@ -98,9 +102,19 @@ QString liveStatusSuffix( const QString& title )
     return {};
 }
 
+QString tabLabelWithoutLiveStatus( QString label )
+{
+    const auto suffix = liveStatusSuffix( label );
+    if ( !suffix.isEmpty() ) {
+        label.chop( suffix.size() );
+    }
+    return label;
+}
+
 QString tabLabelWithLiveStatus( const QString& label, const QString& storedTitle )
 {
-    return label + liveStatusSuffix( storedTitle );
+    const auto suffix = liveStatusSuffix( storedTitle );
+    return suffix.isEmpty() ? label : tabLabelWithoutLiveStatus( label ) + suffix;
 }
 
 bool isGroupChipWidget( const QWidget* widget )
@@ -627,17 +641,18 @@ void TabbedCrawlerWidget::showContextMenu( int tab, QPoint globalPoint )
 
     connect( renameTab, &QAction::triggered, this, [ this, tab, tabPath ] {
         const auto currentName = TabNameMapping::getSynced().tabName( tabPath );
+        const auto storedTitle = myTabBar_.tabData( tab ).toMap().value( TitleKey ).toString();
         const auto defaultName
             = currentName.isEmpty()
-                  ? myTabBar_.tabData( tab ).toMap().value( TitleKey ).toString()
-                  : currentName;
+                  ? tabLabelWithoutLiveStatus( storedTitle )
+                  : tabLabelWithoutLiveStatus( currentName );
         bool isNameEntered = false;
         auto newName = QInputDialog::getText( this, "Rename tab", "Tab name", QLineEdit::Normal,
                                               defaultName, &isNameEntered );
         if ( isNameEntered ) {
+            newName = tabLabelWithoutLiveStatus( newName );
             TabNameMapping::getSynced().setTabName( tabPath, newName ).save();
 
-            const auto storedTitle = myTabBar_.tabData( tab ).toMap().value( TitleKey ).toString();
             if ( newName.isEmpty() ) {
                 myTabBar_.setTabText( tab,
                                       storedTitle.isEmpty() ? QFileInfo( tabPath ).fileName()

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -82,6 +82,27 @@ QIcon makeGroupColorIcon( const QColor& color )
     return QIcon( colorIcon );
 }
 
+QString liveStatusSuffix( const QString& title )
+{
+    static const QStringList suffixes{
+        QStringLiteral( " [disconnected]" ),
+        QStringLiteral( " [error]" ),
+    };
+
+    for ( const auto& suffix : suffixes ) {
+        if ( title.endsWith( suffix ) ) {
+            return suffix;
+        }
+    }
+
+    return {};
+}
+
+QString tabLabelWithLiveStatus( const QString& label, const QString& storedTitle )
+{
+    return label + liveStatusSuffix( storedTitle );
+}
+
 bool isGroupChipWidget( const QWidget* widget )
 {
     return widget != nullptr && widget->property( GroupChipPropertyKey ).toBool();
@@ -222,8 +243,7 @@ void TabbedCrawlerWidget::addTabBarItem( int index, const QString& documentId,
                                          const QString& displayName, const QString& toolTip )
 {
     const auto tabLabel = displayName.isEmpty() ? QFileInfo( documentId ).fileName() : displayName;
-    const auto tabName
-        = displayName.isEmpty() ? TabNameMapping::getSynced().tabName( documentId ) : QString{};
+    const auto tabName = TabNameMapping::getSynced().tabName( documentId );
     const auto nativeToolTip
         = toolTip.isEmpty() ? QDir::toNativeSeparators( documentId ) : QDir::toNativeSeparators( toolTip );
 
@@ -271,8 +291,12 @@ void TabbedCrawlerWidget::updateCrawler( int index, const QString& displayName,
     myTabBar_.setTabToolTip( index, QDir::toNativeSeparators( toolTip ) );
 
     const auto documentId = tabData.value( PathKey ).toString();
-    if ( TabNameMapping::getSynced().tabName( documentId ).isEmpty() ) {
+    const auto customName = TabNameMapping::getSynced().tabName( documentId );
+    if ( customName.isEmpty() ) {
         myTabBar_.setTabText( index, displayName );
+    }
+    else {
+        myTabBar_.setTabText( index, tabLabelWithLiveStatus( customName, displayName ) );
     }
 }
 
@@ -613,11 +637,14 @@ void TabbedCrawlerWidget::showContextMenu( int tab, QPoint globalPoint )
         if ( isNameEntered ) {
             TabNameMapping::getSynced().setTabName( tabPath, newName ).save();
 
+            const auto storedTitle = myTabBar_.tabData( tab ).toMap().value( TitleKey ).toString();
             if ( newName.isEmpty() ) {
-                myTabBar_.setTabText( tab, QFileInfo( tabPath ).fileName() );
+                myTabBar_.setTabText( tab,
+                                      storedTitle.isEmpty() ? QFileInfo( tabPath ).fileName()
+                                                            : storedTitle );
             }
             else {
-                myTabBar_.setTabText( tab, std::move( newName ) );
+                myTabBar_.setTabText( tab, tabLabelWithLiveStatus( newName, storedTitle ) );
             }
         }
     } );
@@ -956,7 +983,7 @@ void TabbedCrawlerWidget::onGroupsChanged()
         const auto originalTabLabel
             = customName.isEmpty()
                   ? ( storedTitle.isEmpty() ? QFileInfo( tabPath ).fileName() : storedTitle )
-                  : customName;
+                  : tabLabelWithLiveStatus( customName, storedTitle );
         const auto originalTooltip
             = storedToolTip.isEmpty() ? QDir::toNativeSeparators( tabPath ) : storedToolTip;
 

--- a/tests/scripts/test_gen_changelog.py
+++ b/tests/scripts/test_gen_changelog.py
@@ -1,0 +1,97 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "gen_changelog.py"
+
+
+def run(cmd, cwd, **kwargs):
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test Author",
+            "GIT_AUTHOR_EMAIL": "author@example.invalid",
+            "GIT_COMMITTER_NAME": "Test Committer",
+            "GIT_COMMITTER_EMAIL": "committer@example.invalid",
+        }
+    )
+    return subprocess.run(cmd, cwd=cwd, env=env, text=True, check=True, **kwargs)
+
+
+def commit(repo, message, file_name):
+    path = repo / file_name
+    path.write_text(message + "\n", encoding="utf-8")
+    run(["git", "add", file_name], repo)
+    run(["git", "commit", "-m", message], repo, stdout=subprocess.PIPE)
+
+
+def init_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run(["git", "init"], repo, stdout=subprocess.PIPE)
+    commit(repo, "chore: initial", "initial.txt")
+    run(["git", "tag", "v1.0.0"], repo)
+    commit(repo, "fix: stable fix", "stable.txt")
+    run(["git", "tag", "v1.1.0"], repo)
+    commit(repo, "feat: continuous feature", "continuous.txt")
+    run(["git", "tag", "continuous"], repo)
+    commit(repo, "fix: follow-up release fix", "release.txt")
+    return repo
+
+
+class GenChangelogTest(unittest.TestCase):
+    def test_prerelease_notes_start_at_latest_version_release(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = init_repo(Path(tmp_dir))
+
+            result = run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "prerelease",
+                    "--to-ref",
+                    "HEAD",
+                ],
+                repo,
+                stdout=subprocess.PIPE,
+            )
+
+        self.assertIn("continuous feature", result.stdout)
+        self.assertIn("follow-up release fix", result.stdout)
+        self.assertNotIn("stable fix", result.stdout)
+        self.assertNotIn("initial", result.stdout)
+
+    def test_release_notes_exclude_current_release_tag_when_selecting_previous(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = init_repo(Path(tmp_dir))
+            run(["git", "tag", "v1.2.0"], repo)
+
+            result = run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "release",
+                    "--current-tag",
+                    "v1.2.0",
+                    "--to-ref",
+                    "v1.2.0",
+                ],
+                repo,
+                stdout=subprocess.PIPE,
+            )
+
+        self.assertIn("continuous feature", result.stdout)
+        self.assertIn("follow-up release fix", result.stdout)
+        self.assertNotIn("stable fix", result.stdout)
+        self.assertNotIn("initial", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_gen_changelog.py
+++ b/tests/scripts/test_gen_changelog.py
@@ -92,6 +92,32 @@ class GenChangelogTest(unittest.TestCase):
         self.assertNotIn("stable fix", result.stdout)
         self.assertNotIn("initial", result.stdout)
 
+    def test_non_conventional_feature_message_uses_feature_group(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo = init_repo(Path(tmp_dir))
+            commit(repo, "Add search feature polish", "feature-polish.txt")
+
+            result = run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--mode",
+                    "prerelease",
+                    "--to-ref",
+                    "HEAD",
+                ],
+                repo,
+                stdout=subprocess.PIPE,
+            )
+
+        feature_header = "## New features:"
+        bug_fixes_header = "## Bug fixes:"
+        message = "Add search feature polish"
+        self.assertIn(feature_header, result.stdout)
+        self.assertIn(bug_fixes_header, result.stdout)
+        self.assertLess(result.stdout.index(feature_header), result.stdout.index(message))
+        self.assertLess(result.stdout.index(message), result.stdout.index(bug_fixes_header))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -845,7 +845,10 @@ SCENARIO( "Crawler widget search", "[ui]" )
                     const auto viewportHeight = crawlerVisitor.filteredViewportSize().height();
                     REQUIRE( viewportHeight % charH != 0 );
                     REQUIRE( offset >= 0 );
-                    REQUIRE( offset % charH == 0 );
+                    // Bottom-aligned: pixmap is offset upward so the bottom line sits at the
+                    // viewport bottom. The offset is strictly less than one char height for a
+                    // partial-line viewport (no grid snapping).
+                    REQUIRE( offset < charH );
                     // The offset should be at most one viewport's worth of content
                     REQUIRE( offset < charH * 50 );
                 }
@@ -865,6 +868,11 @@ SCENARIO( "Crawler widget search", "[ui]" )
 
                 AND_WHEN( "follow mode is enabled at the filtered bottom" )
                 {
+                    // Force bottom-alignment: scroll to end and explicitly mark the view
+                    // as bottom-aligned so the offset comparison is reliable.
+                    crawlerVisitor.scrollFilteredVerticallyToBottom();
+                    crawlerVisitor.setFilteredLastLineAligned( true );
+                    crawlerVisitor.render();
                     const auto offsetBeforeFollow = crawlerVisitor.filteredDrawingTopOffset();
                     crawlerVisitor.enableFollowMode( true );
                     crawlerVisitor.render();
@@ -872,6 +880,7 @@ SCENARIO( "Crawler widget search", "[ui]" )
                     THEN( "follow mode does not reserve a bottom bar or move the text area" )
                     {
                         REQUIRE( crawlerVisitor.isFollowModeEnabled() );
+                        REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
                         REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == offsetBeforeFollow );
                     }
                 }

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -144,6 +144,23 @@ struct ConfigurationRestoreGuard {
     }
 };
 
+class ScopedShowAllEmptyFilterSetting {
+  public:
+    explicit ScopedShowAllEmptyFilterSetting( bool value )
+        : previousShowAll_( Configuration::get().showAllInFilteredViewWhenSearchEmpty() )
+    {
+        Configuration::get().setShowAllInFilteredViewWhenSearchEmpty( value );
+    }
+
+    ~ScopedShowAllEmptyFilterSetting()
+    {
+        Configuration::get().setShowAllInFilteredViewWhenSearchEmpty( previousShowAll_ );
+    }
+
+  private:
+    bool previousShowAll_;
+};
+
 template <>
 struct AbstractLogView::access_by<AbstractLogViewPrivate> {
     static int drawingTopOffset( const AbstractLogView* view )
@@ -363,6 +380,16 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
     int mainHorizontalScrollValue() const
     {
         return crawler->logMainView_->horizontalScrollBar()->value();
+    }
+
+    int mainVerticalScrollMaximum() const
+    {
+        return crawler->logMainView_->verticalScrollBar()->maximum();
+    }
+
+    int filteredVerticalScrollMaximum() const
+    {
+        return crawler->filteredView_->verticalScrollBar()->maximum();
     }
 
     int filteredHorizontalScrollMaximum() const
@@ -664,6 +691,22 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
                                                                                 value );
     }
 
+    void setMainLastLineAligned( bool value )
+    {
+        AbstractLogView::access_by<AbstractLogViewPrivate>::setLastLineAligned( crawler->logMainView_,
+                                                                                value );
+    }
+
+    LineNumber mainTopLine() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::topLine( crawler->logMainView_ );
+    }
+
+    LineNumber filteredTopLine() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::topLine( crawler->filteredView_ );
+    }
+
     bool filteredShouldBottomAlign() const
     {
         return AbstractLogView::access_by<AbstractLogViewPrivate>::shouldBottomAlignFrame(
@@ -674,6 +717,13 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
     {
         crawler->filteredView_->verticalScrollBar()->setValue(
             crawler->filteredView_->verticalScrollBar()->maximum() );
+        QTest::qWait( 50 );
+    }
+
+    void scrollMainVerticallyToBottom()
+    {
+        crawler->logMainView_->verticalScrollBar()->setValue(
+            crawler->logMainView_->verticalScrollBar()->maximum() );
         QTest::qWait( 50 );
     }
 
@@ -722,9 +772,9 @@ SCENARIO( "Crawler widget search", "[ui]" )
 
     GIVEN( "loaded log data" )
     {
-        THEN( "Has no lines in log view" )
+        THEN( "Has all lines in filtered log view while the filter is empty" )
         {
-            REQUIRE( crawlerVisitor.getLogFilteredNbLines().get() == 0 );
+            REQUIRE( crawlerVisitor.getLogFilteredNbLines().get() == SL_NB_LINES );
         }
 
         WHEN( "search for lines" )
@@ -1292,9 +1342,7 @@ SCENARIO( "Filtered window can mirror the main window while the filter is empty"
     QTemporaryFile file{ "crawler_empty_filter_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
 
-    auto& config = Configuration::get();
-    const auto previousShowAll = config.showAllInFilteredViewWhenSearchEmpty();
-    config.setShowAllInFilteredViewWhenSearchEmpty( true );
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
 
     Session session;
     CrawlerWidgetVisitor crawlerVisitor;
@@ -1308,7 +1356,6 @@ SCENARIO( "Filtered window can mirror the main window while the filter is empty"
     REQUIRE( crawlerVisitor.getLogFilteredNbLines() == crawlerVisitor.getLogNbLines() );
     REQUIRE( counters.operationStarts == 0 );
 
-    config.setShowAllInFilteredViewWhenSearchEmpty( previousShowAll );
 }
 
 SCENARIO( "Filtered window can stay empty while the filter is empty",
@@ -1317,9 +1364,7 @@ SCENARIO( "Filtered window can stay empty while the filter is empty",
     QTemporaryFile file{ "crawler_empty_filter_disabled_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
 
-    auto& config = Configuration::get();
-    const auto previousShowAll = config.showAllInFilteredViewWhenSearchEmpty();
-    config.setShowAllInFilteredViewWhenSearchEmpty( false );
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ false };
 
     Session session;
     CrawlerWidgetVisitor crawlerVisitor;
@@ -1331,7 +1376,6 @@ SCENARIO( "Filtered window can stay empty while the filter is empty",
 
     REQUIRE( crawlerVisitor.getLogFilteredNbLines() == 0_lcount );
 
-    config.setShowAllInFilteredViewWhenSearchEmpty( previousShowAll );
 }
 
 SCENARIO( "Live source search auto-refresh is throttled", "[ui][live]" )
@@ -1457,7 +1501,7 @@ SCENARIO( "Log view repaints after deferred horizontal scrollbar initialization"
         const auto viewportSize = crawlerVisitor.mainViewportSize();
         return !crawlerVisitor.mainTextAreaCacheInvalid() && !pixmapSize.isEmpty()
             && pixmapSize.width() >= viewportSize.width()
-            && pixmapSize.height() >= viewportSize.height();
+            && pixmapSize.height() >= crawlerVisitor.mainTextViewportHeight();
     } ) );
 
     INFO( "viewport=" << crawlerVisitor.mainViewportSize().width() << "x"
@@ -1475,7 +1519,53 @@ SCENARIO( "Log view repaints after deferred horizontal scrollbar initialization"
     REQUIRE( crawlerVisitor.mainTextAreaCachePixmapSize().width()
              >= crawlerVisitor.mainViewportSize().width() );
     REQUIRE( crawlerVisitor.mainTextAreaCachePixmapSize().height()
-             >= crawlerVisitor.mainViewportSize().height() );
+             >= crawlerVisitor.mainTextViewportHeight() );
+}
+
+SCENARIO( "Log views keep the bottom line anchored when non-wrapped height changes",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
+    REQUIRE( generateLongLineDataFile( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViews( 320, 120 );
+    crawlerVisitor.render();
+
+    crawlerVisitor.scrollMainVerticallyToBottom();
+    crawlerVisitor.scrollFilteredVerticallyToBottom();
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+    REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() > 0 );
+    REQUIRE( crawlerVisitor.mainTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.mainVerticalScrollMaximum() ) );
+    REQUIRE( crawlerVisitor.filteredTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.filteredVerticalScrollMaximum() ) );
+
+    crawlerVisitor.setMainLastLineAligned( false );
+    crawlerVisitor.setFilteredLastLineAligned( false );
+
+    crawlerVisitor.resizeViews( 320, 88 );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.mainVerticalScrollMaximum() ) );
+    REQUIRE( crawlerVisitor.filteredTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.filteredVerticalScrollMaximum() ) );
 }
 
 SCENARIO( "Log view reserves space for transient horizontal scrollbars",

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -543,6 +543,17 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
             crawler->logMainView_ );
     }
 
+    int filteredTextViewportHeight() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::textViewportHeight(
+            crawler->filteredView_ );
+    }
+
+    SearchPerformanceCounters searchPerformanceCounters() const
+    {
+        return crawler->logFilteredData_->searchPerformanceCounters();
+    }
+
     int mainGetSelectedTextCallCount() const
     {
         return AbstractLogView::access_by<AbstractLogViewPrivate>::getSelectedTextCallCount(
@@ -1275,6 +1286,54 @@ SCENARIO( "Crawler widget search", "[ui]" )
     }
 }
 
+SCENARIO( "Filtered window can mirror the main window while the filter is empty",
+          "[ui][filter][regression]" )
+{
+    QTemporaryFile file{ "crawler_empty_filter_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    auto& config = Configuration::get();
+    const auto previousShowAll = config.showAllInFilteredViewWhenSearchEmpty();
+    config.setShowAllInFilteredViewWhenSearchEmpty( true );
+
+    Session session;
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    const auto counters = crawlerVisitor.searchPerformanceCounters();
+    REQUIRE( crawlerVisitor.getLogFilteredNbLines() == crawlerVisitor.getLogNbLines() );
+    REQUIRE( counters.operationStarts == 0 );
+
+    config.setShowAllInFilteredViewWhenSearchEmpty( previousShowAll );
+}
+
+SCENARIO( "Filtered window can stay empty while the filter is empty",
+          "[ui][filter][regression]" )
+{
+    QTemporaryFile file{ "crawler_empty_filter_disabled_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    auto& config = Configuration::get();
+    const auto previousShowAll = config.showAllInFilteredViewWhenSearchEmpty();
+    config.setShowAllInFilteredViewWhenSearchEmpty( false );
+
+    Session session;
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    REQUIRE( crawlerVisitor.getLogFilteredNbLines() == 0_lcount );
+
+    config.setShowAllInFilteredViewWhenSearchEmpty( previousShowAll );
+}
+
 SCENARIO( "Live source search auto-refresh is throttled", "[ui][live]" )
 {
     // Use production-like search buffer so each search chunk takes noticeable time.
@@ -1485,7 +1544,7 @@ SCENARIO( "Log view keeps the bottom text gutter stable without horizontal overf
              == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
 }
 
-SCENARIO( "Log view does not reserve hidden classic horizontal scrollbar gutter",
+SCENARIO( "Log views reserve a stable bottom gutter for classic horizontal scrollbars",
           "[ui][scrollbar][regression]" )
 {
     QTemporaryFile file{ "crawler_short_lines_XXXXXX" };
@@ -1514,7 +1573,13 @@ SCENARIO( "Log view does not reserve hidden classic horizontal scrollbar gutter"
 
     REQUIRE( crawlerVisitor.mainHorizontalScrollMaximum() == 0 );
     REQUIRE_FALSE( crawlerVisitor.mainView()->horizontalScrollBar()->isVisible() );
-    REQUIRE( crawlerVisitor.mainTextViewportHeight() == crawlerVisitor.mainViewportSize().height() );
+
+    const auto scrollbarHeight = crawlerVisitor.mainView()->horizontalScrollBar()->sizeHint().height();
+    REQUIRE( scrollbarHeight > 0 );
+    REQUIRE( crawlerVisitor.mainTextViewportHeight()
+             == crawlerVisitor.mainViewportSize().height() - scrollbarHeight );
+    REQUIRE( crawlerVisitor.filteredTextViewportHeight()
+             == crawlerVisitor.filteredViewportSize().height() - scrollbarHeight );
 }
 
 SCENARIO( "Selection drag performance", "[ui][selection][regression]" )

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -917,7 +917,7 @@ class FiniteSuccessfulTestTransport : public ProcessLiveSourceTransport {
 #ifdef Q_OS_WIN
         return { QStringLiteral( "cmd" ),
                  { QStringLiteral( "/c" ),
-                   QStringLiteral( "ping -n 2 127.0.0.1 > nul & exit /b 0" ) } };
+                   QStringLiteral( "ping -n 4 127.0.0.1 > nul & exit /b 0" ) } };
 #else
         return { QStringLiteral( "/bin/sh" ),
                  { QStringLiteral( "-c" ), QStringLiteral( "sleep 0.5; exit 0" ) } };

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -148,3 +148,33 @@ TEST_CASE( "Configuration stores and restores iOS log defaults" )
     REQUIRE( restoredConfig.iosLogAnsiOutputEnabled() );
     REQUIRE( restoredConfig.adbLogcatAnsiOutputEnabled() );
 }
+
+TEST_CASE( "Configuration defaults empty filters to show all lines in filtered view" )
+{
+    Configuration config;
+
+    REQUIRE( config.showAllInFilteredViewWhenSearchEmpty() );
+}
+
+TEST_CASE( "Configuration stores and restores empty-filter filtered-view behavior" )
+{
+    const auto dirPath = makeTestDir( "configuration_empty_filter" );
+    REQUIRE( QDir{ dirPath }.exists() );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration-empty-filter.ini" );
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+
+        Configuration config;
+        config.setShowAllInFilteredViewWhenSearchEmpty( false );
+        config.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+    }
+
+    QSettings restoredSettings( settingsPath, QSettings::IniFormat );
+    Configuration restoredConfig;
+    restoredConfig.retrieveFromStorage( restoredSettings );
+
+    REQUIRE_FALSE( restoredConfig.showAllInFilteredViewWhenSearchEmpty() );
+}

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -22,7 +22,10 @@
 #include <QDir>
 #include <QWidget>
 
+#include <utility>
+
 #include "tabbedcrawlerwidget.h"
+#include "tabnamemapping.h"
 
 class DummyCrawlerWidget : public QWidget {
     Q_OBJECT
@@ -32,6 +35,23 @@ class DummyCrawlerWidget : public QWidget {
 
   Q_SIGNALS:
     void dataStatusChanged( DataStatus status );
+};
+
+class ScopedTabNameMapping {
+  public:
+    ScopedTabNameMapping( QString path, QString name )
+        : path_( std::move( path ) )
+    {
+        TabNameMapping::getSynced().setTabName( path_, std::move( name ) ).save();
+    }
+
+    ~ScopedTabNameMapping()
+    {
+        TabNameMapping::getSynced().setTabName( path_, QString{} ).save();
+    }
+
+  private:
+    QString path_;
 };
 
 TEST_CASE( "TabbedCrawlerWidget keeps live tab title and tooltip across group refreshes" )
@@ -101,6 +121,36 @@ TEST_CASE( "TabbedCrawlerWidget updateCrawler reflects disconnect and error stat
         tabWidget.onGroupsChanged();
         REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "Galaxy S24 [error]" ) );
     }
+}
+
+TEST_CASE( "TabbedCrawlerWidget keeps live status visible on renamed tabs" )
+{
+    const auto documentId = QStringLiteral( "adb://capture-renamed-status" );
+    const ScopedTabNameMapping tabNameMapping{ documentId, QStringLiteral( "Lab Phone" ) };
+
+    TabbedCrawlerWidget tabWidget;
+    auto* crawler = new DummyCrawlerWidget();
+
+    const auto index = tabWidget.addCrawler( crawler, documentId, QStringLiteral( "Galaxy S24" ),
+                                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone" ) );
+
+    tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [disconnected]" ),
+                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString()
+             == std::string( "Lab Phone [disconnected]" ) );
+
+    tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [error]" ),
+                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone [error]" ) );
+
+    tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24" ),
+                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone" ) );
 }
 
 #include "tabbedcrawlerwidget_test.moc"

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -19,7 +19,9 @@
 
 #include <catch2/catch.hpp>
 
+#include <QCoreApplication>
 #include <QDir>
+#include <QTranslator>
 #include <QWidget>
 
 #include <utility>
@@ -52,6 +54,28 @@ class ScopedTabNameMapping {
 
   private:
     QString path_;
+};
+
+class LiveStatusTranslator : public QTranslator {
+  public:
+    QString translate( const char* context, const char* sourceText, const char* disambiguation,
+                       int n ) const override
+    {
+        Q_UNUSED( disambiguation )
+        Q_UNUSED( n )
+
+        if ( QString::fromLatin1( context ) == QStringLiteral( "MainWindow" )
+             && QString::fromLatin1( sourceText ) == QStringLiteral( " [error]" ) ) {
+            return QStringLiteral( " [erreur]" );
+        }
+
+        if ( QString::fromLatin1( context ) == QStringLiteral( "MainWindow" )
+             && QString::fromLatin1( sourceText ) == QStringLiteral( " [disconnected]" ) ) {
+            return QStringLiteral( " [deconnecte]" );
+        }
+
+        return {};
+    }
 };
 
 TEST_CASE( "TabbedCrawlerWidget keeps live tab title and tooltip across group refreshes" )
@@ -151,6 +175,45 @@ TEST_CASE( "TabbedCrawlerWidget keeps live status visible on renamed tabs" )
                              QStringLiteral( "/tmp/galaxy.log" ) );
 
     REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone" ) );
+}
+
+TEST_CASE( "TabbedCrawlerWidget does not duplicate live status from renamed tabs" )
+{
+    const auto documentId = QStringLiteral( "adb://capture-renamed-status-duplicate" );
+    const ScopedTabNameMapping tabNameMapping{ documentId, QStringLiteral( "Lab Phone [error]" ) };
+
+    TabbedCrawlerWidget tabWidget;
+    auto* crawler = new DummyCrawlerWidget();
+
+    const auto index = tabWidget.addCrawler( crawler, documentId, QStringLiteral( "Galaxy S24" ),
+                                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [error]" ),
+                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone [error]" ) );
+}
+
+TEST_CASE( "TabbedCrawlerWidget keeps localized live status visible on renamed tabs" )
+{
+    LiveStatusTranslator translator;
+    QCoreApplication::installTranslator( &translator );
+
+    const auto documentId = QStringLiteral( "adb://capture-renamed-status-localized" );
+    const ScopedTabNameMapping tabNameMapping{ documentId, QStringLiteral( "Lab Phone" ) };
+
+    TabbedCrawlerWidget tabWidget;
+    auto* crawler = new DummyCrawlerWidget();
+
+    const auto index = tabWidget.addCrawler( crawler, documentId, QStringLiteral( "Galaxy S24" ),
+                                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    tabWidget.updateCrawler( index, QStringLiteral( "Galaxy S24 [erreur]" ),
+                             QStringLiteral( "/tmp/galaxy.log" ) );
+
+    QCoreApplication::removeTranslator( &translator );
+
+    REQUIRE( tabWidget.tabText( index ).toStdString() == std::string( "Lab Phone [erreur]" ) );
 }
 
 #include "tabbedcrawlerwidget_test.moc"


### PR DESCRIPTION
## Summary
- Reserve a stable bottom gutter in log views so the last visible row is not hidden by horizontal scrollbars and does not move when classic scrollbars appear.
- Add an empty-filter passthrough mode so the filtered window shows all lines by default without starting a filter scan, with a preferences checkbox to restore the previous empty result behavior.
- Preserve live stream status suffixes such as `[disconnected]` and `[error]` when a tab has been renamed.
- Generate release notes with explicit prerelease/release ranges: continuous prereleases start from the latest version tag, while releases start from the previous version tag excluding the current tag.
- Leave macOS Developer ID signing and notarization commented out until paid Apple Developer credentials are available, while keeping the restoration path documented in the workflow.

## Background
Introduced by: Existing log view layout, filtered search, tab rename, and release automation behavior predates this change; exact introducing commits are unknown.

Use case: Users should be able to read the final visible log row in both main and filtered windows, use an empty filter as a full mirror of the main log without paying filter-scan cost, keep live source state visible after renaming tabs, and publish release notes from the correct tag range.

How to reproduce: Open a log with horizontal scrolling and inspect the last visible row; rename an ADB/iOS live tab, then disconnect or hit an error state; open a log with an empty filter; compare continuous release notes after previous continuous prereleases have overwritten the same tag.

Root cause: The log view only reserved bottom space for transient scrollbars, renamed-tab rendering replaced the whole live-source title instead of composing the custom label with the live status suffix, and `LogFilteredData` had no all-lines passthrough mode for empty searches. The changelog script used a fixed/implicit tag range that did not distinguish continuous prereleases from real version releases.

How to fix: Always reserve the horizontal scrollbar height, add an `allLinesVisible` path in `LogFilteredData`, wire it through a default-on configuration setting and options checkbox, clear the initial combo-box edit text so search history does not masquerade as an active filter, preserve live status suffixes when custom tab names are applied, and move changelog range resolution into `scripts/gen_changelog.py` with `--mode prerelease|release`.

## Tests
- `build_root/output/klogg_tests "Configuration defaults empty filters to show all lines in filtered view,Configuration stores and restores empty-filter filtered-view behavior,TabbedCrawlerWidget keeps live status visible on renamed tabs"`
- `cmake --build build_root --target klogg_itests -j2 && build_root/output/klogg_itests "*Filtered window can mirror*,*Filtered window can stay empty*,*Log views reserve a stable bottom gutter*"`
- `python3 -m unittest discover -s tests/scripts -p 'test_*.py'`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "#{p}: OK" }' .github/actions/agent-package-mac/action.yml .github/workflows/ci-build.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to show all log lines in filtered view when the search field is empty
  * Tab labels now preserve and display live status indicators (disconnected, error)

* **Improvements**
  * Deterministic, improved changelog generation with better grouping and range handling
  * Refined scrollbar and bottom-alignment behavior for more consistent UI layout
  * macOS packaging now omits signing/notarization steps

* **Tests**
  * Added tests for changelog generation, configuration persistence, UI filtered-view and tab-label behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->