### PR TITLE
Fix filtered view top-alignment when content fits and bottom-alignment offset

### DIFF
--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -285,6 +285,38 @@ def _check_close_without_loading_wait(text: str, path: Path) -> list[tuple[int, 
     ]
 
 
+def _check_hardcoded_text_viewport_row_assertion(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag text viewport height assertions that assume fixed font metrics.
+
+    PR #26 exposed this in the offscreen UI tests: a resize that produced a
+    text viewport taller than three rows locally produced only 59 pixels on
+    Windows Qt5 and older Linux containers, so
+    ``TextViewportHeight() > CharHeight() * 3`` failed in CI. Size the view
+    from runtime metrics instead of asserting that one fixed pixel resize has
+    a fixed row capacity.
+    """
+    if path.name != "crawlerwidget_test.cpp" or ALLOW_MARKER in text:
+        return []
+
+    row_assertion_re = re.compile(
+        r"TextViewportHeight\s*\(\s*\)\s*>\s*.*CharHeight\s*\(\s*\)\s*\*\s*\d+"
+    )
+
+    findings: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        if row_assertion_re.search(line):
+            findings.append(
+                (
+                    i,
+                    "Text viewport row-count assertions based on a fixed resize "
+                    "are platform-fragile because Qt font/style metrics differ "
+                    "across CI runners. Resize until the runtime viewport metrics "
+                    "satisfy the row precondition, then assert the behavior under test.",
+                )
+            )
+    return findings
+
+
 _GUARD_RE = re.compile(r"^\s*#\s*if(?:def|n?def)?\s+(Q_OS_\w+)")
 _ELSE_RE = re.compile(r"^\s*#\s*else")
 _ENDIF_RE = re.compile(r"^\s*#\s*endif")
@@ -337,6 +369,10 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "close-without-loading-wait",
         "check": _check_close_without_loading_wait,
+    },
+    {
+        "name": "hardcoded-text-viewport-row-assertion",
+        "check": _check_hardcoded_text_viewport_row_assertion,
     },
 ]
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1226,8 +1226,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     // Calculate effective height for text wrapping and pull-to-follow bar positioning
     const int availableTextHeight = textViewportHeight();
     const int effectiveHeight
-        = ( useTextWrap_ && textAreaCache_.actual_height_ > 0 ) ? textAreaCache_.actual_height_
-                                                                 : wholeHeight;
+        = textAreaCache_.actual_height_ > 0 ? textAreaCache_.actual_height_ : wholeHeight;
 
     drawingTopOffset_ = -pullToFollowHeight;
     int drawingTopPosition = drawingTopOffset_;
@@ -1237,7 +1236,7 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
 
     if ( shouldBottomAlignFrame() ) {
         int hiddenHeightPx = std::max( 0, effectiveHeight - availableTextHeight );
-        drawingTopOffset_ = -hiddenHeightPx;
+        drawingTopOffset_ = verticalScrollBar()->maximum() == 0 ? 0 : -hiddenHeightPx;
         drawingTopPosition = drawingTopOffset_;
 
         const int heightForPullToFollow = ( useTextWrap_ && textAreaCache_.actual_height_ > 0 )

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -499,6 +499,12 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
             .toImage();
     }
 
+    int mainDrawingTopOffset() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::drawingTopOffset(
+            crawler->logMainView_ );
+    }
+
     QColor mainBaseColor() const
     {
         return crawler->logMainView_->palette().color( QPalette::Base );
@@ -539,6 +545,22 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         crawler->logMainView_->resize( width, height );
         crawler->filteredView_->resize( width, height );
         QTest::qWait( 50 );
+    }
+
+    void resizeViewsToPartialTextLineHeight( int width )
+    {
+        for ( int height = 70; height < 140; ++height ) {
+            crawler->logMainView_->setFixedSize( width, height );
+            crawler->filteredView_->setFixedSize( width, height );
+            QTest::qWait( 10 );
+            render();
+
+            if ( mainCharHeight() > 0 && filteredCharHeight() > 0
+                 && mainTextViewportHeight() % mainCharHeight() != 0
+                 && filteredTextViewportHeight() % filteredCharHeight() != 0 ) {
+                return;
+            }
+        }
     }
 
     void enableFollowMode( bool enabled )
@@ -713,6 +735,12 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
             crawler->filteredView_ );
     }
 
+    bool mainShouldBottomAlign() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::shouldBottomAlignFrame(
+            crawler->logMainView_ );
+    }
+
     void scrollFilteredVerticallyToBottom()
     {
         crawler->filteredView_->verticalScrollBar()->setValue(
@@ -845,9 +873,9 @@ SCENARIO( "Crawler widget search", "[ui]" )
                     const auto viewportHeight = crawlerVisitor.filteredViewportSize().height();
                     REQUIRE( viewportHeight % charH != 0 );
                     REQUIRE( offset >= 0 );
-                    // Bottom-aligned: pixmap is offset upward so the bottom line sits at the
-                    // viewport bottom. The offset is strictly less than one char height for a
-                    // partial-line viewport (no grid snapping).
+                    // Bottom-aligned: pixmap is padded from the top so the bottom line sits at
+                    // the viewport bottom. The offset is strictly less than one char height for
+                    // a partial-line viewport (no grid snapping).
                     REQUIRE( offset < charH );
                     // The offset should be at most one viewport's worth of content
                     REQUIRE( offset < charH * 50 );
@@ -1575,6 +1603,163 @@ SCENARIO( "Log views keep the bottom line anchored when non-wrapped height chang
     REQUIRE( crawlerVisitor.filteredTopLine().get()
              == static_cast<LineNumber::UnderlyingType>(
                  crawlerVisitor.filteredVerticalScrollMaximum() ) );
+}
+
+SCENARIO( "Log views remain at bottom when viewport height decreases",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
+    REQUIRE( generateLongLineDataFile( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViews( 320, 200 );
+    crawlerVisitor.render();
+
+    crawlerVisitor.scrollMainVerticallyToBottom();
+    crawlerVisitor.scrollFilteredVerticallyToBottom();
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+    REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() > 0 );
+    REQUIRE( crawlerVisitor.mainTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.mainVerticalScrollMaximum() ) );
+    REQUIRE( crawlerVisitor.filteredTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.filteredVerticalScrollMaximum() ) );
+
+    // Simulate window height change without clearing lastLineAligned_
+    crawlerVisitor.resizeViews( 320, 120 );
+    crawlerVisitor.render();
+
+    // Should still be at the bottom after resize
+    REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.mainTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.mainVerticalScrollMaximum() ) );
+    REQUIRE( crawlerVisitor.filteredTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.filteredVerticalScrollMaximum() ) );
+
+    // Resize again to a smaller height
+    crawlerVisitor.resizeViews( 320, 88 );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.mainTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.mainVerticalScrollMaximum() ) );
+    REQUIRE( crawlerVisitor.filteredTopLine().get()
+             == static_cast<LineNumber::UnderlyingType>(
+                 crawlerVisitor.filteredVerticalScrollMaximum() ) );
+}
+
+SCENARIO( "Log views do not clip text rows at top or bottom in bottom alignment",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
+    REQUIRE( generateLongLineDataFile( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViewsToPartialTextLineHeight( 320 );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainTextViewportHeight() % crawlerVisitor.mainCharHeight() != 0 );
+    REQUIRE( crawlerVisitor.filteredTextViewportHeight() % crawlerVisitor.filteredCharHeight() != 0 );
+
+    crawlerVisitor.scrollMainVerticallyToBottom();
+    crawlerVisitor.scrollFilteredVerticallyToBottom();
+    crawlerVisitor.render();
+
+    const auto mainRowsAtBottom = crawlerVisitor.getLogNbLines() - LinesCount{
+        crawlerVisitor.mainTopLine().get() };
+    const auto filteredRowsAtBottom = crawlerVisitor.getLogFilteredNbLines() - LinesCount{
+        crawlerVisitor.filteredTopLine().get() };
+
+    REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+    // Bottom alignment shifts content upward so the last line sits at the viewport
+    // bottom. The offset is negative (or zero when viewport height is an exact
+    // multiple of char height), matching text-wrap mode behavior.
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset() <= 0 );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset() <= 0 );
+    // The last visible line must end within one char height of the viewport bottom
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset()
+             + static_cast<int>( mainRowsAtBottom.get() ) * crawlerVisitor.mainCharHeight()
+             >= crawlerVisitor.mainTextViewportHeight() - crawlerVisitor.mainCharHeight() );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset()
+             + static_cast<int>( filteredRowsAtBottom.get() ) * crawlerVisitor.filteredCharHeight()
+             >= crawlerVisitor.filteredTextViewportHeight() - crawlerVisitor.filteredCharHeight() );
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset()
+             + static_cast<int>( mainRowsAtBottom.get() ) * crawlerVisitor.mainCharHeight()
+             <= crawlerVisitor.mainTextViewportHeight() );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset()
+             + static_cast<int>( filteredRowsAtBottom.get() ) * crawlerVisitor.filteredCharHeight()
+             <= crawlerVisitor.filteredTextViewportHeight() );
+
+    crawlerVisitor.enableFollowMode( true );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset() <= 0 );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset() <= 0 );
+}
+
+SCENARIO( "Filtered view keeps sparse results top-aligned when follow mode is enabled",
+          "[ui][scrollbar][regression]" )
+{
+    QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
+    REQUIRE( generateLongLineDataFile( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViews( 900, 420 );
+    crawlerVisitor.setSearchPattern( "LOGDATA long line 000042" );
+    crawlerVisitor.runSearch();
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 1; } ) );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() == 0 );
+    REQUIRE( crawlerVisitor.filteredTextViewportHeight() > crawlerVisitor.filteredCharHeight() * 3 );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == 0 );
+
+    crawlerVisitor.enableFollowMode( true );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.isFollowModeEnabled() );
+    REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() == 0 );
+    REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == 0 );
 }
 
 SCENARIO( "Log view reserves space for transient horizontal scrollbars",

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -563,6 +563,23 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         }
     }
 
+    bool resizeViewsToFitFilteredTextRows( int width, int minimumRows )
+    {
+        for ( int height = 120; height <= 720; height += 40 ) {
+            crawler->logMainView_->setFixedSize( width, height );
+            crawler->filteredView_->setFixedSize( width, height );
+            QTest::qWait( 10 );
+            render();
+
+            const auto charHeight = filteredCharHeight();
+            if ( charHeight > 0 && filteredTextViewportHeight() > charHeight * minimumRows ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     void enableFollowMode( bool enabled )
     {
         crawler->logMainView_->followSet( enabled );
@@ -1747,10 +1764,10 @@ SCENARIO( "Filtered view keeps sparse results top-aligned when follow mode is en
     crawlerVisitor.runSearch();
 
     REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 1; } ) );
+    REQUIRE( crawlerVisitor.resizeViewsToFitFilteredTextRows( 900, 3 ) );
     crawlerVisitor.render();
 
     REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() == 0 );
-    REQUIRE( crawlerVisitor.filteredTextViewportHeight() > crawlerVisitor.filteredCharHeight() * 3 );
     REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == 0 );
 
     crawlerVisitor.enableFollowMode( true );


### PR DESCRIPTION
## Summary
- Fix filtered view top-aligning sparse results instead of leaving them bottom-aligned and obscured.
- Fix `drawingTopOffset_` to only force top-alignment when all content fits in the viewport (`scrollMax == 0`), matching text-wrap mode behavior.
- Remove `useTextWrap_` guard from `effectiveHeight` so non-wrap mode also uses the actual pixmap height from `drawTextArea`.
- Add 3 regression tests: bottom-alignment offset correctness, resize preserving bottom scroll position, and filtered view top-alignment with sparse results.

## Background
- **Use case**: Search for a rare pattern in a large log file. When results are sparse (fewer lines than the filtered viewport), the first result line should be visible at the top, not pushed off-screen by forced bottom-alignment.
- **How to reproduce**: Open a file, search for a unique pattern matching a single line. Before this fix, `lastLineAligned_` forced bottom-alignment even though `scrollMax == 0`, pushing the single result to the viewport bottom with blank space above it.
- **Root cause**: Two issues in `AbstractLogView::paintEvent`:
  1. `effectiveHeight` used `wholeHeight` (a ceil-based proxy, `ceil(h/charH) * charH`) for non-wrap mode instead of the actual pixmap height from `drawTextArea`.
  2. `drawingTopOffset_` unconditionally applied bottom-alignment when `shouldBottomAlignFrame()` returned true, even when all content fit in the viewport.
- **How to fix**: Check `verticalScrollBar()->maximum() == 0` to detect "all content fits" and top-align only in that case. Use `textAreaCache_.actual_height_` as `effectiveHeight` in both wrap and non-wrap modes.

## Tests
- `cmake --build . -j$(sysctl -n hw.ncpu)` — builds cleanly
- `./output/klogg_itests -platform offscreen "[ui]"` — 406 assertions, 20 test cases all passed
- `./output/klogg_tests -platform offscreen` — 5041 assertions, 174 test cases all passed
- 3 new regression tests under `[ui][scrollbar][regression]`:
  - `Log views do not clip text rows at top or bottom in bottom alignment`
  - `Log views remain at bottom when viewport height decreases`
  - `Filtered view keeps sparse results top-aligned when follow mode is enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text rendering computation in log view for partial text-line viewports.
  * Corrected bottom-alignment offset calculation to prevent negative offsets when scrollbar is at empty range.

* **Tests**
  * Added regression test scenarios for bottom-alignment behavior during viewport height changes and extreme rendering cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ZEACENT/klogg/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->