### PR TITLE
Fix Go-to-top with active search and quote shell variables

### DIFF
--- a/packaging/linux/appimage/generate_appimage.sh
+++ b/packaging/linux/appimage/generate_appimage.sh
@@ -20,4 +20,4 @@ cp /lib/x86_64-linux-gnu/libssl* appdir/usr/lib
 VERSION=$KLOGG_VERSION ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage
 
 mkdir ./packages
-cp ./klogg-$KLOGG_VERSION-x86_64.AppImage ./packages/klogg-$KLOGG_VERSION-appimage-$KLOGG_PACKAGE_TAG.AppImage
+cp "./klogg-${KLOGG_VERSION}-x86_64.AppImage" "./packages/klogg-${KLOGG_VERSION}-appimage-${KLOGG_PACKAGE_TAG}.AppImage"

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -353,8 +353,11 @@ bool CrawlerWidget::eventFilter( QObject* watched, QEvent* event )
 
 void CrawlerWidget::jumpToTop()
 {
-    logMainView_->selectAndDisplayLine( 0_lnum );
+    // Scroll filtered view first — it emits newSelection which triggers
+    // jumpToMatchingLine, moving the main view to the matching line.
+    // Then scroll the main view to absolute line 0, overriding that.
     filteredView_->selectAndDisplayLine( 0_lnum );
+    logMainView_->selectAndDisplayLine( 0_lnum );
 }
 
 void CrawlerWidget::goToLine()

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -2404,3 +2404,49 @@ SCENARIO( "Go to top (T) scrolls both views regardless of focus", "[ui][shortcut
         }
     }
 }
+
+SCENARIO( "Go to top moves main view to absolute top with active search",
+          "[ui][shortcut][regression]" )
+{
+    QTemporaryFile file{ "crawler_gototop_search_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( false );
+    crawlerVisitor.resizeViews( 320, 120 );
+    crawlerVisitor.render();
+
+    // Search for a specific line not at the top — filtered line 0 maps to main line 42
+    crawlerVisitor.setSearchPattern( "this is line 000042" );
+    crawlerVisitor.runSearch();
+
+    REQUIRE( waitUiState(
+        [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 1; } ) );
+
+    // Scroll main view away from top (filtered view has only 1 line, can't scroll)
+    crawlerVisitor.scrollMainVerticallyToMiddle();
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainTopLine().get() > 0 );
+
+    WHEN( "jumpToTop is called with active search" )
+    {
+        crawlerVisitor.jumpToTop();
+        QTest::qWait( 50 );
+        crawlerVisitor.render();
+
+        THEN( "main view scrolls to absolute top, not the matching line" )
+        {
+            REQUIRE( crawlerVisitor.filteredTopLine().get() == 0 );
+            REQUIRE( crawlerVisitor.mainTopLine().get() == 0 );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Go-to-top (T) shortcut so the main view scrolls to absolute line 0 when a search filter is active, rather than jumping to the matching line of filtered line 0.
- Add a regression test for the Go-to-top + active search scenario.
- Quote `cp` variable expansions in `generate_appimage.sh` to satisfy shellcheck SC2086.

## Background

### Go-to-top fix
- **Introduced by:** The `jumpToMatchingLine` signal-slot connection (`crawlerwidget.cpp:1727`) that synchronizes the main view to the filtered view selection.
- **Use case:** User presses T (Go to top) while a search filter is active. Both the main window and filtered window should scroll to their respective tops.
- **How to reproduce:** Open a file, search for a pattern matching a non-zero line, scroll the main view away from top, press T. The filtered view jumps to its top, but the main view jumps to the line matching filtered line 0 instead of absolute line 0.
- **Root cause:** `CrawlerWidget::jumpToTop()` scrolled the main view to line 0 first, then scrolled the filtered view to line 0. The filtered view `selectAndDisplayLine` emits `newSelection`, which triggers `jumpToMatchingLine` — converting filtered line 0 to its corresponding main data line and overriding the main view position.
- **How to fix:** Swap the call order so `filteredView_->selectAndDisplayLine(0_lnum)` runs first (its side effect moves the main view to the matching line), then `logMainView_->selectAndDisplayLine(0_lnum)` overrides the main view to absolute line 0.

### Shell variable quoting
- **Introduced by:** `generate_appimage.sh` consistently quotes variable expansions elsewhere (lines 6, 12); the single `cp` line on line 22 was inconsistent.

## Tests
- Added regression test "Go to top moves main view to absolute top with active search" — opens a file, sets up a search filter, scrolls away, calls `jumpToTop()`, and asserts both views are at line 0.
- Ran `ctest --build-config RelWithDebInfo --output-on-failure` — all 4 test suites pass (100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 'Jump to Top' behavior when an active filter or search is applied. The function now correctly scrolls to the absolute top of the document first before displaying filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->