### PR TITLE
Fix downloader lifetime, version-check error reporting, i18n strings, and replace OpenSSL with Schannel TLS for Qt6

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -589,10 +589,11 @@ jobs:
           - os: windows
             os_version: 2022
             qt_version: 5.15.2
-            qt_modules: 
+            qt_modules:
             qt_archives: qtbase qtimageformats qttools qttranslations icu qtsvg
             qt_arch: win32_msvc2019
             arch: x86
+            ssl_arch: ""
             package_tag: QTRegex
             cmake_opts: -DKLOGG_USE_SENTRY=OFF -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_VECTORSCAN=OFF
             label: x86-qt5
@@ -603,17 +604,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
+        if: ${{ startsWith(matrix.config.qt_version, '5') }}
         with:
           name: openssl-archive
           path: ${{ github.workspace }}
 
       - name: Unpack prefetched openssl
+        if: ${{ startsWith(matrix.config.qt_version, '5') }}
         run: |
           if ( !(Test-Path openssl.zip) ) {
             Write-Error "Prefetched OpenSSL artifact is required but openssl.zip is missing"
             exit 1
           }
-          7z x openssl.zip 
+          7z x openssl.zip
 
       - uses: actions/download-artifact@v4
         with:
@@ -634,6 +637,7 @@ jobs:
           Expand-Archive -Path $archive -DestinationPath $toolsRoot -Force
 
       - name: Set openssl paths
+        if: ${{ startsWith(matrix.config.qt_version, '5') }}
         shell: sh
         run: |
           echo "SSL_DIR=${{ github.workspace }}\openssl-1.1\${{ matrix.config.arch }}\bin" >> $GITHUB_ENV
@@ -807,7 +811,15 @@ jobs:
           s3-key-id: ${{ secrets.WIN_CS_KEY_ID }}
           s3-secret: ${{ secrets.WIN_CS_SECRET }}
           s3-bucket: ${{ secrets.WIN_CS_BUCKET }}
-     
+
+      - name: Verify SSL/TLS packaging
+        if: ${{ steps.run-tests.outcome == 'success' }}
+        shell: pwsh
+        run: |
+          $releaseDir = Join-Path $env:GITHUB_WORKSPACE "release"
+          $script = Join-Path $env:GITHUB_WORKSPACE "packaging\windows\verify_ssl.ps1"
+          & $script -ReleaseDir $releaseDir -QtVersion $env:KLOGG_QT
+
 # Final upload of all packages
       - uses: actions/upload-artifact@v4
         if: ${{ steps.run-tests.outcome == 'success' }}

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -38,7 +38,7 @@ To build the Vectorscan regular expressions backend (default):
 To build installer for Windows:
 
 - nsis to build installer for Windows
-- Precompiled OpenSSl library to enable https support on Windows
+- Precompiled OpenSSL 1.1.x library (only needed for Qt5 builds; Qt6 uses Schannel TLS backend built into Windows)
 
 Building tests:
 
@@ -139,8 +139,7 @@ CMake should generate `klogg.sln` file in `<path_to_project_root>\build_root` di
 
 Binaries are placed into `build_root/output`.
 
-For https network urls support download precompiled openssl library https://mirror.firedaemon.com/OpenSSL/openssl-1.1.1l-dev.zip.
-Put libcrypto-1_1 and libssl-1_1 for desired architecture near klogg binaries.
+For https network urls support with Qt6, no additional libraries are required — Qt6 uses the Schannel TLS backend built into Windows. For Qt5 builds, download a precompiled OpenSSL 1.1.x library from https://www.firedaemon.com/download-firedaemon-openssl-1.1.1-zip and place `libcrypto-1_1*.dll` and `libssl-1_1*.dll` for the desired architecture next to the klogg binaries.
 
 ### Building on Mac OS
 

--- a/packaging/windows/7z_klogg_listfile.txt
+++ b/packaging/windows/7z_klogg_listfile.txt
@@ -10,3 +10,4 @@
 .\release\platforms\*
 .\release\styles\*
 .\release\imageformats\*
+.\release\tls\*

--- a/packaging/windows/klogg.nsi
+++ b/packaging/windows/klogg.nsi
@@ -135,6 +135,11 @@ Section "Qt Runtime libraries" qtlibs
     SetOutPath $INSTDIR\imageformats
     File release\imageformats\qsvg.dll
 
+!if ${QT_MAJOR} == "Qt6"
+    SetOutPath $INSTDIR\tls
+    File release\tls\qschannelbackend.dll
+!endif
+
 SectionEnd
 
 Section "MSVC Runtime libraries" vcruntime

--- a/packaging/windows/klogg.nsi
+++ b/packaging/windows/klogg.nsi
@@ -142,15 +142,20 @@ Section "MSVC Runtime libraries" vcruntime
     File release\msvcp140.dll
     File release\msvcp140_1.dll
     File release\vcruntime140.dll
-    
+
 !if ${PLATFORM} == "x64"
     File release\vcruntime140_1.dll
+!endif
 
+    ; Qt5 requires OpenSSL 1.1.x for TLS; Qt6 uses the Schannel backend (built into Windows)
+!if ${QT_MAJOR} == "Qt5"
+!if ${PLATFORM} == "x64"
     File release\libcrypto-1_1-x64.dll
     File release\libssl-1_1-x64.dll
 !else
     File release\libcrypto-1_1.dll
     File release\libssl-1_1.dll
+!endif
 !endif
 
 SectionEnd
@@ -220,10 +225,15 @@ Section "Uninstall"
     Delete "$INSTDIR\tbbmalloc_proxy.dll"
     Delete "$INSTDIR\klogg_tbbmalloc.dll"
     Delete "$INSTDIR\klogg_tbbmalloc_proxy.dll"
+!if ${QT_MAJOR} == "Qt5"
     Delete "$INSTDIR\libcrypto-1_1-x64.dll"
     Delete "$INSTDIR\libssl-1_1-x64.dll"
     Delete "$INSTDIR\libcrypto-1_1.dll"
     Delete "$INSTDIR\libssl-1_1.dll"
+!endif
+    ; Qt6 TLS backend (Schannel plugin)
+    Delete "$INSTDIR\tls\qschannelbackend.dll"
+    RMDir "$INSTDIR\tls"
     Delete "$INSTDIR\mimalloc.dll"
     Delete "$INSTDIR\mimalloc_override.dll"
     Delete "$INSTDIR\mimalloc_redirect.dll"

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -69,8 +69,12 @@ xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140.dll" %KLOGG
 xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140_1.dll" %KLOGG_WORKSPACE%\release\ /y
 
 echo "Copying ssl..."
-xcopy %SSL_DIR%\libcrypto-1_1%SSL_ARCH%.dll %KLOGG_WORKSPACE%\release\ /y
-xcopy %SSL_DIR%\libssl-1_1%SSL_ARCH%.dll %KLOGG_WORKSPACE%\release\ /y
+if "%KLOGG_QT%"=="Qt5" (
+    xcopy %SSL_DIR%\libcrypto-1_1%SSL_ARCH%.dll %KLOGG_WORKSPACE%\release\ /y
+    xcopy %SSL_DIR%\libssl-1_1%SSL_ARCH%.dll %KLOGG_WORKSPACE%\release\ /y
+) else (
+    echo "Qt6: Skipping OpenSSL DLLs (Schannel TLS backend will be used instead)"
+)
 
 echo "Copying Qt..."
 set "QTDIR=%KLOGG_QT_DIR:/=\%"
@@ -93,6 +97,13 @@ xcopy %QTDIR%\plugins\styles\qmodernwindowsstyle.dll %KLOGG_WORKSPACE%\release\s
 
 md %KLOGG_WORKSPACE%\release\imageformats
 xcopy %QTDIR%\plugins\imageformats\qsvg.dll %KLOGG_WORKSPACE%\release\imageformats\ /y
+
+rem Qt6 uses Schannel (built into Windows) instead of OpenSSL for TLS
+if "%KLOGG_QT%"=="Qt6" (
+    md %KLOGG_WORKSPACE%\release\tls 2>nul
+    xcopy %QTDIR%\plugins\tls\qschannelbackend.dll %KLOGG_WORKSPACE%\release\tls\ /y
+    echo "Schannel TLS backend deployed"
+)
 
 echo "Copying packaging files..."
 md %KLOGG_WORKSPACE%\chocolately

--- a/packaging/windows/verify_ssl.ps1
+++ b/packaging/windows/verify_ssl.ps1
@@ -1,0 +1,110 @@
+# Verify SSL/TLS packaging correctness
+# Qt6: must NOT ship OpenSSL DLLs, must ship Schannel TLS backend
+# Qt5: must ship OpenSSL 1.1.x DLLs
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$ReleaseDir,
+
+    [Parameter(Mandatory=$true)]
+    [string]$QtVersion  # "Qt5" or "Qt6"
+)
+
+$ErrorActionPreference = "Stop"
+$exitCode = 0
+
+function Write-CheckResult {
+    param([string]$Item, [bool]$Pass)
+    if ($Pass) {
+        Write-Host "  PASS: $Item" -ForegroundColor Green
+    } else {
+        Write-Host "  FAIL: $Item" -ForegroundColor Red
+        $script:exitCode = 1
+    }
+}
+
+Write-Host "========================================"
+Write-Host "SSL/TLS Packaging Verification"
+Write-Host "  Release directory: $ReleaseDir"
+Write-Host "  Qt version: $QtVersion"
+Write-Host "========================================"
+
+if (-not (Test-Path $ReleaseDir)) {
+    Write-Error "Release directory not found: $ReleaseDir"
+    exit 1
+}
+
+# Check for OpenSSL DLLs
+$opensslDlls = Get-ChildItem -Path $ReleaseDir -Filter "libcrypto-*.dll" -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match 'libcrypto-\d.*\.dll$' }
+$osslDlls = Get-ChildItem -Path $ReleaseDir -Filter "libssl-*.dll" -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -match 'libssl-\d.*\.dll$' }
+
+# Check for TLS plugin directory
+$tlsDir = Join-Path $ReleaseDir "tls"
+$schannelDll = Join-Path $tlsDir "qschannelbackend.dll"
+$opensslBackendDll = Join-Path $tlsDir "qopensslbackend.dll"
+
+if ($QtVersion -eq "Qt6") {
+    Write-Host "`nQt6 assertions:"
+    Write-Host "  Expected: NO OpenSSL DLLs in release root"
+    Write-Host "  Expected: tls/qschannelbackend.dll present"
+    Write-Host "  Optional: tls/qopensslbackend.dll may be absent (Schannel preferred)`n"
+
+    # Qt6 must NOT ship OpenSSL 1.1.x DLLs
+    $hasOpenSsl = ($opensslDlls.Count -gt 0) -or ($osslDlls.Count -gt 0)
+    Write-CheckResult "No libcrypto-1_1-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libcrypto-1_1-x64.dll")))
+    Write-CheckResult "No libssl-1_1-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libssl-1_1-x64.dll")))
+    Write-CheckResult "No libcrypto-1_1.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libcrypto-1_1.dll")))
+    Write-CheckResult "No libssl-1_1.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libssl-1_1.dll")))
+
+    # Qt6 must NOT ship OpenSSL 3.x DLLs either (we use Schannel, not OpenSSL)
+    Write-CheckResult "No libcrypto-3-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libcrypto-3-x64.dll")))
+    Write-CheckResult "No libssl-3-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libssl-3-x64.dll")))
+    Write-CheckResult "No libcrypto-3.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libcrypto-3.dll")))
+    Write-CheckResult "No libssl-3.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libssl-3.dll")))
+
+    # Qt6 must ship Schannel TLS backend
+    Write-CheckResult "tls/ directory exists" (Test-Path $tlsDir)
+    Write-CheckResult "tls/qschannelbackend.dll present" (Test-Path $schannelDll)
+
+    # Verify schannel DLL is a real file (not zero bytes)
+    if (Test-Path $schannelDll) {
+        $size = (Get-Item $schannelDll).Length
+        Write-CheckResult "tls/qschannelbackend.dll is non-empty ($size bytes)" ($size -gt 0)
+    }
+
+} elseif ($QtVersion -eq "Qt5") {
+    Write-Host "`nQt5 assertions:"
+    Write-Host "  Expected: OpenSSL 1.1.x DLLs present (x64 or x86 depending on arch)"
+    Write-Host "  Expected: No Schannel requirement (Qt5 uses OpenSSL exclusively)`n"
+
+    # Qt5 must ship OpenSSL 1.1.x DLLs
+    # Check both x64 and x86 naming patterns (one set should exist)
+    $hasX64 = (Test-Path (Join-Path $ReleaseDir "libcrypto-1_1-x64.dll")) -and
+              (Test-Path (Join-Path $ReleaseDir "libssl-1_1-x64.dll"))
+    $hasX86 = (Test-Path (Join-Path $ReleaseDir "libcrypto-1_1.dll")) -and
+              (Test-Path (Join-Path $ReleaseDir "libssl-1_1.dll"))
+    $hasOpenSsl11 = $hasX64 -or $hasX86
+
+    Write-CheckResult "OpenSSL 1.1.x DLLs present (x64: $hasX64, x86: $hasX86)" $hasOpenSsl11
+
+    # Qt5 should NOT ship OpenSSL 3.x DLLs (incompatible)
+    Write-CheckResult "No libcrypto-3-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libcrypto-3-x64.dll")))
+    Write-CheckResult "No libssl-3-x64.dll in release root" (-not (Test-Path (Join-Path $ReleaseDir "libssl-3-x64.dll")))
+
+} else {
+    Write-Error "Unknown QtVersion: $QtVersion (expected Qt5 or Qt6)"
+    exit 1
+}
+
+Write-Host ""
+if ($exitCode -eq 0) {
+    Write-Host "========================================"
+    Write-Host "  ALL CHECKS PASSED" -ForegroundColor Green
+    Write-Host "========================================"
+} else {
+    Write-Host "========================================"
+    Write-Host "  SOME CHECKS FAILED" -ForegroundColor Red
+    Write-Host "========================================"
+}
+exit $exitCode

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -108,11 +108,19 @@ class KloggApp : public QApplication {
 
             // Manual check completed without finding a new version
             connect( &versionChecker_, &VersionChecker::checkCompleted,
-                     []( bool newVersionFound ) {
+                     []( bool newVersionFound, bool hadError ) {
                          Q_UNUSED( newVersionFound );
                          QMessageBox msgBox;
-                         msgBox.setText(
-                             QStringLiteral( "You are using the latest version of klogg." ) );
+                         if ( hadError ) {
+                             msgBox.setIcon( QMessageBox::Warning );
+                             msgBox.setText( tr(
+                                 "Unable to check for updates.\n"
+                                 "Please verify your internet connection." ) );
+                         }
+                         else {
+                             msgBox.setText(
+                                 tr( "You are using the latest version of klogg." ) );
+                         }
                          msgBox.exec();
                      } );
         }
@@ -314,30 +322,30 @@ class KloggApp : public QApplication {
         LOG_DEBUG << "newVersionNotification( " << new_version << " from " << url
                   << ", download: " << downloadUrl << " )";
 
-        QString message = QString( "<p>A new version of klogg (%1) is available for download.</p>"
-                                   "<p><a href=\"%2\">%2</a></p>" )
+        QString message = tr( "<p>A new version of klogg (%1) is available for download.</p>"
+                              "<p><a href=\"%2\">%2</a></p>" )
                               .arg( new_version, url );
 
         if ( !changes.empty() ) {
-            message.append( "<p>Important changes:</p><ul>" );
+            message.append( tr( "<p>Important changes:</p><ul>" ) );
             for ( const auto& change : changes ) {
-                message.append( QString( "<li>%1</li>" ).arg( change ) );
+                message.append( tr( "<li>%1</li>" ).arg( change ) );
             }
-            message.append( "</ul>" );
+            message.append( QStringLiteral( "</ul>" ) );
         }
 
         QMessageBox msgBox;
-        msgBox.setWindowTitle( QStringLiteral( "New Version Available" ) );
+        msgBox.setWindowTitle( tr( "New Version Available" ) );
         msgBox.setText( message );
         msgBox.setTextFormat( Qt::RichText );
         msgBox.setIcon( QMessageBox::Information );
 
         QPushButton* downloadButton
-            = msgBox.addButton( QStringLiteral( "Download" ), QMessageBox::AcceptRole );
+            = msgBox.addButton( tr( "Download" ), QMessageBox::AcceptRole );
         QPushButton* remindButton
-            = msgBox.addButton( QStringLiteral( "Remind Later" ), QMessageBox::RejectRole );
+            = msgBox.addButton( tr( "Remind Later" ), QMessageBox::RejectRole );
         QPushButton* skipButton
-            = msgBox.addButton( QStringLiteral( "Skip This Version" ),
+            = msgBox.addButton( tr( "Skip This Version" ),
                                 QMessageBox::DestructiveRole );
 
         msgBox.setDefaultButton( downloadButton );
@@ -376,23 +384,22 @@ class KloggApp : public QApplication {
         const auto urlFileName = QUrl( downloadUrl ).fileName();
         const auto localPath = downloadsPath + QDir::separator() + urlFileName;
 
+        // outputFile is shared with the completion lambda so it stays alive
+        // until the download finishes (no cycle — QFile is not a QObject).
         auto outputFile = std::make_shared<QFile>( localPath );
         if ( !outputFile->open( QIODevice::WriteOnly ) ) {
             LOG_ERROR << "Cannot open file for writing: " << localPath;
-            QMessageBox::warning( nullptr, QStringLiteral( "Download Failed" ),
-                                  QStringLiteral( "Could not create file:\n%1" ).arg( localPath ) );
+            QMessageBox::warning( nullptr, tr( "Download Failed" ),
+                                  tr( "Could not create file:\n%1" ).arg( localPath ) );
             return;
         }
 
-        auto downloader = std::make_shared<Downloader>();
-        std::weak_ptr<Downloader> weakDownloader = downloader;
+        // Use raw new + deleteLater to avoid the shared_ptr cycle that would
+        // leak, while keeping the Downloader alive for the async request.
+        auto* downloader = new Downloader();
 
-        QObject::connect( downloader.get(), &Downloader::finished,
-                          [ outputFile, weakDownloader, localPath ]( bool success ) {
-                              auto dl = weakDownloader.lock();
-                              if ( !dl ) {
-                                  return;
-                              }
+        QObject::connect( downloader, &Downloader::finished,
+                          [ outputFile, downloader, localPath ]( bool success ) {
                               outputFile->close();
                               if ( success ) {
                                   LOG_INFO << "Update downloaded to " << localPath;
@@ -400,13 +407,14 @@ class KloggApp : public QApplication {
                               }
                               else {
                                   LOG_ERROR << "Update download failed: "
-                                            << dl->lastError();
+                                            << downloader->lastError();
                                   QMessageBox::warning(
-                                      nullptr, QStringLiteral( "Download Failed" ),
-                                      QStringLiteral( "Failed to download update:\n%1" )
-                                          .arg( dl->lastError() ) );
+                                      nullptr, tr( "Download Failed" ),
+                                      tr( "Failed to download update:\n%1" )
+                                          .arg( downloader->lastError() ) );
                                   outputFile->remove();
                               }
+                              downloader->deleteLater();
                           } );
 
         downloader->download( QUrl( downloadUrl ), outputFile.get() );

--- a/src/versioncheck/include/versionchecker.h
+++ b/src/versioncheck/include/versionchecker.h
@@ -114,8 +114,10 @@ class VersionChecker : public QObject {
     void newVersionFound( const QString& version, const QString& url,
                           const QString& downloadUrl, const QStringList& changes );
 
-    // Check completed without finding a new version
-    void checkCompleted( bool newVersionFound );
+    // Check completed without finding a new version.
+    // hadError is true when the network request failed or version checking
+    // is disabled, so callers can distinguish "no update" from "check failed".
+    void checkCompleted( bool newVersionFound, bool hadError = false );
 
   private:
     // Called on the main thread after the background network request completes

--- a/src/versioncheck/src/versionchecker.cpp
+++ b/src/versioncheck/src/versionchecker.cpp
@@ -225,7 +225,7 @@ void VersionChecker::forceCheck()
 
     if ( !appConfig.versionCheckingEnabled() ) {
         LOG_DEBUG << "Version checking is disabled";
-        Q_EMIT checkCompleted( false );
+        Q_EMIT checkCompleted( false, true );
         return;
     }
 
@@ -268,12 +268,12 @@ void VersionChecker::processResponse( QByteArray data, bool hadError, bool wasMa
         const bool foundNewer = checkVersionData( data );
 
         if ( !foundNewer && wasManual ) {
-            Q_EMIT checkCompleted( false );
+            Q_EMIT checkCompleted( false, false );
         }
     }
     else {
         if ( wasManual ) {
-            Q_EMIT checkCompleted( false );
+            Q_EMIT checkCompleted( false, true );
         }
     }
 


### PR DESCRIPTION
## Summary

Three categories of changes:

### 1. Fix downloader lifetime, version-check error reporting, and i18n strings

**Fix 1 — Downloader destroyed immediately after download starts:** The `weak_ptr` fix in PR #30 broke the downloader lifetime. The `shared_ptr<Downloader>` was the only strong reference; it went out of scope when `downloadAndOpenUpdate()` returned, destroying the `QNetworkAccessManager` and aborting the async request. Fixed by using raw `new` + `deleteLater()` in the completion lambda — no reference cycle and the Downloader stays alive for the async request.

**Fix 2 — Manual version check reports "latest" on network errors:** `checkCompleted(bool)` was always emitted with `false`, regardless of success or failure. The handler ignored the parameter. Fixed by adding a `bool hadError` parameter to the signal, passing `true` on failure, and showing a warning dialog when an error occurred.

**Fix 3 — User-facing strings bypass translation:** 10 hardcoded `QStringLiteral` instances replaced with `tr()` for i18n consistency.

### 2. Replace OpenSSL with Schannel TLS backend for Qt6 Windows builds

Qt6 Windows x64 builds no longer bundle OpenSSL 1.1.1w DLLs. Instead they deploy `qschannelbackend.dll`, the native Windows Schannel TLS plugin that ships with Qt6. Schannel is built into Windows 10+ (the minimum required by Qt6) and is automatically patched via Windows Update.

Qt5 x86 Windows builds are unchanged — they continue to bundle OpenSSL 1.1.1w (Qt5 hardcodes `libssl-1_1-x64.dll` and cannot load OpenSSL 3.x).

A post-packaging verification step (`verify_ssl.ps1`) is added to CI to validate that each build ships the correct TLS backend.

### 3. Fix missing Schannel TLS plugin in NSIS installer for Qt6

The NSIS installer's "Qt Runtime libraries" section installed `platforms/`, `styles/`, and `imageformats/` plugins but never deployed `tls/qschannelbackend.dll` for Qt6. The portable release packaging (`prepare_release.cmd`) did include the file, and the uninstall section already expected to clean it up — but the installer itself never placed it. Qt6 Windows users who installed via the setup package had no TLS backend, breaking all HTTPS operations.

Fixed by adding a `!if ${QT_MAJOR} == "Qt6"` guarded block in the Qt Runtime libraries section to create `$INSTDIR\tls` and deploy `qschannelbackend.dll`.

## Tests
- All 4 test suites pass: `klogg_smoke`, `klogg_tests`, `klogg_itests`, `klogg_vectorscan_tests`
- CI `verify_ssl.ps1` step validates packaging output per build configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSL/TLS packaging verification step for Windows releases.

* **Bug Fixes**
  * Conditional OpenSSL vs Schannel packaging on Windows (Qt5 vs Qt6) and installer tweaks.
  * Prefetch/packaging steps gated to Qt5 builds in CI.
  * Version check now differentiates network errors from “no update” and shows an appropriate warning.

* **Documentation**
  * Clarified Windows OpenSSL requirement for Qt5 and Schannel behavior for Qt6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->