### PR TITLE
Post-#39 review fixes: search escaping, line-map caching, folder-tab parity

### DIFF
--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -157,6 +157,12 @@ class FolderSearchResults : public AbstractLogData {
     };
 
     void rebuildVisibleRows();
+    // Snapshot the filePaths of currently-collapsed groups (called at the top of
+    // beginSearch, before groups_ is rebuilt) and re-apply collapse to a group as
+    // it streams back in (called after each push_back). Keyed by filePath because
+    // FileId is reassigned when groups_ is rebuilt (foldersearchtypes.h:33-36).
+    void snapshotCollapsedPaths();
+    void reapplyCollapseForLastGroup();
     bool isLineMarked( const QString& filePath, LineNumber localLine ) const;
     QString headerText( klogg::folder::FileId fileId ) const;
     QString readMatchLine( klogg::folder::FileId fileId, size_t matchIndex ) const;
@@ -166,6 +172,10 @@ class FolderSearchResults : public AbstractLogData {
     std::vector<klogg::folder::FileGroup> groups_;
     std::vector<VisibleRow> visibleRows_;
     QSet<klogg::folder::FileId> collapsed_;
+    // Snapshot of collapsed groups' filePaths captured in beginSearch and
+    // re-applied as each group streams back in, so a re-scan (e.g. a context-line
+    // change) preserves the user's collapse state. Lives one search cycle.
+    QSet<QString> pendingCollapsePaths_;
 
     Visibility visibility_ = Visibility::MarksAndMatches;
     std::function<bool( const QString&, LineNumber )> isMarkedLine_;

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -47,13 +47,52 @@ void FolderSearchResults::setResults( std::vector<klogg::folder::FileGroup> grou
                                    []( const klogg::folder::FileGroup& g ) { return g.matches.empty(); } ),
                    groups_.end() );
 
+    // NOTE: setResults resets collapse (it is a full result-set replacement, not
+    // the live re-search path -- startSearch uses beginSearch, which preserves
+    // collapse via snapshotCollapsedPaths/reapplyCollapseForLastGroup). Callers
+    // that need preservation here should snapshot filePaths the same way.
     collapsed_.clear();
     rebuildVisibleRows();
     Q_EMIT layoutChanged();
 }
 
+void FolderSearchResults::snapshotCollapsedPaths()
+{
+    // Only (re)snapshot while groups_ still holds the current result set. A
+    // follow-up beginSearch can fire before the previous one's scan has streamed
+    // any groups back (e.g. the context combobox and spinbox each trigger a
+    // re-scan); at that point groups_ is empty and re-snapshotting would clobber
+    // the snapshot just captured. Keep the existing pendingCollapsePaths_ so it
+    // survives until the groups actually stream back in.
+    if ( groups_.empty() ) {
+        return;
+    }
+    pendingCollapsePaths_.clear();
+    for ( const auto fid : collapsed_ ) {
+        if ( fid >= 0 && fid < static_cast<int>( groups_.size() ) ) {
+            pendingCollapsePaths_.insert( groups_[ static_cast<size_t>( fid ) ].filePath );
+        }
+    }
+}
+
+void FolderSearchResults::reapplyCollapseForLastGroup()
+{
+    if ( groups_.empty() ) {
+        return;
+    }
+    const auto& lastPath = groups_.back().filePath;
+    if ( pendingCollapsePaths_.contains( lastPath ) ) {
+        collapsed_.insert( static_cast<int>( groups_.size() ) - 1 );
+    }
+}
+
 void FolderSearchResults::beginSearch( const QStringList& expectedFileOrder )
 {
+    // Preserve collapse across this re-scan: snapshot which filePaths are collapsed
+    // BEFORE groups_ is rebuilt and FileIds are reassigned, then re-apply as groups
+    // stream back in (addFileGroup/flushPending). Without this, a context-line
+    // change (which re-scans via beginSearch) would expand every collapsed group.
+    snapshotCollapsedPaths();
     groups_.clear();
     openFiles_.clear();
     collapsed_.clear();
@@ -79,6 +118,7 @@ void FolderSearchResults::addFileGroup( int fileIndex, klogg::folder::FileGroup 
         auto& opt = pendingByIndex_[ nextExpectedIndex_ ];
         if ( !opt->matches.empty() ) {
             groups_.push_back( std::move( *opt ) );
+            reapplyCollapseForLastGroup();
             // Keep file-handle slots aligned to fileId (== group index), matching
             // the setResults contract so fileForGroup() can index directly.
             openFiles_.resize( groups_.size() );
@@ -102,11 +142,14 @@ void FolderSearchResults::flushPending()
         auto& opt = pendingByIndex_[ nextExpectedIndex_ ];
         if ( opt.has_value() && !opt->matches.empty() ) {
             groups_.push_back( std::move( *opt ) );
+            reapplyCollapseForLastGroup();
             openFiles_.resize( groups_.size() );
             appended = true;
         }
         ++nextExpectedIndex_;
     }
+
+    pendingCollapsePaths_.clear(); // the snapshot lives exactly one search cycle
 
     if ( appended ) {
         rebuildVisibleRows();

--- a/src/regex/src/regularexpression.cpp
+++ b/src/regex/src/regularexpression.cpp
@@ -34,6 +34,46 @@
 #include "regularexpression.h"
 
 namespace {
+
+// Number of consecutive backslashes in `pattern` ending immediately before
+// position `pos` (the run that precedes a quote at `pos`). A quote is a real
+// boundary when this count is EVEN (0, 2, 4, ...); ODD means the quote is
+// escaped by the immediately preceding backslash. This replaces the naive
+// single-char lookback (`pattern[pos-1] == '\\'`), which could not represent a
+// boolean operand ending in a backslash: it always treated the closing quote as
+// escaped, throwing "unmatched quotes" for path-like operands that end in a
+// backslash (for example a Windows directory path).
+int precedingBackslashCount( const QString& pattern, int pos )
+{
+    int count = 0;
+    for ( int i = pos - 1; i >= 0 && pattern[ i ] == QChar( '\\' ); --i ) {
+        ++count;
+    }
+    return count;
+}
+
+// Inverse of SearchToolbar::wrapBooleanOperand's operand escaping: un-escape
+// C-style '\\' -> '\' and '\"' -> '"' in a single left-to-right pass. A lone
+// '\' not followed by '\' or '"' is left as-is (it has no escape meaning here).
+// Replaces the old `replace("\\\"", "\"")`, which only handled escaped quotes
+// and left doubled backslashes intact.
+QString unescapeBooleanOperand( const QString& operand )
+{
+    QString out;
+    out.reserve( operand.size() );
+    for ( int i = 0; i < operand.size(); ++i ) {
+        if ( operand[ i ] == QChar( '\\' ) && i + 1 < operand.size()
+             && ( operand[ i + 1 ] == QChar( '\\' ) || operand[ i + 1 ] == QChar( '"' ) ) ) {
+            out.append( operand[ i + 1 ] );
+            ++i; // consume the escaped char
+        }
+        else {
+            out.append( operand[ i ] );
+        }
+    }
+    return out;
+}
+
 klogg::vector<RegularExpressionPattern>
 parseBooleanExpressions( QString& pattern, bool isCaseSensitive, bool isPlainText )
 {
@@ -55,7 +95,7 @@ parseBooleanExpressions( QString& pattern, bool isCaseSensitive, bool isPlainTex
         }
 
         currentIndex = leftQuote + 1;
-        if ( leftQuote > 0 && pattern[ leftQuote - 1 ] == QChar( '\\' ) ) {
+        if ( precedingBackslashCount( pattern, leftQuote ) % 2 != 0 ) {
             leftQuote = -1;
             continue;
         }
@@ -68,7 +108,7 @@ parseBooleanExpressions( QString& pattern, bool isCaseSensitive, bool isPlainTex
             }
 
             currentIndex = rightQuote + 1;
-            if ( rightQuote > 0 && pattern[ rightQuote - 1 ] == QChar( '\\' ) ) {
+            if ( precedingBackslashCount( pattern, rightQuote ) % 2 != 0 ) {
                 rightQuote = -1;
                 continue;
             }
@@ -82,7 +122,7 @@ parseBooleanExpressions( QString& pattern, bool isCaseSensitive, bool isPlainTex
 
         const auto subPatternLength = rightQuote - leftQuote - 1;
         auto subPattern = pattern.mid( leftQuote + 1, subPatternLength );
-        subPattern.replace( "\\\"", "\"" );
+        subPattern = unescapeBooleanOperand( subPattern );
 
         subPatterns.emplace_back( subPattern, isCaseSensitive, false, false, isPlainText );
 

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -159,6 +159,11 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     // (nullopt when the map is empty). Lets headless tests verify the paint-free
     // rebuild without synthesizing a mouse event.
     OptionalLineNumber lineAtYForTest( int yPos ) const { return convertCoordToLine( yPos ); }
+    // Exposed for testing: how many times the paint-free map rebuild
+    // (buildVisibleLineMap, driven by ensureLineMapFresh) has run. Lets headless
+    // tests verify the signature cache skips redundant rebuilds across mouse
+    // events that share the same data/geometry.
+    int visibleLineMapBuildCount() const { return visibleLineMapBuildCount_; }
     // Instructs the widget to update it's content geometry,
     // used when the font is changed.
     void updateDisplaySize();
@@ -551,6 +556,40 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
 
     // Test instrumentation: counts calls to getSelectedText() for perf verification
     mutable int getSelectedTextCallCount_ = 0;
+
+    // Signature of every input that determines wrappedLinesInfo_, captured each
+    // time buildVisibleLineMap runs. ensureLineMapFresh compares the current key
+    // against the last build's and skips the rebuild when they match: consecutive
+    // mouse events that share data/geometry reuse the map instead of re-reading
+    // and re-wrapping the rest of the file (the wrap-mode hover perf bug). If any
+    // input changes the key changes too, so the cache cannot go stale by
+    // construction -- there are no scattered dirty flags to keep in sync.
+    struct VisibleLineMapKey {
+        const AbstractLogData* logData = nullptr;
+        uint64_t totalLines = 0; // logData_->getNbLine().get()
+        uint64_t firstLine = 0; // firstLine_.get()
+        bool useTextWrap = false;
+        int viewportWidth = 0;
+        int viewportHeight = 0;
+        int charWidth = 0;
+        int charHeight = 0;
+        bool lineNumbersVisible = false;
+        // Manual compare (project is C++17; defaulted operator== is C++20).
+        bool operator==( const VisibleLineMapKey& other ) const
+        {
+            return logData == other.logData && totalLines == other.totalLines
+                && firstLine == other.firstLine && useTextWrap == other.useTextWrap
+                && viewportWidth == other.viewportWidth && viewportHeight == other.viewportHeight
+                && charWidth == other.charWidth && charHeight == other.charHeight
+                && lineNumbersVisible == other.lineNumbersVisible;
+        }
+        bool operator!=( const VisibleLineMapKey& other ) const { return !( *this == other ); }
+    };
+    VisibleLineMapKey currentVisibleLineMapKey() const;
+    VisibleLineMapKey lastVisibleLineMapKey_{};
+    bool visibleLineMapKeyValid_ = false;
+    // Test instrumentation: counts paint-free map rebuilds (buildVisibleLineMap).
+    int visibleLineMapBuildCount_ = 0;
 
     LinesCount getNbVisibleLines() const;
     LinesCount getNbBottomWrappedVisibleLines() const;

--- a/src/ui/include/searchtoolbar.h
+++ b/src/ui/include/searchtoolbar.h
@@ -80,6 +80,15 @@ class SearchToolbar : public QWidget {
     QString escapeSearchPattern( const QString& pattern, bool isRegex = false ) const;
     QString& combinePatterns( QString& currentPattern, const QString& newPattern ) const;
 
+    // Wrap `pattern` as a single boolean operand: surround it with double-quotes
+    // and backslash-escape any embedded double-quote first. Does NOT regex-escape.
+    // Used by escapeSearchPattern (boolean branch) and by CrawlerWidget's
+    // excludeFromSearch, which previously inlined a no-op quote replace
+    // (replace('"',"\"") -- a 1-char literal -- leaving embedded quotes to break
+    // the boolean expression). Centralizing the escaping here keeps the two
+    // callers from drifting apart again.
+    QString wrapBooleanOperand( const QString& pattern ) const;
+
     // --- Option flag accessors ---
     bool isMatchCase() const;
     bool isUseRegexp() const;

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2052,12 +2052,48 @@ void AbstractLogView::ensureLineMapFresh()
     // stale/empty map: a click on a freshly swapped folder main view was
     // swallowed (convertCoordToLine -> nullopt -> no selection). Rebuild the map
     // paint-free so hit-testing is correct at click time regardless of paint
-    // delivery. Cheap (visible lines only) and called only from mouse handlers.
+    // delivery. Called only from mouse handlers.
+
+    // Signature cache: this runs on every press/move/release, and in wrap mode
+    // buildVisibleLineMap re-reads and re-wraps every line from the viewport to
+    // EOF. Consecutive mouse events share data/geometry, so skip the rebuild when
+    // nothing that determines the map has changed since the last build -- turning
+    // a per-hover full re-wrap into a cheap key compare. Any real change (scroll,
+    // resize, data swap, wrap toggle, font change) changes the key, so the map
+    // cannot silently go stale. The !empty() guard covers out-of-band clears
+    // (setDataSource, setTextWrap) that empty wrappedLinesInfo_ without touching
+    // the key, so no scattered dirty flags are needed.
+    const auto key = currentVisibleLineMapKey();
+    if ( visibleLineMapKeyValid_ && !wrappedLinesInfo_.empty() && lastVisibleLineMapKey_ == key ) {
+        return;
+    }
     buildVisibleLineMap();
+    lastVisibleLineMapKey_ = key;
+    visibleLineMapKeyValid_ = true;
+}
+
+AbstractLogView::VisibleLineMapKey AbstractLogView::currentVisibleLineMapKey() const
+{
+    VisibleLineMapKey key;
+    key.logData = logData_;
+    key.totalLines = logData_ != nullptr ? logData_->getNbLine().get() : 0;
+    key.firstLine = firstLine_.get();
+    key.useTextWrap = useTextWrap_;
+    key.viewportWidth = viewport()->width();
+    key.viewportHeight = textViewportHeight();
+    key.charWidth = charWidth_;
+    key.charHeight = charHeight_;
+    key.lineNumbersVisible = lineNumbersVisible_;
+    return key;
 }
 
 void AbstractLogView::buildVisibleLineMap()
 {
+    // Test instrumentation: counts every entry into the paint-free rebuild so
+    // headless tests can assert the signature cache (in ensureLineMapFresh)
+    // suppresses redundant rebuilds across mouse events.
+    ++visibleLineMapBuildCount_;
+
     // Geometry-only subset of drawTextArea's per-line loop: reproduces the
     // viewport-y -> LineNumber map (wrappedLinesInfo_) WITHOUT a QPainter. The
     // wrap math MUST mirror drawTextArea (same leftMarginPx_, availableWidth and

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -524,6 +524,13 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
                 if ( *line < logData_->getNbLine() ) {
                     selection_.selectLine( *line );
                     Q_EMIT newSelection( *line, 1_lcount, 0_lcol, 0_length );
+                    // Schedule a repaint so the new selection highlight is visible.
+                    // The Shift-click branch (above) and the drag path already do
+                    // this; having the base class self-repaint on every selection
+                    // change means hosts no longer need a compensating
+                    // connect(newSelection -> update()) -- which FolderCrawlerWidget
+                    // never had, leaving its filtered-view clicks unhighlighted.
+                    update();
                 }
 
                 // Remember the click in case we're starting a selection

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1105,7 +1105,10 @@ void CrawlerWidget::excludeFromSearch( const QString& searchString )
 
     const auto wasInBooleanCombinationMode = searchToolbar_->isBoolean();
     if ( !wasInBooleanCombinationMode ) {
-        currentPattern.replace( '"', "\"" ).prepend( '"' ).append( '"' );
+        // Wrap the existing pattern as one boolean operand. Must backslash-escape
+        // embedded double-quotes (not the no-op replace('"',"\"")); reuse the
+        // shared helper so this can't drift from escapeSearchPattern again.
+        currentPattern = searchToolbar_->wrapBooleanOperand( currentPattern );
     }
 
     searchToolbar_->setBoolean( true );

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -1381,9 +1381,9 @@ void CrawlerWidget::setup()
     connect( visibilityBox_, QOverload<int>::of( &QComboBox::currentIndexChanged ), this,
              &CrawlerWidget::changeFilteredViewVisibility );
 
-    connect( logMainView_, &LogMainView::newSelection,
-             [ this ]( auto ) { logMainView_->update(); } );
-
+    // AbstractLogView self-schedules its viewport repaint on every selection
+    // change (mousePressEvent + the keyboard displayLine paths), so the main
+    // view no longer needs a host-side connect(newSelection -> update()).
     connect( logMainView_, &LogMainView::newSelection, this,
              &CrawlerWidget::updateLineNumberHandler );
 
@@ -1540,8 +1540,9 @@ void CrawlerWidget::changeFontSize( bool increase )
 
 void CrawlerWidget::connectAllFilteredViewSlots( FilteredView* view )
 {
-    connect( view, &FilteredView::newSelection, view, [ view ]( auto ) { view->update(); } );
-
+    // AbstractLogView self-schedules its viewport repaint on selection change
+    // (mousePressEvent), so the filtered view no longer needs a host-side
+    // connect(newSelection -> view->update()).
     connect( view, &FilteredView::newSelection, this, &CrawlerWidget::jumpToMatchingLine );
 
     connect( view, &FilteredView::markLines, this, &CrawlerWidget::markLinesFromFiltered );

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -218,11 +218,15 @@ FolderCrawlerWidget::FolderCrawlerWidget( QWidget* parent )
     contextLinesComboBox_->setCurrentIndex( 0 );
 
     auto* toolbar = new QHBoxLayout;
+    // visibilityBox_ ("Marks and matches") is added FIRST, matching single-file
+    // CrawlerWidget (crawlerwidget.cpp:1287) where it sits at the far left of the
+    // results toolbar, ahead of the search bar. The folder-only collapse/expand
+    // buttons follow the search bar so they no longer displace the shared combo.
+    toolbar->addWidget( visibilityBox_ );
     toolbar->addWidget( searchToolbar_, 1 );
     toolbar->addSpacing( 12 );
     toolbar->addWidget( collapseAllButton_ );
     toolbar->addWidget( expandAllButton_ );
-    toolbar->addWidget( visibilityBox_ );
     toolbar->addWidget( contextLinesSpinBox_ );
     toolbar->addWidget( contextLinesComboBox_ );
     toolbar->addSpacing( 12 );

--- a/src/ui/src/searchtoolbar.cpp
+++ b/src/ui/src/searchtoolbar.cpp
@@ -275,15 +275,22 @@ QString SearchToolbar::escapeSearchPattern( const QString& pattern, bool isRegex
                               : pattern;
 
     if ( booleanButton_->isChecked() ) {
-        // Escape embedded double-quotes (replace " with \") before wrapping in
-        // "...". The literal "\\\"" is the 2-char string backslash+quote; a bare
-        // "\""" would be a 1-char string (the backslash only escapes the quote)
-        // and the replace would be a no-op, leaving embedded quotes to break the
-        // boolean expression.
-        escapedPattern.replace( '"', "\\\"" ).prepend( '"' ).append( '"' );
+        escapedPattern = wrapBooleanOperand( escapedPattern );
     }
 
     return escapedPattern;
+}
+
+QString SearchToolbar::wrapBooleanOperand( const QString& pattern ) const
+{
+    // Escape embedded double-quotes (replace " with \") before wrapping in
+    // "...". The literal "\\\"" is the 2-char string backslash+quote; a bare
+    // "\""" would be a 1-char string (the backslash only escapes the quote)
+    // and the replace would be a no-op, leaving embedded quotes to break the
+    // boolean expression.
+    QString wrapped = pattern;
+    wrapped.replace( '"', "\\\"" ).prepend( '"' ).append( '"' );
+    return wrapped;
 }
 
 QString& SearchToolbar::combinePatterns( QString& currentPattern, const QString& newPattern ) const

--- a/src/ui/src/searchtoolbar.cpp
+++ b/src/ui/src/searchtoolbar.cpp
@@ -283,13 +283,17 @@ QString SearchToolbar::escapeSearchPattern( const QString& pattern, bool isRegex
 
 QString SearchToolbar::wrapBooleanOperand( const QString& pattern ) const
 {
-    // Escape embedded double-quotes (replace " with \") before wrapping in
-    // "...". The literal "\\\"" is the 2-char string backslash+quote; a bare
-    // "\""" would be a 1-char string (the backslash only escapes the quote)
-    // and the replace would be a no-op, leaving embedded quotes to break the
-    // boolean expression.
+    // Escape the operand for inclusion in a "..." boolean operand, C-style:
+    // backslashes FIRST (so a trailing '\' does not escape the closing quote),
+    // then embedded double-quotes. The boolean parser
+    // (parseBooleanExpressions) counts the backslash run before a quote to
+    // decide real-vs-escaped and un-escapes both '\\' and '\\"', so this
+    // round-trips. Order matters: escaping '"' would insert backslashes, which
+    // is why backslashes must be doubled first.
     QString wrapped = pattern;
-    wrapped.replace( '"', "\\\"" ).prepend( '"' ).append( '"' );
+    wrapped.replace( '\\', "\\\\" );
+    wrapped.replace( '"', "\\\"" );
+    wrapped.prepend( '"' ).append( '"' );
     return wrapped;
 }
 

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -298,6 +298,59 @@ TEST_CASE( "FolderCrawlerWidget main view line map refreshes on demand after a d
     REQUIRE( widget.mainView()->isLineMapCurrent() );
 }
 
+TEST_CASE( "FolderCrawlerWidget main view caches the line map across unchanged mouse events",
+           "[folder]" )
+{
+    // ensureLineMapFresh runs on every press/move/release. In wrap mode each call
+    // used to re-read and re-wrap every line from the viewport to EOF. When two
+    // consecutive mouse events share the same data/geometry (the common case --
+    // the user is just moving the mouse), the rebuild is pure waste. The signature
+    // cache must skip it, and must still rebuild when an input actually changes
+    // (here: a data swap via setDataSource).
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "line0\nERROR here\nline2\n" ) );
+    const QString b = writeFile( dir, "b.log", QByteArray( "ERROR in b\nmore\nmore2\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum ); // open a.log
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    auto* const mainView = widget.mainView();
+
+    // First refresh builds the map.
+    mainView->ensureLineMapFresh();
+    REQUIRE( mainView->isLineMapCurrent() );
+    const int buildsAfterFirst = mainView->visibleLineMapBuildCount();
+
+    // A second refresh with no data/geometry change must be a cache hit: it must
+    // NOT re-enter the paint-free rebuild. (RED before the cache: count rises.)
+    mainView->ensureLineMapFresh();
+    REQUIRE( mainView->visibleLineMapBuildCount() == buildsAfterFirst );
+
+    // Swapping the underlying file changes the map's inputs (data ptr + line
+    // count), so the cache must invalidate and the next refresh must rebuild.
+    widget.selectResultRow( 3_lnum ); // open b.log
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    QTest::qWait( 200 );
+
+    mainView->ensureLineMapFresh();
+    REQUIRE( mainView->visibleLineMapBuildCount() > buildsAfterFirst );
+
+    // ...and a follow-up refresh on the new file is again a cache hit.
+    const int buildsAfterSwap = mainView->visibleLineMapBuildCount();
+    mainView->ensureLineMapFresh();
+    REQUIRE( mainView->visibleLineMapBuildCount() == buildsAfterSwap );
+}
+
 TEST_CASE( "FolderCrawlerWidget search toolbar shares the results pane (sits between the views)",
            "[folder]" )
 {

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -25,6 +25,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <QBoxLayout>
 #include <QByteArray>
 #include <QComboBox>
 #include <QDir>
@@ -42,6 +43,7 @@
 #include <vector>
 
 #include "abstractcrawlerwidget.h"
+#include "abstractlogview.h"
 #include "configuration.h"
 #include "foldercrawlerwidget.h"
 #include "folderfilteredview.h"
@@ -165,6 +167,150 @@ struct PredefinedFiltersGuard {
     }
 };
 } // namespace
+
+// Distinct access tag: both crawlerwidget_test.cpp and foldercrawler_test.cpp
+// link into the same klogg_itests binary, so an explicit specialization of
+// AbstractLogView::access_by MUST use a different tag in each translation unit
+// (two definitions of access_by<AbstractLogViewPrivate> would be an ODR clash).
+struct FolderViewTestAccess {
+};
+
+template <>
+struct AbstractLogView::access_by<FolderViewTestAccess> {
+    static bool selectionChanged( const AbstractLogView* view )
+    {
+        return view->selectionChanged_;
+    }
+
+    static int charHeight( const AbstractLogView* view )
+    {
+        return view->charHeight_;
+    }
+
+    static int bulletZoneWidth( const AbstractLogView* view )
+    {
+        return view->bulletZoneWidthPx_;
+    }
+
+    static int drawingTopOffset( const AbstractLogView* view )
+    {
+        return view->drawingTopOffset_;
+    }
+};
+
+TEST_CASE( "FolderCrawlerWidget plain click on a result row repaints the selection highlight",
+           "[folder][selection]" )
+{
+    // AbstractLogView::mousePressEvent's plain-click branch sets selection state
+    // + emits newSelection but historically did NOT call update() (unlike the
+    // Shift-click branch at abstractlogview.cpp:513). Single-file CrawlerWidget
+    // compensates with a host-side connect(FilteredView::newSelection ->
+    // view->update()) (crawlerwidget.cpp:1543); FolderCrawlerWidget does NOT.
+    // So a plain click on a folder result row changed selection_ state but never
+    // scheduled a repaint of the filtered view, so no highlight appeared.
+    // selectionChanged_ (set true in mousePressEvent, cleared only in paintEvent)
+    // is the discriminator: 'false' after the click proves a repaint ran.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log",
+                                 QByteArray( "line0\nERROR a\nline2\nERROR b\nline4\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    // rows: [H0, D1(localLine 1 "ERROR a"), D2(localLine 3 "ERROR b")]
+
+    // Open a.log up front so the later real click takes the synchronous same-file
+    // branch of openFileInMainView (file cached): no async load, and the open
+    // path touches mainView_ only, never repainting the filtered view.
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    auto* const view = widget.filteredView();
+    REQUIRE( view != nullptr );
+
+    // Give the filtered view focus BEFORE the click so the click produces no
+    // focus-transfer repaint -- the incidental repaint that, in the real app,
+    // masked the bug on the first click. With focus already held, the ONLY thing
+    // that can repaint the view is an explicit update().
+    view->setFocus();
+    QTest::qWait( 100 );
+    // Baseline: pump pending paints so the cache is clean before the click.
+    REQUIRE_FALSE(
+        AbstractLogView::access_by<FolderViewTestAccess>::selectionChanged( view ) );
+
+    // Drive a REAL plain left-click on data row D2 (center of visible row index 2)
+    // at an x safely past the bullet/mark zone so mousePressEvent takes the SELECT
+    // branch, not the mark branch.
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+    const int charH = Access::charHeight( view );
+    REQUIRE( charH > 0 );
+    const int top = Access::drawingTopOffset( view );
+    const int bullet = Access::bulletZoneWidth( view );
+    const int xPos = bullet + ( view->viewport()->width() - bullet ) / 2;
+    const int yPos = top + charH * 2 + charH / 2; // center of row index 2
+    QTest::mouseClick( view->viewport(), Qt::LeftButton, {}, QPoint( xPos, yPos ) );
+    QTest::qWait( 100 ); // process the queued update() if the fix scheduled one
+
+    // selectionChanged_ is set true in mousePressEvent and cleared ONLY inside
+    // paintEvent. 'false' here proves a repaint ran and rebuilt the highlight
+    // pixmap from the freshly-selected line. RED before the base-class fix: no
+    // update() is scheduled, no paint runs, the flag stays true.
+    REQUIRE_FALSE( Access::selectionChanged( view ) );
+}
+
+TEST_CASE( "FolderCrawlerWidget places the Marks-and-matches combo leftmost in the toolbar",
+           "[folder][parity]" )
+{
+    // The visibility filter combo (item 0 == "Marks and matches") is the literal
+    // control the user sees. Single-file adds it FIRST in the results toolbar
+    // (crawlerwidget.cpp:1287), left of the search bar; folder must match so the
+    // control sits in the same place on both tab kinds. RED today: folder adds
+    // searchToolbar_ + collapse/expand BEFORE the combo (foldercrawlerwidget.cpp
+    // :221-225), so it is the 4th control, not the leftmost.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "ERROR one\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+
+    QComboBox* visibilityBox = nullptr;
+    const auto target = QStringLiteral( "Marks and matches" );
+    for ( auto* box : widget.findChildren<QComboBox*>() ) {
+        if ( box->count() > 0 && box->itemText( 0 ) == target ) {
+            visibilityBox = box;
+            break;
+        }
+    }
+    REQUIRE( visibilityBox != nullptr );
+
+    // Locate the toolbar sub-layout (a QHBoxLayout nested in the bottom window's
+    // QVBoxLayout) that owns the combo, then assert the combo sits at index 0.
+    auto toolbarIndexOf = []( QComboBox* child ) -> int {
+        auto* parent = child->parentWidget();
+        if ( parent == nullptr ) {
+            return -1;
+        }
+        auto* outer = qobject_cast<QBoxLayout*>( parent->layout() );
+        if ( outer == nullptr ) {
+            return -1;
+        }
+        for ( int i = 0; i < outer->count(); ++i ) {
+            auto* sub = outer->itemAt( i )->layout();
+            if ( sub != nullptr && sub->indexOf( child ) != -1 ) {
+                return sub->indexOf( child );
+            }
+        }
+        return -1;
+    };
+    REQUIRE( toolbarIndexOf( visibilityBox ) == 0 );
+}
 
 TEST_CASE( "FolderCrawlerWidget search populates grouped results", "[folder]" )
 {
@@ -1375,6 +1521,49 @@ TEST_CASE( "FolderCrawlerWidget -A search emits context rows that render plain",
     const auto ctx = widget.folderResults()->sourceForLine( 2_lnum );
     REQUIRE( ctx.filePath == a );
     REQUIRE( ctx.localLine == 2_lnum );
+}
+
+TEST_CASE( "FolderCrawlerWidget context-line change preserves collapsed groups",
+           "[folder][context]" )
+{
+    // Context (-A/-B/-C) is a scan-time property of folder search, so changing
+    // the context window re-scans via startSearch -> FolderSearchResults::beginSearch.
+    // beginSearch used to collapsed_.clear() (foldersearchresults.cpp:59), wiping
+    // the user's per-file collapse set, so any context tweak expanded every
+    // previously-collapsed group. The model must snapshot collapse state (keyed by
+    // the stable filePath, NOT the unstable FileId) across the re-scan.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "ERROR one\nctx1\nERROR two\n" ) );
+    const QString b = writeFile( dir, "b.log", QByteArray( "ERROR three\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    QTest::qWait( 200 ); // settle per CLAUDE.md
+    // rows: [H0(a), D1(a:0), D2(a:2), H3(b), D4(b:0)] = 5.
+    REQUIRE( widget.folderResults()->getNbLine() == 5_lcount );
+
+    // Collapse group a (fileId 0): only its header stays visible.
+    widget.clickHeaderRow( 0_lnum );
+    QTest::qWait( 100 );
+    REQUIRE( widget.folderResults()->isCollapsed( 0 ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount ); // a-header + b(header+match)
+
+    // Reproduce the gesture: switch to After(-A) and increment N from 0 to 1.
+    // Both fire onContextControlsChanged -> startSearch -> beginSearch (pattern
+    // present), the destructive re-scan path.
+    widget.contextLinesComboBox()->setCurrentIndex( 2 ); // "After (-A)"
+    widget.contextLinesSpinBox()->setValue( 1 );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    QTest::qWait( 200 ); // settle: re-scan + streaming commit + layoutChanged
+
+    // Group a must STAY collapsed across the re-scan. RED before the fix:
+    // isCollapsed(0) is false and getNbLine() is 6 (a fully expanded: header +
+    // ERROR one / ctx1(context) / ERROR two = 4, plus b header+match = 2).
+    REQUIRE( widget.folderResults()->isCollapsed( 0 ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount );
 }
 
 TEST_CASE( "FolderCrawlerWidget keep results freezes the current pane on a new search",

--- a/tests/unit/patternmatcher_test.cpp
+++ b/tests/unit/patternmatcher_test.cpp
@@ -72,6 +72,36 @@ SCENARIO( "Pattern matcher in boolean mode", "[patternmatcher]" )
 
         REQUIRE_FALSE( expression.isValid() );
     }
+
+    WHEN( "Using an operand that ends in a backslash (escaped form)" )
+    {
+        // The wrapped/escaped form of operand C:\Users\ is "C:\\Users\\". The
+        // parser must count the backslash run before the closing quote: an even
+        // run means a real boundary, so this operand must parse and match the
+        // literal path. A naive single-char lookback would see the '\'
+        // immediately before the closer and reject it as unmatched.
+        RegularExpression expression(
+            RegularExpressionPattern( "\"C:\\\\Users\\\\\"", false, false, true, true ) );
+        REQUIRE( expression.isValid() );
+
+        const auto matcher = expression.createMatcher();
+        REQUIRE( matcher->hasMatch( "path C:\\Users\\" ) );
+        REQUIRE_FALSE( matcher->hasMatch( "path C:\\Users" ) );
+    }
+
+    WHEN( "Using a boolean OR where the first operand ends in a backslash" )
+    {
+        // Exercises boundary counting across operands: the parser must close the
+        // first operand at the even-run closer, then parse the second normally.
+        RegularExpression expression( RegularExpressionPattern(
+            "\"C:\\\\Users\\\\\" or \"error\"", false, false, true, true ) );
+        REQUIRE( expression.isValid() );
+
+        const auto matcher = expression.createMatcher();
+        REQUIRE( matcher->hasMatch( "path C:\\Users\\" ) );
+        REQUIRE( matcher->hasMatch( "an error here" ) );
+        REQUIRE_FALSE( matcher->hasMatch( "nothing relevant" ) );
+    }
 }
 
 TEST_CASE( "Block scan matches per-line scan results", "[patternmatcher]" )

--- a/tests/unit/searchtoolbar_test.cpp
+++ b/tests/unit/searchtoolbar_test.cpp
@@ -33,6 +33,9 @@
 #include <QToolButton>
 #include <Qt>
 
+#include <string_view>
+
+#include "regularexpression.h"
 #include "regularexpressionpattern.h"
 #include "searchtoolbar.h"
 
@@ -214,6 +217,48 @@ TEST_CASE( "SearchToolbar wrapBooleanOperand quotes and escapes (excludeFromSear
     SECTION( "multiple embedded quotes are each escaped" )
     {
         REQUIRE( toolbar.wrapBooleanOperand( "\"quoted\"" ) == "\"\\\"quoted\\\"\"" );
+    }
+}
+
+TEST_CASE( "wrapBooleanOperand escapes backslashes so the operand stays parseable",
+           "[searchtoolbar]" )
+{
+    // Regression (CodeRabbit, searchtoolbar.cpp:284-295): a boolean operand
+    // ending in a backslash used to wrap as "C:\Users\" -- the trailing '\'
+    // makes the boolean quote parser treat the CLOSING quote as escaped, so the
+    // whole operand became "unmatched quotes" and the search failed. Escape
+    // backslashes first (C-style '\\'), then embedded quotes, so the closing
+    // quote sits after an even backslash run and the parser sees a real closer.
+    SearchToolbar toolbar( nullptr, nullptr );
+
+    SECTION( "trailing backslash is doubled before wrapping" )
+    {
+        // C:\Users\  ->  "C:\\Users\\"  (backslash run before the closer is even)
+        REQUIRE( toolbar.wrapBooleanOperand( "C:\\Users\\" ) == "\"C:\\\\Users\\\\\"" );
+    }
+
+    SECTION( "wrapped trailing-backslash operand parses and matches as boolean" )
+    {
+        const auto wrapped = toolbar.wrapBooleanOperand( "C:\\Users\\" );
+        RegularExpression expression(
+            RegularExpressionPattern( wrapped, false, false, true, true ) );
+        REQUIRE( expression.isValid() );
+        REQUIRE_FALSE( expression.errorString().contains( QLatin1String( "unmatched" ) ) );
+
+        const auto matcher = expression.createMatcher();
+        REQUIRE( matcher->hasMatch( std::string_view{ "path is C:\\Users\\" } ) );
+        REQUIRE_FALSE( matcher->hasMatch( std::string_view{ "path is C:\\Users" } ) );
+    }
+
+    SECTION( "internal backslashes round-trip through the boolean parser" )
+    {
+        const auto wrapped = toolbar.wrapBooleanOperand( "C:\\Users\\admin" );
+        RegularExpression expression(
+            RegularExpressionPattern( wrapped, false, false, true, true ) );
+        REQUIRE( expression.isValid() );
+
+        const auto matcher = expression.createMatcher();
+        REQUIRE( matcher->hasMatch( std::string_view{ "hello C:\\Users\\admin world" } ) );
     }
 }
 

--- a/tests/unit/searchtoolbar_test.cpp
+++ b/tests/unit/searchtoolbar_test.cpp
@@ -147,6 +147,17 @@ TEST_CASE( "SearchToolbar escape/combine helpers (ports crawlerwidget.cpp:1155-1
         REQUIRE( escaped.endsWith( '"' ) );
     }
 
+    SECTION( "boolean escape backslash-escapes embedded double-quotes" )
+    {
+        // Regression: escapeSearchPattern used to call replace('"',"\"") -- a
+        // 1-char literal (just '"') so the replace was a no-op and an embedded
+        // quote broke the wrapped boolean expression. The 2-char literal "\\\""
+        // (backslash+quote) escapes it to \".
+        toolbar.setBoolean( true );
+        const auto escaped = toolbar.escapeSearchPattern( "a\"b", false );
+        REQUIRE( escaped == "\"a\\\"b\"" );
+    }
+
     SECTION( "combine joins regex with '|'" )
     {
         toolbar.setUseRegexp( true );
@@ -170,6 +181,39 @@ TEST_CASE( "SearchToolbar escape/combine helpers (ports crawlerwidget.cpp:1155-1
         QString current;
         toolbar.combinePatterns( current, "first" );
         REQUIRE( current == "first" );
+    }
+}
+
+TEST_CASE( "SearchToolbar wrapBooleanOperand quotes and escapes (excludeFromSearch path)",
+           "[searchtoolbar]" )
+{
+    // CrawlerWidget::excludeFromSearch calls wrapBooleanOperand directly on the
+    // current search text when transitioning into boolean mode -- the toggle may
+    // still be off, so it can't rely on escapeSearchPattern's boolean branch.
+    // This locks the operand-wrapping contract independently of the toggle.
+    SearchToolbar toolbar( nullptr, nullptr );
+
+    SECTION( "plain pattern is surrounded by quotes" )
+    {
+        REQUIRE( toolbar.wrapBooleanOperand( "error" ) == "\"error\"" );
+    }
+
+    SECTION( "embedded double-quote is backslash-escaped" )
+    {
+        // Regression: excludeFromSearch inlined replace('"',"\"") -- a no-op
+        // 1-char literal -- so input a"b wrapped to the broken "a"b" instead of
+        // the correct "a\"b".
+        REQUIRE( toolbar.wrapBooleanOperand( "a\"b" ) == "\"a\\\"b\"" );
+    }
+
+    SECTION( "empty pattern becomes a pair of quotes" )
+    {
+        REQUIRE( toolbar.wrapBooleanOperand( "" ) == "\"\"" );
+    }
+
+    SECTION( "multiple embedded quotes are each escaped" )
+    {
+        REQUIRE( toolbar.wrapBooleanOperand( "\"quoted\"" ) == "\"\\\"quoted\\\"\"" );
     }
 }
 


### PR DESCRIPTION
Follow-up fixes for the Open Folder grep-style search feature (#39), from review and acceptance findings. Four independent commits grouped by topic.

## Summary
- **Boolean exclude-search escaping** (`0cb3b59e`): excluding a search whose text contained a double-quote silently produced a malformed boolean expression.
- **Visible-line map caching** (`e3db29cd`): hovering/moving the mouse over a large wrapped file re-wrapped the whole tail on every mouse event.
- **Folder-tab parity** (`5a16da5c`): three folder-vs-single-file interaction divergences found in acceptance — filtered-view click selection highlight, the "Marks and matches" toolbar position, and collapse state lost when changing the Context-N window.
- **Boolean operand ending in a backslash** (`023bc9c7`): a boolean operand ending in `\` (e.g. `C:\Users\`) failed with "unmatched quotes". CodeRabbit review finding.

## Background

### 1. Boolean exclude-search quote escaping
- **Introduced by:** PR #39. `escapeSearchPattern`'s boolean branch was fixed to backslash-escape embedded double-quotes, but the parallel inline copy in `CrawlerWidget::excludeFromSearch` was missed.
- **Use case:** run an exclude-from-search while the current search text contains a double-quote.
- **How to reproduce:** with a non-boolean search whose text is `a"b`, trigger exclude-from-search → operand became `"a"b"` (broken boolean expression).
- **Root cause:** `replace('"', "\"")` used a 1-char literal (`'"'`), a no-op; the 2-char backslash+quote was required. The escaping existed in two places and drifted.
- **How to fix:** extracted `SearchToolbar::wrapBooleanOperand` (quote-wrap + backslash-escape, no regex-escape) and called it from both sites so they can't drift.

### 2. Visible-line map caching
- **Introduced by:** PR #39's click-swallow fix added `ensureLineMapFresh` (every mouse press/move/release) which unconditionally rebuilt the visible-line map — correct but expensive in wrap mode.
- **Use case:** browsing/hovering a large file with text-wrap on.
- **Root cause:** `buildVisibleLineMap` re-reads and re-wraps every line from the viewport to EOF on each call; called on every mouse event → O(N) per event.
- **How to fix:** capture a signature of every input that determines the map (data ptr, line count, top line, wrap mode, viewport size, font metrics, line-number visibility) and skip the rebuild when unchanged. The map is a pure function of those inputs, so the cache can't go stale by construction. A `!empty()` guard still forces a rebuild after out-of-band clears (`setDataSource`, `setTextWrap`), preserving the original click-swallow fix.

### 3. Folder-tab parity (`5a16da5c`)
- **Filtered-view click selection:** `AbstractLogView::mousePressEvent`'s plain-click branch set selection + emitted `newSelection` but never called `update()` (Shift/drag paths did), silently delegating the repaint to the host. Single-file compensated via a host `connect(newSelection → view->update())`; `FolderCrawlerWidget` never had it → the 2nd click in a folder filtered view showed no highlight (the 1st only worked via the incidental focus-transfer repaint). Fixed by making the repaint a base-class responsibility (`update()` in the plain-click branch); removed the now-redundant host self-repaints in `CrawlerWidget`.
- **"Marks and matches" toolbar position:** the folder toolbar added `visibilityBox_` 4th (after the search bar + collapse/expand); single-file adds it leftmost. Reordered the folder toolbar to match.
- **Context-N expand-all:** `FolderSearchResults::beginSearch()` did `collapsed_.clear()` on every search start. Folder context is scan-time (offset-based), so any `-A/-B/-C` tweak re-scans via `beginSearch`, wiping collapse. Fixed by snapshotting collapsed `filePath`s at the top of `beginSearch` (before the clears) and re-applying as groups stream back in (`addFileGroup`/`flushPending`). Keyed by `filePath`, not `FileId` (reassigned on rebuild); a follow-up `beginSearch` (the combobox and spinbox each re-scan) can fire before the first streams groups back, so the snapshot is kept rather than clobbered when `groups_` is empty.

### 4. Boolean operand ending in a backslash (`023bc9c7`)
- **Found by:** CodeRabbit review on `wrapBooleanOperand` (searchtoolbar.cpp:284-295).
- **Use case:** boolean search for a path-like operand ending in a backslash, e.g. `C:\Users\`.
- **How to reproduce:** enable boolean mode, type `C:\Users\`, run search → "Pattern has unmatched quotes".
- **Root cause:** `parseBooleanExpressions` detected escaped quotes with a naive single-char lookback (`pattern[i-1]=='\\'`) and only un-escaped `\"`→`"`. It cannot close a quote after any backslash, so a trailing-backslash operand's closer was always treated as escaped. `wrapBooleanOperand` escaped only `"`, not `\`. A producer-only "escape backslashes" patch cannot work — the parser still rejects the closer, and doubling backslashes would corrupt normal paths with no matching un-escape. The boolean parser had zero test coverage, so local never caught it.
- **How to fix:** couple producer and parser on C-style escaping so they are exact inverses. `wrapBooleanOperand` doubles `\` first, then escapes `"`, then wraps. The parser counts the backslash run before a quote (even = real boundary) via `precedingBackslashCount` and un-escapes both `\\`→`\` and `\"`→`"` in one left-to-right pass via `unescapeBooleanOperand`. Note: this aligns the manual boolean quoting dialect with C-style (a user-typed `\\` now means one literal `\`); single backslashes and escaped quotes behave exactly as before.

## Tests
- Unit (`klogg_tests`): `wrapBooleanOperand`/escape regression sections under `[searchtoolbar]`; new `[patternmatcher]` boolean backslash cases (operand ending in `\`; multi-operand OR).
- Integration (`klogg_itests`): new `[folder][selection]`, `[folder][parity]`, and `[folder][context]` cases, plus the line-map cache itest.
- Full suites green at HEAD: `klogg_tests` 6219 assertions/378 cases, `klogg_itests` 2559 assertions/103 cases.
- Manual: the app was rebuilt and relaunched for acceptance of the folder-tab parity fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved collapsed folder groups when search results are refreshed.
  - Fixed selection highlights so they appear immediately after clicking a result.
  - Improved quoting and escaping for Boolean search patterns.
  - Reordered folder search toolbar controls for clearer access to visibility options.

- **Performance**
  - Reduced unnecessary visible-line map rebuilds when view content and geometry are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
