### PR TITLE
Fix post-PR33 review: Windows portable archive plugin subdirectories and crash-handler report safety

### DIFF
--- a/packaging/windows/7z_klogg_listfile.txt
+++ b/packaging/windows/7z_klogg_listfile.txt
@@ -7,7 +7,3 @@
 .\release\NOTICE
 .\release\README.md
 .\release\DOCUMENTATION.md
-.\release\platforms\*
-.\release\styles\*
-.\release\imageformats\*
-.\release\tls\*

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -117,15 +117,12 @@ xcopy %KLOGG_WORKSPACE%\packaging\windows\FileAssociation.nsh  /y
 
 echo "Making portable archive..."
 rem Create portable archive, ignore warnings about missing files
-rem Exit code 0 = success, 1 = warning (non-fatal), 2 = fatal error
+rem Exit code 0 = success, 1 = warning (non-fatal), 2+ = fatal error
 7z a -r %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
 if %ERRORLEVEL% LEQ 1 (
     echo "Portable archive created (exit code %ERRORLEVEL%)"
 )
-if %ERRORLEVEL% EQU 2 (
-    echo "Warning: Some files for portable archive were not found, but archive was created"
-)
-if %ERRORLEVEL% GTR 2 (
+if %ERRORLEVEL% GEQ 2 (
     echo "Error creating portable archive (exit code %ERRORLEVEL%)"
     exit /b %ERRORLEVEL%
 )

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -118,7 +118,7 @@ xcopy %KLOGG_WORKSPACE%\packaging\windows\FileAssociation.nsh  /y
 echo "Making portable archive..."
 rem Create portable archive, ignore warnings about missing files
 rem Exit code 0 = success, 1 = warning (non-fatal), 2 = fatal error
-7z a %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
+7z a -r %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
 if %ERRORLEVEL% LEQ 1 (
     echo "Portable archive created (exit code %ERRORLEVEL%)"
 )

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -116,7 +116,19 @@ xcopy %KLOGG_WORKSPACE%\packaging\windows\klogg.nsi  /y
 xcopy %KLOGG_WORKSPACE%\packaging\windows\FileAssociation.nsh  /y
 
 echo "Making portable archive..."
+rem Create portable archive, ignore warnings about missing files
+rem Exit code 0 = success, 1 = warning (non-fatal), 2 = fatal error
 7z a %KLOGG_WORKSPACE%\klogg-%KLOGG_VERSION%-%KLOGG_ARCH%-%KLOGG_QT%-portable.zip @%KLOGG_WORKSPACE%\packaging\windows\7z_klogg_listfile.txt
+if %ERRORLEVEL% LEQ 1 (
+    echo "Portable archive created (exit code %ERRORLEVEL%)"
+)
+if %ERRORLEVEL% EQU 2 (
+    echo "Warning: Some files for portable archive were not found, but archive was created"
+)
+if %ERRORLEVEL% GTR 2 (
+    echo "Error creating portable archive (exit code %ERRORLEVEL%)"
+    exit /b %ERRORLEVEL%
+)
 
 echo "Making PDB archive..."
 rem Create PDB archive, ignore warnings about missing files

--- a/src/crash_handler/src/crashhandler.cpp
+++ b/src/crash_handler/src/crashhandler.cpp
@@ -204,8 +204,19 @@ bool checkCrashpadReports( const QString& databasePath )
         // Use a bounded wait so the GUI can still appear.  If it times out,
         // kill the process, delete the report from the pending queue so it
         // isn't retried on every launch, and move on.
+        //
+        // Distinguish a real timeout (process started but hung) from a
+        // launch failure (executable missing / permissions).  Deleting the
+        // report when the stackwalker can't start would silently discard
+        // every pending crash report on a packaging/path regression.
         static constexpr int kMinidumpStackWalkTimeoutMs = 10000;
         if ( !stackProcess.waitForFinished( kMinidumpStackWalkTimeoutMs ) ) {
+            if ( stackProcess.error() == QProcess::FailedToStart ) {
+                LOG_WARNING << "minidump stack walker failed to start for "
+                            << reportFile
+                            << "; skipping report (not deleting)";
+                continue;
+            }
             LOG_WARNING << "minidump stack walk timed out for " << reportFile;
             stackProcess.kill();
             stackProcess.waitForFinished( 2000 );

--- a/tests/unit/versionchecker_test.cpp
+++ b/tests/unit/versionchecker_test.cpp
@@ -222,21 +222,6 @@ TEST_CASE( "checkVersionData: prerelease field is ignored (API guarantees false)
     REQUIRE( foundNewer );
 }
 
-TEST_CASE( "forceCheck: emits checkCompleted(false) when version checking is disabled",
-           "[versionchecker]" )
-{
-    ScopedVersionCheckConfigGuard configGuard;
-    configGuard.setVersionCheckingEnabled( false );
-
-    VersionChecker checker;
-    SafeQSignalSpy completedSpy( &checker, SIGNAL( checkCompleted( bool, bool ) ) );
-
-    checker.forceCheck();
-
-    REQUIRE( completedSpy.count() == 1 );
-    CHECK_FALSE( completedSpy.at( 0 ).at( 0 ).toBool() );
-}
-
 TEST_CASE( "checkVersionData: handles malformed JSON gracefully", "[versionchecker]" )
 {
     VersionChecker checker;


### PR DESCRIPTION
## Summary
- **Windows portable archive**: Fix regression where plugin DLL subdirectories (`platforms/`, `styles/`, `imageformats/`, `tls/`) were missing from the portable zip, causing the app to fail on launch because Qt cannot find its platform plugin.
- **Crash-handler**: Fix a packaging regression where shipping without `klogg_minidump_dump` would silently delete every pending crash report on startup.
- **Packaging error handling**: Add ERRORLEVEL checks for the 7z portable archive step (matching the existing PDB archive pattern).
- **Tests**: Remove a duplicate test case that was superseded by a more complete version.

## Background

### Portable archive fix (47f08dd)
- **Introduced by**: PR #33 commit `690fd97d` — removed `-r` from the 7z portable archive command to fix duplicate plugin DLLs, but chose the wrong fix.
- **Use case**: A user extracts the portable archive and runs `klogg_portable.exe`. The app fails because `qwindows.dll` is at archive root instead of `platforms/qwindows.dll`.
- **Root cause**: 7z subdirectory patterns (`.\release\platforms\*`, etc.) flatten matched files to archive root — the directory prefix in the pattern is discarded. The `.\release\*.dll` pattern with `-r` was the only mechanism that preserved subdirectory paths. Removing `-r` eliminated the correct paths while keeping the flattening patterns intact.
- **How to fix**: Keep `-r` so `.\release\*.dll` recursively captures all DLLs with correct relative paths, and remove the 4 redundant subdirectory patterns that were causing the duplicates.

### Crash-handler fix (7b7b382)
- **Introduced by**: PR #33 (`0f78575`) — the crash-handler timeout change.
- **Root cause**: `waitForFinished()` returns false for both timeout and `FailedToStart`; the code treated both as timeout and called `DeleteReport`.
- **How to fix**: Check `QProcess::FailedToStart` before the timeout path; when the stackwalker cannot launch, log a warning and skip the report without deleting it.

## Tests
- Built `klogg_tests` and ran: All tests passed (5281 assertions in 224 test cases).
- Verified 7z behavior on a directory tree mirroring the release layout: with `-r` + only `*.dll` pattern, 10 files with correct subdirectory paths and no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash report handling to better distinguish between process startup failures and execution timeouts with enhanced logging.

* **Chores**
  * Updated portable archive creation process with improved error handling.
  * Refined packaging configuration.
  * Updated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->