### PR TITLE
Fix tab bar pill clipping and Go-to-top shortcut for filtered view

### DIFF
--- a/src/ui/include/tabbedcrawlerwidget.h
+++ b/src/ui/include/tabbedcrawlerwidget.h
@@ -64,6 +64,7 @@ class CrawlerTabBar : public QTabBar {
     void mouseReleaseEvent( QMouseEvent* ) override;
     void paintEvent( QPaintEvent* event ) override;
     void resizeEvent( QResizeEvent* event ) override;
+    void showEvent( QShowEvent* event ) override;
 
   private Q_SLOTS:
     void handleTabMoved( int from, int to );
@@ -71,6 +72,7 @@ class CrawlerTabBar : public QTabBar {
   private:
     void syncTabButtonGeometry();
     void scheduleTabButtonGeometrySync();
+    void updateShapeMask();
 
     bool leftButtonPressed_ = false;
     bool tabMovedWhilePressed_ = false;

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -353,7 +353,7 @@ bool CrawlerWidget::eventFilter( QObject* watched, QEvent* event )
 
 void CrawlerWidget::jumpToTop()
 {
-    logMainView_->selectAndDisplayLine( 0_lnum );
+    activeView()->selectAndDisplayLine( 0_lnum );
 }
 
 void CrawlerWidget::goToLine()

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -339,6 +339,9 @@ void TabbedCrawlerWidget::updateTabBarStyle()
                            "QTabBar::tab:hover:!selected {"
                            "background-color: %6;"
                            "color: %5;"
+                           "}"
+                           "QTabBar::tab:focus {"
+                           "outline: none;"
                            "}" )
                            .arg( trackColor.name(), borderColor.name(), mutedTextColor.name(),
                                  selectedColor.name(), textColor.name(), hoverColor.name() );
@@ -704,6 +707,13 @@ void CrawlerTabBar::resizeEvent( QResizeEvent* event )
 {
     QTabBar::resizeEvent( event );
     scheduleTabButtonGeometrySync();
+    updateShapeMask();
+}
+
+void CrawlerTabBar::showEvent( QShowEvent* event )
+{
+    QTabBar::showEvent( event );
+    updateShapeMask();
 }
 
 void CrawlerTabBar::paintEvent( QPaintEvent* event )
@@ -748,6 +758,21 @@ void CrawlerTabBar::scheduleTabButtonGeometrySync()
     // invalidate layout and trigger another paint, creating an
     // infinite repaint loop.
     syncGeometryTimer_.start();
+}
+
+void CrawlerTabBar::updateShapeMask()
+{
+    // Clips the tab bar to a pill (rounded rectangle) shape so that
+    // native-style focus rectangles and other rectangular artifacts
+    // drawn outside the CSS border-radius are masked away.
+    constexpr int kRadius = 14;
+    if ( rect().isEmpty() ) {
+        clearMask();
+        return;
+    }
+    QPainterPath path;
+    path.addRoundedRect( QRectF( rect() ), kRadius, kRadius );
+    setMask( path.toFillPolygon().toPolygon() );
 }
 
 void CrawlerTabBar::syncTabButtonGeometry()

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -551,6 +551,11 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         }
     }
 
+    void jumpToTop()
+    {
+        crawler->jumpToTop();
+    }
+
     void resizeViews( int width, int height )
     {
         crawler->logMainView_->resize( width, height );
@@ -780,6 +785,20 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
     {
         crawler->logMainView_->verticalScrollBar()->setValue(
             crawler->logMainView_->verticalScrollBar()->maximum() );
+        QTest::qWait( 50 );
+    }
+
+    void scrollMainVerticallyToMiddle()
+    {
+        const auto max = crawler->logMainView_->verticalScrollBar()->maximum();
+        crawler->logMainView_->verticalScrollBar()->setValue( max / 2 );
+        QTest::qWait( 50 );
+    }
+
+    void scrollFilteredVerticallyToMiddle()
+    {
+        const auto max = crawler->filteredView_->verticalScrollBar()->maximum();
+        crawler->filteredView_->verticalScrollBar()->setValue( max / 2 );
         QTest::qWait( 50 );
     }
 
@@ -2259,6 +2278,76 @@ SCENARIO( "Elastic pull-to-follow hook does not activate when scroll range is em
                 // The hook is not active, so shouldBottomAlignFrame
                 // returns false when lastLineAligned_ is also false.
                 REQUIRE_FALSE( crawlerVisitor.filteredShouldBottomAlign() );
+            }
+        }
+    }
+}
+
+SCENARIO( "Go to top (T) respects the focused view", "[ui][shortcut]" )
+{
+    QTemporaryFile file{ "crawler_gototop_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViews( 320, 120 );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+
+    GIVEN( "both views scrolled away from the top and filtered view focused" )
+    {
+        crawlerVisitor.scrollMainVerticallyToMiddle();
+        crawlerVisitor.scrollFilteredVerticallyToMiddle();
+        crawlerVisitor.render();
+
+        REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+        REQUIRE( crawlerVisitor.mainTopLine().get() > 0 );
+        REQUIRE( crawlerVisitor.filteredTopLine().get() > 0 );
+
+        crawlerVisitor.focusFilteredView();
+
+        WHEN( "jumpToTop is called" )
+        {
+            crawlerVisitor.jumpToTop();
+            QTest::qWait( 50 );
+            crawlerVisitor.render();
+
+            THEN( "the filtered view scrolls to the top" )
+            {
+                REQUIRE( crawlerVisitor.filteredTopLine().get() == 0 );
+            }
+        }
+    }
+
+    GIVEN( "both views scrolled away from the top and main view focused" )
+    {
+        crawlerVisitor.scrollMainVerticallyToMiddle();
+        crawlerVisitor.scrollFilteredVerticallyToMiddle();
+        crawlerVisitor.render();
+
+        REQUIRE( crawlerVisitor.mainTopLine().get() > 0 );
+        REQUIRE( crawlerVisitor.filteredTopLine().get() > 0 );
+
+        crawlerVisitor.focusMainView();
+
+        WHEN( "jumpToTop is called" )
+        {
+            crawlerVisitor.jumpToTop();
+            QTest::qWait( 50 );
+            crawlerVisitor.render();
+
+            THEN( "the main view scrolls to the top" )
+            {
+                REQUIRE( crawlerVisitor.mainTopLine().get() == 0 );
             }
         }
     }

--- a/tests/unit/shortcut_bindings_test.cpp
+++ b/tests/unit/shortcut_bindings_test.cpp
@@ -262,3 +262,22 @@ TEST_CASE( "Shortcut bindings: editable defaults have no duplicate displayed key
         }
     }
 }
+
+TEST_CASE( "Shortcut bindings: Follow file and Go to top have single-key defaults" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+
+    SECTION( "MainWindowFollowFile is bound to F" )
+    {
+        auto it = shortcuts.find( ShortcutAction::MainWindowFollowFile );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QKeySequence( Qt::Key_F ).toString() ) );
+    }
+
+    SECTION( "MainWindowGoToTop is bound to T" )
+    {
+        auto it = shortcuts.find( ShortcutAction::MainWindowGoToTop );
+        REQUIRE( it != shortcuts.end() );
+        REQUIRE( it->second.keySequence.contains( QKeySequence( Qt::Key_T ).toString() ) );
+    }
+}


### PR DESCRIPTION
## Summary
- Clip the tab bar to a pill (rounded rectangle) shape so native focus indicators don't draw outside the CSS border-radius.
- Fix the **T** (Go to top) shortcut: it now scrolls whichever view has focus (main or filtered), instead of always scrolling the main view.
- Add unit test coverage for F (Follow file) and T (Go to top) default key bindings.
- Add integration test that Go to top respects the focused view.

## Background

### Tab bar pill clipping
- **Introduced by**: Rounded tab bar CSS styling without a corresponding shape mask.
- **Use case**: Tab bar with rounded corners. On some platforms a native-style focus rectangle or highlight would bleed outside the rounded border.
- **Root cause**: CSS `border-radius` affects painting but does not clip platform-drawn focus rings.
- **How to fix**: Apply `setMask()` with a rounded-rect path in `CrawlerTabBar::updateShapeMask()`, called from `resizeEvent` and `showEvent`. Also add `outline: none` in the tab stylesheet to suppress default focus outlines.

### Go to top (T) on filtered view
- **Use case**: Press T (Go to top) when the filtered view has focus. Expected: filtered view scrolls to beginning. Actual: main view scrolled instead.
- **How to reproduce**: Open a file, search to populate the filtered view, scroll away from the top in both views, focus the filtered view, press T.
- **Root cause**: `CrawlerWidget::jumpToTop()` hardcoded `logMainView_->selectAndDisplayLine(0_lnum)`. The `activeView()` method already existed (used by `searchForward()`, `searchBackward()`, `selectAll()`) but was not used here.
- **How to fix**: Call `activeView()->selectAndDisplayLine(0_lnum)` instead.

## Tests
- `ctest` — 100% pass (4/4 targets): klogg_smoke, klogg_tests, klogg_itests, klogg_vectorscan_tests
- New unit test: F→MainWindowFollowFile, T→MainWindowGoToTop default bindings
- New integration test: filtered view scrolls to top when focused, main view scrolls when focused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jump to Top (T) shortcut behavior improved: it now correctly respects which view currently has focus. Activation navigates whichever pane is focused to its top, providing more intuitive navigation instead of always targeting the main log view.

* **Style**
  * Tab bar styling enhancements: rounded pill-shaped design with improved focus outline handling delivers better visual consistency and refined user interface appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->