### PR TITLE
Fix flaky folder-dispatch test: VeryCoarseTimer → PreciseTimer + lint guard

### DIFF
--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -123,6 +123,19 @@ PATTERNS: list[dict] = [
             "to the class instead."
         ),
     },
+    {
+        "name": "very-coarse-timer-in-test",
+        # Qt::VeryCoarseTimer in a test file creates non-deterministic dispatch
+        # delays on Qt 5.12 (Ubuntu 20.04).  Use PreciseTimer or direct calls.
+        "regex": re.compile(r"\bQt::VeryCoarseTimer\b"),
+        "fix": (
+            "Qt::VeryCoarseTimer rounds up to ~1 s granularity on Qt 5.12 "
+            "(Ubuntu 20.04), making UI dispatch non-deterministic. Use "
+            "Qt::PreciseTimer in tests so qWait reliably processes the "
+            "scheduled callback. (PR #43 master CI failure: flaky "
+            "mainwindow_test.cpp folder-dispatch test.)"
+        ),
+    },
 ]
 
 # Multi-line patterns: checked separately via whole-file analysis.

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -173,7 +173,7 @@ SCENARIO( "Main window tests", "[ui]" )
     REQUIRE( activateSpy->safeWait() );
 
     auto runInUiThread = [uiObject = mainWindow.get()]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -317,7 +317,7 @@ SCENARIO( "Tab group chip shows the full group name", "[ui][tabgroup]" )
     QTest::qWait( 100 );
 
     auto runInUiThread = [uiObject = mainWindow.get()]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -354,12 +354,12 @@ SCENARIO( "Tab group chip shows the full group name", "[ui][tabgroup]" )
         groupManager.save();
     } );
 
-    // runInUiThread's internal QTest::qWait(100) is not always enough on
-    // slow runners (Ubuntu 20.04 docker has missed the 100 ms budget,
-    // leaving groupId empty before this REQUIRE).  waitUiState polls
-    // up to 10 s, so the assertion either succeeds quickly on a healthy
-    // runner or fails with a clear timeout instead of a misleading
-    // "groupId is empty" diagnostic.
+    // runInUiThread dispatches synchronously (PreciseTimer → qWait flushes
+    // the event queue), but GroupManager::save() inside the dispatched lambda
+    // may write via QSettings which syncs asynchronously on some platforms.
+    // waitUiState polls up to 10 s, so the assertion either succeeds quickly
+    // or fails with a clear timeout instead of a misleading empty-groupid
+    // diagnostic.
     REQUIRE( waitUiState( [ & ] { return !groupId.isEmpty(); } ) );
 
     auto verifyGroupChipName = [ tabBar ]( const QString& expectedName ) -> int {
@@ -613,7 +613,7 @@ SCENARIO( "MainWindow close keeps persisted open files for session restore", "[u
     QTest::qWait( 100 );
 
     auto runInUiThread = [uiObject = mainWindow.get()]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -707,7 +707,7 @@ SCENARIO( "MainWindow close preserves restored ADB capture files", "[ui][session
     QTest::qWait( 100 );
 
     auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -774,7 +774,7 @@ SCENARIO( "MainWindow restored iOS live log tabs show disconnected state",
     QTest::qWait( 100 );
 
     auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -852,7 +852,7 @@ SCENARIO( "Folder tab in MainWindow does not crash on open/switch/close",
     QTest::qWait( 100 );
 
     auto runInUiThread = [uiObject = mainWindow.get()]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -1032,7 +1032,7 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
     QTest::qWait( 100 );
 
     auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -1130,11 +1130,6 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
         runInUiThread( [ folderWidget ] {
             folderWidget->selectResultRow( 1_lnum );
         } );
-        // Qt 5.12 VeryCoarseTimer (ubuntu-20.04 AppImage) may delay the
-        // single-shot dispatch, shrinking the 10s waitUiState budget.
-        // Give the timer a generous settle window so the async file-open
-        // gets a full budget on slower CI runners.
-        QTest::qWait( 5000 );
         REQUIRE( waitUiState(
             [ & ] { return folderWidget->currentMainFilePath() == expectedPath; } ) );
 
@@ -1171,7 +1166,7 @@ SCENARIO( "Folder QuickFind re-registers on pane changes", "[ui][folder]" )
     QTest::qWait( 100 );
 
     auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };
@@ -1205,10 +1200,6 @@ SCENARIO( "Folder QuickFind re-registers on pane changes", "[ui][folder]" )
         folderWidget->searchFor( "beta" );
     } );
     REQUIRE( waitUiState( [ & ] { return !folderWidget->isSearchActive(); } ) );
-    // Qt 5.12 VeryCoarseTimer: the pane creation after keep-results search is
-    // dispatched through a timer chain (~1s-per-tick on ubuntu-20.04), so give
-    // it a settle window before polling.
-    QTest::qWait( 2000 );
     REQUIRE( waitUiState( [ & ] { return folderWidget->paneCount() == 2; } ) );
 
     WHEN( "the new active pane's view initiates a QuickFind change" )
@@ -1317,7 +1308,7 @@ SCENARIO( "Tab switches coalesce session persistence into a debounced write",
     QTest::qWait( 100 );
 
     auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::VeryCoarseTimer, uiObject,
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
                             std::forward<decltype( func )>( func ) );
         QTest::qWait( 100 );
     };


### PR DESCRIPTION
## Summary
- Replace all `Qt::VeryCoarseTimer` with `Qt::PreciseTimer` in `runInUiThread` test helpers (9 instances in `tests/ui/mainwindow_test.cpp`)
- Remove two ad-hoc `QTest::qWait()` settle windows (5000ms and 2000ms) that were unreliable workarounds
- Add a lint rule to `scripts/lint_platform_fragile.py` to prevent `Qt::VeryCoarseTimer` from being re-introduced

## Background
- **Introduced by:** PR #43 folder-search acceptance tests
- **Use case:** CI push to master on Ubuntu 20.04 AppImage (Qt 5.12) triggers the build matrix; the UI integration test "Folder tab receives the polymorphic MainWindow dispatch" fails non-deterministically
- **Root cause:** `Qt::VeryCoarseTimer` rounds 0ms timeouts to ~1s granularity on Qt 5.12, so `qWait(100)` inside `runInUiThread` returns before the scheduled callback executes. The test then relies on wall-clock settle windows that are inherently non-deterministic
- **How to fix:** `PreciseTimer` fires immediately when the event loop runs, making dispatch deterministic. All callback chains now complete within `runInUiThread`

## Tests
- **macOS:** 4/4 test targets passed (klogg_tests, klogg_itests, klogg_vectorscan_tests, klogg_smoke)
- **Ubuntu 20.04 Docker (Qt 5.12):** 128/128 klogg_itests passed — previously 127/128 (1 flaky failure)
- **Lint:** `python3 scripts/lint_platform_fragile.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI test stability by using precise timer scheduling instead of coarse timing.
  * Removed unnecessary waiting periods from folder-related tests, reducing test execution time.
  * Added lint detection for platform-fragile very coarse timers, with guidance for deterministic alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->