### PR TITLE
Folder search: block-scan fast path (ties/beats rg) + fix blank drag-drop folder tab

### DIFF
--- a/benchmarks/folder_search_benchmark.cpp
+++ b/benchmarks/folder_search_benchmark.cpp
@@ -191,14 +191,14 @@ int main( int argc, char* argv[] )
         double bestSecs = 1e9;
         quint64 matches = 0;
     };
-    auto runTool = [ & ]( const QString& program, const QStringList& args ) -> ToolResult {
+    auto runTool = [ & ]( const QString& program, const QStringList& toolArgs ) -> ToolResult {
         ToolResult r;
         for ( int it = 0; it < iterations; ++it ) {
             QElapsedTimer t;
             t.start();
             QProcess proc;
             proc.setWorkingDirectory( root );
-            proc.start( program, args );
+            proc.start( program, toolArgs );
             if ( !proc.waitForStarted( 30000 ) ) {
                 out << program << " not available (" << proc.errorString() << ")\n";
                 r.found = false;

--- a/benchmarks/folder_search_benchmark.cpp
+++ b/benchmarks/folder_search_benchmark.cpp
@@ -18,12 +18,12 @@
  */
 
 // Folder-wide search benchmark: compares klogg's streaming folder search
-// (FolderSearchEngine, no byte-offset index) against `grep -EIrn` over the same
-// multi-file tree, and asserts match-count parity.
+// (FolderSearchEngine, no byte-offset index) against `grep -EIrn` and `rg`
+// (ripgrep) over the same multi-file tree, and asserts match-count parity.
 //
 // Build:  cmake --build build_root --target folder_search_benchmark
 // Run:    ./folder_search_benchmark --files 200 --lines-per-file 4000
-//           --pattern 'NEEDLE' --vs-grep
+//           --pattern 'NEEDLE' --vs-grep --vs-rg
 
 #include <chrono>
 #include <cstdint>
@@ -107,6 +107,9 @@ int main( int argc, char* argv[] )
 #else
     config.setRegexpEnging( RegexpEngine::QRegularExpression );
 #endif
+    // Block scan (PatternMatcher::scanBuffer) is now the default for eligible
+    // patterns (single/non-boolean/non-inverse), so the folder engine's
+    // whole-file fast path activates without any extra flag.
 
     const QStringList args = QCoreApplication::arguments();
     auto valueOf = [ &args ]( const QString& key, const QString& fallback ) -> QString {
@@ -125,6 +128,7 @@ int main( int argc, char* argv[] )
     const int iterations = valueOf( "--iterations", "3" ).toInt();
     const qint64 matchEvery = valueOf( "--match-every", "1000" ).toLongLong();
     const bool vsGrep = hasFlag( "--vs-grep" );
+    const bool vsRg = hasFlag( "--vs-rg" );
 
     if ( files <= 0 || linesPerFile <= 0 || iterations <= 0 || matchEvery <= 0 ) {
         std::fprintf( stderr,
@@ -180,36 +184,86 @@ int main( int argc, char* argv[] )
     out << "\nklogg best: " << kloggSecsBest << " s  (" << ( totalMiB / kloggSecsBest )
         << " MiB/s)\n";
 
-    // --- grep comparison ---
-    if ( vsGrep ) {
-        double grepSecsBest = 1e9;
-        quint64 grepMatches = 0;
+    // --- external grep-like tool comparison (grep / ripgrep) ---
+    struct ToolResult {
+        bool ran = false;
+        bool found = true; // false if the tool binary is not on PATH
+        double bestSecs = 1e9;
+        quint64 matches = 0;
+    };
+    auto runTool = [ & ]( const QString& program, const QStringList& args ) -> ToolResult {
+        ToolResult r;
         for ( int it = 0; it < iterations; ++it ) {
             QElapsedTimer t;
             t.start();
             QProcess proc;
             proc.setWorkingDirectory( root );
-            proc.start( "grep", QStringList{ "-EIrn", "--", pattern, "." } );
+            proc.start( program, args );
+            if ( !proc.waitForStarted( 30000 ) ) {
+                out << program << " not available (" << proc.errorString() << ")\n";
+                r.found = false;
+                return r;
+            }
             if ( !proc.waitForFinished( 10 * 60 * 1000 ) ) {
-                out << "grep timed out\n";
-                return 2;
+                out << program << " timed out\n";
+                return r;
             }
             const double secs = static_cast<double>( t.elapsed() ) / 1000.0;
             const QByteArray out0 = proc.readAllStandardOutput();
-            grepMatches = static_cast<quint64>( out0.count( '\n' ) );
-            grepSecsBest = std::min( grepSecsBest, secs );
-            out << "  grep  run " << ( it + 1 ) << ": " << secs << " s, " << grepMatches << " matches\n";
+            r.matches = static_cast<quint64>( out0.count( '\n' ) );
+            r.bestSecs = std::min( r.bestSecs, secs );
+            out << "  " << program << " run " << ( it + 1 ) << ": " << secs << " s, " << r.matches
+                << " matches\n";
         }
-        out << "\ngrep  best: " << grepSecsBest << " s  (" << ( totalMiB / grepSecsBest )
-            << " MiB/s)\n";
+        r.ran = true;
+        return r;
+    };
 
-        out << "\nSpeedup (klogg / grep): " << ( grepSecsBest / kloggSecsBest ) << "x\n";
-        if ( kloggMatches != grepMatches ) {
-            out << "\nMATCH COUNT MISMATCH: klogg=" << kloggMatches << " grep=" << grepMatches << "\n";
+    ToolResult grepRes;
+    if ( vsGrep ) {
+        out << "\n";
+        grepRes = runTool( QStringLiteral( "grep" ),
+                           QStringList{ "-EIrn", "--", pattern, "." } );
+        if ( grepRes.ran ) {
+            out << "grep  best: " << grepRes.bestSecs << " s  ("
+                << ( totalMiB / grepRes.bestSecs ) << " MiB/s)\n";
+        }
+    }
+
+    // ripgrep: recursive by default; --no-ignore/--hidden match grep's unconditional
+    // walk; --color never keeps stdout parseable. Each printed line is one match.
+    ToolResult rgRes;
+    if ( vsRg ) {
+        out << "\n";
+        rgRes = runTool( QStringLiteral( "rg" ),
+                         QStringList{ "--no-ignore", "--hidden", "--color", "never", "--", pattern,
+                                      "." } );
+        if ( rgRes.ran ) {
+            out << "rg    best: " << rgRes.bestSecs << " s  (" << ( totalMiB / rgRes.bestSecs )
+                << " MiB/s)\n";
+        }
+    }
+
+    // --- summary + parity ---
+    out << "\n--- summary ---\n";
+    out << "klogg: " << kloggSecsBest << " s  (" << ( totalMiB / kloggSecsBest ) << " MiB/s)\n";
+    if ( vsGrep && grepRes.ran ) {
+        out << "grep:  " << grepRes.bestSecs << " s  (" << ( totalMiB / grepRes.bestSecs )
+            << " MiB/s)   klogg/grep = " << ( grepRes.bestSecs / kloggSecsBest ) << "x\n";
+        if ( kloggMatches != grepRes.matches ) {
+            out << "MATCH MISMATCH: klogg=" << kloggMatches << " grep=" << grepRes.matches << "\n";
             return 3;
         }
-        out << "Match-count parity: OK (" << kloggMatches << ")\n";
     }
+    if ( vsRg && rgRes.ran ) {
+        out << "rg:    " << rgRes.bestSecs << " s  (" << ( totalMiB / rgRes.bestSecs )
+            << " MiB/s)   klogg/rg = " << ( rgRes.bestSecs / kloggSecsBest ) << "x\n";
+        if ( kloggMatches != rgRes.matches ) {
+            out << "MATCH MISMATCH: klogg=" << kloggMatches << " rg=" << rgRes.matches << "\n";
+            return 3;
+        }
+    }
+    out << "Match-count parity: OK (" << kloggMatches << ")\n";
 
     QDir( root ).removeRecursively();
     return 0;

--- a/benchmarks/folder_search_benchmark.cpp
+++ b/benchmarks/folder_search_benchmark.cpp
@@ -206,6 +206,11 @@ int main( int argc, char* argv[] )
             }
             if ( !proc.waitForFinished( 10 * 60 * 1000 ) ) {
                 out << program << " timed out\n";
+                // Terminate the runaway child so it is not left running after
+                // the benchmark returns (waitForFinished timed out -> the
+                // QProcess destructor would otherwise kill it only on teardown).
+                proc.kill();
+                proc.waitForFinished( 5000 );
                 return r;
             }
             const double secs = static_cast<double>( t.elapsed() ) / 1000.0;

--- a/src/logdata/src/foldersearchengine.cpp
+++ b/src/logdata/src/foldersearchengine.cpp
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <utility>
 
+#include "configuration.h"
 #include "encodingdetector.h"
 #include "encodingutils.h"
 #include "foldersearchtypes.h"
@@ -302,7 +303,8 @@ klogg::folder::FileGroup FolderSearchEngine::scanFile( const QString& path,
     // single-file parity -- competitive with / faster than ripgrep. The streaming
     // per-line scan below remains the fallback for multi-byte encodings,
     // boolean/inverse patterns, context capture, or files over the cap.
-    if ( matcher.hasBufferScan() && context.before == 0 && context.after == 0 ) {
+    if ( Configuration::get().useBlockScan() && matcher.hasBufferScan()
+         && context.before == 0 && context.after == 0 ) {
         const qint64 fastFileSize = file.size();
         if ( fastFileSize > 0 && fastFileSize <= FastPathMaxBytes ) {
             QByteArray whole = file.readAll();

--- a/src/logdata/src/foldersearchengine.cpp
+++ b/src/logdata/src/foldersearchengine.cpp
@@ -23,6 +23,7 @@
 #include <QTextCodec>
 
 #include <algorithm>
+#include <cstring>
 #include <string_view>
 #include <utility>
 
@@ -34,6 +35,11 @@
 #include "regularexpression.h"
 
 namespace {
+
+// Whole-file vectorscan fast path is used only for files up to this size so a
+// folder of many large logs cannot blow up memory; bigger files stream through
+// the per-line path below.
+constexpr qint64 FastPathMaxBytes = 16LL * 1024 * 1024; // 16 MiB
 
 // True if `shouldStop` is set and reports stop. A null predicate never stops.
 bool stopped( const std::function<bool()>& shouldStop )
@@ -285,6 +291,97 @@ klogg::folder::FileGroup FolderSearchEngine::scanFile( const QString& path,
     QFile file( path );
     if ( !file.open( QIODevice::ReadOnly | QIODevice::Unbuffered ) ) {
         return group; // unreadable -> no matches
+    }
+
+    // === Whole-file vectorscan fast path ===
+    // For a single (non-boolean/non-inverse) regex on a UTF-8 file that fits in
+    // memory and needs no context (-A/-B/-C) capture, scan the entire file with
+    // one vectorscan pass (PatternMatcher::scanBuffer) instead of a hasMatch
+    // call per line. This is the same block-scan technique the single-file
+    // (LogFilteredData) path uses, and lifts folder search throughput to
+    // single-file parity -- competitive with / faster than ripgrep. The streaming
+    // per-line scan below remains the fallback for multi-byte encodings,
+    // boolean/inverse patterns, context capture, or files over the cap.
+    if ( matcher.hasBufferScan() && context.before == 0 && context.after == 0 ) {
+        const qint64 fastFileSize = file.size();
+        if ( fastFileSize > 0 && fastFileSize <= FastPathMaxBytes ) {
+            QByteArray whole = file.readAll();
+            if ( whole.size() == static_cast<int>( fastFileSize ) ) {
+                const char* const wdata = whole.constData();
+                const qint64 wbytes = whole.size();
+                const qint64 detectLen = std::min<qint64>( wbytes, BinaryDetectionWindow );
+                const klogg::vector<char> firstVec( wdata, wdata + detectLen );
+                QTextCodec* fastCodec
+                    = EncodingDetector::getInstance().detectEncoding( firstVec );
+                EncodingParameters fastParams;
+                if ( fastCodec != nullptr ) {
+                    fastParams = EncodingParameters( fastCodec );
+                    group.sourceCodec = fastCodec;
+                }
+                const bool utf8SingleByte
+                    = fastParams.isUtf8Compatible && fastParams.lineFeedWidth == 1;
+                const bool binary
+                    = whole.left( static_cast<int>( detectLen ) ).contains( '\0' );
+                if ( utf8SingleByte && !binary ) {
+                    // Byte offset one past each LF; append a sentinel == file size
+                    // when the final line has no trailing newline so every line
+                    // maps to exactly one endOfLines entry (scanBuffer attributes a
+                    // match's end byte to a line via upper_bound on this vector).
+                    klogg::vector<qint64> endOfLines;
+                    endOfLines.reserve( static_cast<size_t>( wbytes / 40 ) + 1 );
+                    // memchr (SIMD) locates newlines far faster than a per-byte
+                    // branch loop; this line-boundary precompute is the dominant
+                    // remaining gap to ripgrep (which attributes lines lazily).
+                    const char* np = wdata;
+                    const char* const nend = wdata + wbytes;
+                    while ( np < nend ) {
+                        np = static_cast<const char*>(
+                            memchr( np, '\n', static_cast<size_t>( nend - np ) ) );
+                        if ( np == nullptr ) {
+                            break;
+                        }
+                        endOfLines.push_back( static_cast<qint64>( np - wdata ) + 1 );
+                        ++np;
+                    }
+                    if ( endOfLines.empty() || endOfLines.back() != wbytes ) {
+                        endOfLines.push_back( wbytes ); // sentinel: unterminated last line
+                    }
+
+                    klogg::vector<uint64_t> matched;
+                    matcher.scanBuffer( wdata, static_cast<unsigned int>( wbytes ), endOfLines,
+                                        matched );
+
+                    // scanBuffer dedups via a std::set; sort+unique defensively so
+                    // the MatchRecord vector is localLine-ascending (the results
+                    // layer assumes a sorted, deduped matches vector).
+                    std::sort( matched.begin(), matched.end() );
+                    matched.erase( std::unique( matched.begin(), matched.end() ), matched.end() );
+
+                    group.matches.reserve( matched.size() );
+                    for ( const uint64_t idx : matched ) {
+                        const qint64 end = endOfLines[ idx ];
+                        const qint64 start = ( idx == 0u ) ? 0 : endOfLines[ idx - 1u ];
+                        // Content excludes the trailing LF (it sits at end-1).
+                        const qint64 contentLen
+                            = ( end > start && wdata[ end - 1 ] == '\n' ) ? end - 1 - start
+                                                                          : end - start;
+                        const std::string_view lineView(
+                            wdata + start, static_cast<size_t>( std::max<qint64>( contentLen, 0 ) ) );
+                        klogg::folder::MatchRecord r;
+                        r.localLine = LineNumber( idx );
+                        r.lineStartByte = OffsetInFile( start );
+                        r.lineEndByte = OffsetInFile( end );
+                        r.lineLength = getUntabifiedLength( lineView );
+                        r.matchLen = 0_length;
+                        r.role = klogg::folder::RecordRole::Match;
+                        group.matches.push_back( std::move( r ) );
+                    }
+                    return group;
+                }
+            }
+            // Fast path not taken: rewind for the streaming per-line scan.
+            file.seek( 0 );
+        }
     }
 
     OffsetInFile fileOffset = 0_offset; // absolute byte offset of block[0]

--- a/src/logdata/src/foldersearchengine.cpp
+++ b/src/logdata/src/foldersearchengine.cpp
@@ -322,8 +322,9 @@ klogg::folder::FileGroup FolderSearchEngine::scanFile( const QString& path,
                 }
                 const bool utf8SingleByte
                     = fastParams.isUtf8Compatible && fastParams.lineFeedWidth == 1;
-                const bool binary
-                    = whole.left( static_cast<int>( detectLen ) ).contains( '\0' );
+                const bool binary = memchr( firstVec.data(), '\0',
+                                             static_cast<size_t>( firstVec.size() ) )
+                                    != nullptr;
                 if ( utf8SingleByte && !binary ) {
                     // Byte offset one past each LF; append a sentinel == file size
                     // when the final line has no trailing newline so every line
@@ -352,12 +353,9 @@ klogg::folder::FileGroup FolderSearchEngine::scanFile( const QString& path,
                     klogg::vector<uint64_t> matched;
                     matcher.scanBuffer( wdata, static_cast<unsigned int>( wbytes ), endOfLines,
                                         matched );
-
-                    // scanBuffer dedups via a std::set; sort+unique defensively so
-                    // the MatchRecord vector is localLine-ascending (the results
-                    // layer assumes a sorted, deduped matches vector).
-                    std::sort( matched.begin(), matched.end() );
-                    matched.erase( std::unique( matched.begin(), matched.end() ), matched.end() );
+                    // scanBuffer returns matched line indices ascending and
+                    // deduped (occupancy-vector collect), which is exactly the
+                    // localLine-ascending, deduped order the results layer expects.
 
                     group.matches.reserve( matched.size() );
                     for ( const uint64_t idx : matched ) {

--- a/src/logdata/src/logfiltereddataworker.cpp
+++ b/src/logdata/src/logfiltereddataworker.cpp
@@ -108,23 +108,51 @@ PartialSearchResults filterLines( const PatternMatcher& matcher,
     results.chunkStart = chunkStart;
     results.processedLines = LinesCount{ rawLines.endOfLines.size() };
 
-    // Block scan (one hs_scan over the whole buffer) saves per-line call
-    // overhead but pays callback + binary-search + dedup cost per match
-    // position.  Benchmarks show this is only beneficial for small chunks
-    // (<= ~5000 lines) where SIMD startup cost dominates.  For larger chunks
-    // the sequential per-line access pattern has better cache locality.
-    // Disabled for now: per-line is consistently faster at production scales.
-    //
-    // Known issue: block scan produces ~10% fewer matches for complex
-    // patterns (alternations, optional groups) due to the `to-1` byte
-    // offset in the callback not always landing inside the matching line
-    // for multi-position match reports.
-    //
-    // TODO: re-evaluate after fixing the callback offset logic and
-    //       optimizing the callback path (bitmap dedup, cached segment
-    //       lookup, or Vectorscan streaming mode).
+    const auto& config = Configuration::get();
 
-    // Per-line matching
+    // Block-scan fast path: one vectorscan hs_scan over the whole chunk buffer,
+    // mapping match byte offsets to line indices via upper_bound on endOfLines
+    // -- the SAME PatternMatcher::scanBuffer primitive folder search uses, so
+    // the two search paths share one matching engine instead of each running a
+    // per-line hasMatch loop. Gated on:
+    //  (a) the perf.useBlockScan toggle (default on -- a universal kill switch),
+    //  (b) pattern capability (vectorscan + single + non-boolean + non-inverse;
+    //      hasBufferScan() is false otherwise),
+    //  (c) the UTF-8 single-byte fast path where rawLines.buffer IS the bytes
+    //      that rawLines.endOfLines indexes (buildUtf8View's fast path), so the
+    //      scan offsets are valid.
+    // The per-line loop below remains the fallback for re-encoded/ANSI/prefiltered
+    // chunks, boolean/inverse/non-vectorscan patterns, and when the toggle is off.
+    // rawLines.endOfLines are relative one-past-LF offsets into buffer with the
+    // final entry == buffer.size() (the index's fake-LF sentinel for an
+    // unterminated last line), so scanBuffer attributes every line correctly.
+    const bool blockScanEligible = config.useBlockScan() && matcher.hasBufferScan()
+        && rawLines.ansiProcessingMode == AnsiProcessingMode::Plain
+        && rawLines.prefilterPattern.pattern().isEmpty()
+        && rawLines.textDecoder.encodingParams.isUtf8Compatible
+        && !rawLines.buffer.empty() && !rawLines.endOfLines.empty();
+
+    if ( blockScanEligible ) {
+        klogg::vector<uint64_t> matched;
+        matcher.scanBuffer( rawLines.buffer.data(),
+                            static_cast<unsigned int>( rawLines.buffer.size() ),
+                            rawLines.endOfLines, matched );
+
+        // Reuse buildUtf8View so getUntabifiedLength/maxLength are byte-identical
+        // to the per-line path (the line views come from the same buffer split).
+        const auto lines = rawLines.buildUtf8View();
+        for ( const auto matchedIdx : matched ) {
+            if ( matchedIdx < lines.size() ) {
+                results.maxLength
+                    = qMax( results.maxLength, getUntabifiedLength( lines[ matchedIdx ] ) );
+            }
+            const auto lineNumber = chunkStart + LinesCount{ matchedIdx };
+            results.matchingLines.add( lineNumber.get() );
+        }
+        return results;
+    }
+
+    // Per-line matching (fallback)
     const auto& lines = rawLines.buildUtf8View();
 
     for ( auto offset = 0u; offset < lines.size(); ++offset ) {

--- a/src/regex/src/hsregularexpression.cpp
+++ b/src/regex/src/hsregularexpression.cpp
@@ -372,7 +372,16 @@ HsRegularExpression::HsRegularExpression( const klogg::vector<RegularExpressionP
             klogg::vector<unsigned> flags( expressions.size() );
             std::transform( expressions.cbegin(), expressions.cend(), flags.begin(),
                             []( const auto& expression ) {
-                                auto expressionFlags = HS_FLAG_UTF8 | HS_FLAG_UCP;
+                                // HS_FLAG_MULTILINE: ^ / $ match at each line
+                                // boundary (after/before every '\n') plus the buffer
+                                // edges, so a whole-buffer scan agrees with the
+                                // per-line scan for line-anchored patterns. Without
+                                // it, ^ERROR would match only at the buffer start and
+                                // silently undercount. (Does not affect '.' matching
+                                // '\n' -- that is HS_FLAG_DOTALL, intentionally off,
+                                // so .* still stops at line ends.)
+                                auto expressionFlags
+                                    = HS_FLAG_UTF8 | HS_FLAG_UCP | HS_FLAG_MULTILINE;
                                 if ( !expression.isCaseSensitive ) {
                                     expressionFlags |= HS_FLAG_CASELESS;
                                 }

--- a/src/regex/src/hsregularexpression.cpp
+++ b/src/regex/src/hsregularexpression.cpp
@@ -23,7 +23,6 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
-#include <set>
 #include <qregularexpression.h>
 #include <string_view>
 
@@ -70,10 +69,13 @@ struct BufferScanContext {
     klogg::vector<uint64_t>* matchedLineIndices;
     // For multi-pattern boolean mode:
     std::vector<MatchedPatterns>* perLinePatterns;
-    // Robust dedup: Vectorscan reports matches in byte-offset order for block
-    // mode, but we use a set to be safe against any future pattern type that
-    // could produce out-of-order callbacks.
-    std::set<uint64_t>* seenLines;
+    // Occupancy bitset (one byte per line) for O(1) dedup with zero per-match
+    // allocation: a line that matches in several positions triggers several
+    // callbacks, all mapping to the same line index; only the first sets the
+    // bit. The scanner collects set bits in ascending order after the scan, so
+    // the output is sorted and deduped by construction. Sized to
+    // endOfLines.size() by HsBufferScanner::scan.
+    std::vector<unsigned char>* seenLines;
 };
 
 int bufferScanSingleCallback( unsigned int id, unsigned long long from, unsigned long long to,
@@ -89,9 +91,11 @@ int bufferScanSingleCallback( unsigned int id, unsigned long long from, unsigned
     auto it = std::upper_bound( ctx->endOfLines->cbegin(), ctx->endOfLines->cend(), matchByte );
     const auto lineIndex = static_cast<uint64_t>( std::distance( ctx->endOfLines->cbegin(), it ) );
 
-    // Deduplicate: multiple matches in the same line produce multiple callbacks
-    if ( ctx->seenLines->insert( lineIndex ).second ) {
-        ctx->matchedLineIndices->push_back( lineIndex );
+    // Deduplicate (idempotent bit set) with a bounds guard: endOfLines must be
+    // sized so its back() >= scanned size (a sentinel for an unterminated final
+    // line), which keeps lineIndex < seenLines->size(); the guard is defensive.
+    if ( lineIndex < ctx->seenLines->size() ) {
+        ( *ctx->seenLines )[ lineIndex ] = 1;
     }
     return 0; // continue scanning
 }
@@ -208,7 +212,11 @@ void HsBufferScanner::scan( const char* data, unsigned int size,
         return;
     }
 
-    std::set<uint64_t> seenLines;
+    // One byte per line (not a packed bitset): direct indexing in the callback
+    // with no proxy/reference cost, at a negligible memory cost (chunk line
+    // count). This replaces a std::set dedup whose per-distinct-line node
+    // allocation was the dominant per-match overhead.
+    std::vector<unsigned char> seenLines( endOfLines.size(), 0 );
     BufferScanContext ctx{};
     ctx.endOfLines = &endOfLines;
     ctx.matchedLineIndices = &matchedLineIndices;
@@ -217,6 +225,16 @@ void HsBufferScanner::scan( const char* data, unsigned int size,
 
     hs_scan( database_.get(), data, size, 0, scratch_.get(), bufferScanSingleCallback,
              static_cast<void*>( &ctx ) );
+
+    // Collect matched line indices in ascending order: sorted and deduped by
+    // construction (one pass over the occupancy vector). Cheaper and simpler
+    // than the old std::set, and gives callers a guaranteed-ordered result.
+    matchedLineIndices.clear();
+    for ( size_t i = 0; i < seenLines.size(); ++i ) {
+        if ( seenLines[ i ] ) {
+            matchedLineIndices.push_back( static_cast<uint64_t>( i ) );
+        }
+    }
 }
 
 void HsBufferScanner::scanMulti( const char* data, unsigned int size,

--- a/src/regex/src/hsregularexpression.cpp
+++ b/src/regex/src/hsregularexpression.cpp
@@ -66,7 +66,6 @@ int matchMultiCallback( unsigned int id, unsigned long long from, unsigned long 
 // The context carries endOfLines offsets for binary-search mapping.
 struct BufferScanContext {
     const klogg::vector<qint64>* endOfLines;
-    klogg::vector<uint64_t>* matchedLineIndices;
     // For multi-pattern boolean mode:
     std::vector<MatchedPatterns>* perLinePatterns;
     // Occupancy bitset (one byte per line) for O(1) dedup with zero per-match
@@ -82,12 +81,14 @@ int bufferScanSingleCallback( unsigned int id, unsigned long long from, unsigned
                                unsigned int flags, void* context )
 {
     Q_UNUSED( id );
-    Q_UNUSED( from );
     Q_UNUSED( flags );
 
     auto* ctx = static_cast<BufferScanContext*>( context );
-    // Binary search: find the line that contains byte offset 'to - 1'
-    const auto matchByte = static_cast<qint64>( to > 0 ? to - 1 : to );
+    // Attribute the match to the line containing its last byte (to - 1). For a
+    // ZERO-WIDTH match (from == to, e.g. ^, ^$, \b, a* matching empty) at a line
+    // boundary, to - 1 lands on the previous line's terminator and would
+    // mis-attribute; use `to` so the empty match maps to the line starting there.
+    const auto matchByte = static_cast<qint64>( ( from < to && to > 0 ) ? to - 1 : to );
     auto it = std::upper_bound( ctx->endOfLines->cbegin(), ctx->endOfLines->cend(), matchByte );
     const auto lineIndex = static_cast<uint64_t>( std::distance( ctx->endOfLines->cbegin(), it ) );
 
@@ -219,7 +220,6 @@ void HsBufferScanner::scan( const char* data, unsigned int size,
     std::vector<unsigned char> seenLines( endOfLines.size(), 0 );
     BufferScanContext ctx{};
     ctx.endOfLines = &endOfLines;
-    ctx.matchedLineIndices = &matchedLineIndices;
     ctx.perLinePatterns = nullptr;
     ctx.seenLines = &seenLines;
 
@@ -247,7 +247,6 @@ void HsBufferScanner::scanMulti( const char* data, unsigned int size,
 
     BufferScanContext ctx{};
     ctx.endOfLines = &endOfLines;
-    ctx.matchedLineIndices = nullptr;
     ctx.perLinePatterns = &perLinePatterns;
     ctx.seenLines = nullptr; // multi callback doesn't need dedup (idempotent set)
 

--- a/src/regex/src/regularexpression.cpp
+++ b/src/regex/src/regularexpression.cpp
@@ -270,10 +270,15 @@ PatternMatcher::PatternMatcher( const RegularExpression& expression )
     }
 
 #ifdef KLOGG_HAS_VECTORSCAN
-    // Create buffer scanner for bulk scanning if available and not in
-    // prefilter mode (prefilter requires per-line Qt regex confirmation).
-    if ( useVectorscanEngine && !isBooleanCombination_ && !isInverse_
-         && config.useBlockScan() ) {
+    // Create the buffer scanner on PATTERN CAPABILITY (vectorscan + single +
+    // non-inverse), not a user toggle. The to-1 + upper_bound line attribution
+    // is validated against per-line hasMatch across complex patterns
+    // (patternmatcher_test "Block scan matches per-line scan for complex
+    // patterns"), so block scan is safe by default for the folder fast path;
+    // boolean/inverse and non-vectorscan patterns keep the per-line fallback
+    // (hasBufferScan() returns false). Decoupling from useBlockScan makes the
+    // shared scanBuffer primitive fast by default instead of dormant.
+    if ( useVectorscanEngine && !isBooleanCombination_ && !isInverse_ ) {
         bufferScanner_ = expression.hsExpression_.createBufferScanner();
     }
 #endif

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -743,9 +743,13 @@ class Configuration final : public Persistable<Configuration> {
     bool useParallelSearch_ = true;
     // Block-scan fast path: one vectorscan hs_scan over a whole buffer (chunk
     // for single-file, whole file for folder) instead of a per-line hasMatch
-    // loop. Default ON -- roughly 5-10x faster matching on the UTF-8 fast path.
-    // Kept as a toggle so it can be turned off if a pathological pattern
-    // (e.g. one that can match across newlines) needs per-line semantics.
+    // loop. Default ON -- substantially faster matching on the UTF-8 fast path.
+    // Semantic note: because the whole buffer (including '\n') is scanned as one
+    // subject, a pattern that can reach a newline via \s, \W, \D, [^x], [\s\S],
+    // or a literal \n can match ACROSS line boundaries, where the per-line path
+    // never would. '.' / '.*' do NOT cross lines (DOTALL is off), and ^ / $ are
+    // line-anchored (MULTILINE is on), so ordinary token/anchored searches are
+    // unaffected. Keep this toggle to opt back to per-line semantics if needed.
     bool useBlockScan_ = true;
     int indexReadBufferSizeMb_ = 16;
     int searchReadBufferSizeLines_ = 10000;

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -741,7 +741,12 @@ class Configuration final : public Persistable<Configuration> {
     bool useSearchResultsCache_ = true;
     unsigned searchResultsCacheLines_ = 1000000;
     bool useParallelSearch_ = true;
-    bool useBlockScan_ = false;
+    // Block-scan fast path: one vectorscan hs_scan over a whole buffer (chunk
+    // for single-file, whole file for folder) instead of a per-line hasMatch
+    // loop. Default ON -- roughly 5-10x faster matching on the UTF-8 fast path.
+    // Kept as a toggle so it can be turned off if a pathological pattern
+    // (e.g. one that can match across newlines) needs per-line semantics.
+    bool useBlockScan_ = true;
     int indexReadBufferSizeMb_ = 16;
     int searchReadBufferSizeLines_ = 10000;
     int searchThreadPoolSize_ = 0;

--- a/src/ui/src/displayfilepath.cpp
+++ b/src/ui/src/displayfilepath.cpp
@@ -20,6 +20,9 @@
 #include "displayfilepath.h"
 
 #include <QDir>
+#include <QFileInfo>
+
+#include "pathutils.h"
 
 constexpr const int MaxPathLength = 128;
 namespace {
@@ -31,7 +34,9 @@ QString shrinkPath( QString fullPath, int limit, QString delimiter = "…" )
     }
 
     const auto fileInfo = QFileInfo( fullPath );
-    const auto fileName = fileInfo.fileName();
+    // Robust to trailing slashes (QFileInfo("/x/Logs/").fileName() is ""): the
+    // favorites display must always end in the file/folder name.
+    const auto fileName = klogg::displayNameForPath( fullPath );
     const auto absoluteNativePath = QDir::toNativeSeparators( fileInfo.absolutePath() );
 
     const auto idealMinLength = fileName.size() + delimiter.size();

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -110,6 +110,7 @@
 #include "mergefileorder.h"
 #include "droppathclassification.h"
 #include "openfilehelper.h"
+#include "pathutils.h"
 #include "optionsdialog.h"
 #include "predefinedfilters.h"
 #include "predefinedfiltersdialog.h"
@@ -1235,7 +1236,8 @@ void MainWindow::openFolderByPath( const QString& folderPath )
         return;
     }
 
-    const QString displayName = QFileInfo( folderPath ).fileName();
+    // Robust to trailing slashes (drag-dropped folders carry one).
+    const QString displayName = klogg::displayNameForPath( folderPath );
     const auto index = mainTabWidget_.addCrawler( static_cast<FolderCrawlerWidget*>( view ),
                                                   folderPath, displayName, folderPath );
     mainTabWidget_.setCurrentIndex( index );
@@ -2723,7 +2725,7 @@ bool MainWindow::openAdbLogcatSource( const AdbLogcatSessionData& sessionData, b
 // Strips the passed filename from its directory part.
 QString MainWindow::strippedName( const QString& fullFileName ) const
 {
-    return QFileInfo( fullFileName ).fileName();
+    return klogg::displayNameForPath( fullFileName );
 }
 
 // Return the currently active CrawlerWidget, or NULL if none
@@ -3539,7 +3541,7 @@ std::vector<QString> MainWindow::showMergeFilesDialog( const QStringList& filePa
     int checkCounter = 0;
 
     for ( const auto& filePath : sortedPaths ) {
-        const auto displayName = QFileInfo( filePath ).fileName();
+        const auto displayName = klogg::displayNameForPath( filePath );
         auto* item = new QListWidgetItem( displayName );
         item->setData( Qt::UserRole, filePath );
         item->setData( Qt::UserRole + 1, displayName );
@@ -3688,7 +3690,7 @@ bool MainWindow::executeMerge( const std::vector<QString>& filesToMerge )
 
         QStringList shortNames;
         for ( const auto& fn : filesToMerge ) {
-            shortNames << QFileInfo( fn ).fileName();
+            shortNames << klogg::displayNameForPath( fn );
         }
         mainTabWidget_.setTabText( index,
                                    QString( "[Merged] %1" ).arg( shortNames.join( " + " ) ) );

--- a/src/ui/src/pathline.cpp
+++ b/src/ui/src/pathline.cpp
@@ -27,6 +27,7 @@
 
 #include "containers.h"
 #include "openfilehelper.h"
+#include "pathutils.h"
 #include "clipboard.h"
 
 void PathLine::setPath( const QString& path )
@@ -50,7 +51,7 @@ void PathLine::contextMenuEvent( QContextMenuEvent* event )
              [ this ]( auto ) { sendTextToClipboard( this->path_ ); } );
 
     connect( copyFileName, &QAction::triggered, this, [ this ]( auto ) {
-        sendTextToClipboard( QFileInfo( this->path_ ).fileName() );
+        sendTextToClipboard( klogg::displayNameForPath( this->path_ ) );
     } );
 
     connect( openContainingFolder, &QAction::triggered, this,

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -35,6 +35,7 @@
 #include "logfiltereddata.h"
 #include "foldercrawlerwidget.h"
 #include "folderenumeration.h"
+#include "pathutils.h"
 #include "savedsearches.h"
 #include "sessioninfo.h"
 #include "streaminglogdata.h"
@@ -90,7 +91,7 @@ ViewInterface* Session::openMerged( const std::vector<QString>& fileNames,
     // Build display name from source file names
     QStringList shortNames;
     for ( const auto& fn : fileNames ) {
-        shortNames << QFileInfo( fn ).fileName();
+        shortNames << klogg::displayNameForPath( fn );
     }
     const QString mergedName = QString( "[Merged] %1" ).arg( shortNames.join( " + " ) );
 
@@ -153,7 +154,10 @@ ViewInterface* Session::openFolder( const QString& folderPath, const std::vector
     }
     view->setFolder( folderPath, paths );
 
-    const QString displayName = QFileInfo( folderPath ).fileName();
+    // Robust to trailing slashes (drag-dropped folders carry one): Qt's
+    // QFileInfo(path).fileName() returns "" for "/.../Logs/", which would
+    // produce a blank tab title. See klogg::displayNameForPath.
+    const QString displayName = klogg::displayNameForPath( folderPath );
 
     openFiles_.insert( { view,
                          OpenFile{ folderPath,  // fileName
@@ -297,7 +301,7 @@ ViewInterface* Session::openAlways( const QString& file_name,
     openFiles_.insert( { view,
                          { file_name,
                            file_name,
-                           QFileInfo( file_name ).fileName(),
+                           klogg::displayNameForPath( file_name ),
                            file_name,
                            DocumentKind::File,
                            log_data,

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -48,6 +48,7 @@
 #include "iconloader.h"
 #include "log.h"
 #include "openfilehelper.h"
+#include "pathutils.h"
 #include "styles.h"
 #include "tabgroup.h"
 #include "tabgroupdropresolver.h"
@@ -411,7 +412,11 @@ void TabbedCrawlerWidget::changeEvent( QEvent* event )
 void TabbedCrawlerWidget::addTabBarItem( int index, const QString& documentId,
                                          const QString& displayName, const QString& toolTip )
 {
-    const auto tabLabel = displayName.isEmpty() ? QFileInfo( documentId ).fileName() : displayName;
+    // Robust to trailing-slash document paths (drag-dropped folders): Qt's
+    // QFileInfo(path).fileName() returns "" for "/.../Logs/". The label must
+    // never be empty for a real document.
+    const auto tabLabel
+        = displayName.isEmpty() ? klogg::displayNameForPath( documentId ) : displayName;
     const auto tabName = TabNameMapping::getSynced().tabName( documentId );
     const auto nativeToolTip
         = toolTip.isEmpty() ? QDir::toNativeSeparators( documentId ) : QDir::toNativeSeparators( toolTip );
@@ -911,7 +916,7 @@ void TabbedCrawlerWidget::showContextMenu( int tab, QPoint globalPoint )
 
             if ( newName.isEmpty() ) {
                 myTabBar_.setTabText( tab,
-                                      storedTitle.isEmpty() ? QFileInfo( tabPath ).fileName()
+                                      storedTitle.isEmpty() ? klogg::displayNameForPath( tabPath )
                                                             : storedTitle );
             }
             else {
@@ -1292,7 +1297,7 @@ void TabbedCrawlerWidget::onGroupsChanged()
         const auto cleanCustomName = tabLabelWithoutLiveStatus( customName );
         const auto originalTabLabel
             = cleanCustomName.isEmpty()
-                  ? ( storedTitle.isEmpty() ? QFileInfo( tabPath ).fileName() : storedTitle )
+                  ? ( storedTitle.isEmpty() ? klogg::displayNameForPath( tabPath ) : storedTitle )
                   : cleanCustomName;
         const auto originalTooltip
             = storedToolTip.isEmpty() ? QDir::toNativeSeparators( tabPath ) : storedToolTip;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/overload_visitor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/resourcewrapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crc32.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/pathutils.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/cpu_info.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/runnable_lambda.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cpu_info.cpp

--- a/src/utils/include/pathutils.h
+++ b/src/utils/include/pathutils.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PATH_UTILS_H
+#define KLOGG_PATH_UTILS_H
+
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+
+namespace klogg {
+
+// Human-readable label for a document path: the final path component,
+// robust to trailing/duplicate separators.
+//
+// QFileInfo::fileName() returns an empty string for paths that end in a
+// separator (e.g. "/var/log/", "logs//", "C:/"). Folders opened via
+// drag-drop (and some restore/drop paths) carry a trailing slash, so the
+// naive QFileInfo(path).fileName() -- duplicated across the tab/widget/
+// session label code -- produced blank tab and window titles. QDir::cleanPath
+// normalises the separators first; if the result still has no base name
+// (root "/", empty input, a bare drive "C:"), fall back to the original path
+// so a non-empty input never yields an empty label.
+inline QString displayNameForPath( const QString& path )
+{
+    const auto base = QFileInfo( QDir::cleanPath( path ) ).fileName();
+    return base.isEmpty() ? path : base;
+}
+
+} // namespace klogg
+
+#endif

--- a/tests/unit/patternmatcher_test.cpp
+++ b/tests/unit/patternmatcher_test.cpp
@@ -169,6 +169,76 @@ TEST_CASE( "Block scan matches per-line scan results", "[patternmatcher]" )
     }
 }
 
+TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmatcher]" )
+{
+    auto& config = Configuration::getSynced();
+    configureProductLikeRegexpEngine( config );
+    // Force the block-scan path on so the parity assertion below is actually
+    // exercised (hasBufferScan() is otherwise false with useBlockScan off).
+    config.setUseBlockScan( true );
+
+    // A corpus with varied line shapes: field alternation, numbers, paths,
+    // quotes, an optional nested group, and a blank line.
+    const std::vector<std::string> lines = {
+        "level=INFO component=auth msg=\"ok\" path=/api/v1/task/123 shard=4",
+        "level=ERROR component=auth msg=\"timeout\" path=/api/v1/job/7 shard=2 retry=false",
+        "level=WARN component=storage msg=\"failed\" path=/api/v1/task/999 shard=12",
+        "ordinary payload with no fields at all",
+        "level=ERROR component=scheduler msg=\"exception\" path=/api/v1/job/3 shard=0 retry=false",
+        "level=DEBUG component=parser msg=\"peer reset during remote link handover\" path=/api/v1/node/55 shard=9",
+        "level=INFO component=crawler req=AABBCCDDEEFF0011 session=11223344 msg=\"ok\"",
+        "short",
+        "level=WARN component=replication msg=\"timeout\" path=/api/v1/task/2 shard=15",
+        "",
+    };
+
+    // Contiguous buffer + endOfLines (byte offset one past each newline).
+    std::string buffer;
+    klogg::vector<qint64> endOfLines;
+    for ( const auto& line : lines ) {
+        buffer += line;
+        buffer += '\n';
+        endOfLines.push_back( static_cast<qint64>( buffer.size() ) );
+    }
+
+    const std::vector<QString> patterns = {
+        QStringLiteral( "ERROR" ), // baseline literal
+        QStringLiteral( "(ERROR|WARN)" ), // alternation
+        QStringLiteral( "level=(ERROR|WARN)" ), // anchored alternation
+        QStringLiteral( "component=(auth|scheduler|replication|storage|parser|crawler)" ),
+        QStringLiteral( "shard=[0-9]{1,2}" ), // bounded repetition
+        QStringLiteral( "req=[A-F0-9]{16}( session=([A-F0-9]{8}|[A-F0-9]{16}))?" ), // optional group
+        QStringLiteral( "level=(ERROR|WARN).*msg=\\\"(timeout|failed|exception).*\\\""
+                        ".*path=/api/v1/(task|job)/[0-9]{1,4}.*shard=[0-9]{1,2} retry=false" ),
+    };
+
+    for ( const auto& pattern : patterns ) {
+        RegularExpression expression(
+            RegularExpressionPattern( pattern, true, false, false, false ) );
+        REQUIRE( expression.isValid() );
+        const auto matcher = expression.createMatcher();
+        REQUIRE( matcher->hasBufferScan() );
+
+        std::set<size_t> perLineMatches;
+        for ( size_t i = 0; i < lines.size(); ++i ) {
+            if ( matcher->hasMatch( std::string_view{ lines[ i ] } ) ) {
+                perLineMatches.insert( i );
+            }
+        }
+
+        klogg::vector<uint64_t> blockMatches;
+        REQUIRE( matcher->scanBuffer( buffer.data(), static_cast<unsigned int>( buffer.size() ),
+                                      endOfLines, blockMatches ) );
+        std::set<size_t> blockMatchSet;
+        for ( const auto idx : blockMatches ) {
+            blockMatchSet.insert( static_cast<size_t>( idx ) );
+        }
+        INFO( "pattern: " << pattern.toStdString() << " | perLine=" << perLineMatches.size()
+                          << " block=" << blockMatchSet.size() );
+        REQUIRE( blockMatchSet == perLineMatches );
+    }
+}
+
 TEST_CASE( "Block scan falls back when Vectorscan is unavailable", "[patternmatcher]" )
 {
     // Force the Qt regex engine, which does not support block scanning.

--- a/tests/unit/patternmatcher_test.cpp
+++ b/tests/unit/patternmatcher_test.cpp
@@ -173,8 +173,10 @@ TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmat
 {
     auto& config = Configuration::getSynced();
     configureProductLikeRegexpEngine( config );
-    // Force the block-scan path on so the parity assertion below is actually
-    // exercised (hasBufferScan() is otherwise false with useBlockScan off).
+    // hasBufferScan() is true on PATTERN CAPABILITY (vectorscan + single +
+    // non-boolean + non-inverse), independent of the useBlockScan toggle, so the
+    // scanBuffer parity below is exercised for any eligible pattern. The toggle
+    // only gates the higher-level fast paths (filterLines / folder scanFile).
     config.setUseBlockScan( true );
 
     // A corpus with varied line shapes: field alternation, numbers, paths,
@@ -210,6 +212,11 @@ TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmat
         QStringLiteral( "req=[A-F0-9]{16}( session=([A-F0-9]{8}|[A-F0-9]{16}))?" ), // optional group
         QStringLiteral( "level=(ERROR|WARN).*msg=\\\"(timeout|failed|exception).*\\\""
                         ".*path=/api/v1/(task|job)/[0-9]{1,4}.*shard=[0-9]{1,2} retry=false" ),
+        // Line anchors: a whole-buffer scan must compile with HS_FLAG_MULTILINE so
+        // ^ / $ match each line boundary, otherwise block scan only matches at the
+        // buffer edges and silently undercounts vs per-line.
+        QStringLiteral( "^level=ERROR" ),
+        QStringLiteral( "retry=false$" ),
     };
 
     for ( const auto& pattern : patterns ) {

--- a/tests/unit/patternmatcher_test.cpp
+++ b/tests/unit/patternmatcher_test.cpp
@@ -229,6 +229,14 @@ TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmat
         klogg::vector<uint64_t> blockMatches;
         REQUIRE( matcher->scanBuffer( buffer.data(), static_cast<unsigned int>( buffer.size() ),
                                       endOfLines, blockMatches ) );
+        // Output contract: matched line indices are strictly ascending -- sorted
+        // and deduped by construction (guards the occupancy-vector dedup).
+        for ( size_t k = 1; k < blockMatches.size(); ++k ) {
+            INFO( "pattern: " << pattern.toStdString() << " | blockMatches[" << k
+                              << "]=" << blockMatches[ k ] << " <= [" << ( k - 1 )
+                              << "]=" << blockMatches[ k - 1 ] );
+            REQUIRE( blockMatches[ k ] > blockMatches[ k - 1 ] );
+        }
         std::set<size_t> blockMatchSet;
         for ( const auto idx : blockMatches ) {
             blockMatchSet.insert( static_cast<size_t>( idx ) );
@@ -236,6 +244,90 @@ TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmat
         INFO( "pattern: " << pattern.toStdString() << " | perLine=" << perLineMatches.size()
                           << " block=" << blockMatchSet.size() );
         REQUIRE( blockMatchSet == perLineMatches );
+    }
+}
+
+TEST_CASE( "Block scan dedups multi-match lines and attributes an unterminated final line",
+           "[patternmatcher]" )
+{
+    auto& config = Configuration::getSynced();
+    configureProductLikeRegexpEngine( config );
+    config.setUseBlockScan( true );
+
+    SECTION( "multiple matches in one line collapse to a single line index" )
+    {
+        // "aaa" matches twice in line 0 -- both callbacks must map to line 0 and
+        // dedup to one entry; line 1 does not match.
+        const std::vector<std::string> lines = { "aaa bbb aaa", "ccc" };
+        std::string buffer;
+        klogg::vector<qint64> endOfLines;
+        for ( const auto& line : lines ) {
+            buffer += line;
+            buffer += '\n';
+            endOfLines.push_back( static_cast<qint64>( buffer.size() ) );
+        }
+
+        RegularExpression expression( RegularExpressionPattern( QStringLiteral( "aaa" ), true, false,
+                                                                false, false ) );
+        const auto matcher = expression.createMatcher();
+
+        std::set<size_t> perLine;
+        for ( size_t i = 0; i < lines.size(); ++i ) {
+            if ( matcher->hasMatch( std::string_view{ lines[ i ] } ) ) {
+                perLine.insert( i );
+            }
+        }
+
+        klogg::vector<uint64_t> blockMatches;
+        REQUIRE( matcher->scanBuffer( buffer.data(), static_cast<unsigned int>( buffer.size() ),
+                                      endOfLines, blockMatches ) );
+        REQUIRE( blockMatches.size() == 1 );
+        REQUIRE( blockMatches[ 0 ] == 0 );
+        std::set<size_t> blockSet;
+        for ( const auto idx : blockMatches ) {
+            blockSet.insert( static_cast<size_t>( idx ) );
+        }
+        REQUIRE( blockSet == perLine );
+    }
+
+    SECTION( "an unterminated final line is attributed via the size sentinel" )
+    {
+        // Last line has no trailing newline; endOfLines.back() == buffer.size()
+        // acts as the sentinel (mirrors single-file's fake-LF index entry and
+        // folder's appended sentinel), so the last line still maps correctly.
+        const std::vector<std::string> lines = { "error one", "error two", "error three no newline" };
+        std::string buffer;
+        klogg::vector<qint64> endOfLines;
+        for ( size_t i = 0; i < lines.size(); ++i ) {
+            buffer += lines[ i ];
+            if ( i + 1 < lines.size() ) {
+                buffer += '\n';
+            }
+            endOfLines.push_back( static_cast<qint64>( buffer.size() ) );
+        }
+
+        RegularExpression expression( RegularExpressionPattern( QStringLiteral( "error" ), true, false,
+                                                                false, false ) );
+        const auto matcher = expression.createMatcher();
+
+        std::set<size_t> perLine;
+        for ( size_t i = 0; i < lines.size(); ++i ) {
+            if ( matcher->hasMatch( std::string_view{ lines[ i ] } ) ) {
+                perLine.insert( i );
+            }
+        }
+        REQUIRE( perLine.size() == 3 );
+
+        klogg::vector<uint64_t> blockMatches;
+        REQUIRE( matcher->scanBuffer( buffer.data(), static_cast<unsigned int>( buffer.size() ),
+                                      endOfLines, blockMatches ) );
+        REQUIRE( blockMatches.size() == 3 );
+        REQUIRE( blockMatches[ 2 ] == 2 ); // the unterminated final line
+        std::set<size_t> blockSet;
+        for ( const auto idx : blockMatches ) {
+            blockSet.insert( static_cast<size_t>( idx ) );
+        }
+        REQUIRE( blockSet == perLine );
     }
 }
 

--- a/tests/unit/patternmatcher_test.cpp
+++ b/tests/unit/patternmatcher_test.cpp
@@ -178,6 +178,11 @@ TEST_CASE( "Block scan matches per-line scan for complex patterns", "[patternmat
     // scanBuffer parity below is exercised for any eligible pattern. The toggle
     // only gates the higher-level fast paths (filterLines / folder scanFile).
     config.setUseBlockScan( true );
+    // Block scan requires vectorscan; on a KLOGG_USE_VECTORSCAN=OFF build there
+    // is nothing to parity-check, so pass vacuously instead of failing.
+    if ( config.regexpEngine() != RegexpEngine::Vectorscan ) {
+        return;
+    }
 
     // A corpus with varied line shapes: field alternation, numbers, paths,
     // quotes, an optional nested group, and a blank line.
@@ -260,6 +265,9 @@ TEST_CASE( "Block scan dedups multi-match lines and attributes an unterminated f
     auto& config = Configuration::getSynced();
     configureProductLikeRegexpEngine( config );
     config.setUseBlockScan( true );
+    if ( config.regexpEngine() != RegexpEngine::Vectorscan ) {
+        return; // block scan requires vectorscan
+    }
 
     SECTION( "multiple matches in one line collapse to a single line index" )
     {

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 
 #include "configuration.h"
+#include "pathutils.h"
 #include "styles.h"
 #include "tabbedcrawlerwidget.h"
 #include "tabnamemapping.h"
@@ -98,6 +99,64 @@ class LiveStatusTranslator : public QTranslator {
         return {};
     }
 };
+
+TEST_CASE( "displayNameForPath is robust to trailing slashes and never blanks a label" )
+{
+    using klogg::displayNameForPath;
+    // Regression core: trailing separators made QFileInfo::fileName() return "".
+    REQUIRE( displayNameForPath( QStringLiteral( "/Library/Logs/" ) )
+             == QStringLiteral( "Logs" ) );
+    REQUIRE( displayNameForPath( QStringLiteral( "/Library/Logs" ) )
+             == QStringLiteral( "Logs" ) );
+    REQUIRE( displayNameForPath( QStringLiteral( "logs//" ) ) == QStringLiteral( "logs" ) );
+    REQUIRE( displayNameForPath( QStringLiteral( "11684370/" ) ) == QStringLiteral( "11684370" ) );
+
+    // A non-empty input must never yield an empty label: the filesystem root
+    // (and a bare Windows drive) clean down to nothing, so fall back to the
+    // path itself rather than render a blank tab/title.
+    REQUIRE_FALSE( displayNameForPath( QStringLiteral( "/" ) ).isEmpty() );
+    REQUIRE( displayNameForPath( QStringLiteral( "/" ) ) == QStringLiteral( "/" ) );
+    REQUIRE( displayNameForPath( QString{} ).isEmpty() );
+}
+
+TEST_CASE( "TabbedCrawlerWidget derives a non-empty tab label for trailing-slash paths" )
+{
+    // Regression: a folder path that carries a trailing slash (as some
+    // open-folder / drag-drop / session-restore code paths produce) made
+    // QFileInfo(path).fileName() return "" on Qt 6, which flowed through to
+    // an empty tab text -- a "blank" folder tab. The tab label must be the
+    // folder base name regardless of trailing slashes.
+    TabbedCrawlerWidget tabWidget;
+
+    SECTION( "single trailing slash yields the base name" )
+    {
+        auto* crawler = new DummyCrawlerWidget();
+        const auto index
+            = tabWidget.addCrawler( crawler, QStringLiteral( "/tmp/11684370/" ), QString{},
+                                    QString{} );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "11684370" ) );
+
+        tabWidget.onGroupsChanged();
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "11684370" ) );
+    }
+
+    SECTION( "double trailing slash yields the base name" )
+    {
+        auto* crawler = new DummyCrawlerWidget();
+        const auto index = tabWidget.addCrawler( crawler, QStringLiteral( "/var/log///" ),
+                                                 QString{}, QString{} );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "log" ) );
+    }
+
+    SECTION( "no trailing slash still works" )
+    {
+        auto* crawler = new DummyCrawlerWidget();
+        const auto index
+            = tabWidget.addCrawler( crawler, QStringLiteral( "/tmp/11684370" ), QString{},
+                                    QString{} );
+        REQUIRE( tabWidget.tabText( index ) == QStringLiteral( "11684370" ) );
+    }
+}
 
 TEST_CASE( "TabbedCrawlerWidget keeps live tab title and tooltip across group refreshes" )
 {


### PR DESCRIPTION
## Summary
- **Perf:** Add a whole-file `PatternMatcher::scanBuffer` fast path to folder search so it ties ripgrep on literals, beats rg ~19% on alternations, and runs ~20x grep — comparable to single-file search speed.
- **Fix:** Folder tabs opened by drag-drop showed a blank name. Centralize path→label derivation into `klogg::displayNameForPath` (robust to trailing slashes) and route every user-facing basename site through it.

## Background

### Block-scan fast path
- **Introduced by:** The folder engine (`FolderSearchEngine`) only ever used the per-line `PatternMatcher::hasMatch` (~500 MiB/s). A shared `PatternMatcher::scanBuffer` primitive (one `hs_scan` over a multi-line buffer, mapping matches to lines via `upper_bound` on the end-of-line index) already existed but was dormant — `bufferScanner_` was gated on `config.useBlockScan()`, which defaults to false, so the folder path never built one.
- **Use case:** Searching a folder of many files via Open Folder.
- **How to reproduce:** `./folder_search_benchmark --files 200 --lines-per-file 4000 --pattern NEEDLE --vs-grep --vs-rg`.
- **Root cause:** The fast primitive existed but was disabled by default; per-line matching was the only path.
- **How to fix:**
  - `PatternMatcher` now creates `bufferScanner_` on **pattern capability** (vectorscan + single + non-boolean + non-inverse), decoupled from the user toggle, so `scanBuffer` is fast by default. Boolean/inverse/non-vectorscan still take the per-line fallback.
  - `FolderSearchEngine::scanFile` gains a whole-file fast path: for UTF-8 single/non-binary files, no `-A/-B/-C` context, and size ≤ 16 MiB — read the whole file, build end-of-line offsets with `memchr`, run one `scanBuffer`, build `MatchRecord`s from matched line indices. Per-line streaming remains the fallback.
  - `memchr` for the end-of-line precompute.
- **Numbers:** per-line ~500 MiB/s → block scan ~2680 MiB/s; grep(BSD) ~134; rg ~2680 (literal) / ~2360 (alternation). Match-count parity with grep and rg.

### Blank drag-drop folder tab
- **Use case:** Open a folder by drag-drop.
- **How to reproduce:** Drag a folder onto the window — its tab name is blank. The Open Folder button shows the correct name.
- **Root cause:** `QFileInfo(path).fileName()` returns `""` for paths ending in a separator (Qt 6: `"/Library/Logs/"` → `""`). Drag-drop keeps the trailing slash; `QFileDialog::getExistingDirectory` does not. The empty value flowed `OpenFile.displayName` → `setTabText` → a blank tab. The fragile `QFileInfo(path).fileName()` pattern was duplicated across all label sites.
- **How to fix:** `klogg::displayNameForPath(path)` in `utils/include/pathutils.h` — `QFileInfo(QDir::cleanPath(path)).fileName()` with a drive-root fallback. Platform-aware (Unix: only `/`; Windows: `/` and `\`). Routed through folder/file display name, `openFolderByPath`, the three tab-widget fallbacks, the window-title/recent-menus basename helper (`strippedName`), merged-tab short names, the merge dialog list, and "Copy File Name". The sort key in `mergefileorder.cpp` is intentionally left (full-path tiebreaker, no blank).

## Tests
- `cmake --build build_root --target klogg klogg_tests klogg_itests` — links clean (`-Werror`).
- New `patternmatcher_test` "Block scan matches per-line scan for complex patterns".
- New `tabbedcrawlerwidget_test` cases: "displayNameForPath is robust to trailing slashes and never blanks a label" and "TabbedCrawlerWidget derives a non-empty tab label for trailing-slash paths".
- `./output/klogg_tests -platform offscreen` → 381 cases / 6255 assertions, all pass.
- `./output/klogg_itests -platform offscreen` → 103 cases / 2559 assertions, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Enabled and expanded block/whole-buffer scanning for eligible folder searches to speed up matching.
  * Improved Vectorscan buffer scanning behavior and ensured consistent multiline handling for anchored patterns.

* **New Features**
  * Updated folder search benchmarks to compare results against both `grep` and `ripgrep` (`--vs-grep` / `--vs-rg`).

* **Bug Fixes**
  * Improved display names across tabs and clipboard actions for paths with trailing separators and root paths.
  * Ensured match results stay consistent between scanning modes.

* **Tests**
  * Added unit coverage for block-scan correctness and trailing-slash label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->