### PR TITLE
feat: add live source auto-reconnect, rolling file output, async transport, and fix macOS SIGABRT crashes

### DIFF
--- a/docker/ubuntu20.04/Dockerfile
+++ b/docker/ubuntu20.04/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update -y && \
                     gnupg dirmngr \
                     wget ca-certificates \
                     -y && \
-    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F && \
+    echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main" \
+        > /etc/apt/sources.list.d/ubuntu-toolchain-r-test.list && \
     apt-get update -y && \
     apt-get install --no-install-recommends \
                     qtbase5-dev qt5-qmake qtbase5-dev-tools qttools5-dev qttranslations5-l10n \

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -367,10 +367,7 @@ def _check_data_variable_shadowing(text: str, path: Path) -> list[tuple[int, str
     - Files whose name contains "dialog" (heuristic for QDialog subclasses).
     - A local variable declaration ``Type data;`` or ``Type data{}``.
     """
-    if ALLOW_MARKER in text:
-        return []
-
-    if "dialog" not in path.name.lower():
+    if "dialog" not in path.name.lower() and "widget" not in path.name.lower():
         return []
 
     # Only flag if the file actually includes QWidget/QDialog headers

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -352,6 +352,55 @@ def _check_qt5_arg_limit(text: str, path: Path) -> list[tuple[int, str]]:
     return findings
 
 
+def _check_data_variable_shadowing(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag local variables named ``data`` inside QWidget subclass methods.
+
+    QWidget has a protected member ``data`` (QScopedPointer<QWidgetData>).
+    GCC/Clang ``-Wshadow`` does NOT warn about shadowing protected members,
+    but MSVC C4458 (enabled by /W4, promoted to error by /WX) does.  This
+    causes Windows-only CI failures that pass on macOS/Linux.
+
+    PR #38 exposed this in AdbLogcatDialog::sessionData() and
+    IosLogDialog::sessionData().
+
+    The check looks for:
+    - Files whose name contains "dialog" (heuristic for QDialog subclasses).
+    - A local variable declaration ``Type data;`` or ``Type data{}``.
+    """
+    if ALLOW_MARKER in text:
+        return []
+
+    if "dialog" not in path.name.lower():
+        return []
+
+    # Only flag if the file actually includes QWidget/QDialog headers
+    # or inherits from QDialog — avoids false positives in non-Qt files.
+    if "QDialog" not in text and "QWidget" not in text:
+        return []
+
+    findings: list[tuple[int, str]] = []
+    # Match: TypeIdentifier data;  or  TypeIdentifier data{...}
+    # Captures patterns like:  AdbLogcatSessionData data;
+    decl_re = re.compile(
+        r"^\s+\w+(?:::\w+)*\s+data\s*[;={]"
+    )
+    for i, line in enumerate(text.splitlines(), start=1):
+        if ALLOW_MARKER in line:
+            continue
+        if decl_re.match(line):
+            findings.append(
+                (
+                    i,
+                    "Local variable named 'data' shadows QWidget::data "
+                    "(protected member). GCC/Clang -Wshadow does NOT catch "
+                    "this, but MSVC C4458 does (promoted to error by /WX). "
+                    "Rename the variable (e.g. 'sessionData') to avoid a "
+                    "Windows-only CI failure. (PR #38)",
+                )
+            )
+    return findings
+
+
 def _check_hardcoded_text_viewport_row_assertion(text: str, path: Path) -> list[tuple[int, str]]:
     """Flag text viewport height assertions that assume fixed font metrics.
 
@@ -444,6 +493,10 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "qt5-string-arg-limit",
         "check": _check_qt5_arg_limit,
+    },
+    {
+        "name": "data-variable-shadowing",
+        "check": _check_data_variable_shadowing,
     },
 ]
 

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -54,7 +54,6 @@
 
 #include "configuration.h"
 #include "crashhandler.h"
-#include "downloader.h"
 #include "klogg_version.h"
 #include "log.h"
 #include "session.h"
@@ -65,6 +64,7 @@
 #include "mainwindow.h"
 #include "messagereceiver.h"
 #include "newversiondialog.h"
+#include "updatedownloadhelper.h"
 #include "versionchecker.h"
 
 class KloggApp : public QApplication {
@@ -359,40 +359,32 @@ class KloggApp : public QApplication {
         const auto urlFileName = QUrl( downloadUrl ).fileName();
         const auto localPath = downloadsPath + QDir::separator() + urlFileName;
 
-        // outputFile is shared with the completion lambda so it stays alive
-        // until the download finishes (no cycle — QFile is not a QObject).
-        auto outputFile = std::make_shared<QFile>( localPath );
-        if ( !outputFile->open( QIODevice::WriteOnly ) ) {
+        QFile outputFile( localPath );
+        if ( !outputFile.open( QIODevice::WriteOnly ) ) {
             LOG_ERROR << "Cannot open file for writing: " << localPath;
             QMessageBox::warning( nullptr, tr( "Download Failed" ),
                                   tr( "Could not create file:\n%1" ).arg( localPath ) );
             return;
         }
 
-        // Use raw new + deleteLater to avoid the shared_ptr cycle that would
-        // leak, while keeping the Downloader alive for the async request.
-        auto* downloader = new Downloader();
+        // Show a modal progress dialog while downloading, matching the
+        // pattern used in MainWindow::openRemoteFile().
+        auto* progressDialog
+            = startUpdateDownload( QUrl( downloadUrl ), &outputFile, /*parent=*/nullptr );
 
-        QObject::connect( downloader, &Downloader::finished,
-                          [ outputFile, downloader, localPath ]( bool success ) {
-                              outputFile->close();
-                              if ( success ) {
-                                  LOG_INFO << "Update downloaded to " << localPath;
-                                  QDesktopServices::openUrl( QUrl::fromLocalFile( localPath ) );
-                              }
-                              else {
-                                  LOG_ERROR << "Update download failed: "
-                                            << downloader->lastError();
-                                  QMessageBox::warning(
-                                      nullptr, tr( "Download Failed" ),
-                                      tr( "Failed to download update:\n%1" )
-                                          .arg( downloader->lastError() ) );
-                                  outputFile->remove();
-                              }
-                              downloader->deleteLater();
-                          } );
+        if ( progressDialog->exec() == QDialog::Accepted ) {
+            LOG_INFO << "Update downloaded to " << localPath;
+            QDesktopServices::openUrl( QUrl::fromLocalFile( localPath ) );
+        }
+        else {
+            LOG_ERROR << "Update download was canceled or failed";
+            if ( outputFile.exists() ) {
+                outputFile.remove();
+            }
+        }
 
-        downloader->download( QUrl( downloadUrl ), outputFile.get() );
+        outputFile.close();
+        delete progressDialog;
     }
 
     size_t nextWindowIndex() const

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -367,25 +367,23 @@ class KloggApp : public QApplication {
             return;
         }
 
-        // Show a modal progress dialog while downloading, matching the
-        // pattern used in MainWindow::openRemoteFile().
-        auto* progressDialog
-            = startUpdateDownload( QUrl( downloadUrl ), &outputFile, /*parent=*/nullptr );
+        // Stack-allocated objects — same safe pattern as
+        // MainWindow::openRemoteFile().  Deterministic LIFO destruction
+        // avoids the macOS Cocoa crash caused by processEvents() +
+        // delete after a modal dialog exec().
+        Downloader downloader;
+        QProgressDialog progressDialog;
 
-        const auto result = progressDialog->exec();
+        startUpdateDownload( QUrl( downloadUrl ), &outputFile, downloader, progressDialog );
 
-        // Process deferred deletions so the Downloader (scheduled by the
-        // cancel or finished handler) is destroyed before we delete the
-        // dialog and outputFile go out of scope.  This prevents the
-        // finished lambda from accessing a dangling progressDialog pointer.
-        QCoreApplication::processEvents();
+        const auto result = progressDialog.exec();
 
         if ( result == QDialog::Accepted ) {
             LOG_INFO << "Update downloaded to " << localPath;
             QDesktopServices::openUrl( QUrl::fromLocalFile( localPath ) );
         }
         else {
-            const auto error = progressDialog->property( "downloadError" ).toString();
+            const auto error = progressDialog.property( "downloadError" ).toString();
             if ( !error.isEmpty() ) {
                 LOG_ERROR << "Update download failed: " << error;
                 QMessageBox::warning( nullptr, tr( "Download Failed" ),
@@ -400,7 +398,6 @@ class KloggApp : public QApplication {
         }
 
         outputFile.close();
-        delete progressDialog;
     }
 
     size_t nextWindowIndex() const

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -372,12 +372,28 @@ class KloggApp : public QApplication {
         auto* progressDialog
             = startUpdateDownload( QUrl( downloadUrl ), &outputFile, /*parent=*/nullptr );
 
-        if ( progressDialog->exec() == QDialog::Accepted ) {
+        const auto result = progressDialog->exec();
+
+        // Process deferred deletions so the Downloader (scheduled by the
+        // cancel or finished handler) is destroyed before we delete the
+        // dialog and outputFile go out of scope.  This prevents the
+        // finished lambda from accessing a dangling progressDialog pointer.
+        QCoreApplication::processEvents();
+
+        if ( result == QDialog::Accepted ) {
             LOG_INFO << "Update downloaded to " << localPath;
             QDesktopServices::openUrl( QUrl::fromLocalFile( localPath ) );
         }
         else {
-            LOG_ERROR << "Update download was canceled or failed";
+            const auto error = progressDialog->property( "downloadError" ).toString();
+            if ( !error.isEmpty() ) {
+                LOG_ERROR << "Update download failed: " << error;
+                QMessageBox::warning( nullptr, tr( "Download Failed" ),
+                                      tr( "Download failed:\n%1" ).arg( error ) );
+            }
+            else {
+                LOG_INFO << "Update download canceled by user";
+            }
             if ( outputFile.exists() ) {
                 outputFile.remove();
             }

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -395,6 +395,7 @@ class KloggApp : public QApplication {
 
         if ( result == QDialog::Accepted ) {
             LOG_INFO << "Update downloaded to " << localPath;
+            outputFile.close();
             QDesktopServices::openUrl( QUrl::fromLocalFile( localPath ) );
         }
         else {
@@ -407,12 +408,10 @@ class KloggApp : public QApplication {
             else {
                 LOG_INFO << "Update download canceled by user";
             }
-            if ( outputFile.exists() ) {
-                outputFile.remove();
-            }
+            // Closes our handle before removing: Windows refuses to delete an
+            // open file, so removing first silently leaked the partial download.
+            discardDownloadedFile( outputFile );
         }
-
-        outputFile.close();
     }
 
     size_t nextWindowIndex() const

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -123,6 +123,11 @@ class KloggApp : public QApplication {
                                  tr( "You are using the latest version of klogg." ) );
                          }
                          msgBox.exec();
+
+                         // Drain stale Cocoa events while the dialog's NSWindow
+                         // is still alive.  See newVersionNotification() for the
+                         // full explanation of the macOS Cocoa lifecycle issue.
+                         QCoreApplication::processEvents();
                      } );
         }
     }
@@ -326,6 +331,12 @@ class KloggApp : public QApplication {
         NewVersionDialog dlg( new_version, url, changes );
         dlg.exec();
 
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        // Without this, the destructor releases the NSWindow but orphaned events
+        // remain in the queue; the next processEvents() cycle in the main event
+        // loop tries to dispatch them to the dead window → ObjC exception → SIGABRT.
+        QCoreApplication::processEvents();
+
         if ( dlg.clickedButton() == NewVersionDialog::Download ) {
             if ( !downloadUrl.isEmpty() ) {
                 downloadAndOpenUpdate( downloadUrl, new_version );
@@ -377,6 +388,10 @@ class KloggApp : public QApplication {
         startUpdateDownload( QUrl( downloadUrl ), &outputFile, downloader, progressDialog );
 
         const auto result = progressDialog.exec();
+
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        // See comment in newVersionNotification() for the full explanation.
+        QCoreApplication::processEvents();
 
         if ( result == QDialog::Accepted ) {
             LOG_INFO << "Update downloaded to " << localPath;

--- a/src/app/kloggapp.h
+++ b/src/app/kloggapp.h
@@ -64,6 +64,7 @@
 
 #include "mainwindow.h"
 #include "messagereceiver.h"
+#include "newversiondialog.h"
 #include "versionchecker.h"
 
 class KloggApp : public QApplication {
@@ -322,36 +323,10 @@ class KloggApp : public QApplication {
         LOG_DEBUG << "newVersionNotification( " << new_version << " from " << url
                   << ", download: " << downloadUrl << " )";
 
-        QString message = tr( "<p>A new version of klogg (%1) is available for download.</p>"
-                              "<p><a href=\"%2\">%2</a></p>" )
-                              .arg( new_version, url );
+        NewVersionDialog dlg( new_version, url, changes );
+        dlg.exec();
 
-        if ( !changes.empty() ) {
-            message.append( tr( "<p>Important changes:</p><ul>" ) );
-            for ( const auto& change : changes ) {
-                message.append( tr( "<li>%1</li>" ).arg( change ) );
-            }
-            message.append( QStringLiteral( "</ul>" ) );
-        }
-
-        QMessageBox msgBox;
-        msgBox.setWindowTitle( tr( "New Version Available" ) );
-        msgBox.setText( message );
-        msgBox.setTextFormat( Qt::RichText );
-        msgBox.setIcon( QMessageBox::Information );
-
-        QPushButton* downloadButton
-            = msgBox.addButton( tr( "Download" ), QMessageBox::AcceptRole );
-        QPushButton* remindButton
-            = msgBox.addButton( tr( "Remind Later" ), QMessageBox::RejectRole );
-        QPushButton* skipButton
-            = msgBox.addButton( tr( "Skip This Version" ),
-                                QMessageBox::DestructiveRole );
-
-        msgBox.setDefaultButton( downloadButton );
-        msgBox.exec();
-
-        if ( msgBox.clickedButton() == downloadButton ) {
+        if ( dlg.clickedButton() == NewVersionDialog::Download ) {
             if ( !downloadUrl.isEmpty() ) {
                 downloadAndOpenUpdate( downloadUrl, new_version );
             }
@@ -360,13 +335,13 @@ class KloggApp : public QApplication {
                 QDesktopServices::openUrl( QUrl( url ) );
             }
         }
-        else if ( msgBox.clickedButton() == remindButton ) {
+        else if ( dlg.clickedButton() == NewVersionDialog::RemindLater ) {
             // Set deadline to 1 day from now
             auto& config = VersionCheckerConfig::get();
             config.setNextDeadline( std::time( nullptr ) + 86400 ); // 24 hours
             config.save();
         }
-        else if ( msgBox.clickedButton() == skipButton ) {
+        else if ( dlg.clickedButton() == NewVersionDialog::SkipVersion ) {
             // Store the version to ignore
             auto& config = VersionCheckerConfig::get();
             config.setIgnoredVersion( new_version );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -46,6 +46,95 @@
 #include <windows.h>
 #endif // _WIN32
 
+#ifdef Q_OS_MAC
+// macOS uncaught-NSException diagnostic.
+//
+// Qt's QCocoaEventDispatcher turns an ObjC NSException thrown during event
+// dispatch into a C++ exception that propagates through __cxa_rethrow /
+// objc_exception_rethrow and aborts (SIGABRT).  The stock macOS crash report
+// only shows the terminate path (abort -> -[NSApplication run]), NOT the
+// exception's name/reason — so the actual defect is invisible.  This handler
+// runs from _objc_terminate before abort() and dumps name + reason to stderr
+// and to ~/klogg_nsexception.txt, making the real cause diagnosable.
+//
+// Pure C / objc-runtime only so this file stays a translation unit of C++.
+#include <objc/message.h>
+#include <objc/objc.h>
+#include <objc/runtime.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+struct NSException; // opaque ObjC object
+extern "C" void NSSetUncaughtExceptionHandler( void ( *handler )( NSException* ) );
+
+namespace {
+id objcSend( id receiver, SEL sel )
+{
+    using SendId = id ( * )( id, SEL );
+    return reinterpret_cast<SendId>( objc_msgSend )( receiver, sel );
+}
+
+const char* objcUtf8( id receiver, const char* selectorName )
+{
+    if ( receiver == nullptr ) {
+        return "(null)";
+    }
+    const id value = objcSend( receiver, sel_registerName( selectorName ) );
+    if ( value == nullptr ) {
+        return "(null)";
+    }
+    using SendCstr = const char* ( * )( id, SEL );
+    return reinterpret_cast<SendCstr>( objc_msgSend )( value, sel_registerName( "UTF8String" ) );
+}
+
+void writeAll( int fd, const char* text )
+{
+    if ( text != nullptr && *text != '\0' ) {
+        const auto len = static_cast<size_t>( std::strlen( text ) );
+        ssize_t written = 0;
+        while ( static_cast<size_t>( written ) < len ) {
+            const auto n = ::write( fd, text + written, len - static_cast<size_t>( written ) );
+            if ( n <= 0 ) {
+                break;
+            }
+            written += n;
+        }
+    }
+}
+
+void dumpException( int fd, NSException* exception )
+{
+    writeAll( fd, "\n===== KLOGG uncaught NSException =====\nname:   " );
+    writeAll( fd, objcUtf8( reinterpret_cast<id>( exception ), "name" ) );
+    writeAll( fd, "\nreason: " );
+    writeAll( fd, objcUtf8( reinterpret_cast<id>( exception ), "reason" ) );
+    writeAll( fd, "\n" );
+}
+
+void kloggUncaughtNSExceptionHandler( NSException* exception )
+{
+    dumpException( STDERR_FILENO, exception );
+
+    if ( const auto home = std::getenv( "HOME" ) ) {
+        char path[ 1024 ];
+        const auto n = std::snprintf( path, sizeof( path ), "%s/klogg_nsexception.txt", home );
+        if ( n > 0 && n < static_cast<int>( sizeof( path ) ) ) {
+            const auto fd = ::open( path, O_WRONLY | O_CREAT | O_APPEND, 0644 );
+            if ( fd >= 0 ) {
+                dumpException( fd, exception );
+                ::close( fd );
+            }
+        }
+    }
+}
+} // namespace
+#endif // Q_OS_MAC
+
 #include <mimalloc.h>
 #include <roaring.hh>
 
@@ -144,6 +233,12 @@ QSet<QString> retainedAdbCaptureIds( const SessionInfo& sessionInfo )
 
 int main( int argc, char* argv[] )
 {
+#ifdef Q_OS_MAC
+    // Install as early as possible: NSExceptions can fly during QApplication
+    // construction and the very first event-loop spin.
+    NSSetUncaughtExceptionHandler( &kloggUncaughtNSExceptionHandler );
+#endif
+
 #ifdef KLOGG_USE_MIMALLOC
     mi_process_init();
 #endif

--- a/src/crash_handler/src/crashhandler.cpp
+++ b/src/crash_handler/src/crashhandler.cpp
@@ -324,6 +324,13 @@ CrashHandler::CrashHandler()
 
         QTimer::singleShot( 30 * 1000, &progressDialog, &QProgressDialog::cancel );
         progressDialog.exec();
+
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        // On macOS, a parentless QProgressDialog gets its own NSWindow.  After
+        // exec() returns, orphaned Cocoa events may remain in the queue.  If the
+        // dialog is destroyed before those events are drained, the main event
+        // loop will try to dispatch them to the dead window → SIGABRT.
+        QCoreApplication::processEvents();
     }
 }
 

--- a/src/logdata/CMakeLists.txt
+++ b/src/logdata/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/abstractlogdata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ansicolorprocessor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/capturestore.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/rollingfilemanager.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/concatenatedlogdata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/compressedlinestorage.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/encodingdetector.cpp

--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -111,7 +111,6 @@ class CaptureStore {
     void scanSegment( Segment& segment );
     QByteArray readSegmentLine( const Segment& segment, int localLine ) const;
     bool writeSegmentToDevice( const Segment& segment, QIODevice* device ) const;
-    bool writeCaptureToDevice( QIODevice* device ) const;
     void appendOutputBytes( const QByteArray& bytes, int lineCount = 1 );
     void flushOutputIfNeeded();
     void resetOutputFlushCounters();

--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -13,6 +13,7 @@
 #include <QString>
 
 #include "linetypes.h"
+#include "rollingfilemanager.h"
 #include "searchablelogdata.h"
 
 class CaptureStore {
@@ -20,6 +21,9 @@ class CaptureStore {
     struct Limits {
         qint64 segmentTargetBytes = 1024 * 1024;
         qint64 memoryBudgetBytes = 256 * 1024 * 1024;
+        qint64 rollingMaxFileSize = 0; // 0 = unlimited
+        int rollingBackupCount = 0;
+        qint64 maxTotalLines = 0; // 0 = unlimited
     };
 
     struct Segment {
@@ -67,8 +71,17 @@ class CaptureStore {
     AppendResult finishInput();
     void flush();
     void clear();
+
+    struct TrimResult {
+        LinesCount trimmedLines = 0_lcount;
+        qint64 trimmedBytes = 0;
+    };
+    TrimResult trimToLimits();
+    TrimResult lastTrimResult() const;
+    void clearTrimResult();
     bool bindOutputFile( const QString& outputPath );
     void setOutputFlushedCallback( std::function<void()> callback );
+    void setLimits( Limits limits );
     QString boundOutputFile() const;
     QString captureId() const;
     QString capturePath() const;
@@ -102,6 +115,7 @@ class CaptureStore {
     void appendOutputBytes( const QByteArray& bytes, int lineCount = 1 );
     void flushOutputIfNeeded();
     void resetOutputFlushCounters();
+    void trimToWindowSize();
 
     static constexpr qint64 OutputFlushBytesThreshold = 1024 * 1024;
     static constexpr int OutputFlushLinesThreshold = 1000;
@@ -111,7 +125,7 @@ class CaptureStore {
     QString rootPath_;
     QString capturePath_;
     QString boundOutputFile_;
-    mutable std::unique_ptr<QFile> boundOutputHandle_;
+    RollingFileManager rollingOutput_;
     Limits limits_;
 
     klogg::vector<Segment> segments_;
@@ -128,6 +142,11 @@ class CaptureStore {
     qint64 unflushedOutputBytes_ = 0;
     int unflushedOutputLines_ = 0;
     std::function<void()> outputFlushedCallback_;
+    TrimResult lastTrimResult_;
+
+    // Spill throttling: avoid frequent small spills
+    static constexpr int SpillThrottleMs = 5000;
+    qint64 lastSpillTimeMs_ = 0;
 };
 
 #endif

--- a/src/logdata/include/rollingfilemanager.h
+++ b/src/logdata/include/rollingfilemanager.h
@@ -25,7 +25,7 @@ class RollingFileManager {
     bool isValid() const;
     bool open( bool truncate = false );
     void close();
-    void flush();
+    bool flush();
 
     // Write data to the current file. Automatically rotates if the file exceeds
     // maxFileSize. Returns the number of bytes written (may be less than data.size()
@@ -43,6 +43,11 @@ class RollingFileManager {
 
     // List backup files in order (oldest first).
     QStringList backupFiles() const;
+
+    // Re-read the current file's size from disk.  Call this after writing
+    // directly to currentFile() (bypassing write()) so that needsRotation()
+    // and currentFileSize() reflect the true on-disk size.
+    void resyncSize();
 
     // Delete all files (current + backups).
     void deleteAll();

--- a/src/logdata/include/rollingfilemanager.h
+++ b/src/logdata/include/rollingfilemanager.h
@@ -8,7 +8,8 @@
 // Manages a rolling output file that rotates when it reaches a size limit.
 // When the current file exceeds maxFileSize, it is renamed as a numbered backup
 // and a new file is opened with the original name. Old backups beyond backupCount
-// are automatically deleted.
+// are automatically deleted. When backupCount is 0, all rotated files are kept
+// indefinitely (no cleanup).
 //
 // The rename is done atomically. To avoid data loss during the gap between closing
 // the old file and opening the new one, the rotation opens the new file BEFORE

--- a/src/logdata/include/rollingfilemanager.h
+++ b/src/logdata/include/rollingfilemanager.h
@@ -37,6 +37,10 @@ class RollingFileManager {
     void rotate();
 
     bool needsRotation() const;
+    // True if the most recent write() call (or a force-rotate) rotated the file.
+    // More reliable than comparing currentFileSize() before/after a write, which
+    // misses rotations that leave the new file at least as large as the old one.
+    bool rotated() const;
     qint64 currentFileSize() const;
     qint64 maxFileSize() const;
     int backupCount() const;
@@ -64,6 +68,7 @@ class RollingFileManager {
     int backupCount_ = 0;
     QFile currentFile_;
     qint64 currentBytes_ = 0;
+    bool rotated_ = false;
 };
 
 #endif

--- a/src/logdata/include/rollingfilemanager.h
+++ b/src/logdata/include/rollingfilemanager.h
@@ -1,0 +1,63 @@
+#ifndef ROLLINGFILEMANAGER_H
+#define ROLLINGFILEMANAGER_H
+
+#include <QFile>
+#include <QString>
+#include <QStringList>
+
+// Manages a rolling output file that rotates when it reaches a size limit.
+// When the current file exceeds maxFileSize, it is renamed as a numbered backup
+// and a new file is opened with the original name. Old backups beyond backupCount
+// are automatically deleted.
+//
+// The rename is done atomically. To avoid data loss during the gap between closing
+// the old file and opening the new one, the rotation opens the new file BEFORE
+// closing the old one.
+class RollingFileManager {
+  public:
+    RollingFileManager() = default;
+    RollingFileManager( QString basePath, qint64 maxFileSize, int backupCount );
+    RollingFileManager( RollingFileManager&& other ) noexcept;
+    RollingFileManager& operator=( RollingFileManager&& other ) noexcept;
+    RollingFileManager( const RollingFileManager& ) = delete;
+    RollingFileManager& operator=( const RollingFileManager& ) = delete;
+
+    bool isValid() const;
+    bool open( bool truncate = false );
+    void close();
+    void flush();
+
+    // Write data to the current file. Automatically rotates if the file exceeds
+    // maxFileSize. Returns the number of bytes written (may be less than data.size()
+    // if rotation is needed; call again with the remaining data).
+    qint64 write( const QByteArray& data );
+
+    // Force a rotation (e.g., during CaptureStore trim).
+    void rotate();
+
+    bool needsRotation() const;
+    qint64 currentFileSize() const;
+    qint64 maxFileSize() const;
+    int backupCount() const;
+    QFile* currentFile();
+
+    // List backup files in order (oldest first).
+    QStringList backupFiles() const;
+
+    // Delete all files (current + backups).
+    void deleteAll();
+
+  private:
+    QString backupPath( int index ) const;
+    void cleanupOldBackups();
+    bool openNewFile( bool truncate = false );
+    bool rotateInternal();
+
+    QString basePath_;
+    qint64 maxFileSize_ = 0;
+    int backupCount_ = 0;
+    QFile currentFile_;
+    qint64 currentBytes_ = 0;
+};
+
+#endif

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -75,6 +75,10 @@ class StreamingLogData : public SearchableLogData {
     void scheduleLoadingFinished( int delayMs = 0 );
     ProcessedAnsiLine processedAnsiLine( LineNumber line ) const;
     void clearAnsiDisplayCache();
+    // Reads CaptureStore's pending trim result; if nonzero, clears it and
+    // invalidates the line-keyed raw/ANSI caches (their absolute line numbers
+    // shifted). Returns the consumed result so the caller can emit Truncated.
+    CaptureStore::TrimResult consumeTrimResult();
     void startOutputFlushTimer();
     void stopOutputFlushTimer();
     bool openDisplayOutputFile( const QString& outputPath );

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -80,6 +80,12 @@ class StreamingLogData : public SearchableLogData {
     bool openDisplayOutputFile( const QString& outputPath );
     void closeDisplayOutputFile();
     bool writeDisplayLinesToOutput( LineNumber first, LinesCount count );
+    // Writes the lines appended in `appendResult` to the Strip-mode display
+    // file.  Addresses the appended lines by their current tail position so it
+    // is correct even when trimming has shifted line numbers — never by a
+    // [previous, current) delta (which underflows when trimming removes more
+    // lines than were added).
+    void writeAppendedDisplayLines( const CaptureStore::AppendResult& appendResult );
     klogg::vector<QString> getLines( LineNumber first, LinesCount number ) const;
     void rememberAppendedRawLines( const CaptureStore::AppendResult& appendResult );
     std::optional<RawLines> tryBuildCachedRawLines( LineNumber first, LinesCount number ) const;

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -12,6 +12,7 @@
 #include <QTimer>
 
 #include "capturestore.h"
+#include "rollingfilemanager.h"
 #include "searchablelogdata.h"
 
 enum class LiveLogSaveAnsiMode {
@@ -29,6 +30,7 @@ class StreamingLogData : public SearchableLogData {
     void appendUtf8( const QByteArray& data );
     void finishInput();
     void clearCapture();
+    void setCaptureLimits( CaptureStore::Limits limits );
     bool bindOutputFile( const QString& outputPath );
     bool bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode );
     QString boundOutputFile() const;
@@ -91,7 +93,9 @@ class StreamingLogData : public SearchableLogData {
     QTimer loadingFinishedTimer_;
     QTimer outputFlushTimer_;
     QString boundOutputFile_;
-    QFile boundOutputHandle_;
+    RollingFileManager rollingDisplayOutput_;
+    qint64 rollingMaxFileSize_ = 0;
+    int rollingBackupCount_ = 0;
     LiveLogSaveAnsiMode outputSaveAnsiMode_ = LiveLogSaveAnsiMode::Strip;
     mutable std::mutex cachedRawBatchesMutex_;
     std::deque<CachedRawBatch> cachedRawBatches_;

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <thread>
 
+#include <QDateTime>
 #include <QDir>
 #include <QDirIterator>
 #include <QFileInfo>
@@ -277,8 +278,8 @@ CaptureStore::AppendResult CaptureStore::finishInput()
     }
 
     // Flush any pending output data
-    if ( boundOutputHandle_ && unflushedOutputBytes_ > 0 ) {
-        boundOutputHandle_->flush();
+    if ( rollingOutput_.isValid() && unflushedOutputBytes_ > 0 ) {
+        rollingOutput_.flush();
         resetOutputFlushCounters();
     }
     return appendResult;
@@ -287,8 +288,8 @@ CaptureStore::AppendResult CaptureStore::finishInput()
 void CaptureStore::flush()
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
-    if ( boundOutputHandle_ && unflushedOutputBytes_ > 0 ) {
-        boundOutputHandle_->flush();
+    if ( rollingOutput_.isValid() && unflushedOutputBytes_ > 0 ) {
+        rollingOutput_.flush();
         resetOutputFlushCounters();
     }
 }
@@ -313,37 +314,146 @@ void CaptureStore::clear()
     }
 
     if ( !boundOutputFile_.isEmpty() ) {
-        QFile outputFile( boundOutputFile_ );
-        if ( outputFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
-            outputFile.close();
-        }
-        boundOutputHandle_.reset();
-        bindOutputFile( boundOutputFile_ );
+        rollingOutput_.deleteAll();
+        rollingOutput_ = RollingFileManager( boundOutputFile_, limits_.rollingMaxFileSize,
+                                             limits_.rollingBackupCount );
+        rollingOutput_.open( true );
     }
+}
+
+CaptureStore::TrimResult CaptureStore::trimToLimits()
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    TrimResult result;
+
+    if ( segments_.size() <= 1 ) {
+        return result;
+    }
+
+    // Rolling window: rollingMaxFileSize * rollingBackupCount
+    const auto windowBytes = limits_.rollingMaxFileSize > 0 && limits_.rollingBackupCount > 0
+                                 ? limits_.rollingMaxFileSize * limits_.rollingBackupCount
+                                 : qint64{ 0 };
+    const auto exceedsBytes = windowBytes > 0 && fileSize_ > windowBytes;
+    const auto exceedsLines = limits_.maxTotalLines > 0 && totalLines_ > limits_.maxTotalLines;
+
+    if ( !exceedsBytes && !exceedsLines ) {
+        return result;
+    }
+
+    LinesCount::UnderlyingType totalRemovedLines = 0;
+    bool removedMaxLine = false;
+
+    // Remove oldest segments (FIFO) until within limits.
+    // Never remove the active (last) segment.
+    while ( segments_.size() > 1 ) {
+        const auto stillOverBytes = windowBytes > 0 && fileSize_ > windowBytes;
+        const auto stillOverLines
+            = limits_.maxTotalLines > 0 && totalLines_ > limits_.maxTotalLines;
+
+        if ( !stillOverBytes && !stillOverLines ) {
+            break;
+        }
+
+        auto& front = segments_.front();
+        const auto segmentLines = klogg::ssize( front.lineOffsets );
+        const auto segmentBytes = front.byteSize;
+
+        // Track if we're removing the segment that held maxLineLength
+        for ( const auto len : front.lineLengths ) {
+            if ( len == maxLineLength_ ) {
+                removedMaxLine = true;
+            }
+        }
+
+        // Delete disk file if spilled
+        if ( front.spilled && !front.filePath.isEmpty() ) {
+            QFile::remove( front.filePath );
+        }
+
+        fileSize_ -= segmentBytes;
+        if ( front.memoryData ) {
+            memoryBytes_ -= front.memoryData->size();
+        }
+        totalLines_ -= segmentLines;
+        totalRemovedLines += static_cast<LinesCount::UnderlyingType>( segmentLines );
+
+        result.trimmedLines = result.trimmedLines + LinesCount( static_cast<LinesCount::UnderlyingType>( segmentLines ) );
+        result.trimmedBytes += segmentBytes;
+
+        segments_.erase( segments_.begin() );
+    }
+
+    // O(1) cumulative line count fixup: subtract removed lines from all remaining segments
+    if ( totalRemovedLines > 0 ) {
+        for ( auto& segment : segments_ ) {
+            segment.cumulativeEndLine -= totalRemovedLines;
+        }
+    }
+
+    // Only recompute maxLineLength if we removed the segment that held it
+    if ( removedMaxLine ) {
+        maxLineLength_ = 0;
+        for ( const auto& segment : segments_ ) {
+            for ( const auto len : segment.lineLengths ) {
+                maxLineLength_ = qMax( maxLineLength_, len );
+            }
+        }
+    }
+
+    if ( result.trimmedLines > 0_lcount ) {
+        lastModified_ = QDateTime::currentDateTime();
+        lastTrimResult_ = result;
+
+        LOG_INFO << "CaptureStore trimmed " << result.trimmedLines.get() << " lines ("
+                 << result.trimmedBytes << " bytes), remaining: " << totalLines_ << " lines, "
+                 << fileSize_ << " bytes";
+    }
+
+    return result;
+}
+
+CaptureStore::TrimResult CaptureStore::lastTrimResult() const
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    return lastTrimResult_;
+}
+
+void CaptureStore::clearTrimResult()
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    lastTrimResult_ = {};
 }
 
 bool CaptureStore::bindOutputFile( const QString& outputPath )
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
-    boundOutputHandle_.reset();
+    rollingOutput_.close();
+    rollingOutput_ = RollingFileManager();
     boundOutputFile_ = outputPath;
     if ( boundOutputFile_.isEmpty() ) {
         return true;
     }
 
     QDir().mkpath( QFileInfo( boundOutputFile_ ).absolutePath() );
-    auto outputFile = std::make_unique<QFile>( boundOutputFile_ );
-    if ( !outputFile->open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
+
+    rollingOutput_ = RollingFileManager( boundOutputFile_, limits_.rollingMaxFileSize,
+                                         limits_.rollingBackupCount );
+    if ( !rollingOutput_.open( true ) ) {
         boundOutputFile_.clear();
         return false;
     }
 
-    if ( !writeCaptureToDevice( outputFile.get() ) || !outputFile->flush() ) {
-        boundOutputFile_.clear();
-        return false;
+    // Write existing segments to the rolling file
+    for ( const auto& segment : segments_ ) {
+        if ( !writeSegmentToDevice( segment, rollingOutput_.currentFile() ) ) {
+            boundOutputFile_.clear();
+            rollingOutput_.close();
+            return false;
+        }
     }
+    rollingOutput_.flush();
 
-    boundOutputHandle_ = std::move( outputFile );
     resetOutputFlushCounters();
     return true;
 }
@@ -351,6 +461,12 @@ bool CaptureStore::bindOutputFile( const QString& outputPath )
 void CaptureStore::setOutputFlushedCallback( std::function<void()> callback )
 {
     outputFlushedCallback_ = std::move( callback );
+}
+
+void CaptureStore::setLimits( Limits limits )
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    limits_ = std::move( limits );
 }
 
 QString CaptureStore::boundOutputFile() const
@@ -378,7 +494,8 @@ void CaptureStore::deleteCaptureFiles()
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
     flush();
-    boundOutputHandle_.reset();
+    rollingOutput_.close();
+    rollingOutput_ = RollingFileManager();
     persistBufferedSegmentsOnDestroy_ = false;
     partialLine_.clear();
     segments_.clear();
@@ -686,7 +803,7 @@ void CaptureStore::commitLine( const QByteArray& lineBytes, bool terminated )
     segment.byteSize = segment.memoryData->size();
     segment.spilled = false;
 
-    if ( boundOutputHandle_ ) {
+    if ( rollingOutput_.isValid() ) {
         appendOutputBytes( terminated ? lineBytes + '\n' : lineBytes );
     }
 
@@ -708,7 +825,7 @@ void CaptureStore::commitLines( const AppendResult& appendResult )
         return;
     }
 
-    if ( boundOutputHandle_ ) {
+    if ( rollingOutput_.isValid() ) {
         if ( appendResult.endOfLines.size()
              > static_cast<size_t>( std::numeric_limits<int>::max() ) ) {
             throw std::runtime_error( "Too many output lines while committing capture batch" );
@@ -790,9 +907,21 @@ void CaptureStore::commitLines( const AppendResult& appendResult )
         maxLineLength_ = qMax( maxLineLength_, segmentMaxLineLength );
 
         rotateSegmentIfNeeded();
+        // Throttle spill operations to avoid frequent small spills under heavy load.
+        // Emergency spill if memory exceeds 2x budget.
         if ( memoryBytes_ > limits_.memoryBudgetBytes ) {
-            enforceMemoryBudget();
+            const auto now = QDateTime::currentMSecsSinceEpoch();
+            if ( memoryBytes_ > limits_.memoryBudgetBytes * 2
+                 || now - lastSpillTimeMs_ >= SpillThrottleMs ) {
+                lastSpillTimeMs_ = now;
+                enforceMemoryBudget();
+            }
         }
+    }
+
+    // Trim oldest segments if total limits are exceeded
+    if ( limits_.rollingMaxFileSize > 0 || limits_.maxTotalLines > 0 ) {
+        trimToLimits();
     }
 }
 
@@ -1013,38 +1142,39 @@ bool CaptureStore::writeCaptureToDevice( QIODevice* device ) const
 
 void CaptureStore::appendOutputBytes( const QByteArray& bytes, int lineCount )
 {
-    if ( !boundOutputHandle_ ) {
+    if ( !rollingOutput_.isValid() ) {
         return;
     }
 
-    if ( boundOutputHandle_->write( bytes ) != bytes.size() ) {
-        LOG_WARNING << "Bound output file write failed, unbinding: " << boundOutputFile_;
-        boundOutputHandle_.reset();
+    const auto sizeBefore = rollingOutput_.currentFileSize();
+    const auto written = rollingOutput_.write( bytes );
+    if ( written <= 0 ) {
+        LOG_WARNING << "Rolling output file write failed, unbinding: " << boundOutputFile_;
+        rollingOutput_.close();
+        rollingOutput_ = RollingFileManager();
         boundOutputFile_.clear();
         return;
     }
 
-    unflushedOutputBytes_ += bytes.size();
+    // Detect rotation: if file size decreased, a rotation happened
+    if ( rollingOutput_.currentFileSize() < sizeBefore ) {
+        trimToWindowSize();
+    }
+
+    unflushedOutputBytes_ += written;
     unflushedOutputLines_ += lineCount;
     flushOutputIfNeeded();
 }
 
 void CaptureStore::flushOutputIfNeeded()
 {
-    if ( !boundOutputHandle_ || unflushedOutputBytes_ == 0 ) {
+    if ( !rollingOutput_.isValid() || unflushedOutputBytes_ == 0 ) {
         return;
     }
 
-    // Time-based flushing is handled by StreamingLogData's QTimer,
-    // so only check byte and line thresholds here.
     if ( unflushedOutputBytes_ >= OutputFlushBytesThreshold
          || unflushedOutputLines_ >= OutputFlushLinesThreshold ) {
-        if ( !boundOutputHandle_->flush() ) {
-            LOG_WARNING << "Bound output file flush failed, unbinding: " << boundOutputFile_;
-            boundOutputHandle_.reset();
-            boundOutputFile_.clear();
-            return;
-        }
+        rollingOutput_.flush();
         resetOutputFlushCounters();
         if ( outputFlushedCallback_ ) {
             outputFlushedCallback_();
@@ -1056,4 +1186,16 @@ void CaptureStore::resetOutputFlushCounters()
 {
     unflushedOutputBytes_ = 0;
     unflushedOutputLines_ = 0;
+}
+
+void CaptureStore::trimToWindowSize()
+{
+    // Called when the rolling file rotates. Trim in-memory segments to match the window.
+    // The caller (appendOutputBytes) already holds the mutex via commitLines → appendUtf8.
+    const auto windowBytes = limits_.rollingMaxFileSize > 0 && limits_.rollingBackupCount > 0
+                                 ? limits_.rollingMaxFileSize * limits_.rollingBackupCount
+                                 : qint64{ 0 };
+    if ( windowBytes > 0 ) {
+        trimToLimits();
+    }
 }

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -307,6 +307,7 @@ void CaptureStore::clear()
     maxLineLength_ = 0;
     nextSegmentId_ = 0;
     lastModified_ = QDateTime::currentDateTime();
+    lastTrimResult_ = {};
 
     const auto files = QDir( capturePath_ ).entryList( QDir::Files | QDir::NoDotAndDotDot );
     for ( const auto& fileName : files ) {
@@ -317,7 +318,11 @@ void CaptureStore::clear()
         rollingOutput_.deleteAll();
         rollingOutput_ = RollingFileManager( boundOutputFile_, limits_.rollingMaxFileSize,
                                              limits_.rollingBackupCount );
-        rollingOutput_.open( true );
+        if ( !rollingOutput_.open( true ) ) {
+            LOG_WARNING << "CaptureStore::clear: failed to reopen output file: "
+                        << boundOutputFile_;
+            boundOutputFile_.clear();
+        }
     }
 }
 
@@ -452,6 +457,9 @@ bool CaptureStore::bindOutputFile( const QString& outputPath )
             return false;
         }
     }
+    // Replay writes directly to QFile, bypassing RollingFileManager::write().
+    // Sync the byte counter so needsRotation() reflects the true file size.
+    rollingOutput_.resyncSize();
     rollingOutput_.flush();
 
     resetOutputFlushCounters();
@@ -1129,17 +1137,6 @@ bool CaptureStore::writeSegmentToDevice( const Segment& segment, QIODevice* devi
     return true;
 }
 
-bool CaptureStore::writeCaptureToDevice( QIODevice* device ) const
-{
-    for ( const auto& segment : segments_ ) {
-        if ( !writeSegmentToDevice( segment, device ) ) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 void CaptureStore::appendOutputBytes( const QByteArray& bytes, int lineCount )
 {
     if ( !rollingOutput_.isValid() ) {
@@ -1174,7 +1171,15 @@ void CaptureStore::flushOutputIfNeeded()
 
     if ( unflushedOutputBytes_ >= OutputFlushBytesThreshold
          || unflushedOutputLines_ >= OutputFlushLinesThreshold ) {
-        rollingOutput_.flush();
+        if ( !rollingOutput_.flush() ) {
+            LOG_WARNING << "Rolling output file flush failed, unbinding: "
+                        << boundOutputFile_;
+            rollingOutput_.close();
+            rollingOutput_ = RollingFileManager();
+            boundOutputFile_.clear();
+            resetOutputFlushCounters();
+            return;
+        }
         resetOutputFlushCounters();
         if ( outputFlushedCallback_ ) {
             outputFlushedCallback_();
@@ -1191,11 +1196,8 @@ void CaptureStore::resetOutputFlushCounters()
 void CaptureStore::trimToWindowSize()
 {
     // Called when the rolling file rotates. Trim in-memory segments to match the window.
-    // The caller (appendOutputBytes) already holds the mutex via commitLines → appendUtf8.
-    const auto windowBytes = limits_.rollingMaxFileSize > 0 && limits_.rollingBackupCount > 0
-                                 ? limits_.rollingMaxFileSize * limits_.rollingBackupCount
-                                 : qint64{ 0 };
-    if ( windowBytes > 0 ) {
-        trimToLimits();
-    }
+    // trimToLimits() already checks whether any limits are configured and
+    // acquires the (recursive) mutex — safe because the caller chain
+    // (appendOutputBytes → commitLines → appendUtf8) already holds it.
+    trimToLimits();
 }

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -360,10 +360,18 @@ CaptureStore::TrimResult CaptureStore::trimToLimits()
         return result;
     }
 
-    // Rolling window: rollingMaxFileSize * rollingBackupCount
-    const auto windowBytes = limits_.rollingMaxFileSize > 0 && limits_.rollingBackupCount > 0
-                                 ? limits_.rollingMaxFileSize * limits_.rollingBackupCount
-                                 : qint64{ 0 };
+    // Rolling window: rollingMaxFileSize * rollingBackupCount.
+    // backupCount is the number of retained backups; the current file is
+    // tracked separately via fileSize_.  Use checked multiplication to guard
+    // against overflow from hand-edited or session-restored limits.
+    qint64 windowBytes = 0;
+    if ( limits_.rollingMaxFileSize > 0 && limits_.rollingBackupCount > 0 ) {
+        const auto backupCount = static_cast<qint64>( limits_.rollingBackupCount );
+        windowBytes
+            = limits_.rollingMaxFileSize > std::numeric_limits<qint64>::max() / backupCount
+                  ? std::numeric_limits<qint64>::max()
+                  : limits_.rollingMaxFileSize * backupCount;
+    }
     const auto exceedsBytes = windowBytes > 0 && fileSize_ > windowBytes;
     const auto exceedsLines = limits_.maxTotalLines > 0 && totalLines_ > limits_.maxTotalLines;
 
@@ -417,7 +425,8 @@ CaptureStore::TrimResult CaptureStore::trimToLimits()
     // O(1) cumulative line count fixup: subtract removed lines from all remaining segments
     if ( totalRemovedLines > 0 ) {
         for ( auto& segment : segments_ ) {
-            segment.cumulativeEndLine -= totalRemovedLines;
+            segment.cumulativeEndLine
+                -= static_cast<qint64>( totalRemovedLines );
         }
     }
 

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -42,6 +42,28 @@ void reserveSegmentMemory( QByteArray& data, qint64 targetBytes, qint64 budgetBy
     data.reserve( type_safe::narrow_cast<int>( cappedTarget ) );
 }
 
+// Appended lines always live at the tail of the store. Their first line number
+// must be derived from the CURRENT total (after commit + trim) so it stays
+// correct when trimming shifts every absolute line number down. Using the
+// pre-commit total leaves firstLine stale (too large by the trimmed count).
+LineNumber tailFirstLine( qint64 totalLines, LinesCount lineCount )
+{
+    const auto count = static_cast<qint64>( lineCount.get() );
+    return LineNumber( static_cast<LineNumber::UnderlyingType>(
+        totalLines >= count ? totalLines - count : 0 ) );
+}
+
+// Clamp untrusted limit inputs (session-restore JSON, hand-edited .ini) so the
+// rolling window math (rollingMaxFileSize * rollingBackupCount) and the backup
+// cleanup loop stay within their integer ranges.
+CaptureStore::Limits sanitizeLimits( CaptureStore::Limits limits )
+{
+    constexpr int kMaxRollingBackupCount = 100000;
+    limits.rollingBackupCount
+        = std::clamp( limits.rollingBackupCount, 0, kMaxRollingBackupCount );
+    return limits;
+}
+
 QDateTime latestModificationTime( const QFileInfo& entry )
 {
     auto latestModification = entry.lastModified().toUTC();
@@ -111,7 +133,7 @@ CaptureStore::CaptureStore( QString captureId, QString rootPath, Limits limits )
     : captureId_( std::move( captureId ) )
     , rootPath_( rootPath.isEmpty() ? defaultRootPath() : std::move( rootPath ) )
     , capturePath_( QDir( rootPath_ ).filePath( captureId_ ) )
-    , limits_( limits )
+    , limits_( sanitizeLimits( limits ) )
 {
     ensureCaptureDir();
 }
@@ -234,6 +256,7 @@ CaptureStore::AppendResult CaptureStore::appendUtf8( const QByteArray& data )
         appendResult.lineCount
             = LinesCount( static_cast<LinesCount::UnderlyingType>( appendResult.endOfLines.size() ) );
         commitLines( appendResult );
+        appendResult.firstLine = tailFirstLine( totalLines_, appendResult.lineCount );
         if ( totalLines_ != originalLineCount ) {
             lastModified_ = QDateTime::currentDateTime();
         }
@@ -251,6 +274,7 @@ CaptureStore::AppendResult CaptureStore::appendUtf8( const QByteArray& data )
     appendResult.lineCount
         = LinesCount( static_cast<LinesCount::UnderlyingType>( appendResult.endOfLines.size() ) );
     commitLines( appendResult );
+    appendResult.firstLine = tailFirstLine( totalLines_, appendResult.lineCount );
     if ( totalLines_ != originalLineCount ) {
         lastModified_ = QDateTime::currentDateTime();
     }
@@ -276,6 +300,7 @@ CaptureStore::AppendResult CaptureStore::finishInput()
         appendResult.lineCount = 1_lcount;
         lastModified_ = QDateTime::currentDateTime();
     }
+    appendResult.firstLine = tailFirstLine( totalLines_, appendResult.lineCount );
 
     // Flush any pending output data
     if ( rollingOutput_.isValid() && unflushedOutputBytes_ > 0 ) {
@@ -474,7 +499,7 @@ void CaptureStore::setOutputFlushedCallback( std::function<void()> callback )
 void CaptureStore::setLimits( Limits limits )
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
-    limits_ = std::move( limits );
+    limits_ = sanitizeLimits( std::move( limits ) );
 }
 
 QString CaptureStore::boundOutputFile() const
@@ -1143,7 +1168,6 @@ void CaptureStore::appendOutputBytes( const QByteArray& bytes, int lineCount )
         return;
     }
 
-    const auto sizeBefore = rollingOutput_.currentFileSize();
     const auto written = rollingOutput_.write( bytes );
     if ( written <= 0 ) {
         LOG_WARNING << "Rolling output file write failed, unbinding: " << boundOutputFile_;
@@ -1153,8 +1177,12 @@ void CaptureStore::appendOutputBytes( const QByteArray& bytes, int lineCount )
         return;
     }
 
-    // Detect rotation: if file size decreased, a rotation happened
-    if ( rollingOutput_.currentFileSize() < sizeBefore ) {
+    // write() now writes the whole batch across rotations and reports whether it
+    // rotated. The previous size-before/after heuristic missed rotations that
+    // left the new file at least as large as the old one (e.g. a single write
+    // that fills, rotates and writes a large remainder from an empty file),
+    // skipping the in-memory window trim on the single-line commit path.
+    if ( rollingOutput_.rotated() ) {
         trimToWindowSize();
     }
 

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -1,14 +1,24 @@
 #include "rollingfilemanager.h"
 
+#include <algorithm>
+
 #include <QDir>
 #include <QFileInfo>
 
 #include "log.h"
 
+namespace {
+// Sanity ceiling for backupCount. The GUI spinbox tops out at 999, but the
+// value also arrives from session-restore JSON / Configuration without range
+// validation; clamping here keeps every `backupCount_ + N` expression safely
+// within int range (and the rolling-window byte product within qint64).
+constexpr int kMaxBackupCount = 100000;
+} // namespace
+
 RollingFileManager::RollingFileManager( QString basePath, qint64 maxFileSize, int backupCount )
     : basePath_( std::move( basePath ) )
     , maxFileSize_( maxFileSize )
-    , backupCount_( backupCount )
+    , backupCount_( std::clamp( backupCount, 0, kMaxBackupCount ) )
 {
 }
 
@@ -95,86 +105,86 @@ qint64 RollingFileManager::write( const QByteArray& data )
         return 0;
     }
 
-    // Auto-rotate if current file is full (from previous writes)
-    if ( needsRotation() ) {
-        if ( !rotateInternal() ) {
-            return 0;
-        }
-    }
+    rotated_ = false;
 
-    // maxFileSize_ = 0 means no rolling: write everything without size checks
-    if ( maxFileSize_ <= 0 ) {
-        const auto written = currentFile_.write( data );
-        if ( written > 0 ) {
-            currentBytes_ += written;
-        }
-        return written;
-    }
+    qint64 totalWritten = 0;
+    int offset = 0;
+    const int size = static_cast<int>( data.size() );
 
-    const auto remainingCapacity = maxFileSize_ - currentBytes_;
-
-    // If the entire data fits, write it all
-    if ( data.size() <= remainingCapacity ) {
-        const auto written = currentFile_.write( data );
-        if ( written > 0 ) {
-            currentBytes_ += written;
-        }
-        // Rotate if we've hit the limit
+    while ( offset < size ) {
+        // Auto-rotate if the current file is full from previous writes.
         if ( needsRotation() ) {
-            rotateInternal();
-        }
-        return written;
-    }
-
-    // Data doesn't fit entirely. Find the last complete line that fits.
-    // Write only complete lines to avoid splitting across files.
-    auto bytesToWrite = static_cast<qint64>( data.size() );
-    if ( bytesToWrite > remainingCapacity ) {
-        bytesToWrite = remainingCapacity;
-    }
-
-    // Search backwards for a newline within the write range
-    const auto lastNewline = data.lastIndexOf( '\n', static_cast<int>( bytesToWrite ) - 1 );
-    if ( lastNewline >= 0 ) {
-        // Write up to and including the last complete line
-        bytesToWrite = lastNewline + 1;
-    }
-    else {
-        // No complete line fits in remaining space. Rotate first, then retry.
-        if ( !rotateInternal() ) {
-            return 0;
-        }
-        // After rotation, the file is fresh. Write the entire data.
-        const auto written = currentFile_.write( data );
-        if ( written > 0 ) {
-            currentBytes_ += written;
-        }
-        return written;
-    }
-
-    if ( bytesToWrite <= 0 ) {
-        return 0;
-    }
-
-    const auto written = currentFile_.write( data.constData(), bytesToWrite );
-    if ( written > 0 ) {
-        currentBytes_ += written;
-    }
-
-    // Rotate if we've hit the limit, then write remaining data to the new file
-    if ( needsRotation() ) {
-        rotateInternal();
-        const auto remaining = data.mid( static_cast<int>( written ) );
-        if ( !remaining.isEmpty() && currentFile_.isOpen() ) {
-            const auto extraWritten = currentFile_.write( remaining );
-            if ( extraWritten > 0 ) {
-                currentBytes_ += extraWritten;
+            if ( !rotateInternal() ) {
+                break; // unable to rotate; preserve what was already written
             }
-            return written + extraWritten;
+        }
+
+        // maxFileSize_ = 0 means no rolling: write everything left in one go.
+        if ( maxFileSize_ <= 0 ) {
+            const auto written = currentFile_.write( data.constData() + offset, size - offset );
+            if ( written > 0 ) {
+                currentBytes_ += written;
+                totalWritten += written;
+            }
+            break;
+        }
+
+        const qint64 remainingCapacity = maxFileSize_ - currentBytes_;
+        const qint64 chunkLeft = static_cast<qint64>( size ) - offset;
+
+        // The entire remainder fits in the current file.
+        if ( chunkLeft <= remainingCapacity ) {
+            const auto written = currentFile_.write( data.constData() + offset,
+                                                     static_cast<qint64>( chunkLeft ) );
+            if ( written > 0 ) {
+                currentBytes_ += written;
+                totalWritten += written;
+            }
+            if ( needsRotation() ) {
+                rotateInternal();
+            }
+            break;
+        }
+
+        // Find the last newline within the capacity window so only complete
+        // lines are written to this file (a line is never split across files).
+        const auto searchFrom = static_cast<int>(
+            std::min<qint64>( offset + remainingCapacity - 1, size - 1 ) );
+        const auto lastNewline = data.lastIndexOf( '\n', searchFrom );
+
+        if ( lastNewline >= offset ) {
+            const auto bytesToWrite = lastNewline - offset + 1;
+            const auto written = currentFile_.write( data.constData() + offset, bytesToWrite );
+            if ( written <= 0 ) {
+                break;
+            }
+            currentBytes_ += written;
+            totalWritten += written;
+            offset += static_cast<int>( written );
+            // Loop: the file is now (near) full, so the next iteration rotates
+            // and continues writing the remaining complete lines.
+        }
+        else {
+            // No complete line fits in the remaining capacity: the next line is
+            // longer than the space left. Rotate to a fresh file and write that
+            // one (possibly oversized) line whole so nothing is dropped.
+            if ( !rotateInternal() ) {
+                break;
+            }
+            const auto nextNewline = data.indexOf( '\n', offset );
+            const int lineEnd = ( nextNewline >= 0 ) ? static_cast<int>( nextNewline ) + 1 : size;
+            const auto written = currentFile_.write( data.constData() + offset,
+                                                     lineEnd - offset );
+            if ( written <= 0 ) {
+                break;
+            }
+            currentBytes_ += written;
+            totalWritten += written;
+            offset = lineEnd;
         }
     }
 
-    return written;
+    return totalWritten;
 }
 
 void RollingFileManager::rotate()
@@ -186,6 +196,11 @@ bool RollingFileManager::needsRotation() const
 {
     // maxFileSize_ = 0 means no rolling (single unlimited file)
     return maxFileSize_ > 0 && currentBytes_ >= maxFileSize_;
+}
+
+bool RollingFileManager::rotated() const
+{
+    return rotated_;
 }
 
 qint64 RollingFileManager::currentFileSize() const
@@ -258,7 +273,11 @@ QString RollingFileManager::backupPath( int index ) const
 
 void RollingFileManager::cleanupOldBackups()
 {
-    for ( int i = backupCount_; i < backupCount_ + 100; ++i ) {
+    // backupCount_ is clamped to kMaxBackupCount at construction, so this upper
+    // bound can never overflow int (the previous `backupCount_ + 100` was UB
+    // when backupCount_ was within 100 of INT_MAX and skipped cleanup entirely).
+    const int scanLimit = backupCount_ + 100;
+    for ( int i = backupCount_; i < scanLimit; ++i ) {
         const auto path = backupPath( i );
         if ( QFile::exists( path ) ) {
             QFile::remove( path );
@@ -287,6 +306,8 @@ bool RollingFileManager::rotateInternal()
     if ( !currentFile_.isOpen() ) {
         return openNewFile();
     }
+
+    rotated_ = true;
 
     // 1. Flush pending data
     currentFile_.flush();

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -22,8 +22,13 @@ RollingFileManager::RollingFileManager( RollingFileManager&& other ) noexcept
     if ( other.currentFile_.isOpen() ) {
         other.currentFile_.close();
         currentFile_.setFileName( basePath_ );
-        (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
-        currentBytes_ = currentFile_.size();
+        if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::Append ) ) {
+            currentBytes_ = currentFile_.size();
+        }
+        else {
+            LOG_WARNING << "RollingFileManager: reopen failed during move: " << basePath_;
+            currentBytes_ = 0;
+        }
     }
 }
 
@@ -38,8 +43,14 @@ RollingFileManager& RollingFileManager::operator=( RollingFileManager&& other ) 
         if ( other.currentFile_.isOpen() ) {
             other.currentFile_.close();
             currentFile_.setFileName( basePath_ );
-            (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
-            currentBytes_ = currentFile_.size();
+            if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::Append ) ) {
+                currentBytes_ = currentFile_.size();
+            }
+            else {
+                LOG_WARNING << "RollingFileManager: reopen failed during move assign: "
+                            << basePath_;
+                currentBytes_ = 0;
+            }
         }
     }
     return *this;
@@ -70,11 +81,12 @@ void RollingFileManager::close()
     currentBytes_ = 0;
 }
 
-void RollingFileManager::flush()
+bool RollingFileManager::flush()
 {
     if ( currentFile_.isOpen() ) {
-        currentFile_.flush();
+        return currentFile_.flush();
     }
+    return false;
 }
 
 qint64 RollingFileManager::write( const QByteArray& data )
@@ -206,6 +218,13 @@ QStringList RollingFileManager::backupFiles() const
         }
     }
     return files;
+}
+
+void RollingFileManager::resyncSize()
+{
+    if ( currentFile_.isOpen() ) {
+        currentBytes_ = currentFile_.size();
+    }
 }
 
 void RollingFileManager::deleteAll()

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -1,0 +1,313 @@
+#include "rollingfilemanager.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+#include "log.h"
+
+RollingFileManager::RollingFileManager( QString basePath, qint64 maxFileSize, int backupCount )
+    : basePath_( std::move( basePath ) )
+    , maxFileSize_( maxFileSize )
+    , backupCount_( backupCount )
+{
+}
+
+RollingFileManager::RollingFileManager( RollingFileManager&& other ) noexcept
+    : basePath_( std::move( other.basePath_ ) )
+    , maxFileSize_( other.maxFileSize_ )
+    , backupCount_( other.backupCount_ )
+    , currentBytes_( other.currentBytes_ )
+{
+    // Move the file handle by closing the old one and reopening in the new instance
+    if ( other.currentFile_.isOpen() ) {
+        other.currentFile_.close();
+        currentFile_.setFileName( basePath_ );
+        (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
+        currentBytes_ = currentFile_.size();
+    }
+}
+
+RollingFileManager& RollingFileManager::operator=( RollingFileManager&& other ) noexcept
+{
+    if ( this != &other ) {
+        close();
+        basePath_ = std::move( other.basePath_ );
+        maxFileSize_ = other.maxFileSize_;
+        backupCount_ = other.backupCount_;
+        currentBytes_ = other.currentBytes_;
+        if ( other.currentFile_.isOpen() ) {
+            other.currentFile_.close();
+            currentFile_.setFileName( basePath_ );
+            (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
+            currentBytes_ = currentFile_.size();
+        }
+    }
+    return *this;
+}
+
+bool RollingFileManager::isValid() const
+{
+    // Valid if we have a path. maxFileSize=0 means no rolling (single unlimited file).
+    return !basePath_.isEmpty();
+}
+
+bool RollingFileManager::open( bool truncate )
+{
+    if ( !isValid() ) {
+        return false;
+    }
+
+    QDir().mkpath( QFileInfo( basePath_ ).absolutePath() );
+    return openNewFile( truncate );
+}
+
+void RollingFileManager::close()
+{
+    if ( currentFile_.isOpen() ) {
+        currentFile_.flush();
+        currentFile_.close();
+    }
+    currentBytes_ = 0;
+}
+
+void RollingFileManager::flush()
+{
+    if ( currentFile_.isOpen() ) {
+        currentFile_.flush();
+    }
+}
+
+qint64 RollingFileManager::write( const QByteArray& data )
+{
+    if ( data.isEmpty() || !currentFile_.isOpen() ) {
+        return 0;
+    }
+
+    // Auto-rotate if current file is full (from previous writes)
+    if ( needsRotation() ) {
+        if ( !rotateInternal() ) {
+            return 0;
+        }
+    }
+
+    // maxFileSize_ = 0 means no rolling: write everything without size checks
+    if ( maxFileSize_ <= 0 ) {
+        const auto written = currentFile_.write( data );
+        if ( written > 0 ) {
+            currentBytes_ += written;
+        }
+        return written;
+    }
+
+    const auto remainingCapacity = maxFileSize_ - currentBytes_;
+
+    // If the entire data fits, write it all
+    if ( data.size() <= remainingCapacity ) {
+        const auto written = currentFile_.write( data );
+        if ( written > 0 ) {
+            currentBytes_ += written;
+        }
+        // Rotate if we've hit the limit
+        if ( needsRotation() ) {
+            rotateInternal();
+        }
+        return written;
+    }
+
+    // Data doesn't fit entirely. Find the last complete line that fits.
+    // Write only complete lines to avoid splitting across files.
+    auto bytesToWrite = static_cast<qint64>( data.size() );
+    if ( bytesToWrite > remainingCapacity ) {
+        bytesToWrite = remainingCapacity;
+    }
+
+    // Search backwards for a newline within the write range
+    const auto lastNewline = data.lastIndexOf( '\n', static_cast<int>( bytesToWrite ) - 1 );
+    if ( lastNewline >= 0 ) {
+        // Write up to and including the last complete line
+        bytesToWrite = lastNewline + 1;
+    }
+    else {
+        // No complete line fits in remaining space. Rotate first, then retry.
+        if ( !rotateInternal() ) {
+            return 0;
+        }
+        // After rotation, the file is fresh. Write the entire data.
+        const auto written = currentFile_.write( data );
+        if ( written > 0 ) {
+            currentBytes_ += written;
+        }
+        return written;
+    }
+
+    if ( bytesToWrite <= 0 ) {
+        return 0;
+    }
+
+    const auto written = currentFile_.write( data.constData(), bytesToWrite );
+    if ( written > 0 ) {
+        currentBytes_ += written;
+    }
+
+    // Rotate if we've hit the limit, then write remaining data to the new file
+    if ( needsRotation() ) {
+        rotateInternal();
+        const auto remaining = data.mid( static_cast<int>( written ) );
+        if ( !remaining.isEmpty() && currentFile_.isOpen() ) {
+            const auto extraWritten = currentFile_.write( remaining );
+            if ( extraWritten > 0 ) {
+                currentBytes_ += extraWritten;
+            }
+            return written + extraWritten;
+        }
+    }
+
+    return written;
+}
+
+void RollingFileManager::rotate()
+{
+    rotateInternal();
+}
+
+bool RollingFileManager::needsRotation() const
+{
+    // maxFileSize_ = 0 means no rolling (single unlimited file)
+    return maxFileSize_ > 0 && currentBytes_ >= maxFileSize_;
+}
+
+qint64 RollingFileManager::currentFileSize() const
+{
+    return currentBytes_;
+}
+
+qint64 RollingFileManager::maxFileSize() const
+{
+    return maxFileSize_;
+}
+
+int RollingFileManager::backupCount() const
+{
+    return backupCount_;
+}
+
+QFile* RollingFileManager::currentFile()
+{
+    return currentFile_.isOpen() ? &currentFile_ : nullptr;
+}
+
+QStringList RollingFileManager::backupFiles() const
+{
+    QStringList files;
+    for ( int i = 0; i <= backupCount_ + 1; ++i ) {
+        const auto path = backupPath( i );
+        if ( QFile::exists( path ) ) {
+            files.append( path );
+        }
+    }
+    return files;
+}
+
+void RollingFileManager::deleteAll()
+{
+    close();
+    QFile::remove( basePath_ );
+    for ( int i = 0; i <= backupCount_ + 10; ++i ) {
+        QFile::remove( backupPath( i ) );
+    }
+    QFile::remove( basePath_ + QStringLiteral( ".tmp_rotate" ) );
+}
+
+QString RollingFileManager::backupPath( int index ) const
+{
+    return basePath_ + QStringLiteral( ".%1" ).arg( index );
+}
+
+void RollingFileManager::cleanupOldBackups()
+{
+    for ( int i = backupCount_; i < backupCount_ + 100; ++i ) {
+        const auto path = backupPath( i );
+        if ( QFile::exists( path ) ) {
+            QFile::remove( path );
+        }
+        else {
+            break;
+        }
+    }
+}
+
+bool RollingFileManager::openNewFile( bool truncate )
+{
+    currentFile_.setFileName( basePath_ );
+    const auto mode = truncate ? ( QIODevice::WriteOnly | QIODevice::Truncate )
+                               : ( QIODevice::WriteOnly | QIODevice::Append );
+    if ( !currentFile_.open( mode ) ) {
+        LOG_WARNING << "RollingFileManager: failed to open " << basePath_;
+        return false;
+    }
+    currentBytes_ = truncate ? 0 : currentFile_.size();
+    return true;
+}
+
+bool RollingFileManager::rotateInternal()
+{
+    if ( !currentFile_.isOpen() ) {
+        return openNewFile();
+    }
+
+    // 1. Flush pending data
+    currentFile_.flush();
+
+    // 2. Open temp file BEFORE closing old one (no data loss gap)
+    const auto tmpPath = basePath_ + QStringLiteral( ".tmp_rotate" );
+    QFile tmpFile( tmpPath );
+    if ( !tmpFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
+        LOG_WARNING << "RollingFileManager: failed to open temp file: " << tmpPath;
+        return false;
+    }
+    tmpFile.close();
+
+    // 3. Close old current file
+    currentFile_.close();
+
+    // 4. Shift backups: backup[i-1] → backup[i] (oldest first to avoid overwrite)
+    //    This frees up backup[0] for the old current file.
+    for ( int i = backupCount_ - 1; i >= 0; --i ) {
+        const auto src = backupPath( i );
+        const auto dst = backupPath( i + 1 );
+        QFile::remove( dst );
+        if ( QFile::exists( src ) ) {
+            QFile::rename( src, dst );
+        }
+    }
+
+    // 5. Rename old current → backup[0]
+    const auto backup0 = backupPath( 0 );
+    QFile::remove( backup0 );
+    if ( !QFile::rename( basePath_, backup0 ) ) {
+        LOG_WARNING << "RollingFileManager: rename failed: " << basePath_ << " → " << backup0;
+        // Restore: reopen old file as current
+        currentFile_.setFileName( basePath_ );
+        (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
+        currentBytes_ = currentFile_.size();
+        QFile::remove( tmpPath );
+        return false;
+    }
+
+    // 6. Rename temp → new current
+    if ( !QFile::rename( tmpPath, basePath_ ) ) {
+        LOG_WARNING << "RollingFileManager: rename failed: " << tmpPath << " → " << basePath_;
+        // Restore
+        QFile::rename( backup0, basePath_ );
+        currentFile_.setFileName( basePath_ );
+        (void) currentFile_.open( QIODevice::WriteOnly | QIODevice::Append );
+        currentBytes_ = currentFile_.size();
+        return false;
+    }
+
+    // 7. Cleanup excess backups
+    cleanupOldBackups();
+
+    // 8. Open new current file
+    return openNewFile();
+}

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -211,10 +211,17 @@ QFile* RollingFileManager::currentFile()
 QStringList RollingFileManager::backupFiles() const
 {
     QStringList files;
-    for ( int i = 0; i <= backupCount_ + 1; ++i ) {
+    // When backupCount_ = 0 (keep all), search a reasonable upper bound;
+    // otherwise search up to backupCount_ + 1 to catch any excess.
+    const int searchLimit = ( backupCount_ > 0 ) ? backupCount_ + 1 : 100;
+    for ( int i = 0; i <= searchLimit; ++i ) {
         const auto path = backupPath( i );
         if ( QFile::exists( path ) ) {
             files.append( path );
+        }
+        else if ( i > 0 ) {
+            // Stop at the first gap — backups are numbered sequentially
+            break;
         }
     }
     return files;
@@ -231,8 +238,15 @@ void RollingFileManager::deleteAll()
 {
     close();
     QFile::remove( basePath_ );
-    for ( int i = 0; i <= backupCount_ + 10; ++i ) {
-        QFile::remove( backupPath( i ) );
+    const int searchLimit = ( backupCount_ > 0 ) ? backupCount_ + 10 : 100;
+    for ( int i = 0; i <= searchLimit; ++i ) {
+        const auto path = backupPath( i );
+        if ( QFile::exists( path ) ) {
+            QFile::remove( path );
+        }
+        else if ( i > 0 ) {
+            break;
+        }
     }
     QFile::remove( basePath_ + QStringLiteral( ".tmp_rotate" ) );
 }
@@ -289,9 +303,26 @@ bool RollingFileManager::rotateInternal()
     // 3. Close old current file
     currentFile_.close();
 
-    // 4. Shift backups: backup[i-1] → backup[i] (oldest first to avoid overwrite)
+    // 4. Shift backups: backup[i-1] → backup[i] (oldest first to avoid overwrite).
     //    This frees up backup[0] for the old current file.
-    for ( int i = backupCount_ - 1; i >= 0; --i ) {
+    //    When backupCount_ = 0 (keep all), shift all existing backups up.
+    int shiftUpper;
+    if ( backupCount_ > 0 ) {
+        shiftUpper = backupCount_ - 1;
+    }
+    else {
+        // Find the highest existing backup index
+        shiftUpper = 0;
+        for ( int probe = 0; probe < 1000; ++probe ) {
+            if ( QFile::exists( backupPath( probe ) ) ) {
+                shiftUpper = probe;
+            }
+            else if ( probe > 0 ) {
+                break;
+            }
+        }
+    }
+    for ( int i = shiftUpper; i >= 0; --i ) {
         const auto src = backupPath( i );
         const auto dst = backupPath( i + 1 );
         QFile::remove( dst );
@@ -324,8 +355,10 @@ bool RollingFileManager::rotateInternal()
         return false;
     }
 
-    // 7. Cleanup excess backups
-    cleanupOldBackups();
+    // 7. Cleanup excess backups (skip when backupCount_ = 0: keep all rotated files)
+    if ( backupCount_ > 0 ) {
+        cleanupOldBackups();
+    }
 
     // 8. Open new current file
     return openNewFile();

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -64,21 +64,19 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     const auto t2 = std::chrono::steady_clock::now();
 #endif
 
-    // Check if trimming occurred during append (oldest segments removed due to limits)
-    const auto trimResult = captureStore_.lastTrimResult();
+    // consumeTrimResult() clears line-keyed caches when CaptureStore trimmed
+    // during the append (oldest segments removed -> absolute line numbers shift).
+    const auto trimResult = consumeTrimResult();
     const bool wasTrimmed = trimResult.trimmedLines > 0_lcount;
-    if ( wasTrimmed ) {
-        captureStore_.clearTrimResult();
-        // Invalidate caches since line numbers shifted
-        {
-            std::lock_guard<std::mutex> lock( cachedRawBatchesMutex_ );
-            cachedRawBatches_.clear();
-            cachedRawBytes_ = 0;
-        }
-        clearAnsiDisplayCache();
-    }
 
-    rememberAppendedRawLines( appendResult );
+    // Cache the appended batch unless trimming removed some of its own lines
+    // (a burst larger than the whole window): then the batch no longer lines up
+    // with the surviving tail and serving it would return stale data.
+    const auto preAppendTotal = static_cast<qint64>( previousLineCount.get() );
+    if ( !wasTrimmed
+         || static_cast<qint64>( trimResult.trimmedLines.get() ) <= preAppendTotal ) {
+        rememberAppendedRawLines( appendResult );
+    }
 
 #ifdef KLOGG_PERF_MEASURE_STREAMING
     const auto t3 = std::chrono::steady_clock::now();
@@ -118,15 +116,48 @@ void StreamingLogData::finishInput()
     stopOutputFlushTimer();
     const auto previousLineCount = captureStore_.lineCount();
     const auto appendResult = captureStore_.finishInput();
-    rememberAppendedRawLines( appendResult );
+
+    // finishInput() can rotate+trim the Preserve-mode output via the single-line
+    // commit path (commitLine -> appendOutputBytes). Handle it exactly like
+    // appendUtf8() so caches stay consistent and Truncated fires — previously
+    // finishInput() skipped this entirely.
+    const auto trimResult = consumeTrimResult();
+    const bool wasTrimmed = trimResult.trimmedLines > 0_lcount;
+    const auto preAppendTotal = static_cast<qint64>( previousLineCount.get() );
+    if ( !wasTrimmed
+         || static_cast<qint64>( trimResult.trimmedLines.get() ) <= preAppendTotal ) {
+        rememberAppendedRawLines( appendResult );
+    }
+
     // Same tail-position write as appendUtf8() — never an underflowing delta.
     writeAppendedDisplayLines( appendResult );
+    if ( wasTrimmed ) {
+        Q_EMIT fileChanged( MonitoredFileStatus::Truncated );
+    }
     const auto currentLineCount = captureStore_.lineCount();
     if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
     }
     rollingDisplayOutput_.flush();
+}
+
+CaptureStore::TrimResult StreamingLogData::consumeTrimResult()
+{
+    const auto trimResult = captureStore_.lastTrimResult();
+    if ( trimResult.trimmedLines <= 0_lcount ) {
+        return trimResult;
+    }
+    captureStore_.clearTrimResult();
+    // Trimming removes oldest segments, shifting every absolute line number
+    // down; both caches are keyed by absolute line number, so drop them all.
+    {
+        std::lock_guard<std::mutex> lock( cachedRawBatchesMutex_ );
+        cachedRawBatches_.clear();
+        cachedRawBytes_ = 0;
+    }
+    clearAnsiDisplayCache();
+    return trimResult;
 }
 
 void StreamingLogData::clearCapture()

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -85,11 +85,12 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
 #endif
 
     const auto currentLineCount = captureStore_.lineCount();
-    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip
-         && currentLineCount != previousLineCount ) {
-        writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
-                                   currentLineCount - previousLineCount );
-    }
+    // Write the freshly appended lines to the Strip-mode display file.  This
+    // MUST go by appended count / tail position (see writeAppendedDisplayLines),
+    // NOT by a [previousLineCount, currentLineCount) delta: trimming can remove
+    // more lines than were appended, making currentLineCount < previousLineCount
+    // and underflowing the uint64 range -> std::length_error -> SIGABRT.
+    writeAppendedDisplayLines( appendResult );
     if ( wasTrimmed ) {
         Q_EMIT fileChanged( MonitoredFileStatus::Truncated );
     }
@@ -104,7 +105,7 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     const auto cacheUs = std::chrono::duration_cast<std::chrono::microseconds>( t3 - t2 ).count();
     const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>( t4 - t0 ).count();
     LOG_INFO << "PERF [streaming] appendUtf8 size=" << data.size()
-             << " lines=" << ( currentLineCount.get() - previousLineCount.get() )
+             << " lines=" << appendResult.lineCount.get()
              << " trimmed=" << trimResult.trimmedLines.get()
              << " capture_us=" << captureUs
              << " cache_us=" << cacheUs
@@ -118,12 +119,9 @@ void StreamingLogData::finishInput()
     const auto previousLineCount = captureStore_.lineCount();
     const auto appendResult = captureStore_.finishInput();
     rememberAppendedRawLines( appendResult );
+    // Same tail-position write as appendUtf8() — never an underflowing delta.
+    writeAppendedDisplayLines( appendResult );
     const auto currentLineCount = captureStore_.lineCount();
-    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip
-         && currentLineCount != previousLineCount ) {
-        writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
-                                   currentLineCount - previousLineCount );
-    }
     if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
@@ -481,12 +479,47 @@ bool StreamingLogData::writeDisplayLinesToOutput( LineNumber first, LinesCount c
     return true;
 }
 
+void StreamingLogData::writeAppendedDisplayLines( const CaptureStore::AppendResult& appendResult )
+{
+    if ( outputSaveAnsiMode_ != LiveLogSaveAnsiMode::Strip ) {
+        return;
+    }
+
+    const auto appended = appendResult.lineCount.get();
+    if ( appended == 0 ) {
+        return;
+    }
+
+    // CaptureStore::trimToLimits() removes oldest segments from the FRONT, so
+    // the freshly appended lines always live at the TAIL, at
+    // [totalLines - appended, totalLines).  Addressing them there is correct
+    // whether or not trimming occurred, and cannot underflow.
+    //
+    // The previous code used writeDisplayLinesToOutput(previousLineCount,
+    // currentLineCount - previousLineCount): when trimming removed more lines
+    // than were appended, currentLineCount < previousLineCount, the uint64
+    // subtraction wrapped to ~2^64, and getLines() reserve() threw
+    // std::length_error("vector") -> uncaught on the macOS main event loop ->
+    // SIGABRT (objc_exception_rethrow -> -[NSApplication run]).
+    const auto totalLines = captureStore_.lineCount().get();
+    const auto safeAppended = std::min( appended, totalLines );
+    const auto firstLine = totalLines - safeAppended;
+    writeDisplayLinesToOutput( LineNumber( firstLine ), LinesCount( safeAppended ) );
+}
+
 klogg::vector<QString> StreamingLogData::getLines( LineNumber first, LinesCount number ) const
 {
+    // Clamp to the valid [0, nbLine) range.  A caller may pass a first/count
+    // derived from line counts that shifted (e.g. after trimming); never throw
+    // std::length_error from reserve() on an out-of-range or inverted request —
+    // returning the available subset is the correct, crash-free behavior.
+    const auto totalLines = doGetNbLine().get();
+    const auto begin = std::min( first.get(), totalLines );
+    const auto count = std::min( number.get(), totalLines - begin );
+
     klogg::vector<QString> lines;
-    const auto lastLine = qMin( first.get() + number.get(), doGetNbLine().get() );
-    lines.reserve( qMax<LinesCount::UnderlyingType>( 0, lastLine - first.get() ) );
-    for ( auto line = first.get(); line < lastLine; ++line ) {
+    lines.reserve( static_cast<size_t>( count ) );
+    for ( auto line = begin; line < begin + count; ++line ) {
         lines.push_back( doGetLineString( LineNumber( line ) ) );
     }
     return lines;

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -7,8 +7,6 @@
 #include "logfiltereddata.h"
 
 namespace {
-constexpr qint64 OutputFlushBytesThreshold = 1024 * 1024;
-constexpr LinesCount::UnderlyingType OutputFlushLinesThreshold = 1000;
 constexpr qint64 CachedRawBatchBytesLimit = 256 * 1024 * 1024;
 constexpr int LiveAppendRefreshIntervalMs = 33;
 constexpr size_t AnsiDisplayCacheLineLimit = 4096;
@@ -29,9 +27,7 @@ StreamingLogData::StreamingLogData( QString captureId, QString captureRoot )
 
     outputFlushTimer_.setInterval( 1000 );
     connect( &outputFlushTimer_, &QTimer::timeout, this, [this] {
-        if ( boundOutputHandle_.isOpen() ) {
-            boundOutputHandle_.flush();
-        }
+        rollingDisplayOutput_.flush();
         if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Preserve ) {
             captureStore_.flush();
         }
@@ -68,6 +64,20 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     const auto t2 = std::chrono::steady_clock::now();
 #endif
 
+    // Check if trimming occurred during append (oldest segments removed due to limits)
+    const auto trimResult = captureStore_.lastTrimResult();
+    const bool wasTrimmed = trimResult.trimmedLines > 0_lcount;
+    if ( wasTrimmed ) {
+        captureStore_.clearTrimResult();
+        // Invalidate caches since line numbers shifted
+        {
+            std::lock_guard<std::mutex> lock( cachedRawBatchesMutex_ );
+            cachedRawBatches_.clear();
+            cachedRawBytes_ = 0;
+        }
+        clearAnsiDisplayCache();
+    }
+
     rememberAppendedRawLines( appendResult );
 
 #ifdef KLOGG_PERF_MEASURE_STREAMING
@@ -79,6 +89,9 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
          && currentLineCount != previousLineCount ) {
         writeDisplayLinesToOutput( LineNumber( previousLineCount.get() ),
                                    currentLineCount - previousLineCount );
+    }
+    if ( wasTrimmed ) {
+        Q_EMIT fileChanged( MonitoredFileStatus::Truncated );
     }
     if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
@@ -92,6 +105,7 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>( t4 - t0 ).count();
     LOG_INFO << "PERF [streaming] appendUtf8 size=" << data.size()
              << " lines=" << ( currentLineCount.get() - previousLineCount.get() )
+             << " trimmed=" << trimResult.trimmedLines.get()
              << " capture_us=" << captureUs
              << " cache_us=" << cacheUs
              << " total_us=" << totalUs;
@@ -114,9 +128,7 @@ void StreamingLogData::finishInput()
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
         scheduleLoadingFinished();
     }
-    if ( boundOutputHandle_.isOpen() ) {
-        boundOutputHandle_.flush();
-    }
+    rollingDisplayOutput_.flush();
 }
 
 void StreamingLogData::clearCapture()
@@ -124,6 +136,7 @@ void StreamingLogData::clearCapture()
     const auto timerWasActive = outputFlushTimer_.isActive();
     stopOutputFlushTimer();
     captureStore_.clear();
+    clearAnsiDisplayCache();
     clearAnsiDisplayCache();
     {
         std::lock_guard<std::mutex> lock( cachedRawBatchesMutex_ );
@@ -143,6 +156,13 @@ void StreamingLogData::clearCapture()
 
     Q_EMIT fileChanged( MonitoredFileStatus::Truncated );
     scheduleLoadingFinished();
+}
+
+void StreamingLogData::setCaptureLimits( CaptureStore::Limits limits )
+{
+    rollingMaxFileSize_ = limits.rollingMaxFileSize;
+    rollingBackupCount_ = limits.rollingBackupCount;
+    captureStore_.setLimits( std::move( limits ) );
 }
 
 bool StreamingLogData::bindOutputFile( const QString& outputPath )
@@ -409,8 +429,11 @@ bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
     }
 
     QDir().mkpath( QFileInfo( boundOutputFile_ ).absolutePath() );
-    boundOutputHandle_.setFileName( boundOutputFile_ );
-    if ( !boundOutputHandle_.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
+
+    // Use CaptureStore's rolling settings for the display file
+    rollingDisplayOutput_ = RollingFileManager( boundOutputFile_, rollingMaxFileSize_,
+                                                 rollingBackupCount_ );
+    if ( !rollingDisplayOutput_.open() ) {
         boundOutputFile_.clear();
         return false;
     }
@@ -420,49 +443,42 @@ bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
         return false;
     }
 
-    boundOutputHandle_.flush();
+    rollingDisplayOutput_.flush();
     return true;
 }
 
 void StreamingLogData::closeDisplayOutputFile()
 {
-    if ( boundOutputHandle_.isOpen() ) {
-        boundOutputHandle_.flush();
-        boundOutputHandle_.close();
-    }
+    rollingDisplayOutput_.close();
+    rollingDisplayOutput_ = RollingFileManager();
     boundOutputFile_.clear();
 }
 
 bool StreamingLogData::writeDisplayLinesToOutput( LineNumber first, LinesCount count )
 {
-    if ( !boundOutputHandle_.isOpen() || count <= 0_lcount ) {
+    if ( !rollingDisplayOutput_.isValid() || count <= 0_lcount ) {
         return true;
     }
 
-    qint64 unflushedBytes = 0;
-    LinesCount::UnderlyingType unflushedLines = 0;
     const auto lines = getLines( first, count );
     for ( const auto& line : lines ) {
-        const auto outputLine = processAnsiSequences( line, AnsiProcessingMode::Strip ).text.toUtf8();
-        if ( boundOutputHandle_.write( outputLine ) != outputLine.size()
-             || boundOutputHandle_.write( "\n", 1 ) != 1 ) {
+        auto outputLine = processAnsiSequences( line, AnsiProcessingMode::Strip ).text.toUtf8();
+        outputLine.append( '\n' );
+
+        const auto sizeBefore = rollingDisplayOutput_.currentFileSize();
+        const auto written = rollingDisplayOutput_.write( outputLine );
+        if ( written <= 0 ) {
             closeDisplayOutputFile();
             return false;
         }
 
-        unflushedBytes += outputLine.size() + 1;
-        ++unflushedLines;
-        if ( unflushedBytes >= OutputFlushBytesThreshold
-             || unflushedLines >= OutputFlushLinesThreshold ) {
-            if ( !boundOutputHandle_.flush() ) {
-                closeDisplayOutputFile();
-                return false;
-            }
-            unflushedBytes = 0;
-            unflushedLines = 0;
-        }
+        // If rotation happened, the display file is now a rolling window.
+        // No need to trim CaptureStore here — it handles its own trimming
+        // when the Preserve mode rolling file rotates.
+        Q_UNUSED( sizeBefore );
     }
 
+    rollingDisplayOutput_.flush();
     return true;
 }
 

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -137,7 +137,6 @@ void StreamingLogData::clearCapture()
     stopOutputFlushTimer();
     captureStore_.clear();
     clearAnsiDisplayCache();
-    clearAnsiDisplayCache();
     {
         std::lock_guard<std::mutex> lock( cachedRawBatchesMutex_ );
         cachedRawBatches_.clear();
@@ -433,7 +432,7 @@ bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
     // Use CaptureStore's rolling settings for the display file
     rollingDisplayOutput_ = RollingFileManager( boundOutputFile_, rollingMaxFileSize_,
                                                  rollingBackupCount_ );
-    if ( !rollingDisplayOutput_.open() ) {
+    if ( !rollingDisplayOutput_.open( true ) ) {
         boundOutputFile_.clear();
         return false;
     }

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -489,6 +489,23 @@ class Configuration final : public Persistable<Configuration> {
         liveCaptureRollingMaxFileSize_ = maxFileSize;
     }
 
+    // Whole-megabyte view used by the live-source dialogs' spinboxes. Converting
+    // bytes->MB rounds to the nearest megabyte so a sub-megabyte stored value
+    // (e.g. migrated from an older format, or hand-edited) is not silently
+    // truncated to 0 (which the UI treats as "unlimited").
+    static constexpr qint64 LiveCaptureRollingBytesPerMb = 1024LL * 1024;
+    int liveCaptureRollingMaxFileSizeMb() const
+    {
+        const qint64 mb = ( liveCaptureRollingMaxFileSize_ + LiveCaptureRollingBytesPerMb / 2 )
+                          / LiveCaptureRollingBytesPerMb;
+        return static_cast<int>( qMin( mb, static_cast<qint64>( 2000000000LL ) ) );
+    }
+    void setLiveCaptureRollingMaxFileSizeMb( int megabytes )
+    {
+        liveCaptureRollingMaxFileSize_
+            = static_cast<qint64>( megabytes ) * LiveCaptureRollingBytesPerMb;
+    }
+
     int liveCaptureRollingBackupCount() const
     {
         return liveCaptureRollingBackupCount_;

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -462,6 +462,42 @@ class Configuration final : public Persistable<Configuration> {
         iosLogAnsiOutputEnabled_ = enabled;
     }
 
+    bool liveAutoReconnectEnabled() const
+    {
+        return liveAutoReconnectEnabled_;
+    }
+    void setLiveAutoReconnectEnabled( bool enabled )
+    {
+        liveAutoReconnectEnabled_ = enabled;
+    }
+
+    int liveAutoReconnectMaxAttempts() const
+    {
+        return liveAutoReconnectMaxAttempts_;
+    }
+    void setLiveAutoReconnectMaxAttempts( int maxAttempts )
+    {
+        liveAutoReconnectMaxAttempts_ = maxAttempts;
+    }
+
+    qint64 liveCaptureRollingMaxFileSize() const
+    {
+        return liveCaptureRollingMaxFileSize_;
+    }
+    void setLiveCaptureRollingMaxFileSize( qint64 maxFileSize )
+    {
+        liveCaptureRollingMaxFileSize_ = maxFileSize;
+    }
+
+    int liveCaptureRollingBackupCount() const
+    {
+        return liveCaptureRollingBackupCount_;
+    }
+    void setLiveCaptureRollingBackupCount( int backupCount )
+    {
+        liveCaptureRollingBackupCount_ = backupCount;
+    }
+
     bool forceFontAntialiasing() const
     {
         return forceFontAntialiasing_;
@@ -710,6 +746,27 @@ class Configuration final : public Persistable<Configuration> {
     QString iosLogExecutable_;
     QString iosLogExtraArgs_;
     bool iosLogAnsiOutputEnabled_ = true;
+
+    // Whether to automatically attempt reconnection when a live source
+    // (ADB logcat, iOS log stream) unexpectedly disconnects or encounters
+    // an error. When enabled, klogg uses exponential backoff starting at
+    // 1 second and capping at 30 seconds between attempts.
+    bool liveAutoReconnectEnabled_ = true;
+    // Maximum number of automatic reconnection attempts before giving up.
+    // Set to 0 for unlimited retries. Each retry waits longer: the delay
+    // doubles with each attempt (1s, 2s, 4s, 8s, ... up to 30s).
+    int liveAutoReconnectMaxAttempts_ = 0; // 0 = unlimited
+    // Maximum size in bytes of each rolling capture file. When the live
+    // capture output file exceeds this size, it is rotated (renamed as a
+    // numbered backup) and a new file is started. Old backups beyond
+    // liveCaptureRollingBackupCount_ are deleted. Set to 0 to disable
+    // size-based rolling (single unlimited file).
+    qint64 liveCaptureRollingMaxFileSize_ = 0; // 0 = unlimited
+    // Number of old capture backup files to retain when rolling by file
+    // size. Files beyond this count are deleted (oldest first). Set to 0
+    // to disable rolling backup — only the current file is kept. Effective
+    // only when liveCaptureRollingMaxFileSize_ is also > 0.
+    int liveCaptureRollingBackupCount_ = 0;
 
     bool forceFontAntialiasing_ = false;
     bool enableQtHighDpi_ = true;

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -751,7 +751,7 @@ class Configuration final : public Persistable<Configuration> {
     // (ADB logcat, iOS log stream) unexpectedly disconnects or encounters
     // an error. When enabled, klogg uses exponential backoff starting at
     // 1 second and capping at 30 seconds between attempts.
-    bool liveAutoReconnectEnabled_ = true;
+    bool liveAutoReconnectEnabled_ = false;
     // Maximum number of automatic reconnection attempts before giving up.
     // Set to 0 for unlimited retries. Each retry waits longer: the delay
     // doubles with each attempt (1s, 2s, 4s, 8s, ... up to 30s).
@@ -761,12 +761,12 @@ class Configuration final : public Persistable<Configuration> {
     // numbered backup) and a new file is started. Old backups beyond
     // liveCaptureRollingBackupCount_ are deleted. Set to 0 to disable
     // size-based rolling (single unlimited file).
-    qint64 liveCaptureRollingMaxFileSize_ = 0; // 0 = unlimited
+    qint64 liveCaptureRollingMaxFileSize_ = 1000LL * 1024 * 1024; // 1000 MB
     // Number of old capture backup files to retain when rolling by file
     // size. Files beyond this count are deleted (oldest first). Set to 0
-    // to disable rolling backup — only the current file is kept. Effective
+    // to keep all rotated files indefinitely (no cleanup). Effective
     // only when liveCaptureRollingMaxFileSize_ is also > 0.
-    int liveCaptureRollingBackupCount_ = 0;
+    int liveCaptureRollingBackupCount_ = 0; // 0 = keep all rotated files
 
     bool forceFontAntialiasing_ = false;
     bool enableQtHighDpi_ = true;

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -299,6 +299,23 @@ void Configuration::retrieveFromStorage( QSettings& settings )
         = settings.value( "iosLog.ansiOutput", DefaultConfiguration.iosLogAnsiOutputEnabled_ )
               .toBool();
 
+    liveAutoReconnectEnabled_
+        = settings.value( "liveSource.autoReconnectEnabled",
+                          DefaultConfiguration.liveAutoReconnectEnabled_ )
+              .toBool();
+    liveAutoReconnectMaxAttempts_
+        = settings.value( "liveSource.autoReconnectMaxAttempts",
+                          DefaultConfiguration.liveAutoReconnectMaxAttempts_ )
+              .toInt();
+    liveCaptureRollingMaxFileSize_
+        = settings.value( "liveSource.captureRollingMaxFileSize",
+                          DefaultConfiguration.liveCaptureRollingMaxFileSize_ )
+              .toLongLong();
+    liveCaptureRollingBackupCount_
+        = settings.value( "liveSource.captureRollingBackupCount",
+                          DefaultConfiguration.liveCaptureRollingBackupCount_ )
+              .toInt();
+
     // View settings
     overviewVisible_
         = settings.value( "view.overviewVisible", DefaultConfiguration.overviewVisible_ ).toBool();
@@ -480,6 +497,10 @@ void Configuration::saveToStorage( QSettings& settings ) const
     settings.setValue( "iosLog.executable", iosLogExecutable_ );
     settings.setValue( "iosLog.extraArgs", iosLogExtraArgs_ );
     settings.setValue( "iosLog.ansiOutput", iosLogAnsiOutputEnabled_ );
+    settings.setValue( "liveSource.autoReconnectEnabled", liveAutoReconnectEnabled_ );
+    settings.setValue( "liveSource.autoReconnectMaxAttempts", liveAutoReconnectMaxAttempts_ );
+    settings.setValue( "liveSource.captureRollingMaxFileSize", liveCaptureRollingMaxFileSize_ );
+    settings.setValue( "liveSource.captureRollingBackupCount", liveCaptureRollingBackupCount_ );
 
     settings.setValue( "view.overviewVisible", overviewVisible_ );
     settings.setValue( "view.lineNumbersVisibleInMain", lineNumbersVisibleInMain_ );

--- a/src/settings/src/styles.cpp
+++ b/src/settings/src/styles.cpp
@@ -373,6 +373,7 @@ QGroupBox::title {
 
 QLabel {
     color: __TEXT__;
+    padding: 2px 0;
 }
 
 QLineEdit, QComboBox, QSpinBox, QDoubleSpinBox, QKeySequenceEdit,
@@ -476,6 +477,8 @@ QToolButton:checked:hover {
 
 QCheckBox, QRadioButton {
     spacing: 6px;
+    min-height: 20px;
+    padding: 2px 0;
 }
 QCheckBox::indicator, QRadioButton::indicator {
     width: 14px;

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -3,9 +3,11 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/abstractlogview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adblogcatdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adbprocesstransport.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/adbdevicelistprovider.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adblogcatsource.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/commandargumenttokenizer.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crawlerwidget.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/devicelistprovider.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/filteredview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighteredit.h
@@ -21,6 +23,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/infoline.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogdialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/ioslogprocesstransport.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosdevicelistprovider.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/iosdeviceparser.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathline.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/logmainview.h
@@ -68,6 +71,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/abstractlogview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adblogcatdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adbprocesstransport.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/adbdevicelistprovider.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adblogcatsource.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/crawlerwidget.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/filteredview.cpp
@@ -84,6 +88,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/infoline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ioslogprocesstransport.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosdevicelistprovider.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/iosdeviceparser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/pathline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/logmainview.cpp

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/decompressor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/fontutils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/colorlabelsmanager.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/newversiondialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighteredit.ui
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersetedit.ui
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersdialog.ui
@@ -117,6 +118,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/downloader.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/decompressor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/colorlabelsmanager.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/newversiondialog.cpp
 )
 
 set_target_properties(klogg_ui PROPERTIES AUTOUIC ON)

--- a/src/ui/include/adbdeviceinfo.h
+++ b/src/ui/include/adbdeviceinfo.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_ADBDEVICEINFO_H
+#define KLOGG_ADBDEVICEINFO_H
+
+#include <QString>
+
+struct AdbDeviceInfo {
+    QString serial;
+    QString displayName;
+    QString description;
+};
+
+#endif // KLOGG_ADBDEVICEINFO_H

--- a/src/ui/include/adbdevicelistprovider.h
+++ b/src/ui/include/adbdevicelistprovider.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_ADBDEVICELISTPROVIDER_H
+#define KLOGG_ADBDEVICELISTPROVIDER_H
+
+#include "adbdeviceinfo.h"
+#include "devicelistprovider.h"
+
+// Provides ADB device enumeration by running `adb devices -l`.
+//
+// Isolates the blocking subprocess call so transport and UI layers
+// do not need to manage QProcess directly.  Use listDevices() for
+// synchronous enumeration (modal dialogs) or listDevicesAsync() for
+// background enumeration (non-blocking UI).
+class AdbDeviceListProvider : public DeviceListProviderBase<AdbDeviceInfo> {
+    Q_OBJECT
+
+  public:
+    explicit AdbDeviceListProvider( QString adbExecutable,
+                                    QObject* parent = nullptr );
+
+    // Resolve the adb executable path through well-known locations.
+    // Exposed for "Detect adb" UI affordances.
+    static QString detectAdbExecutable();
+
+    // Normalize an adb executable path (expand tilde, resolve known locations).
+    static QString normalizedExecutable( const QString& adbExecutable );
+
+  protected:
+    QList<AdbDeviceInfo> doListDevices( QString* error ) const override;
+    bool deviceMatches( const AdbDeviceInfo& device,
+                        const QString& deviceId ) const override;
+
+  private:
+    QString adbExecutable_;
+};
+
+#endif // KLOGG_ADBDEVICELISTPROVIDER_H

--- a/src/ui/include/adblogcatdialog.h
+++ b/src/ui/include/adblogcatdialog.h
@@ -11,6 +11,7 @@ class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
+class QSpinBox;
 
 class AdbLogcatDialog : public QDialog {
     Q_OBJECT
@@ -34,6 +35,10 @@ class AdbLogcatDialog : public QDialog {
     QComboBox* deviceCombo_ = nullptr;
     QLineEdit* extraArgsEdit_ = nullptr;
     QCheckBox* ansiOutputCheckBox_ = nullptr;
+    QCheckBox* autoReconnectCheckBox_ = nullptr;
+    QSpinBox* maxAttemptsSpinBox_ = nullptr;
+    QSpinBox* maxFileSizeSpinBox_ = nullptr;
+    QSpinBox* backupCountSpinBox_ = nullptr;
     QLabel* statusLabel_ = nullptr;
     QDialogButtonBox* buttonBox_ = nullptr;
 };

--- a/src/ui/include/adblogcatdialog.h
+++ b/src/ui/include/adblogcatdialog.h
@@ -2,7 +2,9 @@
 #define ADBLOGCATDIALOG_H
 
 #include <QDialog>
+#include <QFutureWatcher>
 
+#include "adbdeviceinfo.h"
 #include "adblogcatsource.h"
 
 class QComboBox;
@@ -28,8 +30,11 @@ class AdbLogcatDialog : public QDialog {
     void updateAcceptState();
     void loadSettings();
     void saveSettings() const;
+    // Populates the device combo from the async refresh result.
+    void onDevicesEnumerated();
 
   private:
+    QFutureWatcher<QList<AdbDeviceInfo>>* deviceRefreshWatcher_ = nullptr;
     QLineEdit* adbExecutableEdit_ = nullptr;
     QPushButton* refreshButton_ = nullptr;
     QComboBox* deviceCombo_ = nullptr;

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -61,7 +61,6 @@ class AdbLogcatSource : public QObject {
     const AdbLogcatSessionData& sessionData() const;
     State state() const;
     QString lastError() const;
-    bool isManualDisconnect() const;
 
   Q_SIGNALS:
     void stateChanged( AdbLogcatSource::State state );

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -97,8 +97,11 @@ class AdbLogcatSource : public QObject {
     QString lastError_;
     bool manualDisconnect_ = false;
 
-    // Auto-reconnect state
-    bool autoReconnectEnabled_ = true;
+    // Auto-reconnect state. Defaults to disabled: the user's setting is applied
+    // via setAutoReconnectEnabled() before the first connect. A true default
+    // armed the reconnect timer during the construction-to-registration window
+    // with the wrong (unlimited) setting.
+    bool autoReconnectEnabled_ = false;
     int autoReconnectMaxAttempts_ = 0; // 0 = unlimited
     int reconnectAttempt_ = 0;
     bool reconnectionProven_ = false; // set when first stdout data arrives

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -5,6 +5,7 @@
 
 #include <QJsonObject>
 #include <QObject>
+#include <QTimer>
 
 #include "livesourcetransport.h"
 #include "streaminglogdata.h"
@@ -60,14 +61,30 @@ class AdbLogcatSource : public QObject {
     const AdbLogcatSessionData& sessionData() const;
     State state() const;
     QString lastError() const;
+    bool isManualDisconnect() const;
 
   Q_SIGNALS:
     void stateChanged( AdbLogcatSource::State state );
     void errorOccurred( const QString& error );
+    void reconnectAttemptStarted( int attempt );
+
+  public:
+    static constexpr int InitialReconnectDelayMs = 1000;
+    static constexpr int MaxReconnectDelayMs = 30000;
+
+    void setAutoReconnectEnabled( bool enabled );
+    void setAutoReconnectMaxAttempts( int maxAttempts );
+    bool isAutoReconnectActive() const;
+    int reconnectAttempt() const;
+    void cancelAutoReconnect();
+    void setCaptureLimits( qint64 rollingMaxFileSize, int rollingBackupCount,
+                           qint64 maxTotalLines = 0 );
 
   private:
     void setState( State state );
     void setStateFromTransport( LiveSourceTransport::State state );
+    void scheduleReconnect();
+    void attemptReconnect();
 
   private:
     AdbLogcatSessionData sessionData_;
@@ -75,6 +92,14 @@ class AdbLogcatSource : public QObject {
     std::unique_ptr<LiveSourceTransport> transport_;
     State state_{ State::Disconnected };
     QString lastError_;
+    bool manualDisconnect_ = false;
+
+    // Auto-reconnect state
+    bool autoReconnectEnabled_ = true;
+    int autoReconnectMaxAttempts_ = 0; // 0 = unlimited
+    int reconnectAttempt_ = 0;
+    bool reconnectionProven_ = false; // set when first stdout data arrives
+    QTimer reconnectTimer_;
 };
 
 #endif

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -26,6 +26,10 @@ struct AdbLogcatSessionData {
     QString boundOutputFile;
     LiveLogSourceType sourceType = LiveLogSourceType::AdbLogcat;
     bool ansiOutputEnabled = false;
+    bool autoReconnectEnabled = false;
+    int maxReconnectAttempts = 0; // 0 = unlimited
+    qint64 captureMaxFileSize = 0; // bytes, 0 = unlimited
+    int captureBackupCount = 0; // 0 = keep all rotated files
 
     QString displayName() const;
     QString documentId() const;

--- a/src/ui/include/adbprocesstransport.h
+++ b/src/ui/include/adbprocesstransport.h
@@ -2,14 +2,11 @@
 #define ADBPROCESSTRANSPORT_H
 
 #include <QList>
+#include <memory>
 
+#include "adbdeviceinfo.h"
+#include "adbdevicelistprovider.h"
 #include "livesourcetransport.h"
-
-struct AdbDeviceInfo {
-    QString serial;
-    QString displayName;
-    QString description;
-};
 
 class AdbProcessTransport : public ProcessLiveSourceTransport {
     Q_OBJECT
@@ -18,16 +15,16 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
     AdbProcessTransport( QString adbExecutable, QString deviceSerial, QString extraArgs,
                          bool ansiOutputEnabled = false, QObject* parent = nullptr );
 
+    // Delegate to AdbDeviceListProvider.  Kept for backward compatibility
+    // with dialog callers that call this static method directly.
     static QList<AdbDeviceInfo> listDevices( const QString& adbExecutable, QString* error );
 
     // Probe well-known adb install locations and return the absolute path of
-    // the first executable hit.  Returns an empty string when no candidate
-    // exists.  Useful for "Detect adb" UI affordances; see docs/PORTABILITY.md
-    // for the rationale (macOS GUI launchd PATH does not include the typical
-    // SDK / Homebrew install directories).
+    // the first executable hit.
     static QString detectAdbExecutable();
 
-    bool isDeviceAvailable() const override;
+    // Access the device list provider for async enumeration.
+    AdbDeviceListProvider* deviceListProvider() const;
 
   protected:
     Command streamingCommand() const override;
@@ -42,6 +39,7 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
     QString deviceSerial_;
     QString extraArgs_;
     bool ansiOutputEnabled_;
+    std::unique_ptr<AdbDeviceListProvider> deviceProvider_;
 };
 
 #endif

--- a/src/ui/include/adbprocesstransport.h
+++ b/src/ui/include/adbprocesstransport.h
@@ -27,6 +27,8 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
     // SDK / Homebrew install directories).
     static QString detectAdbExecutable();
 
+    bool isDeviceAvailable() const override;
+
   protected:
     Command streamingCommand() const override;
     Command clearCommand() const override;

--- a/src/ui/include/devicelistprovider.h
+++ b/src/ui/include/devicelistprovider.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_DEVICELISTPROVIDER_H
+#define KLOGG_DEVICELISTPROVIDER_H
+
+#include <QList>
+#include <QObject>
+#include <QString>
+
+#include <QtConcurrent>
+
+// Base template for device list providers.
+//
+// Both ADB and iOS need to enumerate connected devices via a subprocess
+// (adb devices -l / pymobiledevice3 usbmux list).  Both calls block for
+// up to 8 seconds.  This template isolates the blocking call behind a
+// uniform interface so that:
+//   - Transport classes delegate to a provider instead of running the
+//     subprocess directly.
+//   - Callers can choose sync (modal dialogs) or async (background)
+//     enumeration.
+//   - The subprocess logic is independently testable.
+//
+// Derived classes must implement doListDevices() and provide a
+// Q_OBJECT macro (MOC does not support template classes).
+template <typename DeviceInfo>
+class DeviceListProviderBase : public QObject {
+  public:
+    explicit DeviceListProviderBase( QObject* parent = nullptr )
+        : QObject( parent )
+    {
+    }
+
+    // Synchronous device enumeration.  Blocks the calling thread.
+    // Returns an empty list on error; check *error for details.
+    QList<DeviceInfo> listDevices( QString* error = nullptr ) const
+    {
+        return doListDevices( error );
+    }
+
+    // Asynchronous device enumeration.  Runs on the global thread pool.
+    // The returned QFuture resolves to the device list.
+    QFuture<QList<DeviceInfo>> listDevicesAsync() const
+    {
+        auto* self = const_cast<DeviceListProviderBase*>( this );
+        return QtConcurrent::run( [self]() { return self->doListDevices( nullptr ); } );
+    }
+
+    // Check whether a specific device (serial / UDID) is connected.
+    // Returns true if the device is found, false if not found.
+    // Returns true on subprocess error (optimistic fallback — let the
+    // actual connection attempt handle the real error).
+    bool isDeviceAvailable( const QString& deviceId ) const
+    {
+        QString error;
+        const auto devices = doListDevices( &error );
+        if ( !error.isEmpty() ) {
+            return true; // optimistic fallback
+        }
+        for ( const auto& device : devices ) {
+            if ( deviceMatches( device, deviceId ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+  protected:
+    // Subclasses implement the actual subprocess call.
+    virtual QList<DeviceInfo> doListDevices( QString* error ) const = 0;
+
+    // Subclasses implement device identifier matching.
+    virtual bool deviceMatches( const DeviceInfo& device,
+                                const QString& deviceId ) const = 0;
+};
+
+#endif // KLOGG_DEVICELISTPROVIDER_H

--- a/src/ui/include/devicelistprovider.h
+++ b/src/ui/include/devicelistprovider.h
@@ -22,6 +22,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QPointer>
 #include <QString>
 
 #include <QtConcurrent>
@@ -57,10 +58,18 @@ class DeviceListProviderBase : public QObject {
 
     // Asynchronous device enumeration.  Runs on the global thread pool.
     // The returned QFuture resolves to the device list.
+    //
+    // The provider is guarded by a QPointer: if the provider (or its owning
+    // transport) is destroyed before the pool runs the task, the lambda returns
+    // an empty list instead of dereferencing freed memory. (Full mid-execution
+    // safety would require shared_ptr ownership of the provider; callers that
+    // need that guarantee should hold a shared_ptr themselves.)
     QFuture<QList<DeviceInfo>> listDevicesAsync() const
     {
-        auto* self = const_cast<DeviceListProviderBase*>( this );
-        return QtConcurrent::run( [self]() { return self->doListDevices( nullptr ); } );
+        const QPointer<DeviceListProviderBase> self(
+            const_cast<DeviceListProviderBase*>( this ) );
+        return QtConcurrent::run(
+            [self]() { return self ? self->doListDevices( nullptr ) : QList<DeviceInfo>{}; } );
     }
 
     // Check whether a specific device (serial / UDID) is connected.

--- a/src/ui/include/downloader.h
+++ b/src/ui/include/downloader.h
@@ -30,6 +30,11 @@ class Downloader : public QObject {
 
     void download( const QUrl& url, QFile* outputFile );
 
+    // Abort the current download.  After this call the Downloader is safe to
+    // delete — no further signals will be emitted and the QNetworkReply is
+    // terminated.
+    void abort();
+
     QString lastError() const;
 
   Q_SIGNALS:

--- a/src/ui/include/iosdevicelistprovider.h
+++ b/src/ui/include/iosdevicelistprovider.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_IOSDEVICELISTPROVIDER_H
+#define KLOGG_IOSDEVICELISTPROVIDER_H
+
+#include "devicelistprovider.h"
+#include "iosdeviceparser.h"
+
+// Provides iOS device enumeration by running `pymobiledevice3 usbmux list`.
+//
+// Isolates the blocking subprocess call so transport and UI layers
+// do not need to manage QProcess directly.  Use listDevices() for
+// synchronous enumeration (modal dialogs) or listDevicesAsync() for
+// background enumeration (non-blocking UI).
+//
+// Only functional on macOS; returns empty with an error on other platforms.
+class IosDeviceListProvider : public DeviceListProviderBase<IosDeviceInfo> {
+    Q_OBJECT
+
+  public:
+    explicit IosDeviceListProvider( QString executable, QObject* parent = nullptr );
+
+    // Probe well-known pymobiledevice3 install locations and return the
+    // absolute path of the first executable hit.
+    static QString detectIosSyslogExecutable();
+
+    // Normalize the pymobiledevice3 executable path.
+    static QString normalizedExecutable( const QString& executable );
+
+  protected:
+    QList<IosDeviceInfo> doListDevices( QString* error ) const override;
+    bool deviceMatches( const IosDeviceInfo& device,
+                        const QString& deviceId ) const override;
+
+  private:
+    QString executable_;
+};
+
+#endif // KLOGG_IOSDEVICELISTPROVIDER_H

--- a/src/ui/include/ioslogdialog.h
+++ b/src/ui/include/ioslogdialog.h
@@ -11,6 +11,7 @@ class QCheckBox;
 class QLabel;
 class QLineEdit;
 class QPushButton;
+class QSpinBox;
 
 class IosLogDialog : public QDialog {
     Q_OBJECT
@@ -34,6 +35,10 @@ class IosLogDialog : public QDialog {
     QComboBox* deviceCombo_ = nullptr;
     QLineEdit* extraArgsEdit_ = nullptr;
     QCheckBox* ansiOutputCheckBox_ = nullptr;
+    QCheckBox* autoReconnectCheckBox_ = nullptr;
+    QSpinBox* maxAttemptsSpinBox_ = nullptr;
+    QSpinBox* maxFileSizeSpinBox_ = nullptr;
+    QSpinBox* backupCountSpinBox_ = nullptr;
     QLabel* statusLabel_ = nullptr;
     QDialogButtonBox* buttonBox_ = nullptr;
 };

--- a/src/ui/include/ioslogdialog.h
+++ b/src/ui/include/ioslogdialog.h
@@ -2,8 +2,10 @@
 #define IOSLOGDIALOG_H
 
 #include <QDialog>
+#include <QFutureWatcher>
 
 #include "adblogcatsource.h"
+#include "iosdeviceparser.h"
 
 class QComboBox;
 class QDialogButtonBox;
@@ -28,8 +30,11 @@ class IosLogDialog : public QDialog {
     void updateAcceptState();
     void loadSettings();
     void saveSettings() const;
+    // Populates the device combo from the async refresh result.
+    void onDevicesEnumerated();
 
   private:
+    QFutureWatcher<QList<IosDeviceInfo>>* deviceRefreshWatcher_ = nullptr;
     QLineEdit* executableEdit_ = nullptr;
     QPushButton* refreshButton_ = nullptr;
     QComboBox* deviceCombo_ = nullptr;

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -18,6 +18,7 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
 
     bool clearRemote( QString* error ) override;
     bool connectTransport() override;
+    bool isDeviceAvailable() const override;
 
   protected:
     Command streamingCommand() const override;

--- a/src/ui/include/ioslogprocesstransport.h
+++ b/src/ui/include/ioslogprocesstransport.h
@@ -2,7 +2,9 @@
 #define IOSLOGPROCESSTRANSPORT_H
 
 #include <QList>
+#include <memory>
 
+#include "iosdevicelistprovider.h"
 #include "iosdeviceparser.h"
 #include "livesourcetransport.h"
 
@@ -13,12 +15,16 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     IosLogProcessTransport( QString executable, QString deviceUdid, QString extraArgs,
                             bool ansiOutputEnabled = false, QObject* parent = nullptr );
 
+    // Delegate to IosDeviceListProvider.  Kept for backward compatibility
+    // with dialog callers that call this static method directly.
     static QList<IosDeviceInfo> listDevices( const QString& executable, QString* error );
     static QString detectIosSyslogExecutable();
 
+    // Access the device list provider for async enumeration.
+    IosDeviceListProvider* deviceListProvider() const;
+
     bool clearRemote( QString* error ) override;
     bool connectTransport() override;
-    bool isDeviceAvailable() const override;
 
   protected:
     Command streamingCommand() const override;
@@ -35,6 +41,7 @@ class IosLogProcessTransport : public ProcessLiveSourceTransport {
     bool ansiOutputEnabled_;
     bool ptyPrefixStripped_ = false;
     QByteArray pendingPrefixProbe_;
+    std::unique_ptr<IosDeviceListProvider> deviceProvider_;
 };
 
 #endif

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -25,13 +25,6 @@ class LiveSourceTransport : public QObject {
     virtual void disconnectTransport() = 0;
     virtual bool clearRemote( QString* error ) = 0;
     virtual QString lastError() const = 0;
-    // Check whether the target device is currently available. Returns true
-    // if the device can be found (e.g. via adb devices / pymobiledevice3).
-    // Default implementation returns true (no pre-check).
-    virtual bool isDeviceAvailable() const
-    {
-        return true;
-    }
 
   Q_SIGNALS:
     void bytesReceived( const QByteArray& data );

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -22,6 +22,11 @@ class LiveSourceTransport : public QObject {
     ~LiveSourceTransport() override = default;
 
     virtual bool connectTransport() = 0;
+    // Non-blocking variant: starts the subprocess and sets up signal-driven
+    // startup detection (grace timer + error/finished handlers) instead of
+    // blocking the calling thread.  Intended for the auto-reconnect path
+    // where the caller does not need a synchronous success/failure result.
+    virtual void connectTransportAsync() = 0;
     virtual void disconnectTransport() = 0;
     virtual bool clearRemote( QString* error ) = 0;
     virtual QString lastError() const = 0;
@@ -45,6 +50,7 @@ class ProcessLiveSourceTransport : public LiveSourceTransport {
     ~ProcessLiveSourceTransport() override;
 
     bool connectTransport() override;
+    void connectTransportAsync() override;
     void disconnectTransport() override;
     bool clearRemote( QString* error ) override;
     QString lastError() const override;

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -25,6 +25,13 @@ class LiveSourceTransport : public QObject {
     virtual void disconnectTransport() = 0;
     virtual bool clearRemote( QString* error ) = 0;
     virtual QString lastError() const = 0;
+    // Check whether the target device is currently available. Returns true
+    // if the device can be found (e.g. via adb devices / pymobiledevice3).
+    // Default implementation returns true (no pre-check).
+    virtual bool isDeviceAvailable() const
+    {
+        return true;
+    }
 
   Q_SIGNALS:
     void bytesReceived( const QByteArray& data );
@@ -55,6 +62,15 @@ class ProcessLiveSourceTransport : public LiveSourceTransport {
     virtual void filterReceivedBytes( QByteArray& data );
     bool runBlockingCommand( const Command& command, QByteArray* stdErr ) const;
 
+    // Path of the temp file that captures the subprocess stderr (it never
+    // reaches the log view).  Exposed so a transport that wraps the command in
+    // a PTY can redirect the inner command's stderr to this file *outside* the
+    // PTY — a PTY otherwise merges stderr into stdout.
+    QString stderrFilePath() const
+    {
+        return stderrFilePath_;
+    }
+
   private:
     void setState( State state );
     void createProcess();
@@ -63,6 +79,7 @@ class ProcessLiveSourceTransport : public LiveSourceTransport {
     std::unique_ptr<QProcess> process_;
     State state_{ State::Disconnected };
     QString lastError_;
+    QString stderrFilePath_;
     bool destroyed_ = false;
     bool disconnectRequested_ = false;
 };

--- a/src/ui/include/newversiondialog.h
+++ b/src/ui/include/newversiondialog.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_NEWVERSIONDIALOG_H
+#define KLOGG_NEWVERSIONDIALOG_H
+
+#include <QDialog>
+#include <QString>
+#include <QStringList>
+
+class QTextBrowser;
+
+// Dialog shown when a new version of klogg is available.
+// Displays version information and a scrollable, height-limited
+// changelog area so that long release notes do not make the
+// dialog taller than the screen.
+class NewVersionDialog : public QDialog {
+    Q_OBJECT
+
+  public:
+    enum Button {
+        Download,
+        RemindLater,
+        SkipVersion,
+    };
+
+    explicit NewVersionDialog( const QString& version, const QString& url,
+                               const QStringList& changes,
+                               QWidget* parent = nullptr );
+
+    Button clickedButton() const
+    {
+        return clickedButton_;
+    }
+
+    // Exposed for testing: the maximum height of the changelog text area.
+    static constexpr int kMaxChangesHeight = 200;
+
+  private:
+    void setupUi( const QString& version, const QString& url,
+                  const QStringList& changes );
+
+    Button clickedButton_ = RemindLater;
+    QTextBrowser* changesBrowser_ = nullptr;
+};
+
+#endif // KLOGG_NEWVERSIONDIALOG_H

--- a/src/ui/include/optionsdialog.h
+++ b/src/ui/include/optionsdialog.h
@@ -103,6 +103,7 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     void resetGeneralDefaults();
     void resetViewDefaults();
     void resetFileDefaults();
+    void resetLiveSourceDefaults();
     void resetShortcutsDefaults();
     void resetAdvancedDefaults();
 
@@ -120,6 +121,7 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     void setupIosLogSettings();
     void setupLiveSourceSettings();
     void setupPanelResetButtons();
+    void standardizeLayoutSpacing();
 
     int updateTranslate();
 

--- a/src/ui/include/optionsdialog.h
+++ b/src/ui/include/optionsdialog.h
@@ -118,6 +118,7 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     void setupEncodings();
     void setupLanguageList();
     void setupIosLogSettings();
+    void setupLiveSourceSettings();
     void setupPanelResetButtons();
 
     int updateTranslate();
@@ -141,6 +142,11 @@ class OptionsDialog : public QDialog, public Ui::OptionsDialog {
     QLineEdit* iosLogExecutableLineEdit_ = nullptr;
     QLineEdit* iosLogArgsLineEdit_ = nullptr;
     QCheckBox* iosLogAnsiOutputCheckBox_ = nullptr;
+    QGroupBox* liveSourceGroupBox_ = nullptr;
+    QCheckBox* liveSourceAutoReconnectCheckBox_ = nullptr;
+    QSpinBox* liveSourceMaxAttemptsSpinBox_ = nullptr;
+    QSpinBox* liveSourceRollingMaxFileSizeSpinBox_ = nullptr;
+    QSpinBox* liveSourceRollingBackupCountSpinBox_ = nullptr;
 };
 
 #endif

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -719,6 +719,26 @@
         </widget>
        </item>
        <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="liveSourceTab">
+      <attribute name="title">
+       <string>Live Source</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_liveSource">
+       <item>
         <widget class="QGroupBox" name="adbGroupBox">
          <property name="title">
           <string>ADB</string>
@@ -780,7 +800,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_3">
+        <spacer name="verticalSpacer_liveSource">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>

--- a/src/ui/include/tabbedcrawlerwidget.h
+++ b/src/ui/include/tabbedcrawlerwidget.h
@@ -39,7 +39,8 @@ enum class LiveTabStatus {
     None, // Normal file tab (no live source)
     Connected, // Live stream connected
     Disconnected, // Live stream disconnected
-    Error // Live stream error
+    Error, // Live stream error
+    Reconnecting // Auto-reconnect in progress
 };
 
 // This class represents glogg's main widget, a tabbed
@@ -164,7 +165,7 @@ class TabbedCrawlerWidget : public QTabWidget {
     QIcon newfiltered_icon_;
 
     // Colored icons for live stream tabs: [liveStatus][dataStatus]
-    QIcon live_icons_[ 4 ][ 3 ];
+    QIcon live_icons_[ 5 ][ 3 ];
 
     QString draggedTabPath_;
     bool tabDragInProgress_ = false;

--- a/src/ui/include/updatedownloadhelper.h
+++ b/src/ui/include/updatedownloadhelper.h
@@ -85,4 +85,22 @@ inline void startUpdateDownload( const QUrl& url, QFile* outputFile,
     downloader.download( url, outputFile );
 }
 
+// Close our write handle (if open) and delete a (partial) downloaded file.
+// Closing BEFORE removing is required on Windows, which refuses to delete a
+// file that is still open — the previous cancel path removed the file while the
+// handle was still open, so on Windows the delete silently failed and the
+// partial download leaked onto disk. On POSIX the file is unlinked regardless
+// of an open handle, so this is an ordering no-op there, but the idiom is
+// correct cross-platform.
+inline bool discardDownloadedFile( QFile& file )
+{
+    if ( file.isOpen() ) {
+        file.close();
+    }
+    if ( file.exists() ) {
+        return file.remove();
+    }
+    return true;
+}
+
 #endif // KLOGG_UPDATEDOWNLOADHELPER_H

--- a/src/ui/include/updatedownloadhelper.h
+++ b/src/ui/include/updatedownloadhelper.h
@@ -28,56 +28,61 @@
 #include "downloader.h"
 #include "progress.h"
 
-// Starts an update download and returns a QProgressDialog that displays
-// download progress. The dialog is modal — call exec() to show it.
+// Wires up a stack-allocated Downloader and QProgressDialog for an update
+// download.  The caller owns both objects and controls their lifetime.
 //
-// The returned QProgressDialog is owned by the caller.
+// This is the safe pattern for macOS: stack allocation gives deterministic
+// LIFO destruction, so no processEvents() or explicit delete is needed
+// and no stale Cocoa NSWindow references can survive the function return.
+//
 // The outputFile must already be opened for writing and its lifetime must
 // cover the download duration.
 //
-// On cancel, the download is aborted and the dialog closes.
-// On completion, the dialog closes automatically — check the Downloader's
-// finished signal for success/failure.
+// On cancel, the download is aborted and the dialog closes (Rejected).
+// On completion, the dialog closes automatically (Accepted on success,
+// Rejected on failure).  Check progressDialog.property("downloadError")
+// for the error string after exec() returns Rejected.
+//
+// IMPORTANT: abort() disconnects the network reply, so the finished()
+// signal is never emitted after cancel.  Therefore it is safe to capture
+// &downloader in the finished handler — the handler only runs when the
+// download completes naturally (success or network error), never after
+// a user-initiated abort.
 
-inline QProgressDialog* startUpdateDownload( const QUrl& url, QFile* outputFile,
-                                              QWidget* parent = nullptr )
+inline void startUpdateDownload( const QUrl& url, QFile* outputFile,
+                                 Downloader& downloader,
+                                 QProgressDialog& progressDialog )
 {
-    auto* downloader = new Downloader();
-    auto* progressDialog = new QProgressDialog( parent );
-
-    progressDialog->setLabelText(
+    progressDialog.setLabelText(
         QCoreApplication::translate( "KloggApp", "Downloading %1" ).arg( url.fileName() ) );
-    progressDialog->setWindowTitle(
+    progressDialog.setWindowTitle(
         QCoreApplication::translate( "KloggApp", "Klogg - Update Download" ) );
-    progressDialog->setMinimumDuration( 0 );
-    progressDialog->setCancelButtonText(
+    progressDialog.setMinimumDuration( 0 );
+    progressDialog.setCancelButtonText(
         QCoreApplication::translate( "KloggApp", "Cancel" ) );
 
-    QObject::connect( downloader, &Downloader::downloadProgress,
-                      [ progressDialog ]( qint64 bytesReceived, qint64 bytesTotal ) {
+    QObject::connect( &downloader, &Downloader::downloadProgress,
+                      [ &progressDialog ]( qint64 bytesReceived, qint64 bytesTotal ) {
                           const auto progress = calculateProgress( bytesReceived, bytesTotal );
-                          progressDialog->setRange( 0, 100 );
-                          progressDialog->setValue( progress );
+                          progressDialog.setRange( 0, 100 );
+                          progressDialog.setValue( progress );
                       } );
 
-    QObject::connect( downloader, &Downloader::finished,
-                      [ progressDialog, downloader ]( bool success ) {
+    QObject::connect( &downloader, &Downloader::finished,
+                      [ &progressDialog, &downloader ]( bool success ) {
                           if ( !success ) {
-                              progressDialog->setProperty( "downloadError",
-                                                           downloader->lastError() );
+                              progressDialog.setProperty( "downloadError",
+                                                         downloader.lastError() );
                           }
-                          progressDialog->done( success ? QDialog::Accepted : QDialog::Rejected );
-                          downloader->deleteLater();
+                          progressDialog.done( success ? QDialog::Accepted
+                                                      : QDialog::Rejected );
                       } );
 
-    QObject::connect( progressDialog, &QProgressDialog::canceled, [ downloader ]() {
-        downloader->abort();
-        downloader->deleteLater();
+    QObject::connect( &progressDialog, &QProgressDialog::canceled, [ &downloader ]() {
+        downloader.abort();
     } );
 
-    downloader->download( url, outputFile );
-
-    return progressDialog;
+    downloader.download( url, outputFile );
 }
 
 #endif // KLOGG_UPDATEDOWNLOADHELPER_H

--- a/src/ui/include/updatedownloadhelper.h
+++ b/src/ui/include/updatedownloadhelper.h
@@ -62,14 +62,16 @@ inline QProgressDialog* startUpdateDownload( const QUrl& url, QFile* outputFile,
 
     QObject::connect( downloader, &Downloader::finished,
                       [ progressDialog, downloader ]( bool success ) {
-                          Q_UNUSED( success );
+                          if ( !success ) {
+                              progressDialog->setProperty( "downloadError",
+                                                           downloader->lastError() );
+                          }
                           progressDialog->done( success ? QDialog::Accepted : QDialog::Rejected );
                           downloader->deleteLater();
                       } );
 
     QObject::connect( progressDialog, &QProgressDialog::canceled, [ downloader ]() {
-        // Downloader doesn't expose abort, but we can close the dialog
-        // and the finished signal will handle cleanup.
+        downloader->abort();
         downloader->deleteLater();
     } );
 

--- a/src/ui/include/updatedownloadhelper.h
+++ b/src/ui/include/updatedownloadhelper.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_UPDATEDOWNLOADHELPER_H
+#define KLOGG_UPDATEDOWNLOADHELPER_H
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QProgressDialog>
+#include <QUrl>
+
+#include "downloader.h"
+#include "progress.h"
+
+// Starts an update download and returns a QProgressDialog that displays
+// download progress. The dialog is modal — call exec() to show it.
+//
+// The returned QProgressDialog is owned by the caller.
+// The outputFile must already be opened for writing and its lifetime must
+// cover the download duration.
+//
+// On cancel, the download is aborted and the dialog closes.
+// On completion, the dialog closes automatically — check the Downloader's
+// finished signal for success/failure.
+
+inline QProgressDialog* startUpdateDownload( const QUrl& url, QFile* outputFile,
+                                              QWidget* parent = nullptr )
+{
+    auto* downloader = new Downloader();
+    auto* progressDialog = new QProgressDialog( parent );
+
+    progressDialog->setLabelText(
+        QCoreApplication::translate( "KloggApp", "Downloading %1" ).arg( url.fileName() ) );
+    progressDialog->setWindowTitle(
+        QCoreApplication::translate( "KloggApp", "Klogg - Update Download" ) );
+    progressDialog->setMinimumDuration( 0 );
+    progressDialog->setCancelButtonText(
+        QCoreApplication::translate( "KloggApp", "Cancel" ) );
+
+    QObject::connect( downloader, &Downloader::downloadProgress,
+                      [ progressDialog ]( qint64 bytesReceived, qint64 bytesTotal ) {
+                          const auto progress = calculateProgress( bytesReceived, bytesTotal );
+                          progressDialog->setRange( 0, 100 );
+                          progressDialog->setValue( progress );
+                      } );
+
+    QObject::connect( downloader, &Downloader::finished,
+                      [ progressDialog, downloader ]( bool success ) {
+                          Q_UNUSED( success );
+                          progressDialog->done( success ? QDialog::Accepted : QDialog::Rejected );
+                          downloader->deleteLater();
+                      } );
+
+    QObject::connect( progressDialog, &QProgressDialog::canceled, [ downloader ]() {
+        // Downloader doesn't expose abort, but we can close the dialog
+        // and the finished signal will handle cleanup.
+        downloader->deleteLater();
+    } );
+
+    downloader->download( url, outputFile );
+
+    return progressDialog;
+}
+
+#endif // KLOGG_UPDATEDOWNLOADHELPER_H

--- a/src/ui/src/adbdevicelistprovider.cpp
+++ b/src/ui/src/adbdevicelistprovider.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "adbdevicelistprovider.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QProcess>
+#include <QProcessEnvironment>
+
+#include "commandargumenttokenizer.h"
+#include "log.h"
+
+namespace {
+
+using ui::internal::expandTildePath;
+
+// See AdbDeviceListProvider::detectAdbExecutable for rationale and probe order.
+QString findAdbAtKnownLocation()
+{
+    const auto env = QProcessEnvironment::systemEnvironment();
+
+#if defined( Q_OS_WIN )
+    const QString exe = QStringLiteral( "adb.exe" );
+#else
+    const QString exe = QStringLiteral( "adb" );
+#endif
+
+    QStringList candidates;
+    const auto appendDir = [ &candidates, &exe ]( const QString& dir ) {
+        if ( !dir.isEmpty() ) {
+            candidates.append( QDir::cleanPath( dir + QLatin1Char( '/' ) + exe ) );
+        }
+    };
+    const auto appendEnvDir
+        = [ &env, &appendDir ]( const char* envVar, const QString& suffix ) {
+              const auto value = env.value( QString::fromLatin1( envVar ) );
+              if ( !value.isEmpty() ) {
+                  appendDir( value + suffix );
+              }
+          };
+
+    appendEnvDir( "ANDROID_SDK_ROOT", QStringLiteral( "/platform-tools" ) );
+    appendEnvDir( "ANDROID_HOME", QStringLiteral( "/platform-tools" ) );
+
+#if defined( Q_OS_WIN )
+    appendEnvDir( "LOCALAPPDATA", QStringLiteral( "/Android/Sdk/platform-tools" ) );
+    appendEnvDir( "ProgramFiles", QStringLiteral( "/Android/android-sdk/platform-tools" ) );
+#elif defined( Q_OS_MAC )
+    candidates.append( QStringLiteral( "/usr/local/bin/adb" ) );
+    candidates.append( QStringLiteral( "/opt/homebrew/bin/adb" ) );
+    appendDir( QDir::homePath() + QStringLiteral( "/Library/Android/sdk/platform-tools" ) );
+#else
+    candidates.append( QStringLiteral( "/usr/local/bin/adb" ) );
+    candidates.append( QStringLiteral( "/usr/bin/adb" ) );
+    appendDir( QDir::homePath() + QStringLiteral( "/Android/Sdk/platform-tools" ) );
+#endif
+
+    for ( const auto& candidate : candidates ) {
+        const QFileInfo info( candidate );
+        if ( info.exists() && info.isFile() && info.isExecutable() ) {
+            return info.absoluteFilePath();
+        }
+    }
+    return {};
+}
+
+bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
+{
+    if ( process.waitForFinished( timeoutMs ) ) {
+        return true;
+    }
+
+    process.kill();
+    process.waitForFinished( 1500 );
+    return false;
+}
+
+} // namespace
+
+AdbDeviceListProvider::AdbDeviceListProvider( QString adbExecutable, QObject* parent )
+    : DeviceListProviderBase( parent )
+    , adbExecutable_( std::move( adbExecutable ) )
+{
+}
+
+QString AdbDeviceListProvider::detectAdbExecutable()
+{
+    return findAdbAtKnownLocation();
+}
+
+QString AdbDeviceListProvider::normalizedExecutable( const QString& adbExecutable )
+{
+    const auto expanded = expandTildePath( adbExecutable.trimmed() );
+    if ( !expanded.isEmpty() ) {
+        return expanded;
+    }
+
+    const auto resolved = findAdbAtKnownLocation();
+    if ( !resolved.isEmpty() ) {
+        return resolved;
+    }
+
+    return QStringLiteral( "adb" );
+}
+
+bool AdbDeviceListProvider::deviceMatches( const AdbDeviceInfo& device,
+                                           const QString& deviceId ) const
+{
+    return device.serial == deviceId;
+}
+
+QList<AdbDeviceInfo> AdbDeviceListProvider::doListDevices( QString* error ) const
+{
+    QProcess process;
+    process.start( normalizedExecutable( adbExecutable_ ),
+                   { QStringLiteral( "devices" ), QStringLiteral( "-l" ) } );
+    if ( !process.waitForStarted( 3000 ) ) {
+        if ( error ) {
+            *error = process.errorString();
+        }
+        return {};
+    }
+
+    if ( !waitForFinishedOrKill( process, 5000 ) ) {
+        if ( error ) {
+            *error = QObject::tr( "Timed out waiting for adb devices output" );
+        }
+        return {};
+    }
+
+    if ( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ) {
+        if ( error ) {
+            const auto stdErr = QString::fromUtf8( process.readAllStandardError() ).trimmed();
+            *error = stdErr.isEmpty() ? process.errorString() : stdErr;
+        }
+        return {};
+    }
+
+    QList<AdbDeviceInfo> devices;
+    const auto lines = QString::fromUtf8( process.readAllStandardOutput() ).split( '\n' );
+    for ( auto line : lines ) {
+        line = line.trimmed();
+        if ( line.isEmpty() || line.startsWith( QStringLiteral( "List of devices attached" ) ) ) {
+            continue;
+        }
+
+        const auto parts = line.simplified().split( ' ' );
+        if ( parts.size() < 2 || parts[ 1 ] != QStringLiteral( "device" ) ) {
+            continue;
+        }
+
+        const auto serial = parts.front();
+        QString model;
+        QString device;
+        QString product;
+        for ( auto i = 2; i < parts.size(); ++i ) {
+            const auto& part = parts[ i ];
+            if ( part.startsWith( QStringLiteral( "model:" ) ) ) {
+                model = part.mid( 6 ).replace( '_', ' ' );
+            }
+            else if ( part.startsWith( QStringLiteral( "device:" ) ) ) {
+                device = part.mid( 7 ).replace( '_', ' ' );
+            }
+            else if ( part.startsWith( QStringLiteral( "product:" ) ) ) {
+                product = part.mid( 8 ).replace( '_', ' ' );
+            }
+        }
+
+        QString description = model;
+        if ( description.isEmpty() ) {
+            description = device;
+        }
+        if ( description.isEmpty() ) {
+            description = product;
+        }
+        if ( description.isEmpty() ) {
+            description = serial;
+        }
+
+        devices.push_back( AdbDeviceInfo{ serial,
+                                          QStringLiteral( "%1 (%2)" ).arg( description, serial ),
+                                          line } );
+    }
+
+    return devices;
+}

--- a/src/ui/src/adblogcatdialog.cpp
+++ b/src/ui/src/adblogcatdialog.cpp
@@ -125,19 +125,19 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
 
 AdbLogcatSessionData AdbLogcatDialog::sessionData() const
 {
-    AdbLogcatSessionData data;
-    data.adbExecutable = adbExecutableEdit_->text().trimmed();
-    data.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
-    data.deviceDescription = deviceCombo_->currentText();
-    data.extraArgs = extraArgsEdit_->text().trimmed();
-    data.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
-    data.sourceType = LiveLogSourceType::AdbLogcat;
-    data.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
-    data.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
-    data.maxReconnectAttempts = maxAttemptsSpinBox_->value();
-    data.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
-    data.captureBackupCount = backupCountSpinBox_->value();
-    return data;
+    AdbLogcatSessionData sessionData;
+    sessionData.adbExecutable = adbExecutableEdit_->text().trimmed();
+    sessionData.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
+    sessionData.deviceDescription = deviceCombo_->currentText();
+    sessionData.extraArgs = extraArgsEdit_->text().trimmed();
+    sessionData.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    sessionData.sourceType = LiveLogSourceType::AdbLogcat;
+    sessionData.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
+    sessionData.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
+    sessionData.maxReconnectAttempts = maxAttemptsSpinBox_->value();
+    sessionData.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
+    sessionData.captureBackupCount = backupCountSpinBox_->value();
+    return sessionData;
 }
 
 void AdbLogcatDialog::refreshDevices()

--- a/src/ui/src/adblogcatdialog.cpp
+++ b/src/ui/src/adblogcatdialog.cpp
@@ -12,7 +12,11 @@
 #include <QSpinBox>
 #include <QVBoxLayout>
 #include <QUuid>
+#include <QtConcurrent>
 
+#include <memory>
+
+#include "adbdevicelistprovider.h"
 #include "adbprocesstransport.h"
 #include "configuration.h"
 
@@ -111,6 +115,10 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
     } );
     connect( buttonBox_, &QDialogButtonBox::rejected, this, &QDialog::reject );
 
+    deviceRefreshWatcher_ = new QFutureWatcher<QList<AdbDeviceInfo>>( this );
+    connect( deviceRefreshWatcher_, &QFutureWatcher<QList<AdbDeviceInfo>>::finished, this,
+             &AdbLogcatDialog::onDevicesEnumerated );
+
     loadSettings();
     refreshDevices();
 }
@@ -135,16 +143,29 @@ AdbLogcatSessionData AdbLogcatDialog::sessionData() const
 void AdbLogcatDialog::refreshDevices()
 {
     deviceCombo_->clear();
+    updateAcceptState();
+    statusLabel_->setText( tr( "Detecting ADB devices..." ) );
 
-    QString error;
-    const auto devices = AdbProcessTransport::listDevices( adbExecutableEdit_->text(), &error );
+    // Enumerate off the GUI thread: `adb devices` can block for up to ~8s, and
+    // the previous synchronous call froze the whole dialog. A shared_ptr keeps
+    // the provider alive for the entire task, so this is use-after-free safe
+    // even if the dialog is closed mid-enumeration (the watcher is a dialog
+    // child; its finished handler is disconnected automatically on destruction).
+    auto provider = std::make_shared<AdbDeviceListProvider>( adbExecutableEdit_->text() );
+    deviceRefreshWatcher_->setFuture(
+        QtConcurrent::run( [provider]() { return provider->listDevices(); } ) );
+}
+
+void AdbLogcatDialog::onDevicesEnumerated()
+{
+    const auto devices = deviceRefreshWatcher_->result();
     for ( const auto& device : devices ) {
         deviceCombo_->addItem( device.displayName, device.serial );
         deviceCombo_->setItemData( deviceCombo_->count() - 1, device.description, Qt::ToolTipRole );
     }
 
     if ( devices.isEmpty() ) {
-        statusLabel_->setText( error.isEmpty() ? tr( "No online ADB devices detected." ) : error );
+        statusLabel_->setText( tr( "No online ADB devices detected." ) );
     }
     else {
         statusLabel_->setText(
@@ -169,8 +190,7 @@ void AdbLogcatDialog::loadSettings()
     ansiOutputCheckBox_->setChecked( config.adbLogcatAnsiOutputEnabled() );
     autoReconnectCheckBox_->setChecked( config.liveAutoReconnectEnabled() );
     maxAttemptsSpinBox_->setValue( config.liveAutoReconnectMaxAttempts() );
-    maxFileSizeSpinBox_->setValue(
-        static_cast<int>( config.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    maxFileSizeSpinBox_->setValue( config.liveCaptureRollingMaxFileSizeMb() );
     backupCountSpinBox_->setValue( config.liveCaptureRollingBackupCount() );
 }
 
@@ -182,8 +202,7 @@ void AdbLogcatDialog::saveSettings() const
     config.setAdbLogcatAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
     config.setLiveAutoReconnectEnabled( autoReconnectCheckBox_->isChecked() );
     config.setLiveAutoReconnectMaxAttempts( maxAttemptsSpinBox_->value() );
-    config.setLiveCaptureRollingMaxFileSize(
-        static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024 );
+    config.setLiveCaptureRollingMaxFileSizeMb( maxFileSizeSpinBox_->value() );
     config.setLiveCaptureRollingBackupCount( backupCountSpinBox_->value() );
     config.save();
 }

--- a/src/ui/src/adblogcatdialog.cpp
+++ b/src/ui/src/adblogcatdialog.cpp
@@ -9,6 +9,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QVBoxLayout>
 #include <QUuid>
 
@@ -20,7 +21,7 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
 {
     setWindowTitle( tr( "Open ADB Logcat" ) );
     setModal( true );
-    resize( 720, 220 );
+    resize( 720, 380 );
 
     auto* rootLayout = new QVBoxLayout( this );
     auto* formLayout = new QFormLayout();
@@ -42,10 +43,53 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
     ansiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), this );
     ansiOutputCheckBox_->setObjectName( QStringLiteral( "ansiOutputCheckBox" ) );
 
+    // Auto-reconnect: enables automatic reconnection with exponential backoff
+    autoReconnectCheckBox_
+        = new QCheckBox( tr( "Enable auto-reconnect on connection loss" ), this );
+    autoReconnectCheckBox_->setObjectName( QStringLiteral( "autoReconnectCheckBox" ) );
+    autoReconnectCheckBox_->setToolTip(
+        tr( "When enabled, klogg automatically attempts to reconnect to the live source "
+            "after an unexpected disconnection or error. Uses exponential backoff "
+            "starting at 1 second and capping at 30 seconds between attempts." ) );
+
+    // Max reconnect attempts
+    maxAttemptsSpinBox_ = new QSpinBox( this );
+    maxAttemptsSpinBox_->setObjectName( QStringLiteral( "maxAttemptsSpinBox" ) );
+    maxAttemptsSpinBox_->setRange( 0, 9999 );
+    maxAttemptsSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    maxAttemptsSpinBox_->setToolTip(
+        tr( "Maximum number of automatic reconnection attempts before giving up. "
+            "Set to 0 for unlimited retries. Each retry uses increasing delay "
+            "(1s, 2s, 4s, 8s, ... up to 30s)." ) );
+
+    // Max capture file size (displayed in MB, stored in bytes)
+    maxFileSizeSpinBox_ = new QSpinBox( this );
+    maxFileSizeSpinBox_->setObjectName( QStringLiteral( "maxFileSizeSpinBox" ) );
+    maxFileSizeSpinBox_->setRange( 0, 1048576 ); // 0 to ~1 TB in MB
+    maxFileSizeSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    maxFileSizeSpinBox_->setSuffix( tr( " MB" ) );
+    maxFileSizeSpinBox_->setToolTip(
+        tr( "Maximum size of each rolling capture file in megabytes. "
+            "When exceeded, the file is rotated and a new one is started. "
+            "Set to 0 to disable size-based rolling." ) );
+
+    // Rolling backup count
+    backupCountSpinBox_ = new QSpinBox( this );
+    backupCountSpinBox_->setObjectName( QStringLiteral( "backupCountSpinBox" ) );
+    backupCountSpinBox_->setRange( 0, 999 );
+    backupCountSpinBox_->setToolTip(
+        tr( "Number of old capture files to keep when rolling by file size. "
+            "Older files beyond this count are deleted. "
+            "Set to 0 to keep all rotated files indefinitely." ) );
+
     formLayout->addRow( tr( "ADB executable" ), adbRowLayout );
     formLayout->addRow( tr( "Device" ), deviceCombo_ );
     formLayout->addRow( tr( "Extra logcat args" ), extraArgsEdit_ );
     formLayout->addRow( QString{}, ansiOutputCheckBox_ );
+    formLayout->addRow( QString{}, autoReconnectCheckBox_ );
+    formLayout->addRow( tr( "Max reconnect attempts" ), maxAttemptsSpinBox_ );
+    formLayout->addRow( tr( "Max capture file size" ), maxFileSizeSpinBox_ );
+    formLayout->addRow( tr( "Rolling backup count" ), backupCountSpinBox_ );
 
     statusLabel_ = new QLabel( this );
     statusLabel_->setObjectName( QStringLiteral( "adbStatusLabel" ) );
@@ -73,16 +117,19 @@ AdbLogcatDialog::AdbLogcatDialog( QWidget* parent )
 
 AdbLogcatSessionData AdbLogcatDialog::sessionData() const
 {
-    return AdbLogcatSessionData{
-        adbExecutableEdit_->text().trimmed(),
-        deviceCombo_->currentData( Qt::UserRole ).toString(),
-        deviceCombo_->currentText(),
-        extraArgsEdit_->text().trimmed(),
-        QUuid::createUuid().toString( QUuid::WithoutBraces ),
-        {},
-        LiveLogSourceType::AdbLogcat,
-        ansiOutputCheckBox_->isChecked(),
-    };
+    AdbLogcatSessionData data;
+    data.adbExecutable = adbExecutableEdit_->text().trimmed();
+    data.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
+    data.deviceDescription = deviceCombo_->currentText();
+    data.extraArgs = extraArgsEdit_->text().trimmed();
+    data.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    data.sourceType = LiveLogSourceType::AdbLogcat;
+    data.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
+    data.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
+    data.maxReconnectAttempts = maxAttemptsSpinBox_->value();
+    data.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
+    data.captureBackupCount = backupCountSpinBox_->value();
+    return data;
 }
 
 void AdbLogcatDialog::refreshDevices()
@@ -120,6 +167,11 @@ void AdbLogcatDialog::loadSettings()
     adbExecutableEdit_->setText( config.adbExecutable() );
     extraArgsEdit_->setText( config.adbLogcatExtraArgs() );
     ansiOutputCheckBox_->setChecked( config.adbLogcatAnsiOutputEnabled() );
+    autoReconnectCheckBox_->setChecked( config.liveAutoReconnectEnabled() );
+    maxAttemptsSpinBox_->setValue( config.liveAutoReconnectMaxAttempts() );
+    maxFileSizeSpinBox_->setValue(
+        static_cast<int>( config.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    backupCountSpinBox_->setValue( config.liveCaptureRollingBackupCount() );
 }
 
 void AdbLogcatDialog::saveSettings() const
@@ -128,5 +180,10 @@ void AdbLogcatDialog::saveSettings() const
     config.setAdbExecutable( adbExecutableEdit_->text().trimmed() );
     config.setAdbLogcatExtraArgs( extraArgsEdit_->text().trimmed() );
     config.setAdbLogcatAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
+    config.setLiveAutoReconnectEnabled( autoReconnectCheckBox_->isChecked() );
+    config.setLiveAutoReconnectMaxAttempts( maxAttemptsSpinBox_->value() );
+    config.setLiveCaptureRollingMaxFileSize(
+        static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024 );
+    config.setLiveCaptureRollingBackupCount( backupCountSpinBox_->value() );
     config.save();
 }

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -2,8 +2,10 @@
 
 #include <QDateTime>
 #include <QJsonDocument>
+#include <QRandomGenerator>
 
 #include "adbprocesstransport.h"
+#include "capturestore.h"
 #include "ioslogprocesstransport.h"
 #include "log.h"
 #include "livesourcetransport.h"
@@ -136,10 +138,23 @@ AdbLogcatSource::AdbLogcatSource( AdbLogcatSessionData sessionData,
     , logData_( std::move( logData ) )
     , transport_( makeTransport( sessionData_ ) )
 {
+    reconnectTimer_.setSingleShot( true );
+    connect( &reconnectTimer_, &QTimer::timeout, this, &AdbLogcatSource::attemptReconnect );
+
     connect( transport_.get(), &LiveSourceTransport::bytesReceived, this,
              [ this ]( const QByteArray& data ) {
                  if ( logData_ ) {
                      logData_->appendUtf8( data );
+                 }
+                 // First stdout data after a reconnect proves the connection
+                 // is truly working — reset the backoff counter.  Reconnect
+                 // progress is surfaced via the status bar only; nothing is
+                 // written to the log view (fully silent retries).
+                 if ( !reconnectionProven_ && reconnectAttempt_ > 0 ) {
+                     reconnectionProven_ = true;
+                     LOG_INFO << "Auto-reconnect succeeded after " << reconnectAttempt_
+                              << " attempt(s)";
+                     reconnectAttempt_ = 0;
                  }
              } );
     connect( transport_.get(), &LiveSourceTransport::stateChanged, this,
@@ -156,6 +171,7 @@ AdbLogcatSource::AdbLogcatSource( AdbLogcatSessionData sessionData,
 
 AdbLogcatSource::~AdbLogcatSource()
 {
+    reconnectTimer_.stop();
     disconnectSource();
 }
 
@@ -169,6 +185,20 @@ bool AdbLogcatSource::connectSource()
 
     if ( state_ == State::Connected ) {
         return true;
+    }
+
+    manualDisconnect_ = false;
+
+    // Pre-check: verify the target device is available before starting the
+    // stream process. This avoids spawning pymobiledevice3 only to have it
+    // fail immediately when the device is gone (e.g. "Device not found").
+    if ( !transport_->isDeviceAvailable() ) {
+        lastError_ = tr( "Device not found: %1" )
+                         .arg( sessionData_.deviceSerial.isEmpty()
+                                   ? sessionData_.deviceDescription
+                                   : sessionData_.deviceSerial );
+        setState( State::Error );
+        return false;
     }
 
     if ( !transport_->connectTransport() ) {
@@ -187,6 +217,8 @@ void AdbLogcatSource::disconnectSource()
         return;
     }
 
+    manualDisconnect_ = true;
+    reconnectTimer_.stop();
     transport_->disconnectTransport();
 }
 
@@ -198,6 +230,7 @@ bool AdbLogcatSource::reconnectSource()
                                 .arg( QDateTime::currentDateTime().toString( Qt::ISODate ) );
         logData_->appendUtf8( marker.toUtf8() );
     }
+    manualDisconnect_ = false;
     return connectSource();
 }
 
@@ -274,6 +307,11 @@ QString AdbLogcatSource::lastError() const
     return lastError_;
 }
 
+bool AdbLogcatSource::isManualDisconnect() const
+{
+    return manualDisconnect_;
+}
+
 void AdbLogcatSource::setState( State state )
 {
     if ( state_ == state ) {
@@ -287,21 +325,34 @@ void AdbLogcatSource::setStateFromTransport( LiveSourceTransport::State state )
 {
     switch ( state ) {
     case LiveSourceTransport::State::Connected:
+        reconnectTimer_.stop();
+        // The connection is not yet proven — we wait for the first stdout
+        // data before declaring success (see bytesReceived handler above).
+        // If the process dies without producing data, the failure is surfaced
+        // via the status bar / lastError_ (see setStateFromTransport(Error)).
+        reconnectionProven_ = false;
         setState( State::Connected );
         break;
     case LiveSourceTransport::State::Error:
+        // Reconnect failures are surfaced via the status bar / lastError_
+        // only — nothing is written to the log view (fully silent retries).
         if ( logData_ ) {
             logData_->finishInput();
         }
+        reconnectionProven_ = false;
         if ( transport_ ) {
             lastError_ = transport_->lastError();
         }
         setState( State::Error );
+        if ( !manualDisconnect_ && autoReconnectEnabled_ ) {
+            scheduleReconnect();
+        }
         break;
     case LiveSourceTransport::State::Connecting:
         setState( State::Disconnected );
         break;
     case LiveSourceTransport::State::Disconnected:
+        reconnectionProven_ = false;
         if ( logData_ ) {
             logData_->finishInput();
         }
@@ -309,3 +360,95 @@ void AdbLogcatSource::setStateFromTransport( LiveSourceTransport::State state )
         break;
     }
 }
+
+void AdbLogcatSource::setAutoReconnectEnabled( bool enabled )
+{
+    autoReconnectEnabled_ = enabled;
+    if ( !enabled ) {
+        reconnectTimer_.stop();
+        reconnectAttempt_ = 0;
+    }
+}
+
+void AdbLogcatSource::setAutoReconnectMaxAttempts( int maxAttempts )
+{
+    autoReconnectMaxAttempts_ = maxAttempts;
+}
+
+bool AdbLogcatSource::isAutoReconnectActive() const
+{
+    return reconnectTimer_.isActive();
+}
+
+int AdbLogcatSource::reconnectAttempt() const
+{
+    return reconnectAttempt_;
+}
+
+void AdbLogcatSource::cancelAutoReconnect()
+{
+    reconnectTimer_.stop();
+    reconnectAttempt_ = 0;
+}
+
+void AdbLogcatSource::setCaptureLimits( qint64 rollingMaxFileSize, int rollingBackupCount,
+                                        qint64 maxTotalLines )
+{
+    if ( logData_ ) {
+        CaptureStore::Limits limits;
+        limits.rollingMaxFileSize = rollingMaxFileSize;
+        limits.rollingBackupCount = rollingBackupCount;
+        limits.maxTotalLines = maxTotalLines;
+        logData_->setCaptureLimits( std::move( limits ) );
+    }
+}
+
+void AdbLogcatSource::scheduleReconnect()
+{
+    if ( autoReconnectMaxAttempts_ > 0 && reconnectAttempt_ >= autoReconnectMaxAttempts_ ) {
+        // Reconnect exhaustion is surfaced via the status bar (state becomes
+        // Error with lastError_) — nothing is written to the log view.
+        LOG_INFO << "Auto-reconnect max attempts (" << autoReconnectMaxAttempts_ << ") reached, giving up";
+        return;
+    }
+
+    // Exponential backoff with ±20% jitter
+    const auto baseDelay
+        = qMin( InitialReconnectDelayMs * ( 1 << qMin( reconnectAttempt_, 15 ) ),
+                MaxReconnectDelayMs );
+    const auto jitter = QRandomGenerator::global()->bounded( baseDelay / 5 ); // ±20%
+    const auto delay = baseDelay + jitter - ( baseDelay / 10 );
+
+    LOG_INFO << "Scheduling auto-reconnect attempt " << ( reconnectAttempt_ + 1 ) << " in " << delay
+             << "ms";
+    reconnectTimer_.start( delay );
+    Q_EMIT reconnectAttemptStarted( reconnectAttempt_ + 1 );
+}
+
+void AdbLogcatSource::attemptReconnect()
+{
+    if ( !autoReconnectEnabled_ ) {
+        return;
+    }
+
+    ++reconnectAttempt_;
+    LOG_INFO << "Auto-reconnect attempt " << reconnectAttempt_;
+
+    if ( !transport_ ) {
+        LOG_WARNING << "Auto-reconnect: transport unavailable";
+        return;
+    }
+
+    // Reset manualDisconnect_ so setStateFromTransport() can trigger
+    // another scheduleReconnect() on failure.
+    manualDisconnect_ = false;
+
+    if ( !transport_->connectTransport() ) {
+        // connectTransport() failed synchronously — the transport emitted
+        // stateChanged(Error) which triggered setStateFromTransport(Error),
+        // which calls scheduleReconnect() (failures stay out of the log view).
+        LOG_WARNING << "Auto-reconnect attempt " << reconnectAttempt_ << " failed: "
+                    << transport_->lastError();
+    }
+}
+

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -203,6 +203,13 @@ bool AdbLogcatSource::connectSource()
 
     manualDisconnect_ = false;
 
+    // A fresh (re)connect starts a new reconnect cycle: reset the attempt
+    // counter and cancel any pending auto-reconnect. Without this, a manual
+    // Reconnect after auto-reconnect exhaustion left reconnectAttempt_ at its
+    // stale high value, suppressing further retries.
+    reconnectTimer_.stop();
+    reconnectAttempt_ = 0;
+
     // connectTransport() handles device-not-found errors directly.
     // The isDeviceAvailable() pre-check was removed because it runs a
     // blocking subprocess (adb devices / pymobiledevice3 usbmux list)

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -307,11 +307,6 @@ QString AdbLogcatSource::lastError() const
     return lastError_;
 }
 
-bool AdbLogcatSource::isManualDisconnect() const
-{
-    return manualDisconnect_;
-}
-
 void AdbLogcatSource::setState( State state )
 {
     if ( state_ == state ) {

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -189,18 +189,10 @@ bool AdbLogcatSource::connectSource()
 
     manualDisconnect_ = false;
 
-    // Pre-check: verify the target device is available before starting the
-    // stream process. This avoids spawning pymobiledevice3 only to have it
-    // fail immediately when the device is gone (e.g. "Device not found").
-    if ( !transport_->isDeviceAvailable() ) {
-        lastError_ = tr( "Device not found: %1" )
-                         .arg( sessionData_.deviceSerial.isEmpty()
-                                   ? sessionData_.deviceDescription
-                                   : sessionData_.deviceSerial );
-        setState( State::Error );
-        return false;
-    }
-
+    // connectTransport() handles device-not-found errors directly.
+    // The isDeviceAvailable() pre-check was removed because it runs a
+    // blocking subprocess (adb devices / pymobiledevice3 usbmux list)
+    // on the UI thread for up to 8 seconds.
     if ( !transport_->connectTransport() ) {
         lastError_ = transport_->lastError();
         return false;

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -451,12 +451,12 @@ void AdbLogcatSource::attemptReconnect()
     // another scheduleReconnect() on failure.
     manualDisconnect_ = false;
 
-    if ( !transport_->connectTransport() ) {
-        // connectTransport() failed synchronously — the transport emitted
-        // stateChanged(Error) which triggered setStateFromTransport(Error),
-        // which calls scheduleReconnect() (failures stay out of the log view).
-        LOG_WARNING << "Auto-reconnect attempt " << reconnectAttempt_ << " failed: "
-                    << transport_->lastError();
-    }
+    // Use the non-blocking async path: connectTransportAsync() starts the
+    // subprocess and sets up signal-driven startup detection (grace timer +
+    // error/finished handlers) instead of blocking the GUI thread for up to
+    // 3.25 seconds.  The result (Connected or Error) arrives via stateChanged
+    // → setStateFromTransport, which handles the reconnect cycle.
+    transport_->connectTransportAsync();
+    LOG_INFO << "Auto-reconnect attempt " << reconnectAttempt_ << " started (async)";
 }
 

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -113,22 +113,36 @@ QJsonObject AdbLogcatSessionData::toJson() const
         { QStringLiteral( "captureId" ), captureId },
         { QStringLiteral( "boundOutputFile" ), boundOutputFile },
         { QStringLiteral( "ansiOutputEnabled" ), ansiOutputEnabled },
+        { QStringLiteral( "autoReconnectEnabled" ), autoReconnectEnabled },
+        { QStringLiteral( "maxReconnectAttempts" ), maxReconnectAttempts },
+        { QStringLiteral( "captureMaxFileSize" ), static_cast<qint64>( captureMaxFileSize ) },
+        { QStringLiteral( "captureBackupCount" ), captureBackupCount },
     };
 }
 
 AdbLogcatSessionData AdbLogcatSessionData::fromJson( const QString& json )
 {
     const auto jsonObject = QJsonDocument::fromJson( json.toUtf8() ).object();
-    return AdbLogcatSessionData{
-        jsonObject.value( QStringLiteral( "adbExecutable" ) ).toString(),
-        jsonObject.value( QStringLiteral( "deviceSerial" ) ).toString(),
-        jsonObject.value( QStringLiteral( "deviceDescription" ) ).toString(),
-        jsonObject.value( QStringLiteral( "extraArgs" ) ).toString(),
-        jsonObject.value( QStringLiteral( "captureId" ) ).toString(),
-        jsonObject.value( QStringLiteral( "boundOutputFile" ) ).toString(),
-        sourceTypeFromString( jsonObject.value( QStringLiteral( "sourceType" ) ).toString() ),
-        jsonObject.value( QStringLiteral( "ansiOutputEnabled" ) ).toBool( false ),
-    };
+    AdbLogcatSessionData data;
+    data.adbExecutable = jsonObject.value( QStringLiteral( "adbExecutable" ) ).toString();
+    data.deviceSerial = jsonObject.value( QStringLiteral( "deviceSerial" ) ).toString();
+    data.deviceDescription = jsonObject.value( QStringLiteral( "deviceDescription" ) ).toString();
+    data.extraArgs = jsonObject.value( QStringLiteral( "extraArgs" ) ).toString();
+    data.captureId = jsonObject.value( QStringLiteral( "captureId" ) ).toString();
+    data.boundOutputFile = jsonObject.value( QStringLiteral( "boundOutputFile" ) ).toString();
+    data.sourceType
+        = sourceTypeFromString( jsonObject.value( QStringLiteral( "sourceType" ) ).toString() );
+    data.ansiOutputEnabled
+        = jsonObject.value( QStringLiteral( "ansiOutputEnabled" ) ).toBool( false );
+    data.autoReconnectEnabled
+        = jsonObject.value( QStringLiteral( "autoReconnectEnabled" ) ).toBool( false );
+    data.maxReconnectAttempts
+        = jsonObject.value( QStringLiteral( "maxReconnectAttempts" ) ).toInt( 0 );
+    data.captureMaxFileSize
+        = jsonObject.value( QStringLiteral( "captureMaxFileSize" ) ).toVariant().toLongLong();
+    data.captureBackupCount
+        = jsonObject.value( QStringLiteral( "captureBackupCount" ) ).toInt( 0 );
+    return data;
 }
 
 AdbLogcatSource::AdbLogcatSource( AdbLogcatSessionData sessionData,

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -1,97 +1,7 @@
 #include "adbprocesstransport.h"
+#include "adbdevicelistprovider.h"
 #include "commandargumenttokenizer.h"
 #include "log.h"
-
-#include <QDir>
-#include <QFile>
-#include <QFileInfo>
-#include <QProcess>
-#include <QProcessEnvironment>
-
-namespace {
-
-using ui::internal::expandTildePath;
-// See AdbProcessTransport::detectAdbExecutable for rationale and probe order.
-QString findAdbAtKnownLocation()
-{
-    const auto env = QProcessEnvironment::systemEnvironment();
-
-#if defined( Q_OS_WIN )
-    const QString exe = QStringLiteral( "adb.exe" );
-#else
-    const QString exe = QStringLiteral( "adb" );
-#endif
-
-    QStringList candidates;
-    const auto appendDir = [ &candidates, &exe ]( const QString& dir ) {
-        if ( !dir.isEmpty() ) {
-            candidates.append( QDir::cleanPath( dir + QLatin1Char( '/' ) + exe ) );
-        }
-    };
-    const auto appendEnvDir
-        = [ &env, &appendDir ]( const char* envVar, const QString& suffix ) {
-              const auto value = env.value( QString::fromLatin1( envVar ) );
-              if ( !value.isEmpty() ) {
-                  appendDir( value + suffix );
-              }
-          };
-
-    appendEnvDir( "ANDROID_SDK_ROOT", QStringLiteral( "/platform-tools" ) );
-    appendEnvDir( "ANDROID_HOME", QStringLiteral( "/platform-tools" ) );
-
-#if defined( Q_OS_WIN )
-    appendEnvDir( "LOCALAPPDATA", QStringLiteral( "/Android/Sdk/platform-tools" ) );
-    appendEnvDir( "ProgramFiles", QStringLiteral( "/Android/android-sdk/platform-tools" ) );
-#elif defined( Q_OS_MAC )
-    candidates.append( QStringLiteral( "/usr/local/bin/adb" ) );
-    candidates.append( QStringLiteral( "/opt/homebrew/bin/adb" ) );
-    appendDir( QDir::homePath() + QStringLiteral( "/Library/Android/sdk/platform-tools" ) );
-#else
-    candidates.append( QStringLiteral( "/usr/local/bin/adb" ) );
-    candidates.append( QStringLiteral( "/usr/bin/adb" ) );
-    appendDir( QDir::homePath() + QStringLiteral( "/Android/Sdk/platform-tools" ) );
-#endif
-
-    for ( const auto& candidate : candidates ) {
-        const QFileInfo info( candidate );
-        if ( info.exists() && info.isFile() && info.isExecutable() ) {
-            return info.absoluteFilePath();
-        }
-    }
-    return {};
-}
-
-QString normalizedExecutable( const QString& adbExecutable )
-{
-    const auto expanded = expandTildePath( adbExecutable.trimmed() );
-    if ( !expanded.isEmpty() ) {
-        return expanded;
-    }
-
-    const auto resolved = findAdbAtKnownLocation();
-    if ( !resolved.isEmpty() ) {
-        return resolved;
-    }
-
-    // Last resort: bare "adb" lets QProcess fall back to PATH lookup.  This
-    // matches the historical behavior on hosts where the user's shell PATH
-    // (Linux from terminal) or System PATH (Windows with Android SDK) is
-    // already correctly configured.
-    return QStringLiteral( "adb" );
-}
-
-bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
-{
-    if ( process.waitForFinished( timeoutMs ) ) {
-        return true;
-    }
-
-    process.kill();
-    process.waitForFinished( 1500 );
-    return false;
-}
-
-} // namespace
 
 using ui::internal::splitCommandArguments;
 
@@ -103,102 +13,24 @@ AdbProcessTransport::AdbProcessTransport( QString adbExecutable, QString deviceS
     , deviceSerial_( std::move( deviceSerial ) )
     , extraArgs_( std::move( extraArgs ) )
     , ansiOutputEnabled_( ansiOutputEnabled )
+    , deviceProvider_( std::make_unique<AdbDeviceListProvider>( adbExecutable_, this ) )
 {
 }
 
 QList<AdbDeviceInfo> AdbProcessTransport::listDevices( const QString& adbExecutable, QString* error )
 {
-    QProcess process;
-    process.start( normalizedExecutable( adbExecutable ),
-                   { QStringLiteral( "devices" ), QStringLiteral( "-l" ) } );
-    if ( !process.waitForStarted( 3000 ) ) {
-        if ( error ) {
-            *error = process.errorString();
-        }
-        return {};
-    }
-
-    if ( !waitForFinishedOrKill( process, 5000 ) ) {
-        if ( error ) {
-            *error = QObject::tr( "Timed out waiting for adb devices output" );
-        }
-        return {};
-    }
-
-    if ( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ) {
-        if ( error ) {
-            const auto stdErr = QString::fromUtf8( process.readAllStandardError() ).trimmed();
-            *error = stdErr.isEmpty() ? process.errorString() : stdErr;
-        }
-        return {};
-    }
-
-    QList<AdbDeviceInfo> devices;
-    const auto lines = QString::fromUtf8( process.readAllStandardOutput() ).split( '\n' );
-    for ( auto line : lines ) {
-        line = line.trimmed();
-        if ( line.isEmpty() || line.startsWith( QStringLiteral( "List of devices attached" ) ) ) {
-            continue;
-        }
-
-        const auto parts = line.simplified().split( ' ' );
-        if ( parts.size() < 2 || parts[ 1 ] != QStringLiteral( "device" ) ) {
-            continue;
-        }
-
-        const auto serial = parts.front();
-        QString model;
-        QString device;
-        QString product;
-        for ( auto i = 2; i < parts.size(); ++i ) {
-            const auto& part = parts[ i ];
-            if ( part.startsWith( QStringLiteral( "model:" ) ) ) {
-                model = part.mid( 6 ).replace( '_', ' ' );
-            }
-            else if ( part.startsWith( QStringLiteral( "device:" ) ) ) {
-                device = part.mid( 7 ).replace( '_', ' ' );
-            }
-            else if ( part.startsWith( QStringLiteral( "product:" ) ) ) {
-                product = part.mid( 8 ).replace( '_', ' ' );
-            }
-        }
-
-        QString description = model;
-        if ( description.isEmpty() ) {
-            description = device;
-        }
-        if ( description.isEmpty() ) {
-            description = product;
-        }
-        if ( description.isEmpty() ) {
-            description = serial;
-        }
-
-        devices.push_back( AdbDeviceInfo{ serial,
-                                          QStringLiteral( "%1 (%2)" ).arg( description, serial ),
-                                          line } );
-    }
-
-    return devices;
+    AdbDeviceListProvider provider( adbExecutable );
+    return provider.listDevices( error );
 }
 
-bool AdbProcessTransport::isDeviceAvailable() const
+QString AdbProcessTransport::detectAdbExecutable()
 {
-    QString error;
-    const auto devices = listDevices( normalizedAdbExecutable(), &error );
-    if ( !error.isEmpty() ) {
-        // The list command itself failed (e.g. adb not installed).
-        // Assume the device is available — let connectTransport() handle the
-        // actual connection attempt.
-        LOG_WARNING << "adb device pre-check unavailable: " << error;
-        return true;
-    }
-    for ( const auto& device : devices ) {
-        if ( device.serial == deviceSerial_ ) {
-            return true;
-        }
-    }
-    return false;
+    return AdbDeviceListProvider::detectAdbExecutable();
+}
+
+AdbDeviceListProvider* AdbProcessTransport::deviceListProvider() const
+{
+    return deviceProvider_.get();
 }
 
 ProcessLiveSourceTransport::Command AdbProcessTransport::streamingCommand() const
@@ -215,12 +47,7 @@ ProcessLiveSourceTransport::Command AdbProcessTransport::clearCommand() const
 
 QString AdbProcessTransport::normalizedAdbExecutable() const
 {
-    return normalizedExecutable( adbExecutable_ );
-}
-
-QString AdbProcessTransport::detectAdbExecutable()
-{
-    return findAdbAtKnownLocation();
+    return AdbDeviceListProvider::normalizedExecutable( adbExecutable_ );
 }
 
 QStringList AdbProcessTransport::logcatArguments() const

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -1,5 +1,6 @@
 #include "adbprocesstransport.h"
 #include "commandargumenttokenizer.h"
+#include "log.h"
 
 #include <QDir>
 #include <QFile>
@@ -179,6 +180,25 @@ QList<AdbDeviceInfo> AdbProcessTransport::listDevices( const QString& adbExecuta
     }
 
     return devices;
+}
+
+bool AdbProcessTransport::isDeviceAvailable() const
+{
+    QString error;
+    const auto devices = listDevices( normalizedAdbExecutable(), &error );
+    if ( !error.isEmpty() ) {
+        // The list command itself failed (e.g. adb not installed).
+        // Assume the device is available — let connectTransport() handle the
+        // actual connection attempt.
+        LOG_WARNING << "adb device pre-check unavailable: " << error;
+        return true;
+    }
+    for ( const auto& device : devices ) {
+        if ( device.serial == deviceSerial_ ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 ProcessLiveSourceTransport::Command AdbProcessTransport::streamingCommand() const

--- a/src/ui/src/downloader.cpp
+++ b/src/ui/src/downloader.cpp
@@ -35,6 +35,18 @@ QString Downloader::lastError() const
     return lastError_;
 }
 
+void Downloader::abort()
+{
+    if ( currentDownload_ ) {
+        // Disconnect all signals from the reply so downloadFinished/downloadReadyRead
+        // are never called after abort.
+        currentDownload_->disconnect( this );
+        currentDownload_->abort();
+        currentDownload_->deleteLater();
+        currentDownload_ = nullptr;
+    }
+}
+
 void Downloader::download( const QUrl& url, QFile* outputFile )
 {
     output_ = outputFile;

--- a/src/ui/src/downloader.cpp
+++ b/src/ui/src/downloader.cpp
@@ -74,12 +74,17 @@ void Downloader::download( const QUrl& url, QFile* outputFile )
 void Downloader::downloadFinished()
 {
     output_->close();
-    currentDownload_->deleteLater();
 
-    if ( currentDownload_->error() ) {
+    // Null currentDownload_ before any further handling so abort() never
+    // dereferences a reply that has already been scheduled for deletion.
+    auto* reply = currentDownload_;
+    currentDownload_ = nullptr;
+    reply->deleteLater();
+
+    if ( reply->error() ) {
         // download failed
-        LOG_ERROR << "Download failed: " << currentDownload_->errorString();
-        lastError_ = currentDownload_->errorString();
+        LOG_ERROR << "Download failed: " << reply->errorString();
+        lastError_ = reply->errorString();
         output_->remove();
         Q_EMIT finished( false );
     }

--- a/src/ui/src/iosdevicelistprovider.cpp
+++ b/src/ui/src/iosdevicelistprovider.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "iosdevicelistprovider.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QProcess>
+#include <QStandardPaths>
+
+#include "commandargumenttokenizer.h"
+#include "iosdeviceparser.h"
+#include "log.h"
+
+namespace {
+
+using ui::internal::expandTildePath;
+
+#ifdef Q_OS_MAC
+QStringList knownExecutableCandidatePaths( const QString& executable )
+{
+    QStringList candidates{
+        QDir::cleanPath( QStringLiteral( "/opt/homebrew/bin/" ) + executable ),
+        QDir::cleanPath( QStringLiteral( "/usr/local/bin/" ) + executable ),
+    };
+
+    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
+    if ( !homeDir.isEmpty() ) {
+        const auto pythonRoot = QDir( homeDir + QStringLiteral( "/Library/Python" ) );
+        const auto versionDirs = pythonRoot.entryList( QDir::Dirs | QDir::NoDotAndDotDot );
+        for ( const auto& version : versionDirs ) {
+            candidates.append(
+                QDir::cleanPath( pythonRoot.absoluteFilePath( version + QStringLiteral( "/bin/" ) + executable ) ) );
+        }
+    }
+
+    return candidates;
+}
+
+QString findExecutableAtKnownLocation( const QString& executable )
+{
+    const auto candidates = knownExecutableCandidatePaths( executable );
+    for ( const auto& candidate : candidates ) {
+        const QFileInfo info( candidate );
+        if ( info.exists() && info.isFile() && info.isExecutable() ) {
+            return info.absoluteFilePath();
+        }
+    }
+
+    const auto fromPath = QStandardPaths::findExecutable( executable );
+    if ( !fromPath.isEmpty() ) {
+        return fromPath;
+    }
+
+    return {};
+}
+
+bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
+{
+    if ( process.waitForFinished( timeoutMs ) ) {
+        return true;
+    }
+
+    process.kill();
+    process.waitForFinished( 1500 );
+    return false;
+}
+
+bool runPymobiledeviceListCommand( const QString& executable, const QStringList& arguments,
+                                   QList<IosDeviceInfo>* devices, QString* error )
+{
+    QProcess process;
+    process.start( executable, arguments );
+    if ( !process.waitForStarted( 3000 ) ) {
+        if ( error ) {
+            *error = process.errorString();
+        }
+        return false;
+    }
+
+    if ( !waitForFinishedOrKill( process, 5000 ) ) {
+        if ( error ) {
+            *error = QObject::tr( "Timed out waiting for iOS device list output" );
+        }
+        return false;
+    }
+
+    const auto stdOut = process.readAllStandardOutput();
+    if ( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ) {
+        if ( error ) {
+            const auto stdErr = QString::fromUtf8( process.readAllStandardError() ).trimmed();
+            *error = stdErr.isEmpty() ? process.errorString() : stdErr;
+        }
+        return false;
+    }
+
+    *devices = parsePymobiledeviceSimpleDeviceList( stdOut );
+    return true;
+}
+
+QStringList pymobiledeviceSimpleListArguments()
+{
+    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ), QStringLiteral( "--simple" ) };
+}
+
+QStringList pymobiledeviceLegacyListArguments()
+{
+    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ) };
+}
+#endif // Q_OS_MAC
+
+} // namespace
+
+IosDeviceListProvider::IosDeviceListProvider( QString executable, QObject* parent )
+    : DeviceListProviderBase( parent )
+    , executable_( std::move( executable ) )
+{
+}
+
+QString IosDeviceListProvider::detectIosSyslogExecutable()
+{
+#ifdef Q_OS_MAC
+    return findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
+#else
+    return {};
+#endif
+}
+
+QString IosDeviceListProvider::normalizedExecutable( const QString& executable )
+{
+    const auto expanded = expandTildePath( executable.trimmed() );
+    if ( !expanded.isEmpty() ) {
+        return expanded;
+    }
+
+#ifdef Q_OS_MAC
+    const auto detected = findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
+    if ( !detected.isEmpty() ) {
+        return detected;
+    }
+#endif
+
+    return QStringLiteral( "pymobiledevice3" );
+}
+
+bool IosDeviceListProvider::deviceMatches( const IosDeviceInfo& device,
+                                           const QString& deviceId ) const
+{
+    return device.udid == deviceId;
+}
+
+QList<IosDeviceInfo> IosDeviceListProvider::doListDevices( QString* error ) const
+{
+#ifndef Q_OS_MAC
+    Q_UNUSED( error );
+    if ( error ) {
+        *error = QObject::tr( "iOS log streaming is supported only on macOS." );
+    }
+    return {};
+#else
+    QList<IosDeviceInfo> devices;
+    const auto pymobiledeviceExecutable = normalizedExecutable( executable_ );
+    // Try the full JSON output first — it includes DeviceName, ProductType,
+    // ProductVersion, etc.  Fall back to --simple (UDID-only) only if the
+    // full listing is not supported by the installed pymobiledevice3 version.
+    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceLegacyListArguments(),
+                                        &devices, error ) ) {
+        QString simpleError;
+        if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable,
+                                            pymobiledeviceSimpleListArguments(), &devices,
+                                            &simpleError ) ) {
+            if ( error && !simpleError.isEmpty() ) {
+                *error = simpleError;
+            }
+            return {};
+        }
+
+        if ( error ) {
+            error->clear();
+        }
+    }
+
+    if ( devices.isEmpty() && error ) {
+        *error = QObject::tr( "No iOS devices reported by pymobiledevice3." );
+    }
+    return devices;
+#endif
+}

--- a/src/ui/src/iosdevicelistprovider.cpp
+++ b/src/ui/src/iosdevicelistprovider.cpp
@@ -94,7 +94,9 @@ bool runPymobiledeviceListCommand( const QString& executable, const QStringList&
         return false;
     }
 
-    if ( !waitForFinishedOrKill( process, 5000 ) ) {
+    // pymobiledevice3 can take ~8s on the slow path; use 10s to avoid
+    // premature timeouts on healthy-but-slow probes.
+    if ( !waitForFinishedOrKill( process, 10000 ) ) {
         if ( error ) {
             *error = QObject::tr( "Timed out waiting for iOS device list output" );
         }

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -127,19 +127,19 @@ IosLogDialog::IosLogDialog( QWidget* parent )
 
 AdbLogcatSessionData IosLogDialog::sessionData() const
 {
-    AdbLogcatSessionData data;
-    data.adbExecutable = executableEdit_->text().trimmed();
-    data.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
-    data.deviceDescription = deviceCombo_->currentText();
-    data.extraArgs = extraArgsEdit_->text().trimmed();
-    data.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
-    data.sourceType = LiveLogSourceType::IosLogStream;
-    data.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
-    data.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
-    data.maxReconnectAttempts = maxAttemptsSpinBox_->value();
-    data.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
-    data.captureBackupCount = backupCountSpinBox_->value();
-    return data;
+    AdbLogcatSessionData sessionData;
+    sessionData.adbExecutable = executableEdit_->text().trimmed();
+    sessionData.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
+    sessionData.deviceDescription = deviceCombo_->currentText();
+    sessionData.extraArgs = extraArgsEdit_->text().trimmed();
+    sessionData.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    sessionData.sourceType = LiveLogSourceType::IosLogStream;
+    sessionData.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
+    sessionData.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
+    sessionData.maxReconnectAttempts = maxAttemptsSpinBox_->value();
+    sessionData.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
+    sessionData.captureBackupCount = backupCountSpinBox_->value();
+    return sessionData;
 }
 
 void IosLogDialog::refreshDevices()

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -8,6 +8,7 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QUuid>
@@ -20,7 +21,7 @@ IosLogDialog::IosLogDialog( QWidget* parent )
 {
     setWindowTitle( tr( "Open iOS Log Stream" ) );
     setModal( true );
-    resize( 720, 220 );
+    resize( 720, 380 );
 
     auto* rootLayout = new QVBoxLayout( this );
     auto* formLayout = new QFormLayout();
@@ -44,10 +45,53 @@ IosLogDialog::IosLogDialog( QWidget* parent )
     ansiOutputCheckBox_ = new QCheckBox( tr( "Enable ANSI color output" ), this );
     ansiOutputCheckBox_->setObjectName( QStringLiteral( "ansiOutputCheckBox" ) );
 
+    // Auto-reconnect: enables automatic reconnection with exponential backoff
+    autoReconnectCheckBox_
+        = new QCheckBox( tr( "Enable auto-reconnect on connection loss" ), this );
+    autoReconnectCheckBox_->setObjectName( QStringLiteral( "autoReconnectCheckBox" ) );
+    autoReconnectCheckBox_->setToolTip(
+        tr( "When enabled, klogg automatically attempts to reconnect to the live source "
+            "after an unexpected disconnection or error. Uses exponential backoff "
+            "starting at 1 second and capping at 30 seconds between attempts." ) );
+
+    // Max reconnect attempts
+    maxAttemptsSpinBox_ = new QSpinBox( this );
+    maxAttemptsSpinBox_->setObjectName( QStringLiteral( "maxAttemptsSpinBox" ) );
+    maxAttemptsSpinBox_->setRange( 0, 9999 );
+    maxAttemptsSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    maxAttemptsSpinBox_->setToolTip(
+        tr( "Maximum number of automatic reconnection attempts before giving up. "
+            "Set to 0 for unlimited retries. Each retry uses increasing delay "
+            "(1s, 2s, 4s, 8s, ... up to 30s)." ) );
+
+    // Max capture file size (displayed in MB, stored in bytes)
+    maxFileSizeSpinBox_ = new QSpinBox( this );
+    maxFileSizeSpinBox_->setObjectName( QStringLiteral( "maxFileSizeSpinBox" ) );
+    maxFileSizeSpinBox_->setRange( 0, 1048576 ); // 0 to ~1 TB in MB
+    maxFileSizeSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    maxFileSizeSpinBox_->setSuffix( tr( " MB" ) );
+    maxFileSizeSpinBox_->setToolTip(
+        tr( "Maximum size of each rolling capture file in megabytes. "
+            "When exceeded, the file is rotated and a new one is started. "
+            "Set to 0 to disable size-based rolling." ) );
+
+    // Rolling backup count
+    backupCountSpinBox_ = new QSpinBox( this );
+    backupCountSpinBox_->setObjectName( QStringLiteral( "backupCountSpinBox" ) );
+    backupCountSpinBox_->setRange( 0, 999 );
+    backupCountSpinBox_->setToolTip(
+        tr( "Number of old capture files to keep when rolling by file size. "
+            "Older files beyond this count are deleted. "
+            "Set to 0 to keep all rotated files indefinitely." ) );
+
     formLayout->addRow( tr( "pymobiledevice3 executable" ), executableRowLayout );
     formLayout->addRow( tr( "Device" ), deviceCombo_ );
     formLayout->addRow( tr( "Extra iOS log args" ), extraArgsEdit_ );
     formLayout->addRow( QString{}, ansiOutputCheckBox_ );
+    formLayout->addRow( QString{}, autoReconnectCheckBox_ );
+    formLayout->addRow( tr( "Max reconnect attempts" ), maxAttemptsSpinBox_ );
+    formLayout->addRow( tr( "Max capture file size" ), maxFileSizeSpinBox_ );
+    formLayout->addRow( tr( "Rolling backup count" ), backupCountSpinBox_ );
 
     statusLabel_ = new QLabel( this );
     statusLabel_->setObjectName( QStringLiteral( "iosLogStatusLabel" ) );
@@ -75,16 +119,19 @@ IosLogDialog::IosLogDialog( QWidget* parent )
 
 AdbLogcatSessionData IosLogDialog::sessionData() const
 {
-    return AdbLogcatSessionData{
-        executableEdit_->text().trimmed(),
-        deviceCombo_->currentData( Qt::UserRole ).toString(),
-        deviceCombo_->currentText(),
-        extraArgsEdit_->text().trimmed(),
-        QUuid::createUuid().toString( QUuid::WithoutBraces ),
-        {},
-        LiveLogSourceType::IosLogStream,
-        ansiOutputCheckBox_->isChecked(),
-    };
+    AdbLogcatSessionData data;
+    data.adbExecutable = executableEdit_->text().trimmed();
+    data.deviceSerial = deviceCombo_->currentData( Qt::UserRole ).toString();
+    data.deviceDescription = deviceCombo_->currentText();
+    data.extraArgs = extraArgsEdit_->text().trimmed();
+    data.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    data.sourceType = LiveLogSourceType::IosLogStream;
+    data.ansiOutputEnabled = ansiOutputCheckBox_->isChecked();
+    data.autoReconnectEnabled = autoReconnectCheckBox_->isChecked();
+    data.maxReconnectAttempts = maxAttemptsSpinBox_->value();
+    data.captureMaxFileSize = static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024;
+    data.captureBackupCount = backupCountSpinBox_->value();
+    return data;
 }
 
 void IosLogDialog::refreshDevices()
@@ -122,6 +169,11 @@ void IosLogDialog::loadSettings()
     executableEdit_->setText( config.iosLogExecutable() );
     extraArgsEdit_->setText( config.iosLogExtraArgs() );
     ansiOutputCheckBox_->setChecked( config.iosLogAnsiOutputEnabled() );
+    autoReconnectCheckBox_->setChecked( config.liveAutoReconnectEnabled() );
+    maxAttemptsSpinBox_->setValue( config.liveAutoReconnectMaxAttempts() );
+    maxFileSizeSpinBox_->setValue(
+        static_cast<int>( config.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    backupCountSpinBox_->setValue( config.liveCaptureRollingBackupCount() );
 }
 
 void IosLogDialog::saveSettings() const
@@ -130,5 +182,10 @@ void IosLogDialog::saveSettings() const
     config.setIosLogExecutable( executableEdit_->text().trimmed() );
     config.setIosLogExtraArgs( extraArgsEdit_->text().trimmed() );
     config.setIosLogAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
+    config.setLiveAutoReconnectEnabled( autoReconnectCheckBox_->isChecked() );
+    config.setLiveAutoReconnectMaxAttempts( maxAttemptsSpinBox_->value() );
+    config.setLiveCaptureRollingMaxFileSize(
+        static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024 );
+    config.setLiveCaptureRollingBackupCount( backupCountSpinBox_->value() );
     config.save();
 }

--- a/src/ui/src/ioslogdialog.cpp
+++ b/src/ui/src/ioslogdialog.cpp
@@ -12,8 +12,12 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QUuid>
+#include <QtConcurrent>
+
+#include <memory>
 
 #include "configuration.h"
+#include "iosdevicelistprovider.h"
 #include "ioslogprocesstransport.h"
 
 IosLogDialog::IosLogDialog( QWidget* parent )
@@ -113,6 +117,10 @@ IosLogDialog::IosLogDialog( QWidget* parent )
     } );
     connect( buttonBox_, &QDialogButtonBox::rejected, this, &QDialog::reject );
 
+    deviceRefreshWatcher_ = new QFutureWatcher<QList<IosDeviceInfo>>( this );
+    connect( deviceRefreshWatcher_, &QFutureWatcher<QList<IosDeviceInfo>>::finished, this,
+             &IosLogDialog::onDevicesEnumerated );
+
     loadSettings();
     QTimer::singleShot( 0, this, &IosLogDialog::refreshDevices );
 }
@@ -137,16 +145,28 @@ AdbLogcatSessionData IosLogDialog::sessionData() const
 void IosLogDialog::refreshDevices()
 {
     deviceCombo_->clear();
+    updateAcceptState();
+    statusLabel_->setText( tr( "Detecting iOS devices..." ) );
 
-    QString error;
-    const auto devices = IosLogProcessTransport::listDevices( executableEdit_->text(), &error );
+    // Enumerate off the GUI thread: pymobiledevice3 can block for up to ~8s,
+    // and the previous synchronous call froze the whole dialog. A shared_ptr
+    // keeps the provider alive for the entire task, so this is use-after-free
+    // safe even if the dialog is closed mid-enumeration.
+    auto provider = std::make_shared<IosDeviceListProvider>( executableEdit_->text() );
+    deviceRefreshWatcher_->setFuture(
+        QtConcurrent::run( [provider]() { return provider->listDevices(); } ) );
+}
+
+void IosLogDialog::onDevicesEnumerated()
+{
+    const auto devices = deviceRefreshWatcher_->result();
     for ( const auto& device : devices ) {
         deviceCombo_->addItem( device.displayName, device.udid );
         deviceCombo_->setItemData( deviceCombo_->count() - 1, device.description, Qt::ToolTipRole );
     }
 
     if ( devices.isEmpty() ) {
-        statusLabel_->setText( error.isEmpty() ? tr( "No iOS devices detected." ) : error );
+        statusLabel_->setText( tr( "No iOS devices detected." ) );
     }
     else {
         statusLabel_->setText(
@@ -171,8 +191,7 @@ void IosLogDialog::loadSettings()
     ansiOutputCheckBox_->setChecked( config.iosLogAnsiOutputEnabled() );
     autoReconnectCheckBox_->setChecked( config.liveAutoReconnectEnabled() );
     maxAttemptsSpinBox_->setValue( config.liveAutoReconnectMaxAttempts() );
-    maxFileSizeSpinBox_->setValue(
-        static_cast<int>( config.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    maxFileSizeSpinBox_->setValue( config.liveCaptureRollingMaxFileSizeMb() );
     backupCountSpinBox_->setValue( config.liveCaptureRollingBackupCount() );
 }
 
@@ -184,8 +203,7 @@ void IosLogDialog::saveSettings() const
     config.setIosLogAnsiOutputEnabled( ansiOutputCheckBox_->isChecked() );
     config.setLiveAutoReconnectEnabled( autoReconnectCheckBox_->isChecked() );
     config.setLiveAutoReconnectMaxAttempts( maxAttemptsSpinBox_->value() );
-    config.setLiveCaptureRollingMaxFileSize(
-        static_cast<qint64>( maxFileSizeSpinBox_->value() ) * 1024 * 1024 );
+    config.setLiveCaptureRollingMaxFileSizeMb( maxFileSizeSpinBox_->value() );
     config.setLiveCaptureRollingBackupCount( backupCountSpinBox_->value() );
     config.save();
 }

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -1,6 +1,7 @@
 #include "ioslogprocesstransport.h"
 #include "commandargumenttokenizer.h"
 #include "iosdeviceparser.h"
+#include "log.h"
 
 #include <QDir>
 #include <QFileInfo>
@@ -199,6 +200,25 @@ QString IosLogProcessTransport::detectIosSyslogExecutable()
     return findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
 }
 
+bool IosLogProcessTransport::isDeviceAvailable() const
+{
+    QString error;
+    const auto devices = listDevices( normalizedExecutable(), &error );
+    if ( !error.isEmpty() ) {
+        // The list command itself failed (e.g. pymobiledevice3 not found).
+        // Assume the device is available — let connectTransport() handle the
+        // actual connection attempt.
+        LOG_WARNING << "iOS device pre-check unavailable: " << error;
+        return true;
+    }
+    for ( const auto& device : devices ) {
+        if ( device.udid == deviceUdid_ ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool IosLogProcessTransport::clearRemote( QString* error )
 {
     if ( error ) {
@@ -223,10 +243,28 @@ ProcessLiveSourceTransport::Command IosLogProcessTransport::streamingCommand() c
     // QProcess pipes stdout, isatty() is false so ANSI escape codes are never
     // emitted.  Wrap with /usr/bin/script to allocate a PTY so that
     // pymobiledevice3 sees a terminal and actually produces colored output.
+    //
+    // A PTY merges the child's stderr into stdout, which would let
+    // pymobiledevice3's diagnostic output (ERROR logs, urllib3 warnings) leak
+    // into the log view.  Run the inner command via a shell that redirects its
+    // stderr to the transport's temp file *outside* the PTY:
+    //   sh -c 'exec "$@" 2>"$0"' <stderrFile> <program> <args...>
+    // "$0" is the stderr file, "$@" is the program + args (passed through
+    // literally, with no shell-quoting hazard).  stderr is still captured for
+    // error detection (read from the temp file in the finished handler) but
+    // never reaches the log view.  macOS script(1) runs the command "with an
+    // optional argument vector" (execvp directly), so the sh -c string and the
+    // following args pass through unmodified.
     if ( ansiOutputEnabled_ ) {
-        auto args = QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
-                                 innerCommand.program }
-                    + innerCommand.arguments;
+        auto args = QStringList{
+            QStringLiteral( "-q" ),
+            QStringLiteral( "/dev/null" ),
+            QStringLiteral( "/bin/sh" ),
+            QStringLiteral( "-c" ),
+            QStringLiteral( "exec \"$@\" 2>\"$0\"" ),
+            stderrFilePath(),
+            innerCommand.program,
+        } + innerCommand.arguments;
         return Command{ QStringLiteral( "/usr/bin/script" ), std::move( args ) };
     }
 #endif

--- a/src/ui/src/ioslogprocesstransport.cpp
+++ b/src/ui/src/ioslogprocesstransport.cpp
@@ -1,133 +1,14 @@
 #include "ioslogprocesstransport.h"
 #include "commandargumenttokenizer.h"
 #include "iosdeviceparser.h"
+#include "iosdevicelistprovider.h"
 #include "log.h"
-
-#include <QDir>
-#include <QFileInfo>
-#include <QProcess>
-#include <QStandardPaths>
 
 #include <utility>
 
 namespace {
 
 using ui::internal::splitCommandArguments;
-using ui::internal::expandTildePath;
-
-#ifdef Q_OS_MAC
-QStringList knownExecutableCandidatePaths( const QString& executable )
-{
-    QStringList candidates{
-        QDir::cleanPath( QStringLiteral( "/opt/homebrew/bin/" ) + executable ),
-        QDir::cleanPath( QStringLiteral( "/usr/local/bin/" ) + executable ),
-    };
-
-    const auto homeDir = QStandardPaths::writableLocation( QStandardPaths::HomeLocation );
-    if ( !homeDir.isEmpty() ) {
-        const auto pythonRoot = QDir( homeDir + QStringLiteral( "/Library/Python" ) );
-        const auto versionDirs = pythonRoot.entryList( QDir::Dirs | QDir::NoDotAndDotDot );
-        for ( const auto& version : versionDirs ) {
-            candidates.append(
-                QDir::cleanPath( pythonRoot.absoluteFilePath( version + QStringLiteral( "/bin/" ) + executable ) ) );
-        }
-    }
-
-    return candidates;
-}
-#endif
-
-QString findExecutableAtKnownLocation( const QString& executable )
-{
-#ifdef Q_OS_MAC
-    const auto candidates = knownExecutableCandidatePaths( executable );
-    for ( const auto& candidate : candidates ) {
-        const QFileInfo info( candidate );
-        if ( info.exists() && info.isFile() && info.isExecutable() ) {
-            return info.absoluteFilePath();
-        }
-    }
-
-    const auto fromPath = QStandardPaths::findExecutable( executable );
-    if ( !fromPath.isEmpty() ) {
-        return fromPath;
-    }
-#else
-    Q_UNUSED( executable );
-#endif
-
-    return {};
-}
-
-QString normalizedIosSyslogExecutable( const QString& executable )
-{
-    const auto expanded = expandTildePath( executable.trimmed() );
-    if ( !expanded.isEmpty() ) {
-        return expanded;
-    }
-
-    const auto detected = findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
-    if ( !detected.isEmpty() ) {
-        return detected;
-    }
-
-    return QStringLiteral( "pymobiledevice3" );
-}
-
-#ifdef Q_OS_MAC
-bool waitForFinishedOrKill( QProcess& process, int timeoutMs )
-{
-    if ( process.waitForFinished( timeoutMs ) ) {
-        return true;
-    }
-
-    process.kill();
-    process.waitForFinished( 1500 );
-    return false;
-}
-
-bool runPymobiledeviceListCommand( const QString& executable, const QStringList& arguments,
-                                   QList<IosDeviceInfo>* devices, QString* error )
-{
-    QProcess process;
-    process.start( executable, arguments );
-    if ( !process.waitForStarted( 3000 ) ) {
-        if ( error ) {
-            *error = process.errorString();
-        }
-        return false;
-    }
-
-    if ( !waitForFinishedOrKill( process, 5000 ) ) {
-        if ( error ) {
-            *error = QObject::tr( "Timed out waiting for iOS device list output" );
-        }
-        return false;
-    }
-
-    const auto stdOut = process.readAllStandardOutput();
-    if ( process.exitStatus() != QProcess::NormalExit || process.exitCode() != 0 ) {
-        if ( error ) {
-            const auto stdErr = QString::fromUtf8( process.readAllStandardError() ).trimmed();
-            *error = stdErr.isEmpty() ? process.errorString() : stdErr;
-        }
-        return false;
-    }
-
-    *devices = parsePymobiledeviceSimpleDeviceList( stdOut );
-    return true;
-}
-
-QStringList pymobiledeviceSimpleListArguments()
-{
-    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ), QStringLiteral( "--simple" ) };
-}
-
-QStringList pymobiledeviceLegacyListArguments()
-{
-    return { QStringLiteral( "usbmux" ), QStringLiteral( "list" ) };
-}
-#endif
 
 QStringList pymobiledeviceStreamingArguments( const QString& deviceUdid )
 {
@@ -153,70 +34,25 @@ IosLogProcessTransport::IosLogProcessTransport( QString executable, QString devi
     , deviceUdid_( std::move( deviceUdid ) )
     , extraArgs_( std::move( extraArgs ) )
     , ansiOutputEnabled_( ansiOutputEnabled )
+    , deviceProvider_( std::make_unique<IosDeviceListProvider>( executable_, this ) )
 {
 }
 
 QList<IosDeviceInfo> IosLogProcessTransport::listDevices( const QString& executable,
                                                           QString* error )
 {
-#ifndef Q_OS_MAC
-    Q_UNUSED( executable );
-    if ( error ) {
-        *error = QObject::tr( "iOS log streaming is supported only on macOS." );
-    }
-    return {};
-#else
-    QList<IosDeviceInfo> devices;
-    const auto pymobiledeviceExecutable = normalizedIosSyslogExecutable( executable );
-    // Try the full JSON output first — it includes DeviceName, ProductType,
-    // ProductVersion, etc.  Fall back to --simple (UDID-only) only if the
-    // full listing is not supported by the installed pymobiledevice3 version.
-    if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable, pymobiledeviceLegacyListArguments(),
-                                        &devices, error ) ) {
-        QString simpleError;
-        if ( !runPymobiledeviceListCommand( pymobiledeviceExecutable,
-                                            pymobiledeviceSimpleListArguments(), &devices,
-                                            &simpleError ) ) {
-            if ( error && !simpleError.isEmpty() ) {
-                *error = simpleError;
-            }
-            return {};
-        }
-
-        if ( error ) {
-            error->clear();
-        }
-    }
-
-    if ( devices.isEmpty() && error ) {
-        *error = QObject::tr( "No iOS devices reported by pymobiledevice3." );
-    }
-    return devices;
-#endif
+    IosDeviceListProvider provider( executable );
+    return provider.listDevices( error );
 }
 
 QString IosLogProcessTransport::detectIosSyslogExecutable()
 {
-    return findExecutableAtKnownLocation( QStringLiteral( "pymobiledevice3" ) );
+    return IosDeviceListProvider::detectIosSyslogExecutable();
 }
 
-bool IosLogProcessTransport::isDeviceAvailable() const
+IosDeviceListProvider* IosLogProcessTransport::deviceListProvider() const
 {
-    QString error;
-    const auto devices = listDevices( normalizedExecutable(), &error );
-    if ( !error.isEmpty() ) {
-        // The list command itself failed (e.g. pymobiledevice3 not found).
-        // Assume the device is available — let connectTransport() handle the
-        // actual connection attempt.
-        LOG_WARNING << "iOS device pre-check unavailable: " << error;
-        return true;
-    }
-    for ( const auto& device : devices ) {
-        if ( device.udid == deviceUdid_ ) {
-            return true;
-        }
-    }
-    return false;
+    return deviceProvider_.get();
 }
 
 bool IosLogProcessTransport::clearRemote( QString* error )
@@ -284,7 +120,7 @@ ProcessLiveSourceTransport::Command IosLogProcessTransport::clearCommand() const
 
 QString IosLogProcessTransport::normalizedExecutable() const
 {
-    return normalizedIosSyslogExecutable( executable_ );
+    return IosDeviceListProvider::normalizedExecutable( executable_ );
 }
 
 QStringList IosLogProcessTransport::streamArguments() const

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -177,6 +177,57 @@ bool ProcessLiveSourceTransport::connectTransport()
     return true;
 }
 
+void ProcessLiveSourceTransport::connectTransportAsync()
+{
+    if ( state_ == State::Connected ) {
+        return;
+    }
+
+    const auto command = streamingCommand();
+    lastError_.clear();
+    QFile::remove( stderrFilePath_ );
+    process_->setStandardErrorFile( stderrFilePath_ );
+    process_->setProgram( command.program );
+    process_->setArguments( command.arguments );
+    disconnectRequested_ = false;
+    setState( State::Connecting );
+    process_->start();
+
+    // After the grace period, if we're still in Connecting state and the
+    // process is running, we're connected.  If the process failed to start
+    // (errorOccurred FailedToStart) or crashed during the grace (finished),
+    // the existing handlers already transitioned to Error — the timer just
+    // confirms the happy path.
+    QPointer<ProcessLiveSourceTransport> self( this );
+    QTimer::singleShot( StartupFailureGracePeriodMs, this, [ this, self ]() {
+        if ( !self || destroyed_ || disconnectRequested_ ) {
+            return;
+        }
+        // Another handler (errorOccurred / finished) already moved us past
+        // Connecting — nothing to do.
+        if ( state_ != State::Connecting ) {
+            return;
+        }
+
+        if ( process_->state() == QProcess::Running ) {
+            setState( State::Connected );
+        }
+        else {
+            // Process exited during the grace without triggering the normal
+            // errorOccurred/finished handlers — read stderr for diagnostics.
+            QString stdErr;
+            QFile stderrFile( stderrFilePath_ );
+            if ( stderrFile.open( QIODevice::ReadOnly ) ) {
+                stdErr = QString::fromUtf8( stderrFile.readAll() ).trimmed();
+                stderrFile.close();
+            }
+            lastError_ = stdErr.isEmpty() ? tr( "Live source terminated during startup" ) : stdErr;
+            setState( State::Error );
+            Q_EMIT errorOccurred( lastError_ );
+        }
+    } );
+}
+
 void ProcessLiveSourceTransport::disconnectTransport()
 {
     if ( !process_ || process_->state() == QProcess::NotRunning ) {

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -199,13 +199,23 @@ void ProcessLiveSourceTransport::connectTransportAsync()
     // the existing handlers already transitioned to Error — the timer just
     // confirms the happy path.
     QPointer<ProcessLiveSourceTransport> self( this );
-    QTimer::singleShot( StartupFailureGracePeriodMs, this, [ this, self ]() {
+    // Capture the specific process instance so a reconnect that replaces
+    // process_ before the timer fires cannot promote the wrong process to
+    // Connected.
+    auto* startedProcess = process_.get();
+    QTimer::singleShot( StartupFailureGracePeriodMs, this,
+                         [ this, self, startedProcess ]() {
         if ( !self || destroyed_ || disconnectRequested_ ) {
             return;
         }
         // Another handler (errorOccurred / finished) already moved us past
         // Connecting — nothing to do.
         if ( state_ != State::Connecting ) {
+            return;
+        }
+
+        // A reconnect replaced process_ — this timer is stale.
+        if ( process_.get() != startedProcess ) {
             return;
         }
 

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -176,6 +176,11 @@ void ProcessLiveSourceTransport::disconnectTransport()
         return;
     }
 
+    // Clean up the stderr temp file before detaching the process.
+    // The finished lambda (which normally removes this file) will never
+    // fire because we're about to disconnect it.
+    QFile::remove( stderrFilePath_ );
+
     // Detach old process and cut all signal connections
     auto* dying = process_.release();
     dying->disconnect( this );

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -156,7 +156,16 @@ bool ProcessLiveSourceTransport::connectTransport()
 
     if ( state_ == State::Error || process_->state() == QProcess::NotRunning ) {
         if ( lastError_.isEmpty() ) {
-            const auto stdErr = QString::fromUtf8( process_->readAllStandardError() ).trimmed();
+            // stderr is redirected to stderrFilePath_ via setStandardErrorFile(),
+            // so readAllStandardError() is always empty here. Read the temp file
+            // instead so the real startup error surfaces (matches the finished
+            // handler).
+            QString stdErr;
+            QFile stderrFile( stderrFilePath_ );
+            if ( stderrFile.open( QIODevice::ReadOnly ) ) {
+                stdErr = QString::fromUtf8( stderrFile.readAll() ).trimmed();
+                stderrFile.close();
+            }
             lastError_ = stdErr.isEmpty() ? tr( "Live source terminated during startup" ) : stdErr;
             setState( State::Error );
             Q_EMIT errorOccurred( lastError_ );

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -1,7 +1,9 @@
 #include "livesourcetransport.h"
 
 #include <QCoreApplication>
+#include <QDir>
 #include <QElapsedTimer>
+#include <QFile>
 #include <QMetaType>
 #include <QPointer>
 #include <QProcess>
@@ -36,6 +38,11 @@ void ProcessLiveSourceTransport::createProcess()
     process_ = std::make_unique<QProcess>();
     process_->setProcessChannelMode( QProcess::SeparateChannels );
 
+    // Redirect stderr to a temp file so it never reaches the log view.
+    // We read the file in the finished handler for error detection only.
+    stderrFilePath_ = QDir::tempPath() + QStringLiteral( "/klogg_stderr_%1.log" )
+                          .arg( reinterpret_cast<quintptr>( this ), 0, 16 );
+
     connect( process_.get(), &QProcess::readyReadStandardOutput, this, [ this ] {
         auto data = process_->readAllStandardOutput();
         if ( !data.isEmpty() ) {
@@ -43,14 +50,6 @@ void ProcessLiveSourceTransport::createProcess()
             if ( !data.isEmpty() ) {
                 Q_EMIT bytesReceived( data );
             }
-        }
-    } );
-
-    connect( process_.get(), &QProcess::readyReadStandardError, this, [ this ] {
-        const auto stdErr = QString::fromUtf8( process_->readAllStandardError() ).trimmed();
-        if ( !stdErr.isEmpty() ) {
-            lastError_ = stdErr;
-            LOG_WARNING << "live source stderr " << stdErr;
         }
     } );
 
@@ -79,6 +78,21 @@ void ProcessLiveSourceTransport::createProcess()
                  }
 
                  if ( state_ == State::Connected || state_ == State::Connecting ) {
+                     // Read stderr from the temp file for error detection.
+                     // Stderr never reaches the log view because it's
+                     // redirected to this file.
+                     if ( lastError_.isEmpty() ) {
+                         QFile stderrFile( stderrFilePath_ );
+                         if ( stderrFile.open( QIODevice::ReadOnly ) ) {
+                             const auto stdErr
+                                 = QString::fromUtf8( stderrFile.readAll() ).trimmed();
+                             if ( !stdErr.isEmpty() ) {
+                                 lastError_ = stdErr;
+                                 LOG_WARNING << "live source stderr " << stdErr;
+                             }
+                             stderrFile.close();
+                         }
+                     }
                      if ( lastError_.isEmpty() ) {
                          lastError_ = exitStatus == QProcess::NormalExit
                                           ? tr( "Live source exited unexpectedly (%1)" ).arg( exitCode )
@@ -87,6 +101,9 @@ void ProcessLiveSourceTransport::createProcess()
                      setState( State::Error );
                      Q_EMIT errorOccurred( lastError_ );
                  }
+
+                 // Clean up stderr temp file
+                 QFile::remove( stderrFilePath_ );
              } );
 }
 
@@ -104,6 +121,11 @@ bool ProcessLiveSourceTransport::connectTransport()
 
     const auto command = streamingCommand();
     lastError_.clear();
+    // Clean up any previous stderr temp file and redirect stderr so it never
+    // appears in the log view. We read it in the finished handler for error
+    // detection only.
+    QFile::remove( stderrFilePath_ );
+    process_->setStandardErrorFile( stderrFilePath_ );
     process_->setProgram( command.program );
     process_->setArguments( command.arguments );
     disconnectRequested_ = false;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -2393,9 +2393,17 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
         const auto state = source->state();
         LiveTabStatus liveStatus = LiveTabStatus::Connected;
         if ( state == AdbLogcatSource::State::Error ) {
-            liveStatus = LiveTabStatus::Error;
-            if ( !source->lastError().isEmpty() ) {
-                toolTip = tr( "%1\nError: %2" ).arg( baseTip, source->lastError() );
+            if ( source->isAutoReconnectActive() ) {
+                liveStatus = LiveTabStatus::Reconnecting;
+                toolTip = tr( "%1\nReconnecting... (attempt %2)" )
+                              .arg( baseTip )
+                              .arg( source->reconnectAttempt() );
+            }
+            else {
+                liveStatus = LiveTabStatus::Error;
+                if ( !source->lastError().isEmpty() ) {
+                    toolTip = tr( "%1\nError: %2" ).arg( baseTip, source->lastError() );
+                }
             }
         }
         else if ( state == AdbLogcatSource::State::Disconnected ) {
@@ -2418,6 +2426,13 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
         return;
     }
 
+    // Apply auto-reconnect and capture limit configuration
+    const auto& config = Configuration::get();
+    adbSource->setAutoReconnectEnabled( config.liveAutoReconnectEnabled() );
+    adbSource->setAutoReconnectMaxAttempts( config.liveAutoReconnectMaxAttempts() );
+    adbSource->setCaptureLimits( config.liveCaptureRollingMaxFileSize(),
+                                 config.liveCaptureRollingBackupCount() );
+
     connect( adbSource, &AdbLogcatSource::stateChanged, this,
              [ this, crawler ]( AdbLogcatSource::State ) {
                  if ( currentCrawlerWidget() == crawler ) {
@@ -2434,6 +2449,8 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
                  }
                  updateLiveTabAppearance( crawler );
              } );
+    connect( adbSource, &AdbLogcatSource::reconnectAttemptStarted, this,
+             [ this, crawler ]( int ) { updateLiveTabAppearance( crawler ); } );
 
     // Sync tab appearance immediately in case the source is already
     // in Error or Disconnected state (e.g. during session restore).
@@ -2518,7 +2535,7 @@ void MainWindow::updateMenuBarFromDocument( const CrawlerWidget* crawler )
     const auto sourceState
         = adbSource ? adbSource->state() : AdbLogcatSource::State::Disconnected;
     disconnectSourceAction->setEnabled( isLiveDocument
-                                        && sourceState == AdbLogcatSource::State::Connected );
+                                        && sourceState != AdbLogcatSource::State::Disconnected );
     reconnectSourceAction->setEnabled( isLiveDocument
                                        && sourceState != AdbLogcatSource::State::Connected );
 }

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1394,9 +1394,20 @@ void MainWindow::saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode )
     QString outputPath;
     {
         ScopedMainWindowShortcutSuspender shortcutSuspender( this );
+        // Use non-native dialog on macOS: the native NSSavePanel creates a
+        // standalone NSWindow.  After the panel is dismissed, stale Cocoa
+        // events linger in the queue.  bindOutputFile() below performs
+        // heavy synchronous I/O (writing buffered segments with file
+        // splitting), which blocks the event loop.  By the time control
+        // returns to the main event loop, the NSSavePanel's NSWindow is
+        // gone, and dispatching the stale events to the dead window
+        // triggers an ObjC exception → SIGABRT.
+        //
+        // The non-native Qt file dialog avoids the NSWindow altogether.
         outputPath = QFileDialog::getSaveFileName(
             this, tr( "Save live log" ), suggestedPath,
-            tr( "Log files (*.log *.txt);;All files (*)" ) );
+            tr( "Log files (*.log *.txt);;All files (*)" ), nullptr,
+            QFileDialog::DontUseNativeDialog );
     }
     if ( outputPath.isEmpty() ) {
         return;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1394,20 +1394,9 @@ void MainWindow::saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode )
     QString outputPath;
     {
         ScopedMainWindowShortcutSuspender shortcutSuspender( this );
-        // Use non-native dialog on macOS: the native NSSavePanel creates a
-        // standalone NSWindow.  After the panel is dismissed, stale Cocoa
-        // events linger in the queue.  bindOutputFile() below performs
-        // heavy synchronous I/O (writing buffered segments with file
-        // splitting), which blocks the event loop.  By the time control
-        // returns to the main event loop, the NSSavePanel's NSWindow is
-        // gone, and dispatching the stale events to the dead window
-        // triggers an ObjC exception → SIGABRT.
-        //
-        // The non-native Qt file dialog avoids the NSWindow altogether.
         outputPath = QFileDialog::getSaveFileName(
             this, tr( "Save live log" ), suggestedPath,
-            tr( "Log files (*.log *.txt);;All files (*)" ), nullptr,
-            QFileDialog::DontUseNativeDialog );
+            tr( "Log files (*.log *.txt);;All files (*)" ) );
     }
     if ( outputPath.isEmpty() ) {
         return;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -2426,12 +2426,13 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
         return;
     }
 
-    // Apply auto-reconnect and capture limit configuration
-    const auto& config = Configuration::get();
-    adbSource->setAutoReconnectEnabled( config.liveAutoReconnectEnabled() );
-    adbSource->setAutoReconnectMaxAttempts( config.liveAutoReconnectMaxAttempts() );
-    adbSource->setCaptureLimits( config.liveCaptureRollingMaxFileSize(),
-                                 config.liveCaptureRollingBackupCount() );
+    // Apply auto-reconnect and capture limit configuration from session data
+    // (populated by the open dialog or session restore).
+    const auto& sessionData = adbSource->sessionData();
+    adbSource->setAutoReconnectEnabled( sessionData.autoReconnectEnabled );
+    adbSource->setAutoReconnectMaxAttempts( sessionData.maxReconnectAttempts );
+    adbSource->setCaptureLimits( sessionData.captureMaxFileSize,
+                                 sessionData.captureBackupCount );
 
     connect( adbSource, &AdbLogcatSource::stateChanged, this,
              [ this, crawler ]( AdbLogcatSource::State ) {

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1177,7 +1177,16 @@ void MainWindow::openRemoteFile( const QUrl& url )
     auto tempFile = new QTemporaryFile( tempDir_.filePath( url.fileName() ), this );
     if ( tempFile->open() ) {
         downloader.download( url, tempFile );
-        if ( !progressDialog.exec() ) {
+        const auto downloadResult = progressDialog.exec();
+
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        // On macOS, a parentless QProgressDialog gets its own NSWindow.  After
+        // exec() returns, orphaned Cocoa events may remain in the queue.  If the
+        // dialog is destroyed before those events are drained, the main event
+        // loop will try to dispatch them to the dead window → SIGABRT.
+        QCoreApplication::processEvents();
+
+        if ( !downloadResult ) {
             loadFile( tempFile->fileName() );
         }
         else {
@@ -2153,6 +2162,11 @@ bool MainWindow::extractAndLoadFile( const QString& fileName )
     progressDialog.setLabelText( tr( "Extracting %1" ).arg( fileName ) );
     progressDialog.setRange( 0, 0 );
 
+    // Note: this progressDialog is parentless.  After each exec() call below,
+    // QCoreApplication::processEvents() must be called to drain stale Cocoa
+    // events while the NSWindow is still alive.  See openRemoteFile() for the
+    // full explanation of the macOS Cocoa lifecycle issue.
+
     connect( &decompressor, &Decompressor::finished,
              [ &progressDialog ]( bool isOk ) { progressDialog.done( isOk ? 0 : 1 ); } );
     connect( &progressDialog, &QProgressDialog::canceled,
@@ -2166,8 +2180,15 @@ bool MainWindow::extractAndLoadFile( const QString& fileName )
         auto tempFile = new QTemporaryFile(
             this->tempDir_.filePath( QFileInfo( fileName ).fileName() ), this );
 
-        if ( tempFile->open() && decompressor.decompress( fileName, tempFile, decompressInterrupt )
-             && !progressDialog.exec() ) {
+        const bool decompressOk = tempFile->open()
+                                  && decompressor.decompress( fileName, tempFile,
+                                                              decompressInterrupt );
+        const bool decompressAccepted = decompressOk && !progressDialog.exec();
+
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        QCoreApplication::processEvents();
+
+        if ( decompressAccepted ) {
 
             if ( decompressInterrupt ) {
                 return false;
@@ -2184,8 +2205,15 @@ bool MainWindow::extractAndLoadFile( const QString& fileName )
     else if ( decompressAction == DecompressAction::Extract ) {
         QTemporaryDir archiveDir{ this->tempDir_.filePath( QFileInfo( fileName ).fileName() ) };
         archiveDir.setAutoRemove( false );
-        if ( decompressor.extract( fileName, archiveDir.path(), decompressInterrupt )
-             && !progressDialog.exec() ) {
+
+        const bool extractOk
+            = decompressor.extract( fileName, archiveDir.path(), decompressInterrupt );
+        const bool extractAccepted = extractOk && !progressDialog.exec();
+
+        // Drain stale Cocoa events while the dialog's NSWindow is still alive.
+        QCoreApplication::processEvents();
+
+        if ( extractAccepted ) {
 
             if ( decompressInterrupt ) {
                 return false;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -2425,7 +2425,7 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
                 liveStatus = LiveTabStatus::Reconnecting;
                 toolTip = tr( "%1\nReconnecting... (attempt %2)" )
                               .arg( baseTip )
-                              .arg( source->reconnectAttempt() );
+                              .arg( source->reconnectAttempt() + 1 );
             }
             else {
                 liveStatus = LiveTabStatus::Error;

--- a/src/ui/src/newversiondialog.cpp
+++ b/src/ui/src/newversiondialog.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2019 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "newversiondialog.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QPushButton>
+#include <QTextBrowser>
+#include <QVBoxLayout>
+
+NewVersionDialog::NewVersionDialog( const QString& version, const QString& url,
+                                    const QStringList& changes, QWidget* parent )
+    : QDialog( parent )
+{
+    setWindowTitle( tr( "New Version Available" ) );
+    setupUi( version, url, changes );
+}
+
+void NewVersionDialog::setupUi( const QString& version, const QString& url,
+                                const QStringList& changes )
+{
+    auto* mainLayout = new QVBoxLayout( this );
+
+    // Header: version info with clickable link
+    auto* headerLabel = new QLabel( this );
+    headerLabel->setTextFormat( Qt::RichText );
+    headerLabel->setTextInteractionFlags( Qt::TextBrowserInteraction );
+    headerLabel->setOpenExternalLinks( true );
+    headerLabel->setText(
+        tr( "<p>A new version of klogg (%1) is available for download.</p>"
+            "<p><a href=\"%2\">%2</a></p>" )
+            .arg( version, url ) );
+    headerLabel->setWordWrap( true );
+    mainLayout->addWidget( headerLabel );
+
+    // Changelog area (scrollable, height-limited)
+    if ( !changes.isEmpty() ) {
+        auto* changesLabel = new QLabel( tr( "Important changes:" ), this );
+        mainLayout->addWidget( changesLabel );
+
+        changesBrowser_ = new QTextBrowser( this );
+        changesBrowser_->setReadOnly( true );
+        changesBrowser_->setOpenExternalLinks( true );
+        changesBrowser_->setMaximumHeight( kMaxChangesHeight );
+        changesBrowser_->setMinimumHeight( kMaxChangesHeight / 2 );
+
+        // Build the changelog text. The release body from GitHub is
+        // markdown; use setMarkdown when available (Qt >= 5.14),
+        // otherwise fall back to plain text.
+        QString changelogText;
+        for ( const auto& change : changes ) {
+            if ( !changelogText.isEmpty() ) {
+                changelogText.append( QLatin1String( "\n\n" ) );
+            }
+            changelogText.append( change );
+        }
+
+#if ( QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 ) )
+        changesBrowser_->setMarkdown( changelogText );
+#else
+        changesBrowser_->setPlainText( changelogText );
+#endif
+
+        mainLayout->addWidget( changesBrowser_, /*stretch=*/1 );
+    }
+
+    // Buttons
+    auto* buttonBox = new QDialogButtonBox( this );
+
+    auto* downloadButton
+        = buttonBox->addButton( tr( "Download" ), QDialogButtonBox::AcceptRole );
+    auto* remindButton
+        = buttonBox->addButton( tr( "Remind Later" ), QDialogButtonBox::RejectRole );
+    auto* skipButton
+        = buttonBox->addButton( tr( "Skip This Version" ),
+                                QDialogButtonBox::DestructiveRole );
+
+    buttonBox->setCenterButtons( false );
+
+    mainLayout->addWidget( buttonBox );
+
+    // Connect buttons
+    connect( downloadButton, &QPushButton::clicked, this, [ this ] {
+        clickedButton_ = Download;
+        accept();
+    } );
+    connect( remindButton, &QPushButton::clicked, this, [ this ] {
+        clickedButton_ = RemindLater;
+        reject();
+    } );
+    connect( skipButton, &QPushButton::clicked, this, [ this ] {
+        clickedButton_ = SkipVersion;
+        reject();
+    } );
+
+    // Prevent the dialog from growing beyond the screen
+    setMaximumHeight( 600 );
+}

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -81,6 +81,7 @@ OptionsDialog::OptionsDialog( QWidget* parent )
     setupEncodings();
     setupLanguageList();
     setupIosLogSettings();
+    setupLiveSourceSettings();
     setupPanelResetButtons();
 
     // Validators
@@ -322,6 +323,111 @@ void OptionsDialog::setupIosLogSettings()
 #ifndef Q_OS_MAC
     iosLogGroupBox_->setVisible( false );
 #endif
+}
+
+void OptionsDialog::setupLiveSourceSettings()
+{
+    // Live Source group box with auto-reconnect and capture file rolling settings.
+    // These settings control the behavior of live log streams (ADB logcat, iOS log).
+    // Inserted on the File tab alongside the ADB and iOS log stream settings.
+
+    liveSourceGroupBox_ = new QGroupBox( tr( "Live Source" ), file_watch_tab );
+    liveSourceGroupBox_->setObjectName( QStringLiteral( "liveSourceGroupBox" ) );
+
+    auto* layout = new QVBoxLayout( liveSourceGroupBox_ );
+
+    // Auto-reconnect toggle — enables/disables automatic reconnection when the
+    // live source unexpectedly disconnects or encounters an error. Uses
+    // exponential backoff starting at 1 second and capping at 30 seconds
+    // between attempts.
+    liveSourceAutoReconnectCheckBox_ = new QCheckBox(
+        tr( "Enable auto-reconnect on connection loss" ), liveSourceGroupBox_ );
+    liveSourceAutoReconnectCheckBox_->setObjectName(
+        QStringLiteral( "liveSourceAutoReconnectCheckBox" ) );
+    liveSourceAutoReconnectCheckBox_->setToolTip(
+        tr( "When enabled, klogg automatically attempts to reconnect to the live source "
+            "after an unexpected disconnection or error. Uses exponential backoff "
+            "starting at 1 second and capping at 30 seconds between attempts." ) );
+
+    // Max reconnect attempts — limits the number of automatic reconnection
+    // attempts. Set to 0 for unlimited retries. Each attempt uses increasing
+    // delay (1s, 2s, 4s, 8s, ... up to 30s).
+    auto* maxAttemptsRow = new QHBoxLayout();
+    auto* maxAttemptsLabel = new QLabel( tr( "Max reconnect attempts" ), liveSourceGroupBox_ );
+    maxAttemptsLabel->setToolTip(
+        tr( "Maximum number of automatic reconnection attempts. "
+            "Set to 0 for unlimited retries. Each retry waits longer (exponential backoff)." ) );
+    liveSourceMaxAttemptsSpinBox_ = new QSpinBox( liveSourceGroupBox_ );
+    liveSourceMaxAttemptsSpinBox_->setObjectName(
+        QStringLiteral( "liveSourceMaxAttemptsSpinBox" ) );
+    liveSourceMaxAttemptsSpinBox_->setRange( 0, 9999 );
+    liveSourceMaxAttemptsSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    liveSourceMaxAttemptsSpinBox_->setToolTip(
+        tr( "Maximum number of automatic reconnection attempts. "
+            "Set to 0 for unlimited retries." ) );
+    maxAttemptsRow->addWidget( maxAttemptsLabel );
+    maxAttemptsRow->addWidget( liveSourceMaxAttemptsSpinBox_ );
+    maxAttemptsRow->addStretch();
+
+    // Max capture file size — when the live capture output file exceeds this
+    // size, it is rotated (renamed as a numbered backup) and a new file is
+    // started. Set to 0 to disable size-based rolling.
+    auto* maxFileSizeRow = new QHBoxLayout();
+    auto* maxFileSizeLabel = new QLabel( tr( "Max capture file size (MB)" ), liveSourceGroupBox_ );
+    maxFileSizeLabel->setToolTip(
+        tr( "When the capture file exceeds this size, it is rotated. "
+            "Set to 0 for unlimited size (no rotation by size)." ) );
+    liveSourceRollingMaxFileSizeSpinBox_ = new QSpinBox( liveSourceGroupBox_ );
+    liveSourceRollingMaxFileSizeSpinBox_->setObjectName(
+        QStringLiteral( "liveSourceRollingMaxFileSizeSpinBox" ) );
+    liveSourceRollingMaxFileSizeSpinBox_->setRange( 0, 1048576 ); // 0 to ~1 TB in MB
+    liveSourceRollingMaxFileSizeSpinBox_->setSpecialValueText( tr( "Unlimited" ) );
+    liveSourceRollingMaxFileSizeSpinBox_->setSuffix( tr( " MB" ) );
+    liveSourceRollingMaxFileSizeSpinBox_->setToolTip(
+        tr( "Maximum size of each rolling capture file in megabytes. "
+            "When exceeded, a new file is started and oldest files may be deleted "
+            "if the backup count is also set. Set to 0 to disable rolling by file size." ) );
+    maxFileSizeRow->addWidget( maxFileSizeLabel );
+    maxFileSizeRow->addWidget( liveSourceRollingMaxFileSizeSpinBox_ );
+    maxFileSizeRow->addStretch();
+
+    // Rolling backup count — number of old capture files to retain during
+    // rotation. Files beyond this count are deleted. Set to 0 to disable
+    // rolling backup (no backup files retained, only the current file).
+    auto* backupCountRow = new QHBoxLayout();
+    auto* backupCountLabel = new QLabel( tr( "Rolling backup count" ), liveSourceGroupBox_ );
+    backupCountLabel->setToolTip(
+        tr( "Number of old capture files to keep when rolling. "
+            "Older files beyond this count are automatically deleted. "
+            "Set to 0 to disable rolling backup (only the current file is kept)." ) );
+    liveSourceRollingBackupCountSpinBox_ = new QSpinBox( liveSourceGroupBox_ );
+    liveSourceRollingBackupCountSpinBox_->setObjectName(
+        QStringLiteral( "liveSourceRollingBackupCountSpinBox" ) );
+    liveSourceRollingBackupCountSpinBox_->setRange( 0, 999 );
+    liveSourceRollingBackupCountSpinBox_->setSpecialValueText( tr( "No rolling" ) );
+    liveSourceRollingBackupCountSpinBox_->setToolTip(
+        tr( "Number of backup capture files to retain during rotation. "
+            "Older files beyond this count are deleted. "
+            "Set to 0 to disable rolling backup." ) );
+    backupCountRow->addWidget( backupCountLabel );
+    backupCountRow->addWidget( liveSourceRollingBackupCountSpinBox_ );
+    backupCountRow->addStretch();
+
+    layout->addWidget( liveSourceAutoReconnectCheckBox_ );
+    layout->addLayout( maxAttemptsRow );
+    layout->addLayout( maxFileSizeRow );
+    layout->addLayout( backupCountRow );
+
+    // Help text explaining when settings take effect
+    auto* helpLabel = new QLabel( liveSourceGroupBox_ );
+    helpLabel->setWordWrap( true );
+    helpLabel->setText( tr( "These settings control live log stream capture behavior. "
+                            "Changes take effect for new live source connections." ) );
+    layout->addWidget( helpLabel );
+
+    // Insert before the spacer at the bottom of the File tab layout
+    const auto insertIndex = std::max( 0, verticalLayout_9->count() - 1 );
+    verticalLayout_9->insertWidget( insertIndex, liveSourceGroupBox_ );
 }
 
 void OptionsDialog::setupPanelResetButtons()
@@ -596,6 +702,20 @@ void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
     if ( iosLogAnsiOutputCheckBox_ ) {
         iosLogAnsiOutputCheckBox_->setChecked( config.iosLogAnsiOutputEnabled() );
     }
+    if ( liveSourceAutoReconnectCheckBox_ ) {
+        liveSourceAutoReconnectCheckBox_->setChecked( config.liveAutoReconnectEnabled() );
+    }
+    if ( liveSourceMaxAttemptsSpinBox_ ) {
+        liveSourceMaxAttemptsSpinBox_->setValue( config.liveAutoReconnectMaxAttempts() );
+    }
+    if ( liveSourceRollingMaxFileSizeSpinBox_ ) {
+        // Configuration stores bytes, UI displays MB
+        liveSourceRollingMaxFileSizeSpinBox_->setValue(
+            static_cast<int>( config.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    }
+    if ( liveSourceRollingBackupCountSpinBox_ ) {
+        liveSourceRollingBackupCountSpinBox_->setValue( config.liveCaptureRollingBackupCount() );
+    }
 
     const auto encodingIndex = encodingComboBox->findData( config.defaultEncodingMib() );
     encodingComboBox->setCurrentIndex( encodingIndex < 0 ? 0 : encodingIndex );
@@ -768,6 +888,19 @@ void OptionsDialog::resetFileDefaults()
     }
     if ( iosLogAnsiOutputCheckBox_ ) {
         iosLogAnsiOutputCheckBox_->setChecked( defaults.iosLogAnsiOutputEnabled() );
+    }
+    if ( liveSourceAutoReconnectCheckBox_ ) {
+        liveSourceAutoReconnectCheckBox_->setChecked( defaults.liveAutoReconnectEnabled() );
+    }
+    if ( liveSourceMaxAttemptsSpinBox_ ) {
+        liveSourceMaxAttemptsSpinBox_->setValue( defaults.liveAutoReconnectMaxAttempts() );
+    }
+    if ( liveSourceRollingMaxFileSizeSpinBox_ ) {
+        liveSourceRollingMaxFileSizeSpinBox_->setValue(
+            static_cast<int>( defaults.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    }
+    if ( liveSourceRollingBackupCountSpinBox_ ) {
+        liveSourceRollingBackupCountSpinBox_->setValue( defaults.liveCaptureRollingBackupCount() );
     }
 }
 
@@ -943,6 +1076,20 @@ void OptionsDialog::updateConfigFromDialog()
     }
     if ( iosLogAnsiOutputCheckBox_ ) {
         config.setIosLogAnsiOutputEnabled( iosLogAnsiOutputCheckBox_->isChecked() );
+    }
+    if ( liveSourceAutoReconnectCheckBox_ ) {
+        config.setLiveAutoReconnectEnabled( liveSourceAutoReconnectCheckBox_->isChecked() );
+    }
+    if ( liveSourceMaxAttemptsSpinBox_ ) {
+        config.setLiveAutoReconnectMaxAttempts( liveSourceMaxAttemptsSpinBox_->value() );
+    }
+    if ( liveSourceRollingMaxFileSizeSpinBox_ ) {
+        // Convert MB from UI back to bytes for Configuration
+        config.setLiveCaptureRollingMaxFileSize(
+            static_cast<qint64>( liveSourceRollingMaxFileSizeSpinBox_->value() ) * 1024 * 1024 );
+    }
+    if ( liveSourceRollingBackupCountSpinBox_ ) {
+        config.setLiveCaptureRollingBackupCount( liveSourceRollingBackupCountSpinBox_->value() );
     }
 
     const auto selectedStyle = styleComboBox->currentData().toString();

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -83,6 +83,7 @@ OptionsDialog::OptionsDialog( QWidget* parent )
     setupIosLogSettings();
     setupLiveSourceSettings();
     setupPanelResetButtons();
+    standardizeLayoutSpacing();
 
     // Validators
     QValidator* pollingIntervalValidator = new QIntValidator( PollIntervalMin, PollIntervalMax );
@@ -254,10 +255,11 @@ void OptionsDialog::setupIosLogSettings()
         adbLayout->insertWidget( std::max( 0, adbLayout->count() - 1 ), adbAnsiOutputCheckBox_ );
     }
 
-    iosLogGroupBox_ = new QGroupBox( tr( "iOS Log Stream" ), file_watch_tab );
+    iosLogGroupBox_ = new QGroupBox( tr( "iOS Log Stream" ), liveSourceTab );
     iosLogGroupBox_->setObjectName( QStringLiteral( "iosLogGroupBox" ) );
 
     auto* layout = new QVBoxLayout( iosLogGroupBox_ );
+    layout->setSpacing( 6 );
 
     auto* executableRow = new QHBoxLayout();
     auto* executableLabel = new QLabel( tr( "pymobiledevice3 executable" ), iosLogGroupBox_ );
@@ -293,8 +295,8 @@ void OptionsDialog::setupIosLogSettings()
     layout->addWidget( iosLogAnsiOutputCheckBox_ );
     layout->addWidget( helpLabel );
 
-    const auto insertIndex = std::max( 0, verticalLayout_9->count() - 1 );
-    verticalLayout_9->insertWidget( insertIndex, iosLogGroupBox_ );
+    const auto insertIndex = std::max( 0, verticalLayout_liveSource->count() - 1 );
+    verticalLayout_liveSource->insertWidget( insertIndex, iosLogGroupBox_ );
 
     connect( detectButton, &QPushButton::clicked, this, [ this ] {
         const auto resolved = IosLogProcessTransport::detectIosSyslogExecutable();
@@ -331,10 +333,11 @@ void OptionsDialog::setupLiveSourceSettings()
     // These settings control the behavior of live log streams (ADB logcat, iOS log).
     // Inserted on the File tab alongside the ADB and iOS log stream settings.
 
-    liveSourceGroupBox_ = new QGroupBox( tr( "Live Source" ), file_watch_tab );
+    liveSourceGroupBox_ = new QGroupBox( tr( "Live Source" ), liveSourceTab );
     liveSourceGroupBox_->setObjectName( QStringLiteral( "liveSourceGroupBox" ) );
 
     auto* layout = new QVBoxLayout( liveSourceGroupBox_ );
+    layout->setSpacing( 6 );
 
     // Auto-reconnect toggle — enables/disables automatic reconnection when the
     // live source unexpectedly disconnects or encounters an error. Uses
@@ -426,8 +429,8 @@ void OptionsDialog::setupLiveSourceSettings()
     layout->addWidget( helpLabel );
 
     // Insert before the spacer at the bottom of the File tab layout
-    const auto insertIndex = std::max( 0, verticalLayout_9->count() - 1 );
-    verticalLayout_9->insertWidget( insertIndex, liveSourceGroupBox_ );
+    const auto insertIndex = std::max( 0, verticalLayout_liveSource->count() - 1 );
+    verticalLayout_liveSource->insertWidget( insertIndex, liveSourceGroupBox_ );
 }
 
 void OptionsDialog::setupPanelResetButtons()
@@ -453,8 +456,41 @@ void OptionsDialog::setupPanelResetButtons()
                     &OptionsDialog::resetViewDefaults );
     addResetButton( file_watch_tab, QStringLiteral( "resetFileDefaultsButton" ),
                     &OptionsDialog::resetFileDefaults );
+    addResetButton( liveSourceTab, QStringLiteral( "resetLiveSourceDefaultsButton" ),
+                    &OptionsDialog::resetLiveSourceDefaults );
     addResetButton( advanced_tab, QStringLiteral( "resetAdvancedDefaultsButton" ),
                     &OptionsDialog::resetAdvancedDefaults );
+}
+
+// Apply uniform vertical spacing to every group-box layout in every tab.
+// This prevents "line overlap" caused by inconsistent or missing spacing
+// between widgets inside group boxes.
+void OptionsDialog::standardizeLayoutSpacing()
+{
+    static constexpr int kGroupBoxLayoutSpacing = 6;
+    static constexpr int kTabLayoutSpacing = 6;
+
+    const QList<QWidget*> tabs = { general_tab, viewTab, file_watch_tab,
+                                   liveSourceTab, shortcutsTab, advanced_tab };
+
+    for ( auto* tab : tabs ) {
+        if ( !tab ) {
+            continue;
+        }
+        // Consistent spacing between group boxes on the tab surface
+        if ( auto* tabLayout = tab->layout() ) {
+            tabLayout->setSpacing( kTabLayoutSpacing );
+        }
+
+        // Consistent spacing inside every group box (covers both .ui-defined
+        // and dynamically-created boxes like iOS Log Stream / Live Source)
+        const auto groupBoxes = tab->findChildren<QGroupBox*>();
+        for ( auto* groupBox : groupBoxes ) {
+            if ( auto* groupLayout = groupBox->layout() ) {
+                groupLayout->setSpacing( kGroupBoxLayoutSpacing );
+            }
+        }
+    }
 }
 
 void OptionsDialog::setupPolling()
@@ -875,6 +911,12 @@ void OptionsDialog::resetFileDefaults()
     setupArchives();
 
     verifySslCheckBox->setChecked( defaults.verifySslPeers() );
+}
+
+void OptionsDialog::resetLiveSourceDefaults()
+{
+    const Configuration defaults;
+
     adbExecutableLineEdit->setText( defaults.adbExecutable() );
     adbLogcatArgsLineEdit->setText( defaults.adbLogcatExtraArgs() );
     if ( adbAnsiOutputCheckBox_ ) {

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -95,6 +95,8 @@ QColor liveStatusColor( LiveTabStatus status )
         return QColor( 0xFF, 0xC1, 0x07 ); // Amber
     case LiveTabStatus::Error:
         return QColor( 0xF4, 0x43, 0x36 ); // Red
+    case LiveTabStatus::Reconnecting:
+        return QColor( 0x21, 0x96, 0xF3 ); // Blue — distinct from green/amber/red
     default:
         return {};
     }
@@ -280,6 +282,7 @@ void TabbedCrawlerWidget::loadIcons()
         LiveTabStatus::Connected,
         LiveTabStatus::Disconnected,
         LiveTabStatus::Error,
+        LiveTabStatus::Reconnecting,
     };
     constexpr DataStatus dataStatuses[] = {
         DataStatus::OLD_DATA,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(klogg_tests
     versionchecker_test.cpp
     newversiondialog_test.cpp
     updatedownload_test.cpp
+    live_save_split_test.cpp
     tests_main.cpp
 )
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(klogg_tests
     newversiondialog_test.cpp
     updatedownload_test.cpp
     live_save_split_test.cpp
+    live_save_crash_repro_test.cpp
     tests_main.cpp
 )
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(klogg_tests
     filewatcher_test.cpp
     versionchecker_test.cpp
     newversiondialog_test.cpp
+    updatedownload_test.cpp
     tests_main.cpp
 )
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(klogg_tests
     tabbedcrawlerwidget_test.cpp
     filewatcher_test.cpp
     versionchecker_test.cpp
+    newversiondialog_test.cpp
     tests_main.cpp
 )
 

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -33,6 +33,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSettings>
+#include <QSpinBox>
 #include <QTemporaryDir>
 #include <QUuid>
 
@@ -186,6 +187,11 @@ class TestIosLogProcessTransport : public IosLogProcessTransport {
         return clearCommand();
     }
 
+    QString stderrFilePathForTest() const
+    {
+        return stderrFilePath();
+    }
+
     void filterReceivedBytesForTest( QByteArray& data )
     {
         filterReceivedBytes( data );
@@ -329,9 +335,19 @@ TEST_CASE( "IosLogProcessTransport passes color flags as pymobiledevice3 top-lev
     const auto plainCmd = plainTransport.streamingCommandForTest();
 
 #ifdef Q_OS_MAC
-    REQUIRE( colorCmd.arguments
-             == QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
-                             QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+    // Wrapped with /usr/bin/script + a shell that redirects the inner
+    // command's stderr to the transport's temp file (outside the PTY) so
+    // pymobiledevice3 diagnostics never reach the log view.
+    REQUIRE( colorCmd.program == QStringLiteral( "/usr/bin/script" ) );
+    REQUIRE( colorCmd.arguments.size() == 12 );
+    REQUIRE( colorCmd.arguments[ 0 ] == QStringLiteral( "-q" ) );
+    REQUIRE( colorCmd.arguments[ 1 ] == QStringLiteral( "/dev/null" ) );
+    REQUIRE( colorCmd.arguments[ 2 ] == QStringLiteral( "/bin/sh" ) );
+    REQUIRE( colorCmd.arguments[ 3 ] == QStringLiteral( "-c" ) );
+    REQUIRE( colorCmd.arguments[ 4 ] == QStringLiteral( "exec \"$@\" 2>\"$0\"" ) );
+    REQUIRE( colorCmd.arguments[ 5 ] == colorTransport.stderrFilePathForTest() );
+    REQUIRE( colorCmd.arguments.mid( 6 )
+             == QStringList{ QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
                              QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
                              QStringLiteral( "live" ), QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ) } );
@@ -380,11 +396,19 @@ TEST_CASE( "IosLogProcessTransport wraps with PTY when ANSI output is enabled" )
 
     const auto colorCmd = colorTransport.streamingCommandForTest();
 #ifdef Q_OS_MAC
-    // On macOS, the command is wrapped with script to allocate a PTY.
+    // On macOS, the command is wrapped with script to allocate a PTY.  The
+    // inner command runs via sh -c 'exec "$@" 2>"$0"' so its stderr is
+    // redirected to the transport's temp file (outside the PTY) and cannot
+    // leak into the log view.
     REQUIRE( colorCmd.program == QStringLiteral( "/usr/bin/script" ) );
-    REQUIRE( colorCmd.arguments
-             == QStringList{ QStringLiteral( "-q" ), QStringLiteral( "/dev/null" ),
-                             QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
+    REQUIRE( colorCmd.arguments[ 0 ] == QStringLiteral( "-q" ) );
+    REQUIRE( colorCmd.arguments[ 1 ] == QStringLiteral( "/dev/null" ) );
+    REQUIRE( colorCmd.arguments[ 2 ] == QStringLiteral( "/bin/sh" ) );
+    REQUIRE( colorCmd.arguments[ 3 ] == QStringLiteral( "-c" ) );
+    REQUIRE( colorCmd.arguments[ 4 ] == QStringLiteral( "exec \"$@\" 2>\"$0\"" ) );
+    REQUIRE( colorCmd.arguments[ 5 ] == colorTransport.stderrFilePathForTest() );
+    REQUIRE( colorCmd.arguments.mid( 6 )
+             == QStringList{ QStringLiteral( "/opt/homebrew/bin/pymobiledevice3" ),
                              QStringLiteral( "--color" ), QStringLiteral( "syslog" ),
                              QStringLiteral( "live" ), QStringLiteral( "--udid" ),
                              QStringLiteral( "00008030-001C195E36D8802E" ) } );
@@ -490,6 +514,7 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
                   "else\n"
                   "  echo 'NO_ANSI 12:00:00 App Hello'\n"
                   "fi\n"
+                  "echo 'STDERR_LEAK pymobiledevice3 ERROR Device not found' >&2\n"
                   "sleep 5\n" );
     script.close();
     REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
@@ -522,6 +547,10 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
         REQUIRE( accumulated.contains( '\x1b' ) );
         // Must NOT contain the no-TTY fallback text.
         REQUIRE_FALSE( accumulated.contains( QByteArrayLiteral( "NO_ANSI" ) ) );
+        // pymobiledevice3's stderr must NOT leak into the log view, even though
+        // the PTY (script) merges stdout/stderr — the sh -c wrapper redirects
+        // the inner command's stderr to the transport's temp file.
+        REQUIRE_FALSE( accumulated.contains( QByteArrayLiteral( "STDERR_LEAK" ) ) );
 
         colorTransport.disconnectTransport();
         QCoreApplication::processEvents();
@@ -556,6 +585,8 @@ TEST_CASE( "IosLogProcessTransport PTY wrapper forces ANSI output from script-em
         REQUIRE_FALSE( accumulated.contains( '\x1b' ) );
         // Must contain the no-TTY fallback text.
         REQUIRE( accumulated.contains( QByteArrayLiteral( "NO_ANSI" ) ) );
+        // Without the PTY wrapper, stderr goes to the temp file too — no leak.
+        REQUIRE_FALSE( accumulated.contains( QByteArrayLiteral( "STDERR_LEAK" ) ) );
 
         plainTransport.disconnectTransport();
         QCoreApplication::processEvents();
@@ -1515,4 +1546,360 @@ TEST_CASE( "AdbProcessTransport expands tilde in user-configured executable" )
     const auto streaming = transport.streamingCommandForTest();
     REQUIRE_FALSE( streaming.program.startsWith( QLatin1Char( '~' ) ) );
     REQUIRE( streaming.program.contains( QStringLiteral( "android/sdk/platform-tools/adb" ) ) );
+}
+
+// ---------------------------------------------------------------------------
+// Live source auto-reconnect and rolling file settings tests
+// ---------------------------------------------------------------------------
+
+namespace {
+// Helper: read all lines from a StreamingLogData as a single string for assertions
+QString allLogLines( const std::shared_ptr<StreamingLogData>& logData )
+{
+    QStringList lines;
+    const auto count = logData->getNbLine().get();
+    for ( LineNumber::UnderlyingType i = 0; i < count; ++i ) {
+        lines.append( logData->getLineString( LineNumber( i ) ) );
+    }
+    return lines.join( QLatin1Char( '\n' ) );
+}
+
+// Helper: wait until auto-reconnect is no longer active (max attempts exhausted
+// or reconnect cancelled), i.e., the reconnect timer has stopped.
+bool waitForReconnectExhausted( const AdbLogcatSource& source, int timeoutMs = 10000 )
+{
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( deadline.elapsed() < timeoutMs ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+        QTest::qWait( 50 );
+        // Exhausted when both the timer isn't running and state is Error
+        // (not Disconnected, which would mean manual disconnect)
+        if ( !source.isAutoReconnectActive()
+             && source.state() == AdbLogcatSource::State::Error ) {
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace
+
+TEST_CASE( "AdbLogcatSource keeps auto-reconnect failures out of streaming log data" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+
+    // Use a non-existent executable path so that connectTransport() always fails
+    // synchronously (waitForStarted returns false), triggering the error+reconnect
+    // cycle without depending on process timing.
+    const AdbLogcatSessionData sessionData{
+        QStringLiteral( "/nonexistent/path/to/adb" ),
+        QStringLiteral( "emulator-5554" ),
+        QStringLiteral( "Test Device" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::AdbLogcat,
+    };
+
+    AdbLogcatSource source( sessionData, logData );
+    source.setAutoReconnectEnabled( true );
+    source.setAutoReconnectMaxAttempts( 1 ); // Only 1 retry to keep test fast
+
+    SafeQSignalSpy attemptSpy( &source, &AdbLogcatSource::reconnectAttemptStarted );
+
+    // connectSource() will fail because the executable doesn't exist →
+    // triggers scheduleReconnect → timer fires → attemptReconnect fails →
+    // max attempts reached → streaming log must stay empty (silent retries)
+    REQUIRE_FALSE( source.connectSource() );
+    REQUIRE( source.state() == AdbLogcatSource::State::Error );
+
+    // Wait for the reconnect cycle to complete (max attempts exhausted)
+    REQUIRE( waitForReconnectExhausted( source, 5000 ) );
+
+    // At least one reconnect attempt should have been started
+    REQUIRE( attemptSpy.count() >= 1 );
+
+    // Reconnect failures must NOT be written to the streaming log data
+    // (fully silent retries — failures are surfaced via the status bar only).
+    const auto logText = allLogLines( logData );
+    INFO( "Streaming log content: " << logText.toStdString() );
+
+    CHECK_FALSE( logText.contains( QStringLiteral( "auto-reconnect attempt" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "failed" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "max attempts" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "giving up" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "reconnected" ) ) );
+
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+}
+
+TEST_CASE( "AdbLogcatSource exponential backoff preserves attempt count after rapid "
+           "post-connect death" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based backoff test on Windows." );
+    return;
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    // Script that outputs a line, runs long enough to survive the grace period
+    // (~500ms), then exits. This triggers the brief-connect-then-die pattern
+    // that would reset the backoff counter without the reconnectionProven_ guard.
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "adb" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    // No stdout output — the process exits without producing data.
+    // This triggers the failure path (reconnectionProven_ stays false).
+    script.write( "#!/bin/sh\n"
+                  "sleep 0.5\n"
+                  "echo 'device disconnected' >&2\n"
+                  "exit 1\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+    const AdbLogcatSessionData sessionData{
+        scriptPath,
+        QStringLiteral( "emulator-5554" ),
+        QStringLiteral( "Test Device" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::AdbLogcat,
+    };
+
+    AdbLogcatSource source( sessionData, logData );
+    source.setAutoReconnectEnabled( true );
+    source.setAutoReconnectMaxAttempts( 3 );
+
+    // First connection succeeds (process starts, outputs, survives grace period)
+    REQUIRE( source.connectSource() );
+    REQUIRE( source.state() == AdbLogcatSource::State::Connected );
+
+    // Wait for the process to exit and trigger auto-reconnect
+    REQUIRE( waitForSourceState( source, AdbLogcatSource::State::Error ) );
+    REQUIRE( source.isAutoReconnectActive() );
+
+    // Wait for the first reconnect attempt to start
+    SafeQSignalSpy attemptSpy( &source, &AdbLogcatSource::reconnectAttemptStarted );
+    REQUIRE( attemptSpy.safeWait( 3000 ) );
+
+    // The reconnect attempt should have incremented the counter
+    // (reconnectAttempt_ should be >= 1 after attemptReconnect increments it)
+    const auto attemptAfterFirstReconnect = source.reconnectAttempt();
+    INFO( "reconnectAttempt after first reconnect: " << attemptAfterFirstReconnect );
+    CHECK( attemptAfterFirstReconnect >= 1 );
+
+    // Wait for the reconnect to fail (process exits after 0.5s) and trigger
+    // another scheduleReconnect cycle
+    REQUIRE( waitForSourceState( source, AdbLogcatSource::State::Error ) );
+
+    // After the reconnect attempt connected briefly then died, the backoff
+    // counter should still be preserved (NOT reset to 0).
+    // The reconnectionProven_ flag prevents reset on brief connections.
+    const auto attemptAfterSecondError = source.reconnectAttempt();
+    INFO( "reconnectAttempt after second error: " << attemptAfterSecondError );
+    CHECK( attemptAfterSecondError >= 1 );
+
+    source.cancelAutoReconnect();
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 500 );
+    QCoreApplication::processEvents();
+#endif
+}
+
+TEST_CASE( "AdbLogcatSource keeps async reconnect failure out of streaming log" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based async failure test on Windows." );
+    return;
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    // Script that runs just long enough to survive the grace period (~400ms)
+    // then exits with an error. This triggers the async failure path where
+    // connectTransport() returns true but the process dies shortly after.
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "adb" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    script.write( "#!/bin/sh\n"
+                  "sleep 0.4\n"
+                  "echo 'device offline' >&2\n"
+                  "exit 1\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+    const AdbLogcatSessionData sessionData{
+        scriptPath,
+        QStringLiteral( "emulator-5554" ),
+        QStringLiteral( "Test Device" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::AdbLogcat,
+    };
+
+    AdbLogcatSource source( sessionData, logData );
+    source.setAutoReconnectEnabled( true );
+    source.setAutoReconnectMaxAttempts( 2 );
+
+    // Initial connect: process starts, survives grace period, then dies
+    REQUIRE( source.connectSource() );
+    REQUIRE( source.state() == AdbLogcatSource::State::Connected );
+
+    // Wait for async process death → Error → scheduleReconnect
+    REQUIRE( waitForSourceState( source, AdbLogcatSource::State::Error ) );
+    REQUIRE( source.isAutoReconnectActive() );
+
+    // Wait for the reconnect attempt to fire and the process to die again
+    SafeQSignalSpy attemptSpy( &source, &AdbLogcatSource::reconnectAttemptStarted );
+    REQUIRE( attemptSpy.safeWait( 5000 ) );
+
+    // Wait for the reconnect attempt's process to die asynchronously
+    REQUIRE( waitForSourceState( source, AdbLogcatSource::State::Error ) );
+
+    // Reconnect failures must NOT be written to the streaming log data
+    // (fully silent retries — failures are surfaced via the status bar only).
+    // The mock script's stderr ("device offline") must also not leak.
+    const auto logText = allLogLines( logData );
+    INFO( "Streaming log content after async reconnect failure:\n" << logText.toStdString() );
+
+    CHECK_FALSE( logText.contains( QStringLiteral( "auto-reconnect attempt" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "failed" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "device offline" ) ) );
+    CHECK_FALSE( logText.contains( QStringLiteral( "reconnected" ) ) );
+
+    source.cancelAutoReconnect();
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 500 );
+    QCoreApplication::processEvents();
+#endif
+}
+
+TEST_CASE( "OptionsDialog loads and persists live source auto-reconnect and rolling file settings" )
+{
+    if ( isHeadlessDialogTestEnvironment() ) {
+        WARN( "OptionsDialog UI coverage is skipped on headless/offscreen platforms" );
+        return;
+    }
+
+    ScopedOptionsDialogConfigurationGuard configGuard;
+    auto& config = Configuration::getSynced();
+
+    // Set non-default values
+    config.setLiveAutoReconnectEnabled( true );
+    config.setLiveAutoReconnectMaxAttempts( 10 );
+    config.setLiveCaptureRollingMaxFileSize( 1048576 ); // 1 MB in bytes
+    config.setLiveCaptureRollingBackupCount( 5 );
+    config.save();
+
+    OptionsDialog dialog;
+    auto* autoReconnectCheckBox
+        = dialog.findChild<QCheckBox*>( QStringLiteral( "liveSourceAutoReconnectCheckBox" ) );
+    auto* maxAttemptsSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceMaxAttemptsSpinBox" ) );
+    auto* maxFileSizeSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceRollingMaxFileSizeSpinBox" ) );
+    auto* backupCountSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceRollingBackupCountSpinBox" ) );
+
+    REQUIRE( autoReconnectCheckBox != nullptr );
+    REQUIRE( maxAttemptsSpinBox != nullptr );
+    REQUIRE( maxFileSizeSpinBox != nullptr );
+    REQUIRE( backupCountSpinBox != nullptr );
+
+    // Verify initial values loaded from config
+    CHECK( autoReconnectCheckBox->isChecked() );
+    CHECK( maxAttemptsSpinBox->value() == 10 );
+    // UI stores MB, config stores bytes: 1048576 bytes = 1 MB
+    CHECK( maxFileSizeSpinBox->value() == 1 );
+    CHECK( backupCountSpinBox->value() == 5 );
+
+    // Edit values
+    autoReconnectCheckBox->setChecked( false );
+    maxAttemptsSpinBox->setValue( 20 );
+    maxFileSizeSpinBox->setValue( 50 ); // 50 MB
+    backupCountSpinBox->setValue( 10 );
+
+    REQUIRE( QMetaObject::invokeMethod( &dialog, "updateConfigFromDialog", Qt::DirectConnection ) );
+
+    auto& restoredConfig = Configuration::getSynced();
+    CHECK( restoredConfig.liveAutoReconnectEnabled() == false );
+    CHECK( restoredConfig.liveAutoReconnectMaxAttempts() == 20 );
+    // 50 MB = 52428800 bytes
+    CHECK( restoredConfig.liveCaptureRollingMaxFileSize() == 50 * 1024 * 1024 );
+    CHECK( restoredConfig.liveCaptureRollingBackupCount() == 10 );
+}
+
+TEST_CASE( "OptionsDialog reset restores live source settings to defaults" )
+{
+    if ( isHeadlessDialogTestEnvironment() ) {
+        WARN( "OptionsDialog UI coverage is skipped on headless/offscreen platforms" );
+        return;
+    }
+
+    ScopedOptionsDialogConfigurationGuard configGuard;
+    auto& config = Configuration::getSynced();
+
+    // Set non-default values
+    config.setLiveAutoReconnectEnabled( false );
+    config.setLiveAutoReconnectMaxAttempts( 99 );
+    config.setLiveCaptureRollingMaxFileSize( 999 * 1024 * 1024 );
+    config.setLiveCaptureRollingBackupCount( 50 );
+    config.save();
+
+    OptionsDialog dialog;
+    auto* resetButton = dialog.findChild<QPushButton*>( QStringLiteral( "resetFileDefaultsButton" ) );
+    REQUIRE( resetButton != nullptr );
+
+    // Click the reset button
+    resetButton->click();
+    QCoreApplication::processEvents();
+
+    // Verify widgets show defaults
+    auto* autoReconnectCheckBox
+        = dialog.findChild<QCheckBox*>( QStringLiteral( "liveSourceAutoReconnectCheckBox" ) );
+    auto* maxAttemptsSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceMaxAttemptsSpinBox" ) );
+    auto* maxFileSizeSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceRollingMaxFileSizeSpinBox" ) );
+    auto* backupCountSpinBox
+        = dialog.findChild<QSpinBox*>( QStringLiteral( "liveSourceRollingBackupCountSpinBox" ) );
+
+    REQUIRE( autoReconnectCheckBox != nullptr );
+    REQUIRE( maxAttemptsSpinBox != nullptr );
+    REQUIRE( maxFileSizeSpinBox != nullptr );
+    REQUIRE( backupCountSpinBox != nullptr );
+
+    const Configuration defaults;
+    CHECK( autoReconnectCheckBox->isChecked() == defaults.liveAutoReconnectEnabled() );
+    CHECK( maxAttemptsSpinBox->value() == defaults.liveAutoReconnectMaxAttempts() );
+    CHECK( maxFileSizeSpinBox->value()
+           == static_cast<int>( defaults.liveCaptureRollingMaxFileSize() / ( 1024 * 1024 ) ) );
+    CHECK( backupCountSpinBox->value() == defaults.liveCaptureRollingBackupCount() );
+
+    // Apply the reset values to config
+    REQUIRE( QMetaObject::invokeMethod( &dialog, "updateConfigFromDialog", Qt::DirectConnection ) );
+
+    auto& restoredConfig = Configuration::getSynced();
+    CHECK( restoredConfig.liveAutoReconnectEnabled() == defaults.liveAutoReconnectEnabled() );
+    CHECK( restoredConfig.liveAutoReconnectMaxAttempts() == defaults.liveAutoReconnectMaxAttempts() );
+    CHECK( restoredConfig.liveCaptureRollingMaxFileSize()
+           == defaults.liveCaptureRollingMaxFileSize() );
+    CHECK( restoredConfig.liveCaptureRollingBackupCount()
+           == defaults.liveCaptureRollingBackupCount() );
 }

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -1102,6 +1102,32 @@ class FiniteSuccessfulTestTransport : public ProcessLiveSourceTransport {
 #endif
     }
 };
+
+// Exits during startup after writing a recognizable line to stderr — exercises
+// the connectTransport() startup-failure error-capture path.
+class StartupStderrFailureTransport : public ProcessLiveSourceTransport {
+  public:
+    Command streamingCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "cmd" ),
+                 { QStringLiteral( "/c" ),
+                   QStringLiteral( "echo startup-boom 1>&2 & exit /b 13" ) } };
+#else
+        return { QStringLiteral( "/bin/sh" ),
+                 { QStringLiteral( "-c" ), QStringLiteral( "echo startup-boom >&2; exit 13" ) } };
+#endif
+    }
+
+    Command clearCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return { QStringLiteral( "cmd" ), { QStringLiteral( "/c" ), QStringLiteral( "echo" ) } };
+#else
+        return { QStringLiteral( "true" ), {} };
+#endif
+    }
+};
 } // namespace
 
 TEST_CASE( "ProcessLiveSourceTransport suppresses errorOccurred during intentional disconnect" )
@@ -2029,4 +2055,132 @@ TEST_CASE( "OptionsDialog reset restores live source settings to defaults" )
            == defaults.liveCaptureRollingMaxFileSize() );
     CHECK( restoredConfig.liveCaptureRollingBackupCount()
            == defaults.liveCaptureRollingBackupCount() );
+}
+
+TEST_CASE( "ProcessLiveSourceTransport surfaces real stderr on startup failure" )
+{
+    StartupStderrFailureTransport transport;
+
+    REQUIRE_FALSE( transport.connectTransport() );
+    // stderr is redirected to a file via setStandardErrorFile(); the startup
+    // path must read that file (not readAllStandardError(), which is empty).
+    REQUIRE( transport.lastError().contains( QStringLiteral( "startup-boom" ) ) );
+
+    transport.disconnectTransport();
+    QTest::qWait( 200 );
+}
+
+TEST_CASE( "AdbLogcatSource does not auto-reconnect before being enabled" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based auto-reconnect default test on Windows." );
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+    // A non-existent executable fails connectTransport() deterministically in
+    // waitForStarted() (no dependence on the 250ms startup-grace window).
+    const AdbLogcatSessionData sessionData{
+        QStringLiteral( "/path/that/does/not/exist/adb" ),
+        QStringLiteral( "emulator-5554" ),
+        QStringLiteral( "Pixel Test" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::AdbLogcat,
+    };
+    AdbLogcatSource source( sessionData, logData );
+
+    // No setAutoReconnectEnabled() call: the member default must be disabled so
+    // a failing connect does not arm the reconnect timer.
+    REQUIRE_FALSE( source.connectSource() );
+    QCoreApplication::processEvents();
+    REQUIRE_FALSE( source.isAutoReconnectActive() );
+
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+#endif
+}
+
+TEST_CASE( "AdbLogcatSource manual reconnect resets the attempt counter" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based reconnect reset test on Windows." );
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto captureId = makeCaptureId();
+    auto logData = std::make_shared<StreamingLogData>( captureId, tempDir.path() );
+    // A non-existent executable fails connectTransport() deterministically in
+    // waitForStarted() (no dependence on the 250ms startup-grace window).
+    const AdbLogcatSessionData sessionData{
+        QStringLiteral( "/path/that/does/not/exist/adb" ),
+        QStringLiteral( "emulator-5554" ),
+        QStringLiteral( "Pixel Test" ),
+        QString{},
+        captureId,
+        QString{},
+        LiveLogSourceType::AdbLogcat,
+    };
+    AdbLogcatSource source( sessionData, logData );
+    source.setAutoReconnectEnabled( true );
+    source.setAutoReconnectMaxAttempts( 50 );
+
+    REQUIRE_FALSE( source.connectSource() ); // fails, schedules first reconnect (~1s)
+
+    // Wait for at least one auto-reconnect attempt to fire and increment.
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( source.reconnectAttempt() < 1 && deadline.elapsed() < 5000 ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+        QTest::qWait( 20 );
+    }
+    REQUIRE( source.reconnectAttempt() >= 1 );
+
+    // A manual reconnect must reset the stale attempt counter.
+    source.reconnectSource();
+    REQUIRE( source.reconnectAttempt() == 0 );
+
+    source.setAutoReconnectEnabled( false );
+    source.disconnectSource();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+#endif
+}
+
+TEST_CASE( "DeviceListProvider async enumeration is safe against provider destruction" )
+{
+#ifdef Q_OS_WIN
+    WARN( "Skipping POSIX shell based device-provider lifetime test on Windows." );
+#else
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    // A slow fake adb keeps the async task in flight while we destroy the
+    // provider, exercising the lifetime guard in listDevicesAsync().
+    const auto scriptPath = tempDir.filePath( QStringLiteral( "adb" ) );
+    QFile script( scriptPath );
+    REQUIRE( script.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    script.write( "#!/bin/sh\nsleep 1\nexit 0\n" );
+    script.close();
+    REQUIRE( script.setPermissions( QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner ) );
+
+    auto* provider = new AdbDeviceListProvider( scriptPath );
+    QFuture<QList<AdbDeviceInfo>> future = provider->listDevicesAsync();
+
+    // Destroy the provider while the task is still in flight. The QPointer guard
+    // must keep this from dereferencing freed memory.
+    delete provider;
+    future.waitForFinished(); // must not crash
+
+    REQUIRE( future.resultCount() == 1 );
+    // Guarded path yields an empty list when the provider no longer exists.
+    REQUIRE( future.result().isEmpty() );
+#endif
 }

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -745,7 +745,9 @@ TEST_CASE( "AdbDeviceListProvider listDevicesAsync returns a valid future" )
     auto future = provider.listDevicesAsync();
 
     // The future should be valid (has been started).
-    REQUIRE( future.isValid() );
+    // Use isStarted() instead of isValid() for Qt 5 compatibility
+    // (isValid() was added in Qt 6.0).
+    REQUIRE( future.isStarted() );
 
     // Wait for it to complete — should resolve to an empty list since
     // the executable doesn't exist.
@@ -764,7 +766,8 @@ TEST_CASE( "IosDeviceListProvider listDevicesAsync returns a valid future" )
     IosDeviceListProvider provider( QStringLiteral( "/nonexistent/pymobiledevice3" ) );
     auto future = provider.listDevicesAsync();
 
-    REQUIRE( future.isValid() );
+    // Use isStarted() instead of isValid() for Qt 5 compatibility.
+    REQUIRE( future.isStarted() );
 
     future.waitForFinished();
     // On non-macOS or with nonexistent executable, result should be empty.

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -29,13 +29,17 @@
 #include <QFileInfo>
 #include <QFont>
 #include <QGuiApplication>
+#include <QGroupBox>
 #include <QJsonDocument>
+#include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSettings>
 #include <QSpinBox>
+#include <QTabWidget>
 #include <QTemporaryDir>
 #include <QUuid>
+#include <QWidget>
 
 #include <map>
 
@@ -903,6 +907,7 @@ TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
         QStringLiteral( "resetGeneralDefaultsButton" ),
         QStringLiteral( "resetViewDefaultsButton" ),
         QStringLiteral( "resetFileDefaultsButton" ),
+        QStringLiteral( "resetLiveSourceDefaultsButton" ),
         QStringLiteral( "restoreShortcutsDefaults" ),
         QStringLiteral( "resetAdvancedDefaultsButton" ),
     };
@@ -943,6 +948,68 @@ TEST_CASE( "OptionsDialog reset buttons restore defaults and can be applied" )
     for ( const auto& defaultShortcut : defaultOpenFileShortcuts ) {
         CHECK( restoredOpenFileShortcuts.contains( defaultShortcut ) );
     }
+}
+
+TEST_CASE( "OptionsDialog File and Live Source tab widgets do not overlap vertically" )
+{
+    ScopedOptionsDialogConfigurationGuard configGuard;
+
+    OptionsDialog dialog;
+
+    auto* tabWidget = dialog.findChild<QTabWidget*>( QStringLiteral( "tabWidget" ) );
+    REQUIRE( tabWidget != nullptr );
+
+    dialog.show();
+    QCoreApplication::processEvents();
+
+    // Check each tab for widget overlap at minimum dialog size
+    const QStringList tabNames{
+        QStringLiteral( "file_watch_tab" ),
+        QStringLiteral( "liveSourceTab" ),
+    };
+
+    for ( const auto& tabName : tabNames ) {
+        auto* tab = dialog.findChild<QWidget*>( tabName );
+        REQUIRE( tab != nullptr );
+        tabWidget->setCurrentWidget( tab );
+        QCoreApplication::processEvents();
+
+        dialog.resize( dialog.minimumSizeHint() );
+        QCoreApplication::processEvents();
+
+        auto* layout = tab->layout();
+        REQUIRE( layout != nullptr );
+
+        QList<QWidget*> visibleChildren;
+        for ( int i = 0; i < layout->count(); ++i ) {
+            auto* item = layout->itemAt( i );
+            if ( item && item->widget() && item->widget()->isVisible() ) {
+                visibleChildren.append( item->widget() );
+            }
+        }
+
+        REQUIRE( visibleChildren.size() >= 2 );
+
+        for ( int i = 0; i < visibleChildren.size() - 1; ++i ) {
+            auto* current = visibleChildren[i];
+            auto* next = visibleChildren[i + 1];
+
+            const auto currentBottom = current->geometry().bottom();
+            const auto nextTop = next->geometry().top();
+            const int gap = nextTop - currentBottom;
+
+            INFO( "[" << tabName.toStdString() << "] Widget " << i << ": \""
+                  << current->objectName().toStdString() << "\" bottom=" << currentBottom
+                  << " vs Widget " << ( i + 1 ) << ": \""
+                  << next->objectName().toStdString() << "\" top=" << nextTop
+                  << " gap=" << gap );
+
+            CHECK( gap >= 1 );
+        }
+    }
+
+    dialog.close();
+    QCoreApplication::processEvents();
 }
 
 TEST_CASE( "OptionsDialog adb detect button fills the executable field with the resolved adb path" )

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -40,6 +40,7 @@
 #include <map>
 
 #include "adbprocesstransport.h"
+#include "adbdevicelistprovider.h"
 #include "adblogcatsource.h"
 #include "adblogcatdialog.h"
 #include "commandargumenttokenizer.h"
@@ -705,6 +706,65 @@ TEST_CASE( "AdbProcessTransport listDevices returns an error when adb cannot sta
 
     REQUIRE( devices.isEmpty() );
     REQUIRE_FALSE( error.isEmpty() );
+}
+
+TEST_CASE( "AdbDeviceListProvider returns same results as static listDevices" )
+{
+    // The provider abstraction should return identical results to the
+    // old static method on AdbProcessTransport.
+    QString providerError;
+    AdbDeviceListProvider provider( QStringLiteral( "/path/that/does/not/exist/adb" ) );
+    const auto devices = provider.listDevices( &providerError );
+
+    QString staticError;
+    const auto staticDevices
+        = AdbProcessTransport::listDevices( QStringLiteral( "/path/that/does/not/exist/adb" ),
+                                            &staticError );
+
+    REQUIRE( devices.isEmpty() );
+    REQUIRE( staticDevices.isEmpty() );
+    REQUIRE_FALSE( providerError.isEmpty() );
+    REQUIRE_FALSE( staticError.isEmpty() );
+}
+
+TEST_CASE( "AdbDeviceListProvider isDeviceAvailable returns true on subprocess error" )
+{
+    // When the list command itself fails, isDeviceAvailable should return true
+    // (optimistic fallback — let connectTransport handle the real error).
+    AdbDeviceListProvider provider( QStringLiteral( "/nonexistent/adb" ) );
+    CHECK( provider.isDeviceAvailable( QStringLiteral( "any-serial" ) ) );
+}
+
+TEST_CASE( "AdbDeviceListProvider listDevicesAsync returns a valid future" )
+{
+    AdbDeviceListProvider provider( QStringLiteral( "/nonexistent/adb" ) );
+    auto future = provider.listDevicesAsync();
+
+    // The future should be valid (has been started).
+    REQUIRE( future.isValid() );
+
+    // Wait for it to complete — should resolve to an empty list since
+    // the executable doesn't exist.
+    future.waitForFinished();
+    REQUIRE( future.result().isEmpty() );
+}
+
+TEST_CASE( "IosDeviceListProvider isDeviceAvailable returns true on subprocess error" )
+{
+    IosDeviceListProvider provider( QStringLiteral( "/nonexistent/pymobiledevice3" ) );
+    CHECK( provider.isDeviceAvailable( QStringLiteral( "any-udid" ) ) );
+}
+
+TEST_CASE( "IosDeviceListProvider listDevicesAsync returns a valid future" )
+{
+    IosDeviceListProvider provider( QStringLiteral( "/nonexistent/pymobiledevice3" ) );
+    auto future = provider.listDevicesAsync();
+
+    REQUIRE( future.isValid() );
+
+    future.waitForFinished();
+    // On non-macOS or with nonexistent executable, result should be empty.
+    REQUIRE( future.result().isEmpty() );
 }
 
 TEST_CASE( "AdbProcessTransport surfaces immediate post-start failures as transport errors" )

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -1197,6 +1197,111 @@ TEST_CASE( "ProcessLiveSourceTransport async disconnect returns immediately" )
     QCoreApplication::processEvents();
 }
 
+// ---------------------------------------------------------------------------
+// connectTransportAsync — non-blocking startup detection (replaces the
+// blocking waitForStarted + grace loop for the auto-reconnect path)
+// ---------------------------------------------------------------------------
+
+TEST_CASE( "ProcessLiveSourceTransport connectTransportAsync returns immediately" )
+{
+    LongRunningTestTransport transport;
+
+    QElapsedTimer timer;
+    timer.start();
+    transport.connectTransportAsync();
+    const auto elapsed = timer.elapsed();
+
+    // Must not block for the 250ms grace period or 3s waitForStarted.
+    CHECK( elapsed < 100 );
+
+    transport.disconnectTransport();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+}
+
+namespace {
+bool spyContainsState( const SafeQSignalSpy& spy, LiveSourceTransport::State target )
+{
+    for ( int i = 0; i < spy.count(); ++i ) {
+        if ( spy.at( i ).at( 0 ).value<LiveSourceTransport::State>() == target ) {
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace
+
+TEST_CASE( "ProcessLiveSourceTransport connectTransportAsync connects via grace timer" )
+{
+    LongRunningTestTransport transport;
+
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+    transport.connectTransportAsync();
+
+    // safeWait returns on the first signal (Connecting); we must keep
+    // processing events until the grace timer fires and transitions to
+    // Connected.
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( !spyContainsState( stateSpy, LiveSourceTransport::State::Connected )
+            && deadline.elapsed() < 2000 ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+    }
+    REQUIRE( spyContainsState( stateSpy, LiveSourceTransport::State::Connected ) );
+
+    transport.disconnectTransport();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+}
+
+TEST_CASE( "ProcessLiveSourceTransport connectTransportAsync detects startup failure" )
+{
+    TestAdbProcessTransport transport( QStringLiteral( "/path/that/does/not/exist/adb" ),
+                                      QStringLiteral( "serial" ), {} );
+
+    SafeQSignalSpy errorSpy( &transport, SIGNAL( errorOccurred( QString ) ) );
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+    transport.connectTransportAsync();
+
+    // A non-existent executable triggers errorOccurred(FailedToStart) within
+    // the next event loop cycle.
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( !spyContainsState( stateSpy, LiveSourceTransport::State::Error )
+            && deadline.elapsed() < 2000 ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+    }
+    REQUIRE( spyContainsState( stateSpy, LiveSourceTransport::State::Error ) );
+    REQUIRE( errorSpy.count() >= 1 );
+    REQUIRE_FALSE( transport.lastError().isEmpty() );
+}
+
+TEST_CASE( "ProcessLiveSourceTransport connectTransportAsync detects fast exit" )
+{
+    StartupStderrFailureTransport transport;
+
+    SafeQSignalSpy stateSpy( &transport, SIGNAL( stateChanged( LiveSourceTransport::State ) ) );
+    transport.connectTransportAsync();
+
+    // The process exits (with stderr) within the grace period; the finished
+    // handler must detect this and transition to Error.
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( !spyContainsState( stateSpy, LiveSourceTransport::State::Error )
+            && deadline.elapsed() < 2000 ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 50 );
+    }
+    REQUIRE( spyContainsState( stateSpy, LiveSourceTransport::State::Error ) );
+    REQUIRE( transport.lastError().contains( QStringLiteral( "startup-boom" ) ) );
+
+    transport.disconnectTransport();
+    QCoreApplication::processEvents();
+    QTest::qWait( 200 );
+    QCoreApplication::processEvents();
+}
+
 TEST_CASE( "ProcessLiveSourceTransport reconnects immediately after async disconnect" )
 {
     LongRunningTestTransport transport;

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -31,6 +31,7 @@
 #include <QUuid>
 
 #include "capturestore.h"
+#include "rollingfilemanager.h"
 
 namespace {
 QString makeTestDir( const QString& prefix )
@@ -833,4 +834,402 @@ TEST_CASE( "CaptureStore clear flushes and resets output" )
     QFile output( outputPath );
     REQUIRE( output.open( QIODevice::ReadOnly ) );
     REQUIRE( output.size() == 0 );
+}
+
+TEST_CASE( "CaptureStore trimToLimits removes oldest segments and updates line count" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16; // Very small segments
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3; // Window = 16 * 3 = 48
+
+    const auto rootPath = makeTestDir( "capturestore_trim_limits" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Each line is ~5 bytes + newline = 6 bytes. With segmentTargetBytes=16,
+    // each segment holds ~2-3 lines. With maxTotalBytes=48, we can fit ~3 segments.
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "ln-%1\n" ).arg( i, 3, 10, QLatin1Char( '0' ) ).toUtf8() );
+    }
+
+    // After trimming, total file size should be within the limit
+    const auto stats = store.stats();
+    CHECK( stats.fileSize <= limits.rollingMaxFileSize * limits.rollingBackupCount );
+
+    // Lines should still be addressable from the surviving segments
+    const auto lineCount = store.lineCount();
+    CHECK( lineCount.get() > 0 );
+
+    // The last line should still be "ln-019"
+    auto* codec = QTextCodec::codecForName( "UTF-8" );
+    REQUIRE( store.lineAt( LineNumber( lineCount.get() - 1 ), codec, QRegularExpression{} )
+             == QStringLiteral( "ln-019" ) );
+}
+
+TEST_CASE( "CaptureStore trimToLimits preserves surviving data in bound output file" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "capturestore_trim_output" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "trimmed.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "line-%1\n" ).arg( i ).toUtf8() );
+    }
+    store.flush();
+
+    // Read from current file and all backup files
+    QByteArray allContent;
+    {
+        QFile f( outputPath );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            allContent.append( f.readAll() );
+        }
+    }
+    for ( int i = 0; i < 10; ++i ) {
+        const auto bp = outputPath + QStringLiteral( ".%1" ).arg( i );
+        QFile f( bp );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            allContent.append( f.readAll() );
+        }
+    }
+
+    INFO( "All content: " << allContent.toStdString() );
+
+    // The last line should be "line-19"
+    REQUIRE( allContent.contains( QByteArrayLiteral( "line-19" ) ) );
+
+    // The in-memory CaptureStore should be within limits
+    CHECK( store.stats().fileSize <= limits.rollingMaxFileSize * limits.rollingBackupCount );
+}
+
+TEST_CASE( "CaptureStore trimToLimits returns correct trim result" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "capturestore_trim_result" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "x\n" ).toUtf8() );
+    }
+
+    // Now trigger a trim manually and check the result
+    // First, set a very small limit and append more data
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 2;
+    store.setLimits( limits );
+    store.appendUtf8( QByteArrayLiteral( "trigger\n" ) );
+
+    // At least some lines should have been trimmed
+    CHECK( store.lineCount().get() > 0 );
+
+    // The remaining data should be within the new limit
+    CHECK( store.stats().fileSize <= 32 );
+}
+
+TEST_CASE( "CaptureStore cumulative line counts are correct after front-trim" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "capturestore_trim_cumulative" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+    auto* codec = QTextCodec::codecForName( "UTF-8" );
+
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "L%1\n" ).arg( i, 3, 10, QLatin1Char( '0' ) ).toUtf8() );
+    }
+
+    // Verify every surviving line is addressable and contains the expected content.
+    // After trim, line 0 is the first surviving line (not the original line 0).
+    const auto lineCount = store.lineCount();
+    for ( LinesCount::UnderlyingType i = 0; i < lineCount.get(); ++i ) {
+        INFO( "Checking surviving line " << i );
+        const auto line = store.lineAt( LineNumber( i ), codec, QRegularExpression{} );
+        REQUIRE_FALSE( line.isEmpty() );
+        // Each line should match the pattern "LXXX"
+        REQUIRE( line.startsWith( QLatin1Char( 'L' ) ) );
+    }
+
+    // The first surviving line should NOT be "L000" (it was trimmed)
+    const auto firstLine = store.lineAt( 0_lnum, codec, QRegularExpression{} );
+    REQUIRE( firstLine != QStringLiteral( "L000" ) );
+
+    // The last surviving line should be "L019"
+    const auto lastLine = store.lineAt( LineNumber( lineCount.get() - 1 ), codec, QRegularExpression{} );
+    REQUIRE( lastLine == QStringLiteral( "L019" ) );
+}
+
+TEST_CASE( "CaptureStore buildRawLines works correctly after front-trim" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "capturestore_trim_rawlines" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+    auto* codec = QTextCodec::codecForName( "UTF-8" );
+
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "row-%1\n" ).arg( i ).toUtf8() );
+    }
+
+    const auto lineCount = store.lineCount();
+    const auto rawLines = store.buildRawLines( 0_lnum, lineCount, codec, QRegularExpression{} );
+
+    REQUIRE( rawLines.endOfLines.size() == static_cast<size_t>( lineCount.get() ) );
+
+    const auto decoded = rawLines.decodeLines();
+    REQUIRE( decoded.size() == static_cast<size_t>( lineCount.get() ) );
+
+    // Verify first and last surviving lines
+    REQUIRE( decoded.front().startsWith( QLatin1String( "row-" ) ) );
+    REQUIRE( decoded.back() == QStringLiteral( "row-19" ) );
+
+    // Verify no duplicate or out-of-order lines
+    for ( size_t i = 1; i < decoded.size(); ++i ) {
+        INFO( "Comparing line " << i );
+        REQUIRE( decoded[ i ] != decoded[ i - 1 ] );
+    }
+}
+
+// === RollingFileManager Tests ===
+
+TEST_CASE( "RollingFileManager writes to current file" )
+{
+    const auto rootPath = makeTestDir( "rolling_basic" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 1024, 3 );
+    REQUIRE( manager.open() );
+    REQUIRE( manager.isValid() );
+
+    manager.write( QByteArrayLiteral( "hello world\n" ) );
+    manager.flush();
+
+    REQUIRE( readUtf8File( filePath ) == QStringLiteral( "hello world\n" ) );
+    REQUIRE( manager.currentFileSize() == 12 );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager rotates when file reaches maxFileSize" )
+{
+    const auto rootPath = makeTestDir( "rolling_rotate" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 32, 3 );
+    REQUIRE( manager.open() );
+
+    // Write enough data to exceed 32 bytes
+    const QByteArray data( 20, 'A' );
+    manager.write( data + QByteArrayLiteral( "\n" ) ); // 21 bytes
+    manager.write( data + QByteArrayLiteral( "\n" ) ); // 42 bytes total → triggers rotation
+
+    // After rotation: backup[0] should exist, current file should have remaining data
+    const auto backups = manager.backupFiles();
+    INFO( "Backup files: " << backups.join( QLatin1String( ", " ) ).toStdString() );
+    REQUIRE( backups.size() >= 1 );
+
+    // Current file should exist and have data
+    REQUIRE( QFile::exists( filePath ) );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager maintains backupCount limit" )
+{
+    const auto rootPath = makeTestDir( "rolling_backup_limit" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    constexpr int backupCount = 2;
+    RollingFileManager manager( filePath, 16, backupCount );
+    REQUIRE( manager.open() );
+
+    // Write enough to trigger multiple rotations
+    for ( int i = 0; i < 10; ++i ) {
+        manager.write( QStringLiteral( "line-%1\n" ).arg( i ).toUtf8() );
+    }
+
+    // Should have at most backupCount backup files
+    const auto backups = manager.backupFiles();
+    INFO( "Backup count: " << backups.size() );
+    REQUIRE( backups.size() <= backupCount + 1 ); // +1 for current file
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager deleteAll removes all files" )
+{
+    const auto rootPath = makeTestDir( "rolling_delete_all" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 16, 3 );
+    REQUIRE( manager.open() );
+
+    for ( int i = 0; i < 10; ++i ) {
+        manager.write( QStringLiteral( "data-%1\n" ).arg( i ).toUtf8() );
+    }
+
+    manager.deleteAll();
+
+    REQUIRE_FALSE( QFile::exists( filePath ) );
+    for ( int i = 0; i < 5; ++i ) {
+        REQUIRE_FALSE( QFile::exists( filePath + QStringLiteral( ".%1" ).arg( i ) ) );
+    }
+}
+
+TEST_CASE( "RollingFileManager no data loss within window" )
+{
+    const auto rootPath = makeTestDir( "rolling_no_loss" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    // Window = maxFileSize(32) * backupCount(2) = 64 bytes.
+    // Write 7 lines (56 bytes) — all fit within the window.
+    constexpr int lineCount = 7;
+    RollingFileManager manager( filePath, 32, 2 );
+    REQUIRE( manager.open() );
+
+    for ( int i = 0; i < lineCount; ++i ) {
+        const auto line = QStringLiteral( "line-%1\n" ).arg( i, 3, 10, QLatin1Char( '0' ) );
+        manager.write( line.toUtf8() );
+    }
+
+    manager.flush();
+
+    // Collect all data from current file and backups
+    QByteArray collected;
+    {
+        QFile f( filePath );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            collected.append( f.readAll() );
+        }
+    }
+    const auto backups = manager.backupFiles();
+    for ( const auto& path : backups ) {
+        QFile f( path );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            collected.append( f.readAll() );
+        }
+    }
+
+    INFO( "Collected " << collected.size() << " bytes from " << ( backups.size() + 1 ) << " files" );
+
+    // All data within the window should be present
+    for ( int i = 0; i < lineCount; ++i ) {
+        const auto line = QStringLiteral( "line-%1" ).arg( i, 3, 10, QLatin1Char( '0' ) );
+        INFO( "Checking line " << i );
+        REQUIRE( collected.contains( line.toUtf8() ) );
+    }
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager deletes data outside window" )
+{
+    const auto rootPath = makeTestDir( "rolling_window_delete" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    // Window = 32 * 2 = 64 bytes. Write 10 lines (80 bytes).
+    // The oldest lines (outside the window) should be deleted.
+    RollingFileManager manager( filePath, 32, 2 );
+    REQUIRE( manager.open() );
+
+    for ( int i = 0; i < 10; ++i ) {
+        manager.write( QStringLiteral( "line-%1\n" ).arg( i, 3, 10, QLatin1Char( '0' ) ).toUtf8() );
+    }
+    manager.flush();
+
+    // Collect all data
+    QByteArray collected;
+    {
+        QFile f( filePath );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            collected.append( f.readAll() );
+        }
+    }
+    const auto backups = manager.backupFiles();
+    for ( const auto& path : backups ) {
+        QFile f( path );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            collected.append( f.readAll() );
+        }
+    }
+
+    // Lines 000-001 (16 bytes) should be outside the window and deleted
+    REQUIRE_FALSE( collected.contains( "line-000" ) );
+
+    // Lines 002-009 should be within the window
+    REQUIRE( collected.contains( "line-009" ) );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager zero backupCount keeps only current file" )
+{
+    const auto rootPath = makeTestDir( "rolling_zero_backup" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 32, 0 );
+    REQUIRE( manager.open() );
+
+    for ( int i = 0; i < 10; ++i ) {
+        manager.write( QStringLiteral( "x\n" ).toUtf8() );
+    }
+
+    // No backup files should exist
+    const auto backups = manager.backupFiles();
+    REQUIRE( backups.isEmpty() );
+
+    // Only the current file should exist
+    REQUIRE( QFile::exists( filePath ) );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager reopen after rotation preserves data" )
+{
+    const auto rootPath = makeTestDir( "rolling_reopen" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    {
+        RollingFileManager manager( filePath, 24, 2 );
+        REQUIRE( manager.open() );
+        for ( int i = 0; i < 5; ++i ) {
+            manager.write( QStringLiteral( "line-%1\n" ).arg( i ).toUtf8() );
+        }
+    }
+
+    // Verify files exist after close
+    REQUIRE( QFile::exists( filePath ) );
+
+    // Reopen and verify we can continue writing
+    {
+        RollingFileManager manager( filePath, 24, 2 );
+        REQUIRE( manager.open() );
+        manager.write( QByteArrayLiteral( "new-data\n" ) );
+        REQUIRE( manager.currentFileSize() > 0 );
+    }
+
+    // Cleanup
+    RollingFileManager cleanup( filePath, 24, 2 );
+    cleanup.deleteAll();
 }

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -1366,3 +1366,113 @@ TEST_CASE( "RollingFileManager reopen after rotation preserves data" )
     RollingFileManager cleanup( filePath, 24, 2 );
     cleanup.deleteAll();
 }
+
+TEST_CASE( "RollingFileManager writes every complete line across rotations", "[rolling]" )
+{
+    const auto dir = makeTestDir( "rolling_no_dataloss" );
+    const auto filePath = QDir( dir ).filePath( "live.log" );
+
+    // maxFileSize=30; a 3-line batch (33 bytes) must split. The last newline
+    // that fits lands strictly before the capacity boundary, which previously
+    // caused the trailing complete line to be dropped silently.
+    RollingFileManager manager( filePath, 30, 5 );
+    REQUIRE( manager.open( true ) );
+
+    const QByteArray data = QByteArrayLiteral( "0123456789\n0123456789\n0123456789\n" );
+    const auto written = manager.write( data );
+    manager.flush();
+
+    // Every input byte must be accounted for (old code returned 22, dropping 11).
+    REQUIRE( written == data.size() );
+
+    // Reassemble backups (oldest first) + current and confirm no line was lost.
+    QByteArray all;
+    for ( const auto& path : manager.backupFiles() ) {
+        QFile f( path );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            all.append( f.readAll() );
+        }
+    }
+    {
+        QFile f( filePath );
+        if ( f.open( QIODevice::ReadOnly ) ) {
+            all.append( f.readAll() );
+        }
+    }
+    REQUIRE( all.count( '\n' ) == data.count( '\n' ) );
+    REQUIRE( all.contains( QByteArrayLiteral( "0123456789\n0123456789\n0123456789\n" ) ) );
+
+    RollingFileManager( filePath, 30, 5 ).deleteAll();
+}
+
+TEST_CASE( "RollingFileManager reports rotation via rotated()", "[rolling]" )
+{
+    const auto dir = makeTestDir( "rolling_rotated_flag" );
+    const auto filePath = QDir( dir ).filePath( "live.log" );
+
+    RollingFileManager manager( filePath, 16, 3 );
+    REQUIRE( manager.open( true ) );
+
+    // A write that fits entirely must not report a rotation.
+    manager.write( QByteArrayLiteral( "short\n" ) );
+    REQUIRE_FALSE( manager.rotated() );
+
+    // A write that overflows the file must rotate and report it.
+    manager.write( QByteArrayLiteral( "0123456789ABCDEF0123456789ABCDEF\n" ) );
+    REQUIRE( manager.rotated() );
+
+    RollingFileManager( filePath, 16, 3 ).deleteAll();
+}
+
+TEST_CASE( "RollingFileManager clamps absurd backup counts", "[rolling]" )
+{
+    const auto dir = makeTestDir( "rolling_clamp" );
+    const auto filePath = QDir( dir ).filePath( "live.log" );
+
+    // A backup count within 100 of INT_MAX previously made cleanupOldBackups()
+    // compute `backupCount_ + 100` with signed overflow (UB) and skip cleanup.
+    RollingFileManager manager( filePath, 16, 2147483600 );
+    REQUIRE( manager.backupCount() <= 100000 );
+    REQUIRE( manager.backupCount() >= 0 );
+
+    REQUIRE( manager.open( true ) );
+    for ( int i = 0; i < 4; ++i ) {
+        manager.write( QByteArrayLiteral( "0123456789ABCDEF\n" ) ); // 17 bytes > 16 -> rotate
+    }
+    manager.flush();
+    // Cleanup must have run without overflow; only a bounded number of backups
+    // survive (clamped count + the current file).
+    REQUIRE( manager.backupFiles().size() <= manager.backupCount() + 1 );
+
+    RollingFileManager( filePath, 16, 2147483600 ).deleteAll();
+}
+
+TEST_CASE( "CaptureStore AppendResult firstLine reflects post-trim position", "[capturestore]" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 8;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 1; // window = 16 bytes
+
+    const auto rootPath = makeTestDir( "capture_firstline_trim" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Pre-fill well past the window so the store is already trimming (oldest
+    // segments removed down to the window).
+    store.appendUtf8( QByteArrayLiteral( "AAA\nAAA\nAAA\nAAA\nAAA\nAAA\nAAA\nAAA\nAAA\nAAA\n" ) );
+    const auto preTotal = store.lineCount().get();
+
+    // Small append that forces another trim of OLD data only; its single line
+    // survives at the tail. Its AppendResult.firstLine must address the
+    // post-trim tail position, not the stale pre-trim total.
+    const auto result = store.appendUtf8( QByteArrayLiteral( "BBB\n" ) );
+
+    const auto total = store.lineCount().get();
+    // Guard: trimming must have removed older lines during this append.
+    REQUIRE( total < preTotal + result.lineCount.get() );
+
+    const auto expectedFirst = static_cast<LineNumber::UnderlyingType>(
+        total > result.lineCount.get() ? total - result.lineCount.get() : 0 );
+    REQUIRE( result.firstLine.get() == expectedFirst );
+}

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -234,6 +234,104 @@ TEST_CASE( "CaptureStore bindOutputFile overwrites existing files and replays sp
              == QStringLiteral( "alpha\nbeta\ngamma\ndelta\nepsilon\n" ) );
 }
 
+TEST_CASE( "RollingFileManager resyncSize reads actual file size after direct writes" )
+{
+    const auto rootPath = makeTestDir( "rolling_resync" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 64, 2 );
+    REQUIRE( manager.open() );
+
+    // Write directly to the underlying QFile (bypassing write()).
+    // This is what bindOutputFile does when replaying segments.
+    auto* file = manager.currentFile();
+    REQUIRE( file != nullptr );
+    file->write( QByteArray( 50, 'A' ) );
+    file->flush();
+
+    // Without resyncSize(), currentBytes_ is 0 even though the file has 50 bytes.
+    CHECK( manager.currentFileSize() == 0 );
+    CHECK_FALSE( manager.needsRotation() );
+
+    // After resyncSize(), the size is correct.
+    manager.resyncSize();
+    CHECK( manager.currentFileSize() == 50 );
+    // 50 < 64, so no rotation needed yet
+    CHECK_FALSE( manager.needsRotation() );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "RollingFileManager resyncSize enables rotation after direct writes" )
+{
+    const auto rootPath = makeTestDir( "rolling_resync_rotate" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+
+    RollingFileManager manager( filePath, 32, 2 );
+    REQUIRE( manager.open() );
+
+    // Write 50 bytes directly to QFile (bypassing write()).
+    auto* file = manager.currentFile();
+    REQUIRE( file != nullptr );
+    file->write( QByteArray( 50, 'B' ) );
+    file->flush();
+
+    // Sync the size so needsRotation() works correctly.
+    manager.resyncSize();
+    CHECK( manager.currentFileSize() == 50 );
+    CHECK( manager.needsRotation() ); // 50 >= 32
+
+    // The next write() call should trigger rotation because we're over the limit.
+    manager.write( QByteArray( 10, 'C' ) );
+
+    // After rotation, the current file should only contain the new data.
+    manager.flush();
+    QFile output( filePath );
+    REQUIRE( output.open( QIODevice::ReadOnly ) );
+    CHECK( output.size() == 10 );
+
+    // Backup should contain the old 50-byte file.
+    const auto backups = manager.backupFiles();
+    CHECK( backups.size() >= 1 );
+
+    manager.deleteAll();
+}
+
+TEST_CASE( "CaptureStore bindOutputFile syncs rolling file size after replay" )
+{
+    // Use small limits so replayed data exceeds rollingMaxFileSize.
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 32;
+    limits.rollingBackupCount = 2;
+
+    const auto rootPath = makeTestDir( "capturestore_bind_tracking" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "tracked.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Append data that exceeds rollingMaxFileSize (32 bytes).
+    for ( int i = 0; i < 10; ++i ) {
+        store.appendUtf8( QByteArrayLiteral( "abcdefgh\n" ) );
+    }
+
+    // Bind output file — replays all data into the rolling file
+    // via writeSegmentToDevice() which bypasses RollingFileManager::write().
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append more data — rotation should trigger because resyncSize()
+    // updated currentBytes_ to reflect the replayed data.
+    for ( int i = 0; i < 5; ++i ) {
+        store.appendUtf8( QByteArrayLiteral( "new\n" ) );
+    }
+
+    // At least one rotation should have occurred, producing backup files.
+    const auto backups = QDir( rootPath ).entryList(
+        { QFileInfo( outputPath ).fileName() + ".*" }, QDir::Files );
+    CHECK( backups.size() >= 1 );
+}
+
 TEST_CASE( "CaptureStore finishInput commits a trailing partial line without adding a newline" )
 {
     CaptureStore::Limits limits;
@@ -834,6 +932,35 @@ TEST_CASE( "CaptureStore clear flushes and resets output" )
     QFile output( outputPath );
     REQUIRE( output.open( QIODevice::ReadOnly ) );
     REQUIRE( output.size() == 0 );
+}
+
+TEST_CASE( "CaptureStore clear resets lastTrimResult" )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 2;
+
+    const auto rootPath = makeTestDir( "capturestore_clear_trim_result" );
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Append enough data to exceed the window and trigger trimming
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( QStringLiteral( "line-%1\n" ).arg( i, 3, 10, QLatin1Char( '0' ) ).toUtf8() );
+    }
+
+    // After auto-trim during append, lastTrimResult should be non-zero
+    const auto trimResult = store.lastTrimResult();
+    CHECK( trimResult.trimmedLines > 0_lcount );
+
+    // Clear the store
+    store.clear();
+
+    // After clear, lastTrimResult should be reset to zero
+    const auto afterClear = store.lastTrimResult();
+    CHECK( afterClear.trimmedLines == 0_lcount );
+    CHECK( afterClear.trimmedBytes == 0 );
 }
 
 TEST_CASE( "CaptureStore trimToLimits removes oldest segments and updates line count" )

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -1310,23 +1310,29 @@ TEST_CASE( "RollingFileManager deletes data outside window" )
     manager.deleteAll();
 }
 
-TEST_CASE( "RollingFileManager zero backupCount keeps only current file" )
+TEST_CASE( "RollingFileManager zero backupCount keeps all rotated files" )
 {
     const auto rootPath = makeTestDir( "rolling_zero_backup" );
     const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
 
-    RollingFileManager manager( filePath, 32, 0 );
+    // maxFileSize = 16 bytes, backupCount = 0 (keep all rotated files)
+    RollingFileManager manager( filePath, 16, 0 );
     REQUIRE( manager.open() );
 
-    for ( int i = 0; i < 10; ++i ) {
-        manager.write( QStringLiteral( "x\n" ).toUtf8() );
+    // Write data in small chunks to trigger multiple rotations.
+    // Each "line-NN\n" is 8 bytes; maxFileSize = 16 → rotation every 2 lines.
+    for ( int i = 0; i < 20; ++i ) {
+        const auto line = QStringLiteral( "line-%1\n" )
+                              .arg( i, 2, 10, QLatin1Char( '0' ) )
+                              .toUtf8();
+        manager.write( line );
     }
 
-    // No backup files should exist
+    // Backup files should be retained (no cleanup when backupCount = 0)
     const auto backups = manager.backupFiles();
-    REQUIRE( backups.isEmpty() );
+    REQUIRE( backups.size() >= 2 );
 
-    // Only the current file should exist
+    // The current file should also exist
     REQUIRE( QFile::exists( filePath ) );
 
     manager.deleteAll();

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -243,3 +243,28 @@ TEST_CASE( "Configuration stores and restores empty-filter filtered-view behavio
 
     REQUIRE_FALSE( restoredConfig.showAllInFilteredViewWhenSearchEmpty() );
 }
+
+TEST_CASE( "Configuration live-capture rolling size MB view does not truncate sub-MB values",
+           "[configuration]" )
+{
+    Configuration config;
+
+    // A sub-megabyte byte value must round up to 1 MB, not truncate to 0
+    // (which the live-source dialog treats as "unlimited").
+    config.setLiveCaptureRollingMaxFileSize( 512LL * 1024 );
+    REQUIRE( config.liveCaptureRollingMaxFileSizeMb() == 1 );
+
+    // A value just under half a megabyte rounds down to 0 (legitimately
+    // "unlimited"); exactly half rounds up.
+    config.setLiveCaptureRollingMaxFileSize( 400LL * 1024 );
+    REQUIRE( config.liveCaptureRollingMaxFileSizeMb() == 0 );
+
+    // Whole-megabyte values round-trip exactly through the MB helpers.
+    config.setLiveCaptureRollingMaxFileSizeMb( 250 );
+    REQUIRE( config.liveCaptureRollingMaxFileSize() == 250LL * 1024 * 1024 );
+    REQUIRE( config.liveCaptureRollingMaxFileSizeMb() == 250 );
+
+    // 0 bytes stays 0 MB.
+    config.setLiveCaptureRollingMaxFileSize( 0 );
+    REQUIRE( config.liveCaptureRollingMaxFileSizeMb() == 0 );
+}

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -149,6 +149,71 @@ TEST_CASE( "Configuration stores and restores iOS log defaults" )
     REQUIRE( restoredConfig.adbLogcatAnsiOutputEnabled() );
 }
 
+TEST_CASE( "Configuration defaults auto-reconnect to disabled" )
+{
+    Configuration config;
+
+    REQUIRE_FALSE( config.liveAutoReconnectEnabled() );
+}
+
+TEST_CASE( "Configuration stores and restores auto-reconnect settings" )
+{
+    const auto dirPath = makeTestDir( "configuration_reconnect" );
+    REQUIRE( QDir{ dirPath }.exists() );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration-reconnect.ini" );
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+
+        Configuration config;
+        config.setLiveAutoReconnectEnabled( true );
+        config.setLiveAutoReconnectMaxAttempts( 5 );
+        config.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+    }
+
+    QSettings restoredSettings( settingsPath, QSettings::IniFormat );
+    Configuration restoredConfig;
+    restoredConfig.retrieveFromStorage( restoredSettings );
+
+    REQUIRE( restoredConfig.liveAutoReconnectEnabled() );
+    REQUIRE( restoredConfig.liveAutoReconnectMaxAttempts() == 5 );
+}
+
+TEST_CASE( "Configuration defaults max capture file size to 1000 MB" )
+{
+    Configuration config;
+
+    // 1000 MB in bytes
+    REQUIRE( config.liveCaptureRollingMaxFileSize() == 1000LL * 1024 * 1024 );
+}
+
+TEST_CASE( "Configuration stores and restores capture rolling settings" )
+{
+    const auto dirPath = makeTestDir( "configuration_capture" );
+    REQUIRE( QDir{ dirPath }.exists() );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration-capture.ini" );
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+
+        Configuration config;
+        config.setLiveCaptureRollingMaxFileSize( 500LL * 1024 * 1024 );
+        config.setLiveCaptureRollingBackupCount( 3 );
+        config.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+    }
+
+    QSettings restoredSettings( settingsPath, QSettings::IniFormat );
+    Configuration restoredConfig;
+    restoredConfig.retrieveFromStorage( restoredSettings );
+
+    REQUIRE( restoredConfig.liveCaptureRollingMaxFileSize() == 500LL * 1024 * 1024 );
+    REQUIRE( restoredConfig.liveCaptureRollingBackupCount() == 3 );
+}
+
 TEST_CASE( "Configuration defaults empty filters to show all lines in filtered view" )
 {
     Configuration config;

--- a/tests/unit/live_save_crash_repro_test.cpp
+++ b/tests/unit/live_save_crash_repro_test.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Regression test for the macOS SIGABRT crash that occurred when saving a live
+// log whose in-memory window exceeds the rolling file size, forcing file
+// splitting during the save, followed by continued streaming.
+//
+// Root cause: StreamingLogData::appendUtf8() used to compute the range of lines
+// to write to the Strip-mode display file as [previousLineCount, currentLineCount),
+// i.e. count = currentLineCount - previousLineCount (both uint64).  When
+// CaptureStore::trimToLimits() (invoked during the append once the in-memory
+// window exceeds rollingMaxFileSize * rollingBackupCount) removed MORE lines
+// than were appended, currentLineCount < previousLineCount and the uint64
+// subtraction wrapped to ~2^64.  getLines() then did lines.reserve(lastLine -
+// first), which underflowed too and threw std::length_error("vector").
+//
+// On macOS that exception is thrown from a slot on the main event loop (queued
+// QProcess::readyRead -> AdbLogcatSource -> appendUtf8) and is uncaught, so it
+// propagates through the Cocoa event dispatcher and aborts with SIGABRT
+// (signature: objc_exception_rethrow -> -[NSApplication run]).  An uncaught
+// C++ exception from an event-loop slot is what produced the crash that three
+// prior commits mis-diagnosed as an AppKit NSException.
+
+#include <catch2/catch.hpp>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QUuid>
+
+#include "capturestore.h"
+#include "streaminglogdata.h"
+
+namespace {
+QString makeTestDir( const QString& prefix )
+{
+    const auto dirPath = QDir::cleanPath( QDir::currentPath() + QDir::separator()
+                                          + QLatin1String( "test_tmp" ) + QDir::separator()
+                                          + prefix + QLatin1Char( '_' )
+                                          + QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    QDir{}.mkpath( dirPath );
+    return dirPath;
+}
+
+// iOS-syslog-style line with ANSI color escapes, ~300 bytes.
+QByteArray makeAnsiLine( int index )
+{
+    QByteArray line;
+    line.reserve( 320 );
+    line.append( "\x1b[90m2026-06-28 17:42:0" );
+    line.append( QByteArray::number( index % 10 ) );
+    line.append( "Z device\x1b[0m " );
+    const char* colors[] = { "\x1b[31m", "\x1b[33m", "\x1b[32m", "\x1b[36m", "\x1b[0m" };
+    line.append( colors[ index % 5 ] );
+    line.append( "App[" + QByteArray::number( 1000 + index % 500 ) + "]: " );
+    line.append( "streaming payload segment " );
+    line.append( QByteArray::number( index ) );
+    line.append( " " );
+    line.append( QByteArray( 200, 'x' ) );
+    line.append( "\x1b[0m\n" );
+    return line;
+}
+
+QByteArray makeChunk( int lineStart, int lineCount )
+{
+    QByteArray chunk;
+    chunk.reserve( lineCount * 340 );
+    for ( int i = 0; i < lineCount; ++i ) {
+        chunk.append( makeAnsiLine( lineStart + i ) );
+    }
+    return chunk;
+}
+} // namespace
+
+TEST_CASE( "StreamingLogData: save with file splitting then stream past window does not crash",
+           "[streaming][live_save][live_crash]" )
+{
+    // Field scenario: Max capture file size = 5 MB, Rolling backup count = 3
+    // (window = 15 MB), in-memory window > 14 MB before save.
+    constexpr qint64 RollingMaxBytes = 5 * 1024 * 1024;
+    constexpr int RollingBackups = 3;
+    constexpr qint64 WindowBytes = RollingMaxBytes * RollingBackups;
+
+    StreamingLogData log( QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 1 * 1024 * 1024;
+    limits.memoryBudgetBytes = 256 * 1024 * 1024;
+    limits.rollingMaxFileSize = RollingMaxBytes;
+    limits.rollingBackupCount = RollingBackups;
+    log.setCaptureLimits( limits );
+
+    // Fill the window to just under the limit so NO trimming happens during the
+    // initial feed — mirroring the field case where trimming only kicks in
+    // after the save, as streaming continues.
+    int lineIndex = 0;
+    constexpr int LinesPerChunk = 500;
+    constexpr qint64 TargetBytes = 14 * 1024 * 1024;
+    qint64 fed = 0;
+    while ( fed < TargetBytes ) {
+        const auto chunk = makeChunk( lineIndex, LinesPerChunk );
+        lineIndex += LinesPerChunk;
+        fed += chunk.size();
+        log.appendUtf8( chunk );
+    }
+
+    const auto linesAtSave = log.getNbLine().get();
+    REQUIRE( linesAtSave > 0 );
+    REQUIRE( log.getFileSize() > TargetBytes );
+    REQUIRE( log.getFileSize() < WindowBytes ); // no trim yet
+
+    const auto dir = makeTestDir( "live_crash_repro" );
+    const auto outputPath = QDir( dir ).filePath( QStringLiteral( "iphone.log" ) );
+
+    // The save ("Without ANSI Sequences" = Strip mode).  openDisplayOutputFile()
+    // writes the whole >14MB window through the 5MB rolling file, rotating it.
+    REQUIRE( log.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+    REQUIRE( QFile::exists( outputPath ) );
+
+    // Continue streaming well past the 15 MB window.  These appends trigger
+    // trimToLimits(), which used to underflow the line range and throw.
+    bool threw = false;
+    std::string what;
+    bool observedTrim = false;
+    qint64 observedMin = std::numeric_limits<qint64>::max();
+
+    for ( int step = 0; step < 80; ++step ) {
+        const auto before = static_cast<qint64>( log.getNbLine().get() );
+        try {
+            log.appendUtf8( makeChunk( lineIndex, LinesPerChunk / 5 ) );
+            lineIndex += LinesPerChunk / 5;
+        } catch ( const std::exception& e ) {
+            threw = true;
+            what = e.what();
+            break;
+        }
+        const auto after = static_cast<qint64>( log.getNbLine().get() );
+        observedMin = std::min( observedMin, after );
+        // Trimming removes oldest segments, so a net decrease across an append
+        // proves the buggy path is exercised.
+        if ( after < before ) {
+            observedTrim = true;
+        }
+    }
+
+    INFO( "post-save streaming threw: " << ( threw ? what : std::string( "no" ) ) );
+    REQUIRE_FALSE( threw );
+    REQUIRE( observedTrim ); // genuinely exercised the trim path
+    REQUIRE( observedMin < static_cast<qint64>( linesAtSave ) ); // window is bounded
+
+    // The display file rotated into backups (file splitting).
+    const auto backups = QDir( dir ).entryList(
+        { QFileInfo( outputPath ).fileName() + QStringLiteral( ".*" ) }, QDir::Files );
+    CHECK( backups.size() >= 1 );
+}

--- a/tests/unit/live_save_split_test.cpp
+++ b/tests/unit/live_save_split_test.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QUuid>
+
+#include "capturestore.h"
+#include "rollingfilemanager.h"
+
+namespace {
+QString makeTestDir( const QString& prefix )
+{
+    const auto dirPath = QDir::cleanPath( QDir::currentPath() + QDir::separator()
+                                          + QLatin1String( "test_tmp" ) + QDir::separator()
+                                          + prefix + QLatin1Char( '_' )
+                                          + QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    QDir{}.mkpath( dirPath );
+    return dirPath;
+}
+
+QString makeCaptureId()
+{
+    return QUuid::createUuid().toString( QUuid::WithoutBraces );
+}
+
+// Generate `count` lines of text, each line ~`bytesPerLine` bytes long.
+// Returns the total bytes written.
+QByteArray generateLines( int count, int bytesPerLine )
+{
+    QByteArray data;
+    data.reserve( count * bytesPerLine );
+    for ( int i = 0; i < count; ++i ) {
+        // Fill line: prefix + counter + padding to reach desired length
+        const auto line = QByteArrayLiteral( "L" )
+                          + QByteArray::number( i ).rightJustified( 8, '0' )
+                          + QByteArray( bytesPerLine - 10, 'x' )
+                          + QByteArrayLiteral( "\n" );
+        data.append( line );
+    }
+    return data;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Reproduction of SIGABRT crash when saving a live log with file splitting:
+//
+//   - "Max capture file size" = 5 MB
+//   - "Rolling backup count" = 3
+//   - Memory sliding window has 14 MB+ of buffered lines
+//   - Saving triggers the crash (macOS, Cocoa platform plugin)
+//
+// On macOS the crash signature is:
+//   __cxa_rethrow → objc_exception_rethrow → -[NSApplication run]
+//   → QCocoaEventDispatcher::processEvents → SIGABRT
+//
+// These tests first verify the file-splitting logic is correct (headless),
+// then document the macOS Cocoa lifecycle contract that must be satisfied.
+// ---------------------------------------------------------------------------
+
+TEST_CASE( "Live log save: bindOutputFile with large segments triggers file splitting",
+           "[capturestore][rolling][live_save]" )
+{
+    // Simulate the crash scenario: 14MB+ buffered, 5MB max file, 3 backups.
+    // Scale: use 2MB buffer, 512KB rolling max, 3 backups for quick test.
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 128 * 1024;    // 128 KB segments
+    limits.memoryBudgetBytes = 10 * 1024 * 1024; // 10 MB memory budget
+    limits.rollingMaxFileSize = 512 * 1024;     // 512 KB rolling max (scaled from 5MB)
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "live_save_split" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "iphone.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Feed ~2MB of data (scaled from 14MB) — more than the rolling window of 1.5MB.
+    const auto chunk = generateLines( 1000, 256 ); // ~256KB per chunk
+    const int numChunks = 8;                        // 8 chunks → ~2MB total
+    for ( int i = 0; i < numChunks; ++i ) {
+        store.appendUtf8( chunk );
+    }
+
+    const auto linesBefore = store.lineCount();
+    REQUIRE( linesBefore > 0_lcount );
+    REQUIRE( store.stats().fileSize > limits.rollingMaxFileSize );
+
+    // Bind output file — replays all buffered segments into the rolling file.
+    // This is the operation that triggers the macOS crash.
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Verify the output file was created
+    REQUIRE( QFile::exists( outputPath ) );
+    const auto outputSize = QFileInfo( outputPath ).size();
+    REQUIRE( outputSize > 0 );
+
+    // Append more data to trigger an actual rotation (the first rotation
+    // only happens on the next write after bindOutputFile, because
+    // bindOutputFile writes segments directly bypassing RollingFileManager::write).
+    store.appendUtf8( generateLines( 500, 256 ) ); // another ~128KB
+
+    // After the append, at least one rotation should have occurred,
+    // creating backup files from the oversized initial file.
+    const auto backups = QDir( rootPath ).entryList(
+        { QFileInfo( outputPath ).fileName() + ".*" }, QDir::Files );
+    INFO( "Output size after bind: " << outputSize );
+    INFO( "Backup files found: " << backups.join( ", " ).toStdString() );
+    CHECK( backups.size() >= 1 );
+
+    // The backup should contain the overflow data
+    bool foundBackupWithContent = false;
+    for ( const auto& backupName : backups ) {
+        QFile backupFile( QDir( rootPath ).filePath( backupName ) );
+        if ( backupFile.size() > 0 ) {
+            foundBackupWithContent = true;
+            break;
+        }
+    }
+    CHECK( foundBackupWithContent );
+}
+
+TEST_CASE( "Live log save: repeated bindOutputFile does not corrupt data",
+           "[capturestore][rolling][live_save]" )
+{
+    // Verify that binding, unbinding, and rebinding an output file
+    // does not lose or corrupt data.
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 64 * 1024;
+    limits.memoryBudgetBytes = 10 * 1024 * 1024;
+    limits.rollingMaxFileSize = 256 * 1024;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "live_save_rebind" );
+    const auto outputPath1 = QDir( rootPath ).filePath( QStringLiteral( "output1.log" ) );
+    const auto outputPath2 = QDir( rootPath ).filePath( QStringLiteral( "output2.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+    store.appendUtf8( generateLines( 2000, 128 ) ); // ~256KB
+
+    // Bind first output
+    REQUIRE( store.bindOutputFile( outputPath1 ) );
+    REQUIRE( QFile::exists( outputPath1 ) );
+
+    // Unbind
+    REQUIRE( store.bindOutputFile( QString{} ) );
+
+    // Append more data
+    store.appendUtf8( generateLines( 1000, 128 ) );
+
+    // Bind second output
+    REQUIRE( store.bindOutputFile( outputPath2 ) );
+    REQUIRE( QFile::exists( outputPath2 ) );
+    REQUIRE( QFileInfo( outputPath2 ).size() > 0 );
+}
+
+TEST_CASE( "Live log save: rotation during streaming write does not lose lines",
+           "[capturestore][rolling][live_save]" )
+{
+    // Verify that lines appended after bindOutputFile are correctly
+    // written even when rotation occurs.
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 32 * 1024;
+    limits.memoryBudgetBytes = 10 * 1024 * 1024;
+    limits.rollingMaxFileSize = 64 * 1024; // 64KB — small enough to rotate often
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "live_save_stream" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "stream.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+
+    // Bind output file with some initial data
+    store.appendUtf8( generateLines( 500, 128 ) );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Stream more data — each append may trigger rotation
+    for ( int i = 0; i < 20; ++i ) {
+        store.appendUtf8( generateLines( 100, 128 ) ); // ~12.8KB each
+    }
+
+    // The output file + backups should contain all the data.
+    // Verify by reading back through CaptureStore's line interface.
+    const auto finalLineCount = store.lineCount();
+    REQUIRE( finalLineCount > 0_lcount );
+
+    // The output file should exist and have content
+    REQUIRE( QFile::exists( outputPath ) );
+    REQUIRE( QFileInfo( outputPath ).size() > 0 );
+
+    // Backups should have been created by rotation
+    const auto backups = QDir( rootPath ).entryList(
+        { QFileInfo( outputPath ).fileName() + ".*" }, QDir::Files );
+    INFO( "Backup files: " << backups.join( ", " ).toStdString() );
+    CHECK( backups.size() >= 1 );
+}
+
+TEST_CASE( "Live log save: forceOutputFlush preserves data integrity",
+           "[capturestore][rolling][live_save]" )
+{
+    // Verify that flush() correctly writes buffered output data.
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 64 * 1024;
+    limits.memoryBudgetBytes = 10 * 1024 * 1024;
+    limits.rollingMaxFileSize = 256 * 1024;
+    limits.rollingBackupCount = 3;
+
+    const auto rootPath = makeTestDir( "live_save_flush" );
+    const auto outputPath = QDir( rootPath ).filePath( QStringLiteral( "flush.log" ) );
+
+    CaptureStore store( makeCaptureId(), rootPath, limits );
+    store.appendUtf8( generateLines( 1000, 128 ) );
+    REQUIRE( store.bindOutputFile( outputPath ) );
+
+    // Append data and flush
+    store.appendUtf8( generateLines( 500, 128 ) );
+    store.flush();
+
+    REQUIRE( QFile::exists( outputPath ) );
+    REQUIRE( QFileInfo( outputPath ).size() > 0 );
+}

--- a/tests/unit/newversiondialog_test.cpp
+++ b/tests/unit/newversiondialog_test.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QApplication>
+#include <QScrollBar>
+#include <QTextBrowser>
+#include <QTest>
+
+#include "newversiondialog.h"
+
+namespace {
+
+// Generate a long changelog that simulates a detailed GitHub release body.
+QStringList makeLongChangelog()
+{
+    QStringList changes;
+    QString longBody;
+    // Simulate a detailed release body with many lines
+    longBody += QStringLiteral( "## What's New\n\n" );
+    for ( int i = 1; i <= 50; ++i ) {
+        longBody += QStringLiteral( "- Feature %1: This is a very detailed description "
+                                    "of an exciting new feature that was added.\n" )
+                        .arg( i );
+    }
+    longBody += QStringLiteral( "\n## Bug Fixes\n\n" );
+    for ( int i = 1; i <= 50; ++i ) {
+        longBody += QStringLiteral( "- Bug fix %1: Fixed a critical issue that caused "
+                                    "unexpected behavior when processing large files.\n" )
+                        .arg( i );
+    }
+    changes << longBody;
+    return changes;
+}
+
+} // namespace
+
+TEST_CASE( "NewVersionDialog: height is constrained with long changelog",
+           "[newversiondialog]" )
+{
+    // The dialog must not grow unboundedly when the changelog is long.
+    // Instead, the changelog area should be scrollable and height-limited.
+
+    const auto longChanges = makeLongChangelog();
+    REQUIRE_FALSE( longChanges.isEmpty() );
+
+    NewVersionDialog dlg( QStringLiteral( "99.0.0.0" ),
+                          QStringLiteral( "https://github.com/ZEACENT/klogg/releases/tag/v99.0.0.0" ),
+                          longChanges );
+
+    // The dialog height should be constrained (well under what a long
+    // changelog would produce without a scroll area).
+    const auto hint = dlg.sizeHint();
+
+    // With a scroll area, the dialog should stay below ~600px.
+    // Without it, the QMessageBox would easily exceed 2000px for 100+ lines.
+    CHECK( hint.height() <= 600 );
+
+    // The dialog should have a reasonable minimum height to be usable
+    CHECK( hint.height() >= 200 );
+}
+
+TEST_CASE( "NewVersionDialog: changelog text browser is scrollable",
+           "[newversiondialog]" )
+{
+    const auto longChanges = makeLongChangelog();
+
+    NewVersionDialog dlg( QStringLiteral( "99.0.0.0" ),
+                          QStringLiteral( "https://github.com/ZEACENT/klogg/releases/tag/v99.0.0.0" ),
+                          longChanges );
+
+    // Find the QTextBrowser — it must exist and have a vertical scroll bar
+    // when the content exceeds its maximum height.
+    const auto textBrowsers = dlg.findChildren<QTextBrowser*>();
+    REQUIRE_FALSE( textBrowsers.isEmpty() );
+
+    auto* browser = textBrowsers.first();
+    REQUIRE( browser != nullptr );
+
+    // The browser should have a constrained maximum height
+    CHECK( browser->maximumHeight() == NewVersionDialog::kMaxChangesHeight );
+
+    // Show the dialog offscreen to let layout settle, then check scrollbar
+    dlg.show();
+    QTest::qWait( 50 );
+
+    auto* vScrollBar = browser->verticalScrollBar();
+    REQUIRE( vScrollBar != nullptr );
+
+    // The content should be longer than the visible area, making the
+    // scrollbar necessary (maximum > 0 means scrolling is possible).
+    CHECK( vScrollBar->maximum() > 0 );
+}
+
+TEST_CASE( "NewVersionDialog: no changelog section when changes are empty",
+           "[newversiondialog]" )
+{
+    NewVersionDialog dlg( QStringLiteral( "99.0.0.0" ),
+                          QStringLiteral( "https://github.com/ZEACENT/klogg/releases/tag/v99.0.0.0" ),
+                          QStringList{} );
+
+    // Without changes, there should be no QTextBrowser
+    const auto textBrowsers = dlg.findChildren<QTextBrowser*>();
+    CHECK( textBrowsers.isEmpty() );
+
+    // Dialog should still have a reasonable size
+    const auto hint = dlg.sizeHint();
+    CHECK( hint.height() <= 600 );
+    CHECK( hint.height() >= 100 );
+}
+
+TEST_CASE( "NewVersionDialog: short changelog also fits constraints",
+           "[newversiondialog]" )
+{
+    QStringList shortChanges;
+    shortChanges << QStringLiteral( "## Changes\n\n- Minor bug fix\n- Performance improvement" );
+
+    NewVersionDialog dlg( QStringLiteral( "99.0.0.0" ),
+                          QStringLiteral( "https://github.com/ZEACENT/klogg/releases/tag/v99.0.0.0" ),
+                          shortChanges );
+
+    const auto textBrowsers = dlg.findChildren<QTextBrowser*>();
+    REQUIRE_FALSE( textBrowsers.isEmpty() );
+
+    const auto hint = dlg.sizeHint();
+    CHECK( hint.height() <= 600 );
+    CHECK( hint.height() >= 150 );
+}
+
+TEST_CASE( "NewVersionDialog: buttons emit correct result", "[newversiondialog]" )
+{
+    NewVersionDialog dlg( QStringLiteral( "99.0.0.0" ),
+                          QStringLiteral( "https://github.com/ZEACENT/klogg/releases/tag/v99.0.0.0" ),
+                          QStringList{} );
+
+    // Test that the dialog starts with the expected initial button state
+    // (clickedButton should not be used before exec/show, but defaults to RemindLater)
+    CHECK( dlg.clickedButton() == NewVersionDialog::RemindLater );
+}

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -620,6 +620,82 @@ TEST_CASE( "Streaming live search uses pooled path for medium live update ranges
     REQUIRE( incrementalMatchers < incrementalOps * 4 );
 }
 
+TEST_CASE( "StreamingLogData setCaptureLimits trims data when limit is exceeded" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    logData.setCaptureLimits( limits );
+
+    loadingSpy.clear();
+    for ( int i = 0; i < 20; ++i ) {
+        logData.appendUtf8( QStringLiteral( "stream-%1\n" ).arg( i ).toUtf8() );
+    }
+    REQUIRE( loadingSpy.safeWait() );
+
+    // File size should be within limits
+    CHECK( logData.getFileSize() <= limits.rollingMaxFileSize * limits.rollingBackupCount );
+
+    // Lines should still be readable
+    const auto lineCount = logData.getNbLine();
+    CHECK( lineCount.get() > 0 );
+    REQUIRE( logData.getLineString( LineNumber( lineCount.get() - 1 ) )
+             == QStringLiteral( "stream-19" ) );
+}
+
+TEST_CASE( "StreamingLogData trim emits Truncated signal and invalidates caches" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 3;
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    logData.setCaptureLimits( limits );
+
+    loadingSpy.clear();
+    SafeQSignalSpy fileSpy( &logData, SIGNAL( fileChanged( MonitoredFileStatus ) ) );
+
+    for ( int i = 0; i < 20; ++i ) {
+        logData.appendUtf8( QStringLiteral( "data-%1\n" ).arg( i ).toUtf8() );
+    }
+    REQUIRE( loadingSpy.safeWait() );
+
+    // At least one Truncated signal should have been emitted
+    bool sawTruncated = false;
+    for ( int i = 0; i < fileSpy.count(); ++i ) {
+        if ( fileSpy.at( i ).at( 0 ).value<MonitoredFileStatus>() == MonitoredFileStatus::Truncated ) {
+            sawTruncated = true;
+            break;
+        }
+    }
+    REQUIRE( sawTruncated );
+
+    // The search cache should work correctly after trim
+    const auto rawLines = logData.getLinesRaw( 0_lnum, logData.getNbLine() );
+    REQUIRE( rawLines.endOfLines.size() == static_cast<size_t>( logData.getNbLine().get() ) );
+
+    const auto decoded = rawLines.decodeLines();
+    REQUIRE( decoded.back() == QStringLiteral( "data-19" ) );
+}
+
 TEST_CASE( "Streaming live search coalesces medium updates before starting operations" )
 {
     QTemporaryDir tempDir;

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -791,3 +791,55 @@ TEST_CASE( "Streaming live search coalesces medium updates before starting opera
     REQUIRE( incrementalOps < 4 );
     REQUIRE( coalescedUpdates > 0 );
 }
+
+TEST_CASE( "StreamingLogData finishInput emits Truncated on single-line rotation trim",
+           "[streaming]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 16;
+    limits.rollingBackupCount = 2;
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    logData.setCaptureLimits( limits );
+
+    // Preserve mode routes output through CaptureStore, so finishInput()'s
+    // commitLine() -> appendOutputBytes() path can rotate and trim. appendUtf8()
+    // already handles this; finishInput() previously did not.
+    const auto outPath = QDir( tempDir.path() ).filePath( "out.log" );
+    REQUIRE( logData.bindOutputFile( outPath, LiveLogSaveAnsiMode::Preserve ) );
+
+    SafeQSignalSpy fileSpy( &logData, SIGNAL( fileChanged( MonitoredFileStatus ) ) );
+
+    // Partial lines (no trailing newline) committed via finishInput, forcing
+    // many rotations through the single-line commit path.
+    for ( int i = 0; i < 30; ++i ) {
+        logData.appendUtf8( QStringLiteral( "data-%1" ).arg( i ).toUtf8() );
+        logData.finishInput();
+    }
+    REQUIRE( loadingSpy.safeWait() );
+
+    bool sawTruncated = false;
+    for ( int i = 0; i < fileSpy.count(); ++i ) {
+        if ( fileSpy.at( i ).at( 0 ).value<MonitoredFileStatus>()
+             == MonitoredFileStatus::Truncated ) {
+            sawTruncated = true;
+            break;
+        }
+    }
+    REQUIRE( sawTruncated );
+
+    // Guard: the store must stay readable (tail line resolvable) after
+    // finishInput-driven trims.
+    REQUIRE( logData.getNbLine().get() > 0 );
+    const auto tail = logData.getNbLine().get() - 1;
+    const auto tailLine = logData.getLinesRaw( LineNumber( tail ), 1_lcount );
+    REQUIRE( tailLine.endOfLines.size() == 1 );
+}

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -323,6 +323,55 @@ TEST_CASE( "StreamingLogData can strip ANSI while saving current and future live
     REQUIRE( outputFile.readAll() == QByteArrayLiteral( "I/App first\nE/App second\n" ) );
 }
 
+TEST_CASE( "StreamingLogData clearCapture truncates display output file" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+
+    REQUIRE( loadingSpy.safeWait() );
+    loadingSpy.clear();
+
+    logData.appendUtf8( QByteArrayLiteral( "first line\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "display.log" ) );
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+
+    // Output file now contains "first line\n"
+    QFile output1( outputPath );
+    REQUIRE( output1.open( QIODevice::ReadOnly ) );
+    REQUIRE( output1.readAll() == QByteArrayLiteral( "first line\n" ) );
+    output1.close();
+
+    // Simulate a reconnect: clearCapture reopens the display output file.
+    loadingSpy.clear();
+    logData.clearCapture();
+    REQUIRE( loadingSpy.safeWait() );
+
+    // After clearCapture, the output file should be truncated (empty),
+    // not still containing "first line\n".
+    QFile output2( outputPath );
+    REQUIRE( output2.open( QIODevice::ReadOnly ) );
+    const auto afterClear = output2.readAll();
+    output2.close();
+
+    // The file should be empty — clearCapture should have truncated it.
+    CHECK( afterClear.isEmpty() );
+
+    // New data after clear should be written cleanly (no old data prepended).
+    loadingSpy.clear();
+    logData.appendUtf8( QByteArrayLiteral( "second line\n" ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    QFile output3( outputPath );
+    REQUIRE( output3.open( QIODevice::ReadOnly ) );
+    REQUIRE( output3.readAll() == QByteArrayLiteral( "second line\n" ) );
+    output3.close();
+}
+
 TEST_CASE( "StreamingLogData can preserve ANSI while saving current and future live log lines" )
 {
     QTemporaryDir tempDir;

--- a/tests/unit/updatedownload_test.cpp
+++ b/tests/unit/updatedownload_test.cpp
@@ -87,6 +87,37 @@ TEST_CASE( "UpdateDownload: cancel button aborts download", "[updatedownload][pr
     delete progressDialog;
 }
 
+TEST_CASE( "Downloader abort prevents finished signal",
+           "[updatedownload][downloader]" )
+{
+    // After abort(), the Downloader must not emit finished() — doing so
+    // would cause use-after-free when the caller has already cleaned up.
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    QFile outputFile( tempDir.filePath( QStringLiteral( "out.bin" ) ) );
+    REQUIRE( outputFile.open( QIODevice::WriteOnly ) );
+
+    Downloader downloader;
+    QSignalSpy finishedSpy( &downloader, &Downloader::finished );
+
+    // Start a download to a URL that will never respond quickly.
+    downloader.download( QUrl( QStringLiteral( "http://192.0.2.1:1/nope" ) ), &outputFile );
+
+    // Abort immediately — the reply should be terminated and disconnected.
+    downloader.abort();
+
+    // Process events briefly to verify no signal is emitted.
+    QCoreApplication::processEvents();
+    QThread::msleep( 50 );
+    QCoreApplication::processEvents();
+
+    CHECK( finishedSpy.count() == 0 );
+
+    outputFile.close();
+}
+
 TEST_CASE( "calculateProgress: sanity checks for download progress values",
            "[progress][updatedownload]" )
 {

--- a/tests/unit/updatedownload_test.cpp
+++ b/tests/unit/updatedownload_test.cpp
@@ -31,6 +31,7 @@
 #include "downloader.h"
 #include "progress.h"
 #include "updatedownloadhelper.h"
+#include "updatedownloadhelper.h"
 
 TEST_CASE( "UpdateDownload: progress dialog is created for download",
            "[updatedownload][progress]" )
@@ -215,4 +216,25 @@ TEST_CASE( "calculateProgress: sanity checks for download progress values",
     // Edge: download just started, unknown total
     // When total is -1 (unknown), the calculation should still work
     CHECK( calculateProgress( 0LL, -1LL ) == 0 );
+}
+
+TEST_CASE( "discardDownloadedFile closes the handle and removes the file" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+    const auto path = tempDir.filePath( QStringLiteral( "partial.dmg" ) );
+
+    QFile file( path );
+    REQUIRE( file.open( QIODevice::WriteOnly ) );
+    file.write( "partial" );
+    REQUIRE( file.isOpen() );
+
+    // Must close BEFORE removing (Windows refuses to delete an open file); the
+    // handle is open at this point, so the helper's ordering is what's tested.
+    REQUIRE( discardDownloadedFile( file ) );
+    REQUIRE_FALSE( file.isOpen() );
+    REQUIRE_FALSE( QFile::exists( path ) );
+
+    // Calling again on an already-removed file is a no-op success.
+    REQUIRE( discardDownloadedFile( file ) );
 }

--- a/tests/unit/updatedownload_test.cpp
+++ b/tests/unit/updatedownload_test.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 ZEACENT and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QApplication>
+#include <QFile>
+#include <QProgressDialog>
+#include <QSignalSpy>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QUrl>
+
+#include "downloader.h"
+#include "progress.h"
+#include "updatedownloadhelper.h"
+
+TEST_CASE( "UpdateDownload: progress dialog is created for download",
+           "[updatedownload][progress]" )
+{
+    // When an update download is started, a QProgressDialog must be created
+    // and connected to the Downloader's progress and finished signals.
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = tempDir.filePath( QStringLiteral( "test_update.dmg" ) );
+    auto* outputFile = new QFile( outputPath, /*parent=*/nullptr );
+    REQUIRE( outputFile->open( QIODevice::WriteOnly ) );
+
+    QUrl testUrl( QStringLiteral( "https://example.com/klogg-99.0.0.0-arm64.dmg" ) );
+
+    // The helper must return a non-null QProgressDialog pointer
+    auto* progressDialog = startUpdateDownload( testUrl, outputFile, /*parent=*/nullptr );
+    REQUIRE( progressDialog != nullptr );
+
+    // The dialog should show the download URL or a meaningful label
+    CHECK_FALSE( progressDialog->labelText().isEmpty() );
+
+    // The dialog should start in a usable state
+    CHECK( progressDialog->minimumDuration() >= 0 );
+
+    // Clean up
+    delete outputFile;
+    delete progressDialog;
+}
+
+TEST_CASE( "UpdateDownload: cancel button aborts download", "[updatedownload][progress]" )
+{
+    // The progress dialog must have a cancel button so users can abort
+    // a slow or unwanted download.
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = tempDir.filePath( QStringLiteral( "test_update.exe" ) );
+    auto* outputFile = new QFile( outputPath, /*parent=*/nullptr );
+    REQUIRE( outputFile->open( QIODevice::WriteOnly ) );
+
+    QUrl testUrl( QStringLiteral( "https://example.com/klogg-99.0.0.0-setup.exe" ) );
+
+    auto* progressDialog = startUpdateDownload( testUrl, outputFile, /*parent=*/nullptr );
+    REQUIRE( progressDialog != nullptr );
+
+    // The dialog should be cancelable
+    CHECK( progressDialog->isVisible() == false ); // not shown until exec() or show()
+    CHECK( progressDialog->wasCanceled() == false );
+
+    // Clean up
+    delete outputFile;
+    delete progressDialog;
+}
+
+TEST_CASE( "calculateProgress: sanity checks for download progress values",
+           "[progress][updatedownload]" )
+{
+    // Verify the progress calculation handles all reasonable download sizes.
+
+    // Typical installer sizes
+    CHECK( calculateProgress( 0LL, 50'000'000LL ) == 0 );     // 0 of 50 MB
+    CHECK( calculateProgress( 25'000'000LL, 50'000'000LL ) == 50 ); // half done
+    CHECK( calculateProgress( 50'000'000LL, 50'000'000LL ) == 100 ); // complete
+
+    // Zero total: in practice Downloader always provides a valid total.
+    // Division by zero is undefined; this case is never hit in production.
+    // We document the constraint rather than guarding against it.
+
+    // Edge: download just started, unknown total
+    // When total is -1 (unknown), the calculation should still work
+    CHECK( calculateProgress( 0LL, -1LL ) == 0 );
+}

--- a/tests/unit/updatedownload_test.cpp
+++ b/tests/unit/updatedownload_test.cpp
@@ -25,6 +25,7 @@
 #include <QSignalSpy>
 #include <QStandardPaths>
 #include <QTemporaryDir>
+#include <QTimer>
 #include <QUrl>
 
 #include "downloader.h"
@@ -154,6 +155,47 @@ TEST_CASE( "UpdateDownload: stack-allocated objects avoid Cocoa lifecycle issues
     CHECK( progressDialog.wasCanceled() == false );
 
     outputFile.close();
+}
+
+TEST_CASE( "Parentless dialog must call processEvents before destruction",
+           "[updatedownload][progress]" )
+{
+    // On macOS, a parentless QProgressDialog gets its own NSWindow.
+    // After exec() returns, stale Cocoa events for the NSWindow may
+    // remain in the event queue.  If the dialog is destroyed before
+    // those events are drained, the next processEvents() cycle in the
+    // main event loop will try to dispatch them to the now-dead window,
+    // causing an ObjC exception → SIGABRT.
+    //
+    // The safe pattern is:
+    //   { QDialog dlg; dlg.exec(); processEvents(); }
+    //
+    // This test verifies that the pattern does not crash (the actual
+    // macOS crash only reproduces with the Cocoa platform plugin, but
+    // this documents the required lifecycle contract).
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    {
+        QProgressDialog dlg;
+        dlg.setLabelText( QStringLiteral( "Test" ) );
+        dlg.setMinimumDuration( 0 );
+        dlg.setCancelButtonText( QString() ); // no cancel button
+
+        // Close the dialog after a brief delay so exec() returns.
+        QTimer::singleShot( 50, &dlg, [ &dlg ]() { dlg.done( QDialog::Accepted ); } );
+
+        dlg.exec();
+
+        // CRITICAL: drain stale Cocoa events while the dialog is still alive.
+        QCoreApplication::processEvents();
+
+        // Now the dialog is safe to destroy — no stale events remain.
+    }
+
+    // If we get here without crashing, the pattern is correct.
+    CHECK( true );
 }
 
 TEST_CASE( "calculateProgress: sanity checks for download progress values",

--- a/tests/unit/updatedownload_test.cpp
+++ b/tests/unit/updatedownload_test.cpp
@@ -34,31 +34,30 @@
 TEST_CASE( "UpdateDownload: progress dialog is created for download",
            "[updatedownload][progress]" )
 {
-    // When an update download is started, a QProgressDialog must be created
-    // and connected to the Downloader's progress and finished signals.
+    // When an update download is started, the progress dialog must be
+    // connected to the Downloader's progress and finished signals.
 
     QTemporaryDir tempDir;
     REQUIRE( tempDir.isValid() );
 
     const auto outputPath = tempDir.filePath( QStringLiteral( "test_update.dmg" ) );
-    auto* outputFile = new QFile( outputPath, /*parent=*/nullptr );
-    REQUIRE( outputFile->open( QIODevice::WriteOnly ) );
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::WriteOnly ) );
 
     QUrl testUrl( QStringLiteral( "https://example.com/klogg-99.0.0.0-arm64.dmg" ) );
 
-    // The helper must return a non-null QProgressDialog pointer
-    auto* progressDialog = startUpdateDownload( testUrl, outputFile, /*parent=*/nullptr );
-    REQUIRE( progressDialog != nullptr );
+    Downloader downloader;
+    QProgressDialog progressDialog;
+
+    startUpdateDownload( testUrl, &outputFile, downloader, progressDialog );
 
     // The dialog should show the download URL or a meaningful label
-    CHECK_FALSE( progressDialog->labelText().isEmpty() );
+    CHECK_FALSE( progressDialog.labelText().isEmpty() );
 
     // The dialog should start in a usable state
-    CHECK( progressDialog->minimumDuration() >= 0 );
+    CHECK( progressDialog.minimumDuration() >= 0 );
 
-    // Clean up
-    delete outputFile;
-    delete progressDialog;
+    outputFile.close();
 }
 
 TEST_CASE( "UpdateDownload: cancel button aborts download", "[updatedownload][progress]" )
@@ -70,21 +69,21 @@ TEST_CASE( "UpdateDownload: cancel button aborts download", "[updatedownload][pr
     REQUIRE( tempDir.isValid() );
 
     const auto outputPath = tempDir.filePath( QStringLiteral( "test_update.exe" ) );
-    auto* outputFile = new QFile( outputPath, /*parent=*/nullptr );
-    REQUIRE( outputFile->open( QIODevice::WriteOnly ) );
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::WriteOnly ) );
 
     QUrl testUrl( QStringLiteral( "https://example.com/klogg-99.0.0.0-setup.exe" ) );
 
-    auto* progressDialog = startUpdateDownload( testUrl, outputFile, /*parent=*/nullptr );
-    REQUIRE( progressDialog != nullptr );
+    Downloader downloader;
+    QProgressDialog progressDialog;
+
+    startUpdateDownload( testUrl, &outputFile, downloader, progressDialog );
 
     // The dialog should be cancelable
-    CHECK( progressDialog->isVisible() == false ); // not shown until exec() or show()
-    CHECK( progressDialog->wasCanceled() == false );
+    CHECK( progressDialog.isVisible() == false ); // not shown until exec() or show()
+    CHECK( progressDialog.wasCanceled() == false );
 
-    // Clean up
-    delete outputFile;
-    delete progressDialog;
+    outputFile.close();
 }
 
 TEST_CASE( "Downloader abort prevents finished signal",
@@ -114,6 +113,45 @@ TEST_CASE( "Downloader abort prevents finished signal",
     QCoreApplication::processEvents();
 
     CHECK( finishedSpy.count() == 0 );
+
+    outputFile.close();
+}
+
+TEST_CASE( "UpdateDownload: stack-allocated objects avoid Cocoa lifecycle issues",
+           "[updatedownload][progress]" )
+{
+    // On macOS, heap-allocated parentless QProgressDialog creates its own
+    // NSWindow.  Calling processEvents() after exec() can dispatch stale
+    // Cocoa events for the torn-down NSWindow, causing a SIGABRT crash.
+    //
+    // The fix: startUpdateDownload() must accept stack-allocated Downloader
+    // and QProgressDialog references (matching the safe pattern in
+    // MainWindow::openRemoteFile) so the caller controls lifetime and
+    // never needs processEvents() + explicit delete.
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = tempDir.filePath( QStringLiteral( "test_update.dmg" ) );
+    QFile outputFile( outputPath );
+    REQUIRE( outputFile.open( QIODevice::WriteOnly ) );
+
+    QUrl testUrl( QStringLiteral( "https://example.com/klogg-99.0.0.0-arm64.dmg" ) );
+
+    // Stack-allocated objects — deterministic LIFO destruction, no NSWindow leak.
+    Downloader downloader;
+    QProgressDialog progressDialog;
+
+    // This call must compile and wire up signals between the two objects.
+    // The overload must accept (QUrl, QFile*, Downloader&, QProgressDialog&).
+    startUpdateDownload( testUrl, &outputFile, downloader, progressDialog );
+
+    // The dialog label should be set from the URL.
+    CHECK_FALSE( progressDialog.labelText().isEmpty() );
+
+    // The dialog should be in a usable initial state.
+    CHECK( progressDialog.minimumDuration() >= 0 );
+    CHECK( progressDialog.wasCanceled() == false );
 
     outputFile.close();
 }


### PR DESCRIPTION
## Summary

This PR adds three major features and fixes a cascade of macOS SIGABRT crashes discovered during development:

**Features:**
- **Auto-reconnect for live sources** (ADB/iOS) with exponential backoff (1s–30s) and ±20% jitter, configurable max attempts (0 = unlimited). Tab bar shows live status dots (Connected/Reconnecting/Error).
- **Rolling file output** for capture logs: size-based rotation with configurable backup count. Options dialog additions for rolling file size/backup count. `backupCount = 0` now means "keep all rotated files."
- **Download progress dialog** for the new version update flow with speed, ETA, and cancel support.
- **Per-tab live source settings** (auto-reconnect, max capture size, rolling backups) in ADB/iOS open dialogs.
- **Dedicated "Live Source" Options tab** extracted from the overcrowded File tab.
- **Async device enumeration** via `DeviceListProvider` abstraction — `adb devices -l` / `pymobiledevice3 usbmux list` no longer block the UI thread.
- **Async transport reconnection** — `attemptReconnect()` no longer blocks the GUI thread for up to 3.25s.
- **Scrollable changelog** in the New Version dialog (capped at 600px, changelog area at 200px with scrollbar).

**Bug fixes:**
- **5 macOS SIGABRT crashes** caused by stale Cocoa events after parentless `QDialog::exec()` — drained via `processEvents()` after each exec return.
- **SIGABRT when streaming past the rolling window** after saving a live log — uint64 underflow in line-range computation from `trimToLimits()` removing more lines than were appended.
- **UAF, data corruption, and resource leaks** from code review (9 issues): download cancel UAF, `RollingFileManager` size tracking bypass, append-mode display output, stale `lastTrimResult_`, stderr temp file leak, and more.
- **13 review findings** across rolling output, reconnect, and device enumeration.
- iOS PTY stderr leak silencing — `pymobiledevice3` ERROR/Warning lines no longer appear in the log view when the device disconnects.

## Background

**Introduced by:** The original `QMessageBox`-based version notification (scrolling issue), auto-reconnect and rolling files feature (`c8a5f5c6`), macOS native `NSSavePanel` lifecycle, and the download progress dialog.

**Use case:** Users who stream live ADB/iOS logs with rolling output enabled, auto-reconnect, and save their logs — the most data-intensive live-source workflow.

**Root cause (macOS crashes):** Every parentless `QDialog::exec()` on macOS creates a standalone `NSWindow`. After exec returns, stale Cocoa events linger. The main event loop's `processEvents()` dispatches them to the destroyed window → ObjC exception → `SIGABRT`. The uint64 underflow crash was masked by the NSWindow crash pattern, requiring separate investigation.

## Tests

- **Unit tests:** 291 cases / 5601 assertions pass (`-platform offscreen`)
- **Integration tests:** 60 cases / 2165 assertions pass (`-platform offscreen`)
- **Smoke test:** `klogg -v` exits 0
- **CTest:** All 4 suites pass (klogg_tests, klogg_itests, klogg_smoke, klogg_vectorscan_tests)
- **New test files:** `capturestore_test.cpp`, `live_save_crash_repro_test.cpp`, `live_save_split_test.cpp`, `newversiondialog_test.cpp`, `streaminglogdata_test.cpp`, `updatedownload_test.cpp`, `configuration_test.cpp`, and expanded `adb_ui_transport_test.cpp`

52 files changed: +5402 / -556 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live auto-reconnect for ADB and iOS log streams, with configurable retry attempts and rolling capture limits.
  * Added rolling capture file management (max size, backup count, and total-line trimming).
  * Added a new “new version available” dialog with Download / Remind Later / Skip options.
* **Bug Fixes**
  * Improved macOS stability by preventing dialog-related event-queue crashes during update checks, downloads, file operations, and crash reporting.
  * Fixed log saving/trimming/rolling behavior to keep displayed content consistent and prevent split/trim edge-case failures.
* **Tests**
  * Added/expanded unit coverage for updates, rolling/trimming, and live reconnect/device enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->