### PR TITLE
Fix Go-to-top (T) to scroll both views and fix GitHub release download links

### DIFF
--- a/.github/actions/docker-package/action.yml
+++ b/.github/actions/docker-package/action.yml
@@ -22,7 +22,7 @@ runs:
       if: ${{ matrix.config.os == 'ubuntu_appimage' }}
       shell: sh
       run: |
-        docker run --device /dev/fuse --privileged --env KLOGG_VERSION=$KLOGG_VERSION -v "$KLOGG_WORKSPACE":/usr/local ${{ matrix.config.container }} /bin/bash -c "cd /usr/local/build_root && ../packaging/linux/appimage/generate_appimage.sh"
+        docker run --device /dev/fuse --privileged --env KLOGG_VERSION=$KLOGG_VERSION --env KLOGG_PACKAGE_TAG=$KLOGG_PACKAGE_TAG -v "$KLOGG_WORKSPACE":/usr/local ${{ matrix.config.container }} /bin/bash -c "cd /usr/local/build_root && ../packaging/linux/appimage/generate_appimage.sh"
 
     - name: Copy sym
       shell: sh

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -959,12 +959,29 @@ jobs:
           target_commitish: ${{ github.sha }}
           name: Continuous Build ${{ env.KLOGG_VERSION }}
           body: |
-            Continuous build ${{ env.KLOGG_VERSION }}
-            
-            This is an automated pre-release build. For stable releases, see [releases](https://github.com/ZEACENT/klogg/releases).
+            Continuous Build ${{ env.KLOGG_VERSION }}
+
+            This is an automated pre-release build. For the latest stable release, see [latest release](https://github.com/ZEACENT/klogg/releases/latest).
 
             ## Changes
             ${{ env.CHANGELOG }}
+
+            ## Downloads
+
+            ### Windows
+            - Windows x64 (Qt 6, Vectorscan AVX2): [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe)
+            - Windows x64 (Qt 6, Vectorscan AVX2) portable: [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip)
+            - Windows x86 (Qt 5, QT Regex engine): [klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-setup.exe](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-setup.exe)
+            - Windows x86 (Qt 5, QT Regex engine) portable: [klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-portable.zip](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-portable.zip)
+
+            ### Linux
+            - Ubuntu 22.04 (Jammy, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb)
+            - Ubuntu 24.04 (Noble, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb)
+            - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
+
+            ### macOS
+            - Intel (x64, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg)
+            - Apple Silicon (ARM64, Vectorscan): [klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg)
           prerelease: true
           files: |
             ./packages-all/**/*

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -189,27 +189,26 @@ jobs:
         name: Release v${{ env.KLOGG_VERSION }}
         body: |
           Release v${{ env.KLOGG_VERSION }}
-          
+
           ## Changes
           ${{ env.CHANGELOG }}
-          
+
           ## Downloads
-          - **Windows**: See [Windows packages](#windows)
-          - **Linux**: See [Linux packages](#linux)
-          - **macOS**: See [macOS packages](#macos)
-          
-          ## Windows {#windows}
-          - Windows x64 (Qt 6, Vectorscan AVX2): `klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe`
-          - Windows x86 (Qt 5, QT Regex engine): `klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-setup.exe`
-          
-          ## Linux {#linux}
-          - Ubuntu 22.04 (Jammy, Vectorscan generic): `klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb`
-          - Ubuntu 24.04 (Noble, Vectorscan generic): `klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb`
-          - AppImage (Vectorscan generic): `klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage`
-          
-          ## macOS {#macos}
-          - Intel (x64, Vectorscan generic): `klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg`
-          - Apple Silicon (ARM64, Vectorscan): `klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg`
+
+          ### Windows
+          - Windows x64 (Qt 6, Vectorscan AVX2): [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe)
+          - Windows x64 (Qt 6, Vectorscan AVX2) portable: [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip)
+          - Windows x86 (Qt 5, QT Regex engine): [klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-setup.exe](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-setup.exe)
+          - Windows x86 (Qt 5, QT Regex engine) portable: [klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-portable.zip](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-x86-Qt5-QTRegex-portable.zip)
+
+          ### Linux
+          - Ubuntu 22.04 (Jammy, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb)
+          - Ubuntu 24.04 (Noble, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb)
+          - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
+
+          ### macOS
+          - Intel (x64, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg)
+          - Apple Silicon (ARM64, Vectorscan): [klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg)
         prerelease: false
         files: |
           ./packages-windows-x86-qt5-QTRegex/*

--- a/packaging/linux/appimage/generate_appimage.sh
+++ b/packaging/linux/appimage/generate_appimage.sh
@@ -20,4 +20,4 @@ cp /lib/x86_64-linux-gnu/libssl* appdir/usr/lib
 VERSION=$KLOGG_VERSION ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
 
 mkdir ./packages
-cp ./klogg-$KLOGG_VERSION-x86_64.AppImage ./packages/klogg-$KLOGG_VERSION-x86_64.AppImage
+cp ./klogg-$KLOGG_VERSION-x86_64.AppImage ./packages/klogg-$KLOGG_VERSION-appimage-$KLOGG_PACKAGE_TAG.AppImage

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -353,7 +353,8 @@ bool CrawlerWidget::eventFilter( QObject* watched, QEvent* event )
 
 void CrawlerWidget::jumpToTop()
 {
-    activeView()->selectAndDisplayLine( 0_lnum );
+    logMainView_->selectAndDisplayLine( 0_lnum );
+    filteredView_->selectAndDisplayLine( 0_lnum );
 }
 
 void CrawlerWidget::goToLine()

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -608,6 +608,11 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         return crawler->logMainView_->isFollowEnabled();
     }
 
+    bool isFilteredFollowModeEnabled()
+    {
+        return crawler->filteredView_->isFollowEnabled();
+    }
+
     void applyConfiguration()
     {
         crawler->applyConfiguration();
@@ -2283,7 +2288,52 @@ SCENARIO( "Elastic pull-to-follow hook does not activate when scroll range is em
     }
 }
 
-SCENARIO( "Go to top (T) respects the focused view", "[ui][shortcut]" )
+SCENARIO( "Follow file (F) toggles follow mode on both views simultaneously", "[ui][shortcut]" )
+{
+    QTemporaryFile file{ "crawler_follow_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    GIVEN( "follow mode is off on both views" )
+    {
+        REQUIRE_FALSE( crawlerVisitor.isFollowModeEnabled() );
+        REQUIRE_FALSE( crawlerVisitor.isFilteredFollowModeEnabled() );
+
+        WHEN( "followSet(true) is emitted (F key pressed)" )
+        {
+            Q_EMIT crawlerVisitor.crawler->followSet( true );
+            QTest::qWait( 50 );
+
+            THEN( "both main and filtered views enable follow mode" )
+            {
+                REQUIRE( crawlerVisitor.isFollowModeEnabled() );
+                REQUIRE( crawlerVisitor.isFilteredFollowModeEnabled() );
+            }
+
+            AND_WHEN( "followSet(false) is emitted (F key pressed again)" )
+            {
+                Q_EMIT crawlerVisitor.crawler->followSet( false );
+                QTest::qWait( 50 );
+
+                THEN( "both main and filtered views disable follow mode" )
+                {
+                    REQUIRE_FALSE( crawlerVisitor.isFollowModeEnabled() );
+                    REQUIRE_FALSE( crawlerVisitor.isFilteredFollowModeEnabled() );
+                }
+            }
+        }
+    }
+}
+
+SCENARIO( "Go to top (T) scrolls both views regardless of focus", "[ui][shortcut]" )
 {
     QTemporaryFile file{ "crawler_gototop_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
@@ -2321,9 +2371,10 @@ SCENARIO( "Go to top (T) respects the focused view", "[ui][shortcut]" )
             QTest::qWait( 50 );
             crawlerVisitor.render();
 
-            THEN( "the filtered view scrolls to the top" )
+            THEN( "both views scroll to the top" )
             {
                 REQUIRE( crawlerVisitor.filteredTopLine().get() == 0 );
+                REQUIRE( crawlerVisitor.mainTopLine().get() == 0 );
             }
         }
     }
@@ -2345,9 +2396,10 @@ SCENARIO( "Go to top (T) respects the focused view", "[ui][shortcut]" )
             QTest::qWait( 50 );
             crawlerVisitor.render();
 
-            THEN( "the main view scrolls to the top" )
+            THEN( "both views scroll to the top" )
             {
                 REQUIRE( crawlerVisitor.mainTopLine().get() == 0 );
+                REQUIRE( crawlerVisitor.filteredTopLine().get() == 0 );
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Go-to-top**: `jumpToTop()` now scrolls both `logMainView_` and `filteredView_`, matching the Follow-file (F) design where both views respond together regardless of focus.
- **Follow-file test**: New integration test verifies that `CrawlerWidget::followSet` toggles follow mode on both views simultaneously.
- **Release notes**: Download links in both stable and continuous release bodies are now clickable markdown links instead of unclickable backtick text. Kramdown `{#custom-id}` heading anchors (unsupported in GFM) replaced with plain `###` headings under `## Downloads`. Continuous pre-release now has a full Downloads section. Portable `.zip` entries added for Windows x64 and x86.
- **AppImage naming**: output renamed from `klogg-<VERSION>-x86_64.AppImage` to `klogg-<VERSION>-appimage-<TAG>.AppImage` by passing `KLOGG_PACKAGE_TAG` into the docker container.

## Background

### Go-to-top fix (356c70e)
- **Introduced by**: PR #35 (9149f643) changed `jumpToTop()` from `logMainView_` to `activeView()`, which scrolled only the focused view.
- **Use case**: Press T in any tab — both main and filtered views should scroll to the top.
- **Root cause**: `activeView()` resolves the focused widget, not the set of views in the current tab.
- **How to fix**: `jumpToTop()` directly calls `selectAndDisplayLine(0_lnum)` on both views.
- **Follow-file test**: The Follow-file signal was already wired to both views but had no test coverage. Added `isFilteredFollowModeEnabled()` helper and a new `[ui][shortcut]` test.

### Release notes fix (b25e385)
- **Introduced by**: Release body templates used Kramdown `{#custom-id}` anchors unsupported by GitHub Flavored Markdown, and package names were unclickable code text.
- **Use case**: A user visiting the GitHub Releases page clicks a platform link to download klogg.
- **Root cause**: (1) `{#id}` syntax is Jekyll/Kramdown only; (2) package names in backticks; (3) ci-build.yml had no Downloads section; (4) AppImage used linuxdeployqt default naming instead of package-tag convention.
- **How to fix**: Made every package name a markdown link to `https://github.com/ZEACENT/klogg/releases/download/<tag>/<filename>`, added Downloads section to continuous pre-release, and passed `KLOGG_PACKAGE_TAG` through docker `--env`.

## Tests
- `ctest --build-config RelWithDebInfo --output-on-failure` — 100% pass (4/4 targets).
- New `[ui][shortcut]` tests: Follow-file toggle (both views) + Go-to-top (both views, tested with focus on both main and filtered).
- `bash -n` passes on `generate_appimage.sh`. YAML indentation verified consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "go to top" navigation feature to scroll all viewing panes to the beginning simultaneously, not just the currently active pane.

* **Documentation**
  * Enhanced release notes with direct download URLs for Windows, Linux, and macOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->