### PR TITLE
Fix version checker, CrashHandler, Windows UI, default font size, and CI issues

### DIFF
--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -116,7 +116,7 @@ xcopy %KLOGG_WORKSPACE%\packaging\windows\klogg.nsi  /y
 xcopy %KLOGG_WORKSPACE%\packaging\windows\FileAssociation.nsh  /y
 
 echo "Making portable archive..."
-7z a -r %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
+7z a %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
 
 echo "Making PDB archive..."
 rem Create PDB archive, ignore warnings about missing files

--- a/packaging/windows/verify_ssl.ps1
+++ b/packaging/windows/verify_ssl.ps1
@@ -73,6 +73,20 @@ if ($QtVersion -eq "Qt6") {
         Write-CheckResult "tls/qschannelbackend.dll is non-empty ($size bytes)" ($size -gt 0)
     }
 
+    # Qt plugin DLLs must live in their subdirectories, not in release root.
+    # A root-level copy is a packaging bug (e.g. misconfigured 7z flags).
+    $pluginDlls = @{
+        "tls/qschannelbackend.dll" = "tls"
+        "platforms/qwindows.dll" = "platforms"
+        "styles/qmodernwindowsstyle.dll" = "styles"
+        "imageformats/qsvg.dll" = "imageformats"
+    }
+    foreach ($subPath in $pluginDlls.Keys) {
+        $leaf = Split-Path $subPath -Leaf
+        $rootCopy = Join-Path $ReleaseDir $leaf
+        Write-CheckResult "No $leaf in release root (must be in $($pluginDlls[$subPath])/)" (-not (Test-Path $rootCopy))
+    }
+
 } elseif ($QtVersion -eq "Qt5") {
     Write-Host "`nQt5 assertions:"
     Write-Host "  Expected: OpenSSL 1.1.x DLLs present (x64 or x86 depending on arch)"

--- a/packaging/windows/verify_ssl.ps1
+++ b/packaging/windows/verify_ssl.ps1
@@ -79,6 +79,7 @@ if ($QtVersion -eq "Qt6") {
         "tls/qschannelbackend.dll" = "tls"
         "platforms/qwindows.dll" = "platforms"
         "styles/qmodernwindowsstyle.dll" = "styles"
+        "styles/qwindowsvistastyle.dll" = "styles"
         "imageformats/qsvg.dll" = "imageformats"
     }
     foreach ($subPath in $pluginDlls.Keys) {

--- a/src/crash_handler/src/crashhandler.cpp
+++ b/src/crash_handler/src/crashhandler.cpp
@@ -199,7 +199,17 @@ bool checkCrashpadReports( const QString& databasePath )
 
         QProcess stackProcess;
         stackProcess.start( stackwalker, QStringList() << reportFile );
-        stackProcess.waitForFinished();
+
+        // klogg_minidump_dump can hang on corrupted or very large minidumps.
+        // Use a bounded wait so the GUI can still appear.  If it times out,
+        // kill the process, skip the report, and move on.
+        static constexpr int kMinidumpStackWalkTimeoutMs = 10000;
+        if ( !stackProcess.waitForFinished( kMinidumpStackWalkTimeoutMs ) ) {
+            LOG_WARNING << "minidump stack walk timed out for " << reportFile;
+            stackProcess.kill();
+            stackProcess.waitForFinished( 2000 );
+            continue;
+        }
 
         QString formattedReport = reportFile;
         formattedReport.append( QChar::LineFeed )
@@ -292,7 +302,7 @@ CrashHandler::CrashHandler()
         addExtra( "page_faults", pageFaults );
 #endif
     } );
-    memoryUsageTimer_->start( 10000 );
+    memoryUsageTimer_->start( 60000 );
 
     if ( needWaitForUpload ) {
         QProgressDialog progressDialog;

--- a/src/crash_handler/src/crashhandler.cpp
+++ b/src/crash_handler/src/crashhandler.cpp
@@ -202,12 +202,14 @@ bool checkCrashpadReports( const QString& databasePath )
 
         // klogg_minidump_dump can hang on corrupted or very large minidumps.
         // Use a bounded wait so the GUI can still appear.  If it times out,
-        // kill the process, skip the report, and move on.
+        // kill the process, delete the report from the pending queue so it
+        // isn't retried on every launch, and move on.
         static constexpr int kMinidumpStackWalkTimeoutMs = 10000;
         if ( !stackProcess.waitForFinished( kMinidumpStackWalkTimeoutMs ) ) {
             LOG_WARNING << "minidump stack walk timed out for " << reportFile;
             stackProcess.kill();
             stackProcess.waitForFinished( 2000 );
+            database->DeleteReport( report.uuid );
             continue;
         }
 

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -641,7 +641,14 @@ class Configuration final : public Persistable<Configuration> {
 
   private:
     // Configuration settings
+#ifdef Q_OS_MACOS
+    // macOS uses 72 DPI as its reference, so 13 pt is the right visual size.
     mutable QFont mainFont_ = { "DejaVu Sans Mono", 13 };
+#else
+    // Windows and Linux default to 96 DPI, making the same point size appear
+    // ~33% larger than on macOS. Use a smaller default for visual parity.
+    mutable QFont mainFont_ = { "DejaVu Sans Mono", 10 };
+#endif
     SearchRegexpType mainRegexpType_ = SearchRegexpType::ExtendedRegexp;
     SearchRegexpType quickfindRegexpType_ = SearchRegexpType::ExtendedRegexp;
     bool quickfindIncremental_ = true;

--- a/src/settings/src/styles.cpp
+++ b/src/settings/src/styles.cpp
@@ -345,6 +345,9 @@ QTabBar::tab:hover:!selected {
     background-color: __BUTTON_HOVER__;
     color: __TEXT__;
 }
+QTabBar::tab:focus {
+    outline: none;
+}
 QTabBar::close-button {
     image: url(__TAB_CLOSE__);
     height: 12px;

--- a/src/versioncheck/CMakeLists.txt
+++ b/src/versioncheck/CMakeLists.txt
@@ -12,6 +12,5 @@ target_link_libraries(
          project_warnings
          klogg_settings
          klogg_utils
-         Qt${QT_VERSION_MAJOR}::Concurrent
          Qt${QT_VERSION_MAJOR}::Network
 )

--- a/src/versioncheck/include/versionchecker.h
+++ b/src/versioncheck/include/versionchecker.h
@@ -120,8 +120,13 @@ class VersionChecker : public QObject {
     void checkCompleted( bool newVersionFound, bool hadError = false );
 
   private:
-    // Called on the main thread after the background network request completes
+    // Called on the main thread after the network request completes
     void processResponse( QByteArray data, bool hadError, bool wasManual );
+
+    // Starts the network request on the main thread. The VersionChecker
+    // owns the QNetworkAccessManager used for the request; cleanup is
+    // automatic via the QObject parent-child relationship.
+    void startNetworkRequest( bool wasManual );
 };
 
 #endif

--- a/src/versioncheck/src/versionchecker.cpp
+++ b/src/versioncheck/src/versionchecker.cpp
@@ -48,6 +48,7 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QSysInfo>
+#include <QTimer>
 #include <QUrl>
 #include <QVersionNumber>
 
@@ -218,9 +219,17 @@ void VersionChecker::startNetworkRequest( bool wasManual )
 
     QNetworkRequest request;
     request.setUrl( QUrl( kReleaseApiUrl ) );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     request.setTransferTimeout( kTransferTimeoutMs );
+#endif
 
     QNetworkReply* reply = mgr->get( request );
+
+    // Qt < 5.15 does not have QNetworkRequest::setTransferTimeout.
+    // Use a single-shot timer to abort the reply as a fallback.
+#if QT_VERSION < QT_VERSION_CHECK( 5, 15, 0 )
+    QTimer::singleShot( kTransferTimeoutMs, reply, &QNetworkReply::abort );
+#endif
 
     // Use a QueuedConnection to the VersionChecker itself as the context
     // object.  If the VersionChecker is destroyed before the reply

--- a/src/versioncheck/src/versionchecker.cpp
+++ b/src/versioncheck/src/versionchecker.cpp
@@ -41,22 +41,25 @@
 #include "log.h"
 
 #include "klogg_version.h"
-#include "dispatch_to.h"
 
-#include <QEventLoop>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QPointer>
 #include <QSysInfo>
 #include <QUrl>
-#include <QtConcurrent>
+#include <QVersionNumber>
 
 namespace {
 
 const auto kReleaseApiUrl
     = QLatin1String( "https://api.github.com/repos/ZEACENT/klogg/releases/latest", 58 );
 static constexpr std::time_t CHECK_INTERVAL_S = 3600 * 24 * 7; /* 7 days */
+
+// Timeout for version check network requests.  Prevents a hung TCP/TLS
+// handshake from permanently leaking a QNetworkAccessManager + reply.
+static constexpr int kTransferTimeoutMs = 15000;
 
 bool isVersionNewer( const QString& current_version, const QString& new_version )
 {
@@ -179,37 +182,7 @@ void VersionChecker::startCheck()
 
     // Check the deadline has been reached
     if ( deadlineConfig.nextDeadline() < std::time( nullptr ) ) {
-        LOG_DEBUG << "Requesting new version info from " << kReleaseApiUrl;
-
-        QPointer<VersionChecker> guard( this );
-        [[maybe_unused]] const auto versionCheckFuture = QtConcurrent::run( [ guard ] {
-            QNetworkAccessManager mgr;
-            mgr.setRedirectPolicy( QNetworkRequest::NoLessSafeRedirectPolicy );
-
-            QNetworkRequest request;
-            request.setUrl( QUrl( kReleaseApiUrl ) );
-
-            QNetworkReply* reply = mgr.get( request );
-
-            QEventLoop loop;
-            QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
-            loop.exec();
-
-            const bool hadError = ( reply->error() != QNetworkReply::NoError );
-            const QByteArray data = hadError ? QByteArray() : reply->readAll();
-
-            if ( hadError ) {
-                LOG_WARNING << "Version check download failed: err " << reply->error();
-            }
-
-            reply->deleteLater();
-
-            dispatchToMainThread( [ guard, data, hadError ] {
-                if ( guard ) {
-                    guard->processResponse( data, hadError, false );
-                }
-            } );
-        } );
+        startNetworkRequest( /*wasManual=*/false );
     }
     else {
         LOG_DEBUG << "Deadline not reached yet, next check in "
@@ -229,35 +202,45 @@ void VersionChecker::forceCheck()
         return;
     }
 
-    QPointer<VersionChecker> guard( this );
-    [[maybe_unused]] const auto versionCheckFuture = QtConcurrent::run( [ guard ] {
-        QNetworkAccessManager mgr;
-        mgr.setRedirectPolicy( QNetworkRequest::NoLessSafeRedirectPolicy );
+    startNetworkRequest( /*wasManual=*/true );
+}
 
-        QNetworkRequest request;
-        request.setUrl( QUrl( kReleaseApiUrl ) );
+void VersionChecker::startNetworkRequest( bool wasManual )
+{
+    LOG_DEBUG << "Requesting new version info from " << kReleaseApiUrl;
 
-        QNetworkReply* reply = mgr.get( request );
+    // QNetworkAccessManager is created as a child of VersionChecker so that
+    // it is automatically destroyed when the VersionChecker is destroyed.
+    // This avoids the thread-safety issues of running QNetworkAccessManager
+    // on a QThreadPool thread via QtConcurrent::run.
+    auto* mgr = new QNetworkAccessManager( this );
+    mgr->setRedirectPolicy( QNetworkRequest::NoLessSafeRedirectPolicy );
 
-        QEventLoop loop;
-        QObject::connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
-        loop.exec();
+    QNetworkRequest request;
+    request.setUrl( QUrl( kReleaseApiUrl ) );
+    request.setTransferTimeout( kTransferTimeoutMs );
 
-        const bool hadError = ( reply->error() != QNetworkReply::NoError );
-        const QByteArray data = hadError ? QByteArray() : reply->readAll();
+    QNetworkReply* reply = mgr->get( request );
 
-        if ( hadError ) {
-            LOG_WARNING << "Version check download failed: err " << reply->error();
-        }
+    // Use a QueuedConnection to the VersionChecker itself as the context
+    // object.  If the VersionChecker is destroyed before the reply
+    // completes, the connection is automatically disconnected and the
+    // lambda is never invoked — no dangling pointer, no QPointer guard
+    // needed.
+    connect( reply, &QNetworkReply::finished, this,
+             [ this, reply, mgr, wasManual ]() {
+                 const bool hadError = ( reply->error() != QNetworkReply::NoError );
+                 const QByteArray data = hadError ? QByteArray() : reply->readAll();
 
-        reply->deleteLater();
+                 if ( hadError ) {
+                     LOG_WARNING << "Version check download failed: err " << reply->error();
+                 }
 
-        dispatchToMainThread( [ guard, data, hadError ] {
-            if ( guard ) {
-                guard->processResponse( data, hadError, true );
-            }
-        } );
-    } );
+                 reply->deleteLater();
+                 mgr->deleteLater();
+
+                 processResponse( data, hadError, wasManual );
+             } );
 }
 
 void VersionChecker::processResponse( QByteArray data, bool hadError, bool wasManual )

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -261,14 +261,20 @@ SCENARIO( "Main window tests", "[ui]" )
             {
                 // Wait for the background loading thread to finish before
                 // closing the tab.  stopLoading() only sets an interrupt flag
-                // -- it does not synchronously join the thread.  On slower
-                // runners (Windows x86 32-bit) the thread may still hold heap
-                // references during teardown, corrupting malloc and causing
-                // SIGSEGV in downstream simdutf free().
+                // -- it does not synchronously join the thread.  On Windows
+                // runners the worker thread may still hold heap references or
+                // unwind simdutf-internal state after isFirstLoadDone() returns
+                // true, corrupting malloc and causing SIGSEGV on teardown.
                 REQUIRE( waitUiState( [&] {
                     auto* crawler = qobject_cast<CrawlerWidget*>(tabArea->currentWidget());
                     return crawler != nullptr && crawler->isFirstLoadDone();
                 } ) );
+
+                // Let the worker thread fully unwind before destroying the
+                // tab.  Even after isFirstLoadDone() returns true, the
+                // background thread may still be cleaning up — closing the
+                // tab during that window causes use-after-free.
+                QTest::qWait( 200 );
 
                 runInUiThread( [closeAction] {
                     LOG_INFO << "Close tab";

--- a/tests/unit/styles_test.cpp
+++ b/tests/unit/styles_test.cpp
@@ -76,3 +76,14 @@ TEST_CASE( "Modern style sheet uses compact tab height for macOS 26 pill-tab loo
     // Tab padding should be compact (horizontal + vertical)
     REQUIRE( style.contains( QStringLiteral( "padding: 3px 12px" ) ) );
 }
+
+TEST_CASE( "Modern style sheet suppresses native focus rectangle on tabs" )
+{
+    const ScopedModernStyle styleGuard;
+
+    const auto style = qApp->styleSheet();
+    // Tab focus must use outline:none to prevent Windows native focus rect
+    // from drawing a sharp rectangle over the pill-shaped tab
+    REQUIRE( style.contains( QStringLiteral( "QTabBar::tab:focus" ) ) );
+    REQUIRE( style.contains( QStringLiteral( "outline: none" ) ) );
+}

--- a/tests/unit/versionchecker_test.cpp
+++ b/tests/unit/versionchecker_test.cpp
@@ -451,3 +451,92 @@ TEST_CASE( "checkVersionData: no matching platform asset produces empty download
     CHECK( downloadUrl.isEmpty() );
 #endif
 }
+
+TEST_CASE( "startCheck: does nothing when version checking is disabled",
+           "[versionchecker]" )
+{
+    ScopedVersionCheckConfigGuard configGuard;
+    configGuard.setVersionCheckingEnabled( false );
+
+    VersionChecker checker;
+    SafeQSignalSpy versionSpy(
+        &checker, SIGNAL( newVersionFound( QString, QString, QString, QStringList ) ) );
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
+
+    checker.startCheck();
+
+    // startCheck returns immediately when version checking is disabled.
+    // No signals should be emitted (no network request is made).
+    CHECK( versionSpy.count() == 0 );
+    CHECK( completedSpy.count() == 0 );
+}
+
+TEST_CASE( "startCheck: does nothing when deadline not reached", "[versionchecker]" )
+{
+    ScopedVersionCheckConfigGuard configGuard;
+    configGuard.setVersionCheckingEnabled( true );
+
+    auto& deadlineConfig = VersionCheckerConfig::get();
+    // Set deadline far in the future
+    const auto futureDeadline = std::time( nullptr ) + 86400 * 365;
+    deadlineConfig.setNextDeadline( futureDeadline );
+    deadlineConfig.save();
+
+    VersionChecker checker;
+    SafeQSignalSpy versionSpy(
+        &checker, SIGNAL( newVersionFound( QString, QString, QString, QStringList ) ) );
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
+
+    checker.startCheck();
+
+    // No network request should be made — deadline hasn't passed
+    CHECK( versionSpy.count() == 0 );
+    CHECK( completedSpy.count() == 0 );
+
+    // Reset
+    deadlineConfig.setNextDeadline( 0 );
+    deadlineConfig.save();
+}
+
+TEST_CASE( "forceCheck: emits checkCompleted with hadError when version checking disabled",
+           "[versionchecker]" )
+{
+    ScopedVersionCheckConfigGuard configGuard;
+    configGuard.setVersionCheckingEnabled( false );
+
+    VersionChecker checker;
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
+
+    checker.forceCheck();
+
+    REQUIRE( completedSpy.count() == 1 );
+    CHECK_FALSE( completedSpy.at( 0 ).at( 0 ).toBool() );   // newVersionFound = false
+    CHECK( completedSpy.at( 0 ).at( 1 ).toBool() );          // hadError = true
+}
+
+TEST_CASE( "VersionChecker: lifecycle safety — destroy during pending check",
+           "[versionchecker]" )
+{
+    // Verify that destroying a VersionChecker while a check might be
+    // in-flight does not crash. The QNetworkAccessManager is a child
+    // of VersionChecker and should be cleaned up automatically.
+    ScopedVersionCheckConfigGuard configGuard;
+    configGuard.setVersionCheckingEnabled( true );
+
+    auto& deadlineConfig = VersionCheckerConfig::get();
+    deadlineConfig.setNextDeadline( 0 ); // past deadline
+    deadlineConfig.save();
+
+    {
+        VersionChecker checker;
+        checker.startCheck();
+        // checker is destroyed here — QNetworkAccessManager must be cleaned up
+    }
+
+    // Process any pending events to ensure cleanup
+    QTest::qWait( 100 );
+
+    // Reset
+    deadlineConfig.setNextDeadline( std::time( nullptr ) + 86400 * 365 );
+    deadlineConfig.save();
+}

--- a/tests/unit/versionchecker_test.cpp
+++ b/tests/unit/versionchecker_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE( "checkVersionData: older tag_name returns false, no signal", "[versio
 {
     VersionChecker checker;
     SafeQSignalSpy versionSpy( &checker, SIGNAL( newVersionFound( QString, QString, QString, QStringList ) ) );
-    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool ) ) );
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
 
     const auto json = makeReleaseJsonForVersion( QStringLiteral( "1.0.0.0" ),
                                                   QStringLiteral( "https://example.com" ) );
@@ -126,7 +126,7 @@ TEST_CASE( "checkVersionData: equal tag_name returns false, no signal", "[versio
 {
     VersionChecker checker;
     SafeQSignalSpy versionSpy( &checker, SIGNAL( newVersionFound( QString, QString, QString, QStringList ) ) );
-    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool ) ) );
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
 
     const auto currentVersion = QString::fromLatin1( kloggVersion().data(), kloggVersion().size() );
     const auto json = makeReleaseJsonForVersion( currentVersion,
@@ -229,7 +229,7 @@ TEST_CASE( "forceCheck: emits checkCompleted(false) when version checking is dis
     configGuard.setVersionCheckingEnabled( false );
 
     VersionChecker checker;
-    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool ) ) );
+    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
 
     checker.forceCheck();
 


### PR DESCRIPTION
## Summary

- **Version checker test SIGNAL strings** — Updated test signal strings to match the new `checkCompleted` signature after refactoring.
- **Version checker thread safety & CrashHandler** — Fixed thread safety issues in the version checker, prevented CrashHandler from blocking, corrected memory timer behavior, and delete timed-out crash reports from the pending queue so they do not retry on every launch.
- **Duplicate Qt plugin DLLs** — Removed duplicate Qt plugin DLLs from the portable archive root on Windows.
- **Windows tab bar focus outline** — Fixed a rectangular focus outline that appeared on Windows tab bar tabs.
- **Platform-specific default font size** — Changed the default font size on Windows and Linux from 13 pt to 10 pt to match visual size across platforms (Qt renders point sizes against 96 DPI on Windows/Linux vs 72 DPI on macOS).
- **CI fixes** — Qt 5.12 compatibility for `setTransferTimeout` (Ubuntu 20.04 build), integration test settle delay to prevent SIGSEGV on Windows runners, and `qwindowsvistastyle.dll` added to Windows packaging plugin validation.
- **CLAUDE.md** — Added preventive guard notes for Qt 5.12 baseline and race-prone test patterns.

## Tests

- Full CTest suite on macOS: 100% tests passed (klogg_smoke, klogg_tests, klogg_itests, klogg_vectorscan_tests).
- Version checker unit tests: 22 test cases, 52 assertions — all pass.
- Physical verification on Windows and Linux is still needed to confirm:
  - 10 pt font default looks correct
  - Integration test settle delay resolves the SIGSEGV on Windows x64 CI
  - Qt 5.12 build passes on Ubuntu 20.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version checking now uses direct network requests with improved timeout and lifecycle safety

* **Bug Fixes**
  * 10-second timeout for crash-report processing to avoid indefinite blocking
  * Memory reporting interval increased from 10s to 60s

* **UI Improvements**
  * Default font sizes adjusted (13pt macOS, 10pt others)
  * Added focus styling for tabs in Modern theme

* **Chores**
  * Refined release archive creation and stricter plugin placement validation

* **Tests**
  * Expanded version-checker, tab-styling, and teardown safety tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->