### PR TITLE
Fix multi-line color labels and wrap-mode scrollbar overflow

### DIFF
--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -173,6 +173,12 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     LineNumber getTopLine() const;
     // Return the text of the current selection.
     QString getSelectedText() const;
+    // Return the selected text as one entry per selected line, in row order
+    // (a portion selection yields a single entry). This is the per-line dual
+    // of getSelectedText(): consumers that match text per log line (color
+    // labels) must use it, as a label entry containing a line feed can never
+    // match a single line.
+    QStringList getSelectedLinesText() const;
     // True for partial selection
     bool isPartialSelection() const;
     // Instructs the widget to select the whole text.

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -633,7 +633,17 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     int visibleLineMapBuildCount_ = 0;
 
     LinesCount getNbVisibleLines() const;
-    LinesCount getNbBottomWrappedVisibleLines() const;
+    // Composition of the bottom frame in wrap mode: how many logical lines the
+    // frame holds (its top line counted even when only partially visible, so
+    // the frame stays filled) and whether the wrapped document overflows the
+    // viewport. The scroll range must be derived from BOTH: a document whose
+    // lines all fit the frame count can still overflow (clipped top line), in
+    // which case the range must open for the tail to be reachable.
+    struct WrappedBottomFrame {
+        LinesCount frameLines;
+        bool contentOverflows;
+    };
+    WrappedBottomFrame getWrappedBottomFrame() const;
     LineLength getNbVisibleCols() const;
     int textViewportHeight() const;
     int horizontalScrollBarOverlayHeight() const;

--- a/src/ui/include/colorlabelscontroller.h
+++ b/src/ui/include/colorlabelscontroller.h
@@ -27,6 +27,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
+#include <QStringList>
 
 #include "colorlabelsmanager.h"
 
@@ -80,9 +81,12 @@ class ColorLabelsController : public QObject {
     void clearColorLabels();
     void setQuickColorLabelDefaults( bool ignoreCase, bool wholeWord );
     void applyToViews( const ColorLabelsManager::QuickHighlightersCollection& labels );
-    // The text to (un)label: the emitting view's selection when known, else the
-    // host-active view's selection. Empty when there is nothing to do.
-    QString selectedText( const AbstractLogView* sourceView ) const;
+    // The texts to (un)label: one entry per selected line of the emitting view
+    // when known, else of the host-active view. Multi-line selections yield
+    // per-line entries so every selected line gets labelled (an entry holding
+    // the joined multi-line blob could never match a single log line). Empty
+    // when there is nothing to do.
+    QStringList selectedTexts( const AbstractLogView* sourceView ) const;
 
     ColorLabelsManager manager_;
     QWidget* shortcutsParent_;

--- a/src/ui/include/colorlabelsmanager.h
+++ b/src/ui/include/colorlabelsmanager.h
@@ -21,6 +21,7 @@
 #define KLOGG_COLORLABELSMANAGER_H
 
 #include "abstractlogview.h"
+#include <QStringList>
 #include <optional>
 #include <qobject.h>
 #include <qobjectdefs.h>
@@ -30,13 +31,29 @@ class ColorLabelsManager {
   public:
     using QuickHighlightersCollection = std::vector<AbstractLogView::QuickHighlighters>;
 
+    // Cap on the number of distinct texts labelled in one bulk action (e.g. a
+    // multi-line selection). Every entry becomes one regex evaluated per drawn
+    // line per paint, so unbounded bulk labelling would degrade painting;
+    // oversized selections are truncated with a LOG_WARNING. (Marks have no
+    // such cap: they are line-index flags, not per-line regexes.)
+    static constexpr size_t MaxBulkLabelTexts = 1000;
+
     QuickHighlightersCollection colorLabels() const;
 
+    // The QStringList overloads apply the operation to each distinct
+    // (non-empty) text; the QString overloads are the single-text case.
     QuickHighlightersCollection setColorLabel( size_t label, const QString& text,
                                                QuickHighlighterDefaults defaults );
+    QuickHighlightersCollection setColorLabel( size_t label, const QStringList& texts,
+                                               QuickHighlighterDefaults defaults );
+    // Cycles ONCE per call: every text lands under the single next label.
     QuickHighlightersCollection setNextColorLabel( const QString& text,
                                                    QuickHighlighterDefaults defaults );
+    QuickHighlightersCollection setNextColorLabel( const QStringList& texts,
+                                                   QuickHighlighterDefaults defaults );
+    // Removes every entry matching ANY of the texts.
     QuickHighlightersCollection removeColorLabel( const QString& text );
+    QuickHighlightersCollection removeColorLabel( const QStringList& texts );
 
     std::optional<size_t> currentColorLabelForText( const QString& text ) const;
 
@@ -45,6 +62,11 @@ class ColorLabelsManager {
   private:
     QuickHighlightersCollection updateColorLabel( size_t label, const QString& text,
                                                   QuickHighlighterDefaults defaults );
+    // The label a cycle action targets for the given reference text, honoring
+    // the useInCycle configuration and the current cycle position.
+    std::optional<size_t> nextCycleLabel( const QString& referenceText ) const;
+    // Drop empties, dedup preserving order, truncate to MaxBulkLabelTexts.
+    static QStringList sanitizeBulkTexts( const QStringList& texts );
 
     QuickHighlightersCollection quickHighlighters_ = QuickHighlightersCollection{9};
     std::optional<size_t> currentLabel_;

--- a/src/ui/include/selection.h
+++ b/src/ui/include/selection.h
@@ -22,6 +22,7 @@
 
 #include <QList>
 #include <QString>
+#include <QStringList>
 #include <cstddef>
 #include <utility>
 #include <vector>
@@ -154,6 +155,14 @@ class Selection {
 
     // Returns the text selected from the passed AbstractLogData
     QString getSelectedText( const AbstractLogData* logData, bool lineNumbers = false ) const;
+
+    // Returns the selected text as one string per selected line, in row order
+    // (non-copyable rows, e.g. folder group headers, are skipped). A portion
+    // selection yields a single entry. Unlike getSelectedText() nothing is
+    // joined with platform line separators: consumers that match text per log
+    // line (e.g. color labels) must use this, as an entry containing a line
+    // feed can never match a single line.
+    QStringList getSelectedLinesText( const AbstractLogData* logData ) const;
 
     // Return the position immediately after the current selection
     // (used for searches).

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1198,14 +1198,17 @@ void AbstractLogView::scrollContentsBy( int dx, int /*dy*/ )
     const auto scrollPosition = verticalScrollToLineNumber( scrollValue );
 
     // Determine if we're at the bottom by checking if scroll value >= maximum.
-    // This avoids the expensive getNbBottomWrappedVisibleLines() call on every scroll.
+    // This avoids the expensive getWrappedBottomFrame() call on every scroll.
     // The scroll range is already calculated correctly by updateScrollBars().
     const bool atBottom = scrollMax > 0 && scrollValue >= scrollMax;
 
     if ( atBottom ) {
         // We're at or past the bottom, lock the last line at the bottom
         // For text wrap mode, use the scroll maximum as the firstLine anchor.
-        // scrollMax represents the last valid top line (totalLines - unwrappedLinesAtBottom).
+        // scrollMax is derived from the bottom-frame composition: the logical
+        // lines above the frame (plus one step when the whole document fits
+        // the frame count but the wrapped content still overflows), so at max
+        // the frame shows the tail fully.
         firstLine_ = verticalScrollToLineNumber( scrollMax );
         lastLineAligned_ = true;
     }
@@ -2735,39 +2738,33 @@ void AbstractLogView::considerMouseHovering( int xPos, int yPos )
     }
 }
 
-LinesCount AbstractLogView::getNbBottomWrappedVisibleLines() const
+AbstractLogView::WrappedBottomFrame AbstractLogView::getWrappedBottomFrame() const
 {
     const LinesCount visibleLines = getNbVisibleLines();
-    
-    if ( !useTextWrap_ ) {
-        return visibleLines;
+
+    // "Unknown, assume fits" fallbacks for callers that run before the wrap
+    // layout is available (pre-first-paint) or without wrap enabled.
+    if ( !useTextWrap_ || leftMarginPx_ == 0 ) {
+        return { visibleLines, false };
     }
-    
-    // Early return if leftMarginPx_ hasn't been initialized yet
-    // This prevents using incorrect column count during initialization before drawTextArea() runs
-    // leftMarginPx_ is set in drawTextArea() at line 2541, but this function may be called
-    // earlier (e.g., from updateScrollBars() during initialization)
-    if ( leftMarginPx_ == 0 ) {
-        return visibleLines;
-    }
-    
+
     const LineLength visibleColumns = getNbVisibleCols();
-    
+
     const auto totalLines = logData_->getNbLine();
     if ( totalLines.get() == 0 ) {
-        LOG_DEBUG << "[TextWrap:Calc] getNbBottomWrappedVisibleLines: no lines";
-        return LinesCount{ 0 };
+        return { LinesCount{ 0 }, false };
     }
-    
+
     // Ensure we have valid column count (can happen during initialization)
     if ( visibleColumns.get() <= 0 ) {
-        LOG_DEBUG << "[TextWrap:Calc] getNbBottomWrappedVisibleLines: invalid visibleColumns="
+        LOG_DEBUG << "[TextWrap:Calc] getWrappedBottomFrame: invalid visibleColumns="
                   << visibleColumns.get() << ", returning visibleLines";
-        return visibleLines;
+        return { visibleLines, false };
     }
 
     LinesCount wrappedLinesCount{ 0 };
-    LinesCount unwrappedLinesCount{ 0 };
+    LinesCount frameLines{ 0 };
+    bool contentOverflows = false;
     LineNumber unwrappedLineNumber{ totalLines.get() - 1 };
 
     // Pixel-accurate wrapping width for the text content area
@@ -2777,151 +2774,135 @@ LinesCount AbstractLogView::getNbBottomWrappedVisibleLines() const
         return textWidth( pixmapFontMetrics_, s );
     };
 
-    // Count from bottom: how many unwrapped lines fit when viewport is filled with wrapped lines
+    // Count from bottom: how many unwrapped lines the bottom frame holds when
+    // the viewport is filled with wrapped lines. The frame's top line is
+    // counted even when it only partially fits, so the frame stays filled.
     while ( wrappedLinesCount < visibleLines ) {
         QString expandedLine = logData_->getExpandedLineString( unwrappedLineNumber );
         WrappedString wrapped{ expandedLine, availableWidth, twFn };
         const auto thisLineWrappedCount = LinesCount(
             type_safe::narrow_cast<LinesCount::UnderlyingType>( wrapped.wrappedLinesCount() ) );
-        
-        // Check if adding this line would overshoot the viewport
+
         if ( wrappedLinesCount + thisLineWrappedCount > visibleLines ) {
-            // Line causes overshoot - still count it as the last visible line
-            // (it will be partially visible at the bottom)
-            unwrappedLinesCount++;
-            wrappedLinesCount += thisLineWrappedCount;
+            // The frame's top line does not fully fit: the wrapped document is
+            // taller than the viewport even if every logical line ended up
+            // inside the frame count.
+            frameLines++;
+            contentOverflows = true;
             break;
         }
-        
+
         wrappedLinesCount += thisLineWrappedCount;
-        unwrappedLinesCount++;
+        frameLines++;
 
         if ( unwrappedLineNumber.get() == 0 ) {
-            break;
+            // Every logical line fully inside the frame: content fits.
+            return { frameLines, false };
         }
         unwrappedLineNumber--;
     }
 
-    LOG_DEBUG << "[TextWrap:Calc] getNbBottomWrappedVisibleLines:"
+    // Stopped before reaching the first line: lines above the frame remain.
+    contentOverflows = true;
+
+    LOG_DEBUG << "[TextWrap:Calc] getWrappedBottomFrame:"
               << " totalLines=" << totalLines.get()
               << " visibleLines=" << visibleLines.get()
               << " visibleColumns=" << visibleColumns.get()
-              << " unwrappedCount=" << unwrappedLinesCount.get()
-              << " wrappedCount=" << wrappedLinesCount.get();
-    
-    // Ensure we return at least 1 if there are lines to show
-    if ( unwrappedLinesCount.get() == 0 && totalLines.get() > 0 ) {
-        return LinesCount{ 1 };
-    }
-    
-    return unwrappedLinesCount;
+              << " frameLines=" << frameLines.get()
+              << " contentOverflows=" << contentOverflows;
+
+    return { frameLines, contentOverflows };
 }
 
 void AbstractLogView::updateScrollBars()
 {
     const LinesCount visibleLines = getNbVisibleLines();
     const auto totalLines = logData_->getNbLine();
-    
+
     // Store scrollbar visibility before any calculations to detect changes
     const bool scrollBarWasVisible = verticalScrollBar()->isVisible();
-    
+
     // Track if scrollbar visibility changed during calculation
     // This is needed because visibility can change multiple times (e.g., visible -> hidden -> visible)
     // and we need to invalidate cache even if final state matches initial state
     bool scrollBarVisibilityChanged = false;
-    
-    // Pre-calculate scrollMax to determine if scrollbar will be visible after setRange()
-    // This is needed because getNbBottomWrappedVisibleLines() calls getNbVisibleCols()
-    // which depends on scrollbar visibility, creating a circular dependency
-    int scrollMax = 0;
-    if ( totalLines >= visibleLines ) {
-        if ( useTextWrap_ ) {
-            // For text wrap mode, we need column count to calculate unwrapped lines.
-            // However, column count depends on scrollbar visibility, which depends on scrollMax.
-            // To break the circular dependency:
-            // 1. First, estimate scrollMax assuming current scrollbar visibility
-            // 2. Temporarily set range to determine actual scrollbar visibility
-            // 3. Recalculate with correct visibility if it changed
-            
-            // Special case: if leftMarginPx_ hasn't been initialized yet (e.g., during
-            // initialization before drawTextArea() runs), getNbBottomWrappedVisibleLines()
-            // will return visibleLines early. In this case, we can't perform accurate
-            // wrapped line calculation, so we use a simple fallback calculation.
-            if ( leftMarginPx_ == 0 ) {
-                // leftMarginPx_ not initialized - use simple calculation as fallback
-                // This happens during initialization before drawTextArea() sets leftMarginPx_
-                scrollMax = static_cast<int>( std::min(
-                    ( totalLines - visibleLines ).get(),
-                    maxValue<LinesCount>().get() ) );
-                verticalScrollBar()->setRange( 0, scrollMax );
-                // Check if visibility changed after setting range
-                if ( scrollBarWasVisible != verticalScrollBar()->isVisible() ) {
-                    scrollBarVisibilityChanged = true;
-                }
-            }
-            else {
-                // Estimate scrollMax using current scrollbar visibility
-                // If scrollbar is currently visible, assume it will remain visible
-                // If scrollbar is currently hidden, we need to check if it will appear
-                // We'll use an iterative approach: keep recalculating until visibility stabilizes
-                // This handles cases where visibility changes multiple times due to the circular
-                // dependency between scrollbar visibility and column count calculations
-                
-                // First pass: calculate with current scrollbar visibility
-                auto unwrappedLinesAtBottom = getNbBottomWrappedVisibleLines();
-                if ( totalLines > unwrappedLinesAtBottom ) {
-                    scrollMax = static_cast<int>( std::min(
-                        ( totalLines - unwrappedLinesAtBottom ).get(),
-                        maxValue<LinesCount>().get() ) );
-                }
-                
-                // Iteratively recalculate until scrollbar visibility stabilizes
-                // Maximum iterations to prevent infinite loops (should rarely exceed 2-3 iterations)
-                constexpr int maxIterations = 10;
-                bool previousVisibility = scrollBarWasVisible;
-                
-                for ( int iteration = 0; iteration < maxIterations; ++iteration ) {
-                    // Set range to determine actual scrollbar visibility
-                    verticalScrollBar()->setRange( 0, scrollMax );
-                    
-                    // Check if visibility changed
-                    const bool currentVisibility = verticalScrollBar()->isVisible();
-                    if ( currentVisibility == previousVisibility ) {
-                        // Visibility stabilized - we're done
-                        break;
-                    }
-                    
-                    // Visibility changed - invalidate cache and recalculate
-                    scrollBarVisibilityChanged = true;
-                    cachedVisibleColsValid_ = false;
-                    
-                    // Recalculate unwrappedLinesAtBottom with correct scrollbar visibility
-                    // Note: leftMarginPx_ should be initialized by now, so this should work
-                    unwrappedLinesAtBottom = getNbBottomWrappedVisibleLines();
-                    if ( totalLines > unwrappedLinesAtBottom ) {
-                        scrollMax = static_cast<int>( std::min(
-                            ( totalLines - unwrappedLinesAtBottom ).get(),
-                            maxValue<LinesCount>().get() ) );
-                    }
-                    else {
-                        scrollMax = 0;
-                    }
-                    
-                    // Update previous visibility for next iteration
-                    previousVisibility = currentVisibility;
-                    
-                }
-            }
+
+    // Derive the wrap-mode range from the bottom-frame composition: every
+    // logical line above the frame gets one scroll step, plus one extra step
+    // when the whole document fits the frame count but the wrapped content
+    // still overflows (the frame's top line is clipped -- without the extra
+    // step an empty range would leave the clipped rows unreachable).
+    const auto wrapScrollMax = [totalLines]( const WrappedBottomFrame& frame ) {
+        uint64_t scrollMax = 0;
+        if ( totalLines > frame.frameLines ) {
+            scrollMax = ( totalLines - frame.frameLines ).get();
         }
-        else {
-            scrollMax = static_cast<int>( std::min(
-                ( totalLines - visibleLines ).get(),
-                maxValue<LinesCount>().get() ) );
+        else if ( frame.contentOverflows ) {
+            scrollMax = 1;
+        }
+        return static_cast<int>( std::min( scrollMax, maxValue<LinesCount>().get() ) );
+    };
+
+    int scrollMax = 0;
+    if ( useTextWrap_ && leftMarginPx_ > 0 ) {
+        // Wrap mode: the range reflects the WRAPPED document height, not the
+        // logical line count -- a few long lines can overflow the viewport
+        // without ever reaching it in count, so no totalLines >= visibleLines
+        // gate applies here. The iterative loop resolves the circular
+        // dependency between scrollbar visibility and the visible-column count
+        // (a appearing scrollbar shrinks the text area, rewrapping taller).
+        // Maximum iterations to prevent infinite loops (should rarely exceed 2-3).
+        constexpr int maxIterations = 10;
+        bool previousVisibility = scrollBarWasVisible;
+
+        scrollMax = wrapScrollMax( getWrappedBottomFrame() );
+
+        for ( int iteration = 0; iteration < maxIterations; ++iteration ) {
+            // Set range to determine actual scrollbar visibility
             verticalScrollBar()->setRange( 0, scrollMax );
-            // Check if visibility changed after setting range
-            if ( scrollBarWasVisible != verticalScrollBar()->isVisible() ) {
-                scrollBarVisibilityChanged = true;
+
+            // Check if visibility changed
+            const bool currentVisibility = verticalScrollBar()->isVisible();
+            if ( currentVisibility == previousVisibility ) {
+                // Visibility stabilized - we're done
+                break;
             }
+
+            // Visibility changed - invalidate cache and recalculate
+            scrollBarVisibilityChanged = true;
+            cachedVisibleColsValid_ = false;
+
+            // Recalculate the bottom frame with correct scrollbar visibility
+            scrollMax = wrapScrollMax( getWrappedBottomFrame() );
+            previousVisibility = currentVisibility;
+        }
+    }
+    else if ( useTextWrap_ ) {
+        // leftMarginPx_ not initialized - use simple logical calculation as
+        // fallback. This happens during initialization before drawTextArea()
+        // sets leftMarginPx_; the deferred pendingScrollBarUpdate_ path
+        // recomputes the real wrapped range after the first paint. The
+        // subtraction must be done in SIGNED math: LinesCount is uint64_t, so
+        // totalLines < visibleLines would underflow to a huge range.
+        const auto logicalMax
+            = static_cast<int64_t>( totalLines.get() ) - static_cast<int64_t>( visibleLines.get() );
+        scrollMax = static_cast<int>(
+            std::min( static_cast<uint64_t>( std::max<int64_t>( logicalMax, 0 ) ),
+                      maxValue<LinesCount>().get() ) );
+        verticalScrollBar()->setRange( 0, scrollMax );
+        // Check if visibility changed after setting range
+        if ( scrollBarWasVisible != verticalScrollBar()->isVisible() ) {
+            scrollBarVisibilityChanged = true;
+        }
+    }
+    else if ( totalLines >= visibleLines ) {
+        scrollMax = static_cast<int>(
+            std::min( ( totalLines - visibleLines ).get(), maxValue<LinesCount>().get() ) );
+        verticalScrollBar()->setRange( 0, scrollMax );
+        // Check if visibility changed after setting range
+        if ( scrollBarWasVisible != verticalScrollBar()->isVisible() ) {
+            scrollBarVisibilityChanged = true;
         }
     }
     else {

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1972,6 +1972,11 @@ QString AbstractLogView::getSelectedText() const
     return selection_.getSelectedText( logData_ );
 }
 
+QStringList AbstractLogView::getSelectedLinesText() const
+{
+    return selection_.getSelectedLinesText( logData_ );
+}
+
 bool AbstractLogView::isPartialSelection() const
 {
     return selection_.isPortion();

--- a/src/ui/src/colorlabelscontroller.cpp
+++ b/src/ui/src/colorlabelscontroller.cpp
@@ -105,19 +105,19 @@ void ColorLabelsController::addColorLabelToSelection( size_t label,
                                                       const AbstractLogView* sourceView )
 {
     applyToViews( manager_.setColorLabel(
-        label, selectedText( sourceView ),
+        label, selectedTexts( sourceView ),
         HighlighterSetCollection::get().quickHighlighterDefaults() ) );
 }
 
 void ColorLabelsController::addNextColorLabelToSelection( const AbstractLogView* sourceView )
 {
     applyToViews( manager_.setNextColorLabel(
-        selectedText( sourceView ), HighlighterSetCollection::get().quickHighlighterDefaults() ) );
+        selectedTexts( sourceView ), HighlighterSetCollection::get().quickHighlighterDefaults() ) );
 }
 
 void ColorLabelsController::removeColorLabelFromSelection( const AbstractLogView* sourceView )
 {
-    applyToViews( manager_.removeColorLabel( selectedText( sourceView ) ) );
+    applyToViews( manager_.removeColorLabel( selectedTexts( sourceView ) ) );
 }
 
 void ColorLabelsController::clearColorLabels()
@@ -143,14 +143,14 @@ void ColorLabelsController::applyToViews(
     }
 }
 
-QString ColorLabelsController::selectedText( const AbstractLogView* sourceView ) const
+QStringList ColorLabelsController::selectedTexts( const AbstractLogView* sourceView ) const
 {
     if ( sourceView != nullptr ) {
-        return sourceView->getSelectedText();
+        return sourceView->getSelectedLinesText();
     }
     if ( activeViewProvider_ != nullptr ) {
         if ( auto* const view = activeViewProvider_() ) {
-            return view->getSelectedText();
+            return view->getSelectedLinesText();
         }
     }
     return {};

--- a/src/ui/src/colorlabelsmanager.cpp
+++ b/src/ui/src/colorlabelsmanager.cpp
@@ -19,6 +19,8 @@
 
 #include "colorlabelsmanager.h"
 #include "highlighterset.h"
+#include "log.h"
+#include <QSet>
 #include <algorithm>
 #include <vector>
 
@@ -67,11 +69,54 @@ ColorLabelsManager::QuickHighlightersCollection
 ColorLabelsManager::setColorLabel( size_t label, const QString& text,
                                    QuickHighlighterDefaults defaults )
 {
-    return updateColorLabel( label, text, defaults );
+    return setColorLabel( label, QStringList{ text }, defaults );
+}
+
+ColorLabelsManager::QuickHighlightersCollection
+ColorLabelsManager::setColorLabel( size_t label, const QStringList& texts,
+                                   QuickHighlighterDefaults defaults )
+{
+    const auto sanitized = sanitizeBulkTexts( texts );
+    for ( const auto& text : sanitized ) {
+        updateColorLabel( label, text, defaults );
+    }
+
+    return quickHighlighters_;
 }
 
 ColorLabelsManager::QuickHighlightersCollection
 ColorLabelsManager::setNextColorLabel( const QString& text, QuickHighlighterDefaults defaults )
+{
+    return setNextColorLabel( QStringList{ text }, defaults );
+}
+
+ColorLabelsManager::QuickHighlightersCollection
+ColorLabelsManager::setNextColorLabel( const QStringList& texts,
+                                       QuickHighlighterDefaults defaults )
+{
+    const auto sanitized = sanitizeBulkTexts( texts );
+    if ( sanitized.isEmpty() ) {
+        return quickHighlighters_;
+    }
+
+    // Resolve the cycle ONCE for the whole selection (from the cycle position
+    // or the first text's current label), then apply that single label to
+    // every text.
+    const auto nextLabel = nextCycleLabel( sanitized.front() );
+    if ( !nextLabel.has_value() ) {
+        return quickHighlighters_;
+    }
+
+    currentLabel_ = *nextLabel;
+
+    for ( const auto& text : sanitized ) {
+        updateColorLabel( *nextLabel, text, defaults );
+    }
+
+    return quickHighlighters_;
+}
+
+std::optional<size_t> ColorLabelsManager::nextCycleLabel( const QString& referenceText ) const
 {
     const auto& quickHighlightersConfiguration
         = HighlighterSetCollection::get().quickHighlighters();
@@ -86,14 +131,14 @@ ColorLabelsManager::setNextColorLabel( const QString& text, QuickHighlighterDefa
     }
 
     if ( cycle.empty() ) {
-        return quickHighlighters_;
+        return {};
     }
 
     auto nextLabel = cycle.front();
 
     auto currentLabel = currentLabel_;
     if ( !currentLabel ) {
-        currentLabel = currentColorLabelForText( text );
+        currentLabel = currentColorLabelForText( referenceText );
     }
 
     if ( currentLabel.has_value() ) {
@@ -103,23 +148,32 @@ ColorLabelsManager::setNextColorLabel( const QString& text, QuickHighlighterDefa
         }
     }
 
-    currentLabel_ = nextLabel;
-
-    return updateColorLabel( nextLabel, text, defaults );
+    return nextLabel;
 }
 
 ColorLabelsManager::QuickHighlightersCollection
 ColorLabelsManager::removeColorLabel( const QString& text )
 {
-    if ( text.isEmpty() ) {
+    return removeColorLabel( QStringList{ text } );
+}
+
+ColorLabelsManager::QuickHighlightersCollection
+ColorLabelsManager::removeColorLabel( const QStringList& texts )
+{
+    const auto sanitized = sanitizeBulkTexts( texts );
+    if ( sanitized.isEmpty() ) {
         return quickHighlighters_;
     }
 
     for ( auto& quickHighlighter : quickHighlighters_ ) {
         quickHighlighter.erase(
             std::remove_if( quickHighlighter.begin(), quickHighlighter.end(),
-                            [ &text ]( const auto& entry ) {
-                                return quickLabelMatchesText( entry, text );
+                            [ &sanitized ]( const auto& entry ) {
+                                return std::any_of(
+                                    sanitized.cbegin(), sanitized.cend(),
+                                    [ &entry ]( const auto& text ) {
+                                        return quickLabelMatchesText( entry, text );
+                                    } );
                             } ),
             quickHighlighter.end() );
     }
@@ -127,6 +181,32 @@ ColorLabelsManager::removeColorLabel( const QString& text )
     currentLabel_.reset();
 
     return quickHighlighters_;
+}
+
+QStringList ColorLabelsManager::sanitizeBulkTexts( const QStringList& texts )
+{
+    QStringList result;
+    QSet<QString> seen;
+    bool truncated = false;
+
+    for ( const auto& text : texts ) {
+        if ( text.isEmpty() || seen.contains( text ) ) {
+            continue;
+        }
+        if ( static_cast<size_t>( result.size() ) >= MaxBulkLabelTexts ) {
+            truncated = true;
+            break;
+        }
+        seen.insert( text );
+        result.append( text );
+    }
+
+    if ( truncated ) {
+        LOG_WARNING << "Color label selection truncated to " << MaxBulkLabelTexts
+                    << " distinct texts";
+    }
+
+    return result;
 }
 
 std::optional<size_t> ColorLabelsManager::currentColorLabelForText( const QString& text ) const

--- a/src/ui/src/selection.cpp
+++ b/src/ui/src/selection.cpp
@@ -189,6 +189,19 @@ QString Selection::getSelectedText( const AbstractLogData* logData, bool lineNum
     return text;
 }
 
+QStringList Selection::getSelectedLinesText( const AbstractLogData* logData ) const
+{
+    const auto selectionData = getSelectionWithLineNumbers( logData );
+
+    QStringList texts;
+    texts.reserve( static_cast<QStringList::size_type>( selectionData.size() ) );
+    for ( const auto& [ lineNumber, line ] : selectionData ) {
+        texts.append( line );
+    }
+
+    return texts;
+}
+
 std::vector<std::pair<LineNumber, QString>>
 Selection::getSelectionWithLineNumbers( const AbstractLogData* logData ) const
 {

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -589,6 +589,12 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
             crawler->logMainView_ );
     }
 
+    int filteredTextAreaCacheActualHeight() const
+    {
+        return AbstractLogView::access_by<AbstractLogViewPrivate>::textAreaCacheActualHeight(
+            crawler->filteredView_ );
+    }
+
     qreal mainTextAreaCachePixmapDevicePixelRatio() const
     {
         return AbstractLogView::access_by<
@@ -702,6 +708,26 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
 
             const auto charHeight = filteredCharHeight();
             if ( charHeight > 0 && filteredTextViewportHeight() > charHeight * minimumRows ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Converge the views to a size where the main viewport shows exactly
+    // `rowFloor` FULL text rows (so getNbVisibleLines() == rowFloor + 1).
+    // Font metrics vary per platform, so sweep instead of hardcoding a height.
+    bool resizeViewsToMainTextRowFloor( int width, int rowFloor )
+    {
+        for ( int height = 80; height <= 720; height += 4 ) {
+            crawler->logMainView_->setFixedSize( width, height );
+            crawler->filteredView_->setFixedSize( width, height );
+            QTest::qWait( 10 );
+            render();
+
+            const auto charHeight = mainCharHeight();
+            if ( charHeight > 0 && mainTextViewportHeight() / charHeight == rowFloor ) {
                 return true;
             }
         }
@@ -2006,7 +2032,7 @@ SCENARIO( "Filtered view keeps sparse results top-aligned when follow mode is en
     REQUIRE( crawlerVisitor.filteredDrawingTopOffset() == 0 );
 }
 
-SCENARIO( "Wrapped single-line content keeps EOF anchored when scrollbar range is empty",
+SCENARIO( "Wrapped single-line overflow keeps EOF anchored with a scrollable range",
           "[ui][scrollbar][regression]" )
 {
     QTemporaryFile file{ "crawler_wrapped_single_line_XXXXXX" };
@@ -2023,17 +2049,33 @@ SCENARIO( "Wrapped single-line content keeps EOF anchored when scrollbar range i
 
     REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == 1; } ) );
     REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+    QTest::qWait( 200 );
 
     crawlerVisitor.setTextWrap( true );
     crawlerVisitor.resizeViews( 220, 100 );
     crawlerVisitor.enableFollowMode( true );
     crawlerVisitor.render();
+    // Flush the deferred updateScrollBars (queued from the first paint once
+    // leftMarginPx_ exists) so the wrapped range is settled deterministically.
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
 
-    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() == 0 );
+    // The range must now OPEN for a single over-tall wrapped line (previously
+    // pinned at 0, which made either the head or the tail unreachable):
+    // follow mode keeps EOF anchored at the bottom...
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
     REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
     REQUIRE( crawlerVisitor.mainTextAreaCacheActualHeight()
              > crawlerVisitor.mainTextViewportHeight() );
     REQUIRE( crawlerVisitor.mainDrawingTopOffset() < 0 );
+
+    // ...and with follow released, scrolling to the top reveals the head.
+    crawlerVisitor.enableFollowMode( false );
+    crawlerVisitor.mainView()->verticalScrollBar()->setValue( 0 );
+    QTest::qWait( 50 );
+    crawlerVisitor.render();
+    REQUIRE_FALSE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset() == 0 );
 }
 
 SCENARIO( "Wrapped line paints every visual row of its slot (no trailing blank band)",
@@ -2148,6 +2190,159 @@ SCENARIO( "Wrap-mode line map rebuild stays bounded to the viewport",
                      << " charHeight=" << crawlerVisitor.mainCharHeight() );
     REQUIRE( mapSize > 0 );
     REQUIRE( mapSize < 500 );
+}
+
+SCENARIO( "Wrap mode scrolls when few logical lines overflow the viewport",
+          "[ui][textwrap][scrollbar][regression]" )
+{
+    // Regression: updateScrollBars gated the whole vertical range on LOGICAL
+    // line count >= viewport rows. With fewer logical lines than rows (the
+    // filtered-window report: a handful of long matches), enabling wrap left
+    // the range at (0,0): wrapped rows spilled past the viewport bottom with
+    // no way to scroll to them. The main view shared the same gate.
+    QTemporaryFile file{ "crawler_wrap_few_lines_XXXXXX" };
+    REQUIRE( file.open() );
+    for ( int i = 0; i < 4; ++i ) {
+        file.write( QStringLiteral( "wrap overflow line %1 %2\n" )
+                        .arg( i )
+                        .arg( QString( 800, QLatin1Char( 'x' ) ) )
+                        .toUtf8() );
+    }
+    file.flush();
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == 4; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    // Search first so the (possibly recreated) filtered view gets wrap applied.
+    crawlerVisitor.setSearchPattern( "wrap overflow line" );
+    crawlerVisitor.runSearch();
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 4; } ) );
+
+    crawlerVisitor.setTextWrap( true );
+    crawlerVisitor.resizeViews( 320, 400 );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    // Sanity: the viewport really is taller than 4 logical rows, and wrapping
+    // really overflows it (preconditions of the reported defect).
+    REQUIRE( crawlerVisitor.mainTextViewportHeight() > 4 * crawlerVisitor.mainCharHeight() );
+    REQUIRE( crawlerVisitor.mainTextAreaCacheActualHeight()
+             > crawlerVisitor.mainTextViewportHeight() );
+    REQUIRE( crawlerVisitor.filteredTextAreaCacheActualHeight()
+             > crawlerVisitor.filteredTextViewportHeight() );
+
+    THEN( "the main view offers a scrollable range and its tail is reachable" )
+    {
+        REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+
+        crawlerVisitor.scrollMainVerticallyToBottom();
+        crawlerVisitor.render();
+
+        REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+        REQUIRE( crawlerVisitor.mainDrawingTopOffset() < 0 );
+    }
+
+    THEN( "the filtered view offers a scrollable range and its tail is reachable" )
+    {
+        REQUIRE( crawlerVisitor.filteredVerticalScrollMaximum() > 0 );
+
+        crawlerVisitor.scrollFilteredVerticallyToBottom();
+        crawlerVisitor.render();
+
+        REQUIRE( crawlerVisitor.filteredShouldBottomAlign() );
+        REQUIRE( crawlerVisitor.filteredDrawingTopOffset() < 0 );
+    }
+}
+
+SCENARIO( "Wrap mode keeps an empty scroll range when content fits",
+          "[ui][textwrap][scrollbar]" )
+{
+    // Companion guard to the overflow regression: a few SHORT lines in a tall
+    // viewport genuinely fit when wrapped -- the range must stay (0,0) and the
+    // frame top-anchored with nothing clipped.
+    QTemporaryFile file{ "crawler_wrap_fits_XXXXXX" };
+    REQUIRE( file.open() );
+    for ( int i = 0; i < 4; ++i ) {
+        file.write( QStringLiteral( "short line %1\n" ).arg( i ).toUtf8() );
+    }
+    file.flush();
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == 4; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( true );
+    crawlerVisitor.resizeViews( 320, 400 );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    REQUIRE( crawlerVisitor.mainTextViewportHeight() > 4 * crawlerVisitor.mainCharHeight() );
+    REQUIRE( crawlerVisitor.mainTextAreaCacheActualHeight()
+             <= crawlerVisitor.mainTextViewportHeight() );
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() == 0 );
+    REQUIRE( crawlerVisitor.mainDrawingTopOffset() == 0 );
+}
+
+SCENARIO( "Wrap mode range opens when the bottom frame overflows by a partial line",
+          "[ui][textwrap][scrollbar][regression]" )
+{
+    // Regression for the equality-with-overshoot hole: 11 logical lines where
+    // line 0 wraps to 2 rows and lines 1..10 to 1 row each (12 wrapped rows).
+    // With an 11-row viewport the old bottom-up count included line 0 as
+    // (partially) visible, so count == totalLines kept the range at (0,0)
+    // even though one wrapped row could never be shown. The range must open
+    // so every line becomes fully reachable.
+    QTemporaryFile file{ "crawler_wrap_partial_overshoot_XXXXXX" };
+    REQUIRE( file.open() );
+    file.write( QStringLiteral( "line zero wraps to two rows xxxxxxxxxxxxxxxxxxxxxxxxxxxx\n" )
+                    .toUtf8() );
+    for ( int i = 1; i <= 10; ++i ) {
+        file.write( QStringLiteral( "short %1\n" ).arg( i ).toUtf8() );
+    }
+    file.flush();
+
+    Session session;
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == 11; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.setTextWrap( true );
+
+    // Size the viewport to exactly 11 text rows (font metrics vary per
+    // platform, so converge adaptively instead of hardcoding a height).
+    REQUIRE( crawlerVisitor.resizeViewsToMainTextRowFloor( 320, 10 ) );
+    crawlerVisitor.render();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    crawlerVisitor.render();
+
+    // 11 logical lines == 11 viewport rows: the old gate let this through and
+    // the partial-line count then produced an empty range.
+    REQUIRE( crawlerVisitor.mainVerticalScrollMaximum() > 0 );
+
+    crawlerVisitor.scrollMainVerticallyToBottom();
+    crawlerVisitor.render();
+
+    // Bottom frame: line 0's head is clipped (reachable from the top frame),
+    // every other line fully visible.
+    REQUIRE( crawlerVisitor.mainShouldBottomAlign() );
+    REQUIRE( crawlerVisitor.mainTopLine().get() == 1 );
 }
 
 SCENARIO( "Log view reserves space for transient horizontal scrollbars",

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -523,6 +523,17 @@ struct CrawlerWidget::access_by<CrawlerWidgetPrivate> {
         QTest::qWait( 20 );
     }
 
+    void pressFilteredViewKey( Qt::Key key, Qt::KeyboardModifiers modifiers )
+    {
+        QTest::keyClick( crawler->filteredView_->viewport(), key, modifiers );
+        QTest::qWait( 20 );
+    }
+
+    QString filteredLineText( LineNumber::UnderlyingType lineIndex ) const
+    {
+        return crawler->logFilteredData_->getLineString( LineNumber( lineIndex ) );
+    }
+
     void pressMainViewConfiguredShortcut( const std::string& action )
     {
         pressConfiguredShortcut( crawler->logMainView_->viewport(), action );
@@ -2802,5 +2813,63 @@ SCENARIO( "Crawler widget color labels apply to the selection in all views",
             REQUIRE_FALSE( crawlerVisitor.mainViewHasLabelledText( 0, selectedText ) );
             REQUIRE_FALSE( crawlerVisitor.filteredViewHasLabelledText( 0, selectedText ) );
         }
+    }
+}
+
+SCENARIO( "Crawler widget color labels apply to every line of a multi-line selection",
+          "[ui][colorlabels][regression]" )
+{
+    // Regression: with several whole lines selected, M marks them all, but a
+    // digit key stored the whole LF-joined selection as ONE quick-label entry
+    // whose pattern can never match a single log line (highlighters match per
+    // line) -- nothing was highlighted, and Key_0 could not remove the stale
+    // entry either. Each selected line must become its own label entry, the
+    // same per-line semantics marking already has.
+    QTemporaryFile file{ "crawler_colorlabels_multiline_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    Session session;
+    session.savedSearches().clear();
+
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+    QTest::qWait( 200 );
+
+    crawlerVisitor.focusFilteredView();
+    crawlerVisitor.clickFilteredViewLine( 10 );
+    crawlerVisitor.pressFilteredViewKey( Qt::Key_Down, Qt::ShiftModifier );
+    crawlerVisitor.pressFilteredViewKey( Qt::Key_Down, Qt::ShiftModifier );
+
+    const auto selectedText = crawlerVisitor.filteredViewSelectedText();
+    INFO( "selection must span three lines: " << selectedText.toStdString() );
+    REQUIRE( selectedText.count( QChar::LineFeed ) == 2 );
+
+    const QString line10 = crawlerVisitor.filteredLineText( 10 );
+    const QString line11 = crawlerVisitor.filteredLineText( 11 );
+    const QString line12 = crawlerVisitor.filteredLineText( 12 );
+
+    THEN( "the digit shortcut labels and unlabels every selected line in both views" )
+    {
+        crawlerVisitor.pressFilteredViewKey( Qt::Key_1 );
+
+        REQUIRE( crawlerVisitor.filteredViewHasLabelledText( 0, line10 ) );
+        REQUIRE( crawlerVisitor.filteredViewHasLabelledText( 0, line11 ) );
+        REQUIRE( crawlerVisitor.filteredViewHasLabelledText( 0, line12 ) );
+        REQUIRE( crawlerVisitor.mainViewHasLabelledText( 0, line10 ) );
+        REQUIRE( crawlerVisitor.mainViewHasLabelledText( 0, line11 ) );
+        REQUIRE( crawlerVisitor.mainViewHasLabelledText( 0, line12 ) );
+
+        crawlerVisitor.pressFilteredViewKey( Qt::Key_0 );
+
+        REQUIRE_FALSE( crawlerVisitor.filteredViewHasLabelledText( 0, line10 ) );
+        REQUIRE_FALSE( crawlerVisitor.filteredViewHasLabelledText( 0, line11 ) );
+        REQUIRE_FALSE( crawlerVisitor.filteredViewHasLabelledText( 0, line12 ) );
+        REQUIRE_FALSE( crawlerVisitor.mainViewHasLabelledText( 0, line10 ) );
+        REQUIRE_FALSE( crawlerVisitor.mainViewHasLabelledText( 0, line11 ) );
+        REQUIRE_FALSE( crawlerVisitor.mainViewHasLabelledText( 0, line12 ) );
     }
 }

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -224,6 +224,11 @@ struct AbstractLogView::access_by<FolderViewTestAccess> {
     {
         view->copyWithLineNumbers();
     }
+
+    static klogg::vector<LineNumber> selectedLines( const AbstractLogView* view )
+    {
+        return view->selection_.getLines();
+    }
 };
 
 TEST_CASE( "FolderCrawlerWidget plain click on a result row repaints the selection highlight",
@@ -3000,4 +3005,89 @@ TEST_CASE( "FolderCrawlerWidget color labels apply to the selection in every vie
         REQUIRE_FALSE( hasAnyLabelledText( mainView ) );
         REQUIRE_FALSE( hasAnyLabelledText( filteredView ) );
     }
+}
+
+TEST_CASE( "FolderCrawlerWidget color labels apply per line to multi-row selections",
+           "[folder][colorlabels][regression]" )
+{
+    // Regression (single-file parity): with several result rows selected, a
+    // digit key stored the whole LF-joined selection as ONE quick-label entry
+    // that can never match a single log line -- nothing was highlighted and
+    // Key_0 could not remove the stale entry. Each selected row must become
+    // its own entry. The folder twist: group-header rows are not copyable and
+    // must never produce an entry.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log",
+                                 QByteArray( "line0\nERROR alpha\nline2\nERROR beta\nline4\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    QTest::qWait( 200 );
+
+    auto* const mainView = widget.mainView();
+    auto* const filteredView = widget.filteredView();
+    REQUIRE( mainView != nullptr );
+    REQUIRE( filteredView != nullptr );
+
+    // Results rows: 0 = group header (a.log), 1 = "ERROR alpha", 2 = "ERROR beta".
+    // Anchor at row 2 and extend upwards so the range spans the header row.
+    filteredView->selectAndDisplayLine( 2_lnum );
+    QTest::qWait( 50 );
+    filteredView->viewport()->setFocus();
+    QTest::qWait( 20 );
+    QTest::keyClick( filteredView->viewport(), Qt::Key_Up, Qt::ShiftModifier );
+    QTest::qWait( 20 );
+    QTest::keyClick( filteredView->viewport(), Qt::Key_Up, Qt::ShiftModifier );
+    QTest::qWait( 20 );
+
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+
+    // The range covers all three rows (header included)...
+    const auto selectedRows = Access::selectedLines( filteredView );
+    INFO( "selection must cover rows 0..2, got " << selectedRows.size() << " rows" );
+    REQUIRE( selectedRows.size() == 3 );
+    REQUIRE( selectedRows.front() == 0_lnum );
+
+    // ...but the selection TEXT holds only the two copyable data rows.
+    const auto selectedText = filteredView->getSelectedText();
+    INFO( "selection text: " << selectedText.toStdString() );
+    REQUIRE( selectedText.count( QChar::LineFeed ) == 1 );
+    const auto labelEntries = []( const AbstractLogView* view, size_t label ) {
+        const auto& labels = Access::quickHighlighters( view );
+        return label < labels.size() ? labels[ label ] : AbstractLogView::QuickHighlighters{};
+    };
+
+    QTest::keyClick( filteredView->viewport(), Qt::Key_1 );
+    QTest::qWait( 20 );
+
+    const auto containsText = []( const auto& entries, const QString& text ) {
+        return std::any_of( entries.cbegin(), entries.cend(),
+                            [ & ]( const QuickLabelEntry& e ) { return e.text == text; } );
+    };
+
+    // Exactly the two data rows get entries -- in every view of the tab.
+    // The header row is not copyable, and no entry may be a multi-line blob.
+    const auto filteredEntries = labelEntries( filteredView, 0 );
+    REQUIRE( filteredEntries.size() == 2 );
+    CHECK( containsText( filteredEntries, QStringLiteral( "ERROR alpha" ) ) );
+    CHECK( containsText( filteredEntries, QStringLiteral( "ERROR beta" ) ) );
+    CHECK( std::none_of( filteredEntries.cbegin(), filteredEntries.cend(),
+                         []( const QuickLabelEntry& e ) { return e.text.contains( QChar::LineFeed ); } ) );
+
+    const auto mainEntries = labelEntries( mainView, 0 );
+    REQUIRE( mainEntries.size() == 2 );
+    CHECK( containsText( mainEntries, QStringLiteral( "ERROR alpha" ) ) );
+    CHECK( containsText( mainEntries, QStringLiteral( "ERROR beta" ) ) );
+
+    // Key_0 removes every selected line's entry again.
+    QTest::keyClick( filteredView->viewport(), Qt::Key_0 );
+    QTest::qWait( 20 );
+    CHECK( labelEntries( filteredView, 0 ).isEmpty() );
+    CHECK( labelEntries( mainView, 0 ).isEmpty() );
 }

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -34,6 +34,7 @@
 #include <QFile>
 #include <QLineEdit>
 #include <QMenu>
+#include <QScrollBar>
 #include <QShortcut>
 #include <QSignalSpy>
 #include <QSpinBox>
@@ -3090,4 +3091,54 @@ TEST_CASE( "FolderCrawlerWidget color labels apply per line to multi-row selecti
     QTest::qWait( 20 );
     CHECK( labelEntries( filteredView, 0 ).isEmpty() );
     CHECK( labelEntries( mainView, 0 ).isEmpty() );
+}
+
+
+TEST_CASE( "FolderCrawlerWidget results view scrolls wrapped overflow beyond the viewport",
+           "[folder][textwrap][scrollbar][regression]" )
+{
+    // Regression (single-file parity): the results pane shares
+    // AbstractLogView::updateScrollBars, whose logical-count gate left the
+    // range at (0,0) when few result rows wrapped past the viewport bottom,
+    // making the tail rows unreachable. Few long matches in a small pane must
+    // open a scrollable range.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    QByteArray payload;
+    for ( int i = 0; i < 3; ++i ) {
+        payload.append( QByteArrayLiteral( "ERROR folder wrap line " )
+                        + QByteArray::number( i ) + " " + QByteArray( 800, 'x' ) + "\n" );
+    }
+    const QString a = writeFile( dir, "a.log", payload );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    QTest::qWait( 200 );
+
+    auto* const filteredView = widget.filteredView();
+    REQUIRE( filteredView != nullptr );
+
+    // Rows: 1 group header + 3 data rows. Pin the pane geometry so it is
+    // taller than the 4 logical rows (the gate condition) while each data row
+    // wraps to many visual rows (the overflow condition).
+    filteredView->setFixedSize( 360, 400 );
+    filteredView->textWrapSet( true );
+    QTest::qWait( 50 );
+    widget.grab();
+    QCoreApplication::sendPostedEvents( nullptr, QEvent::MetaCall );
+    widget.grab();
+
+    REQUIRE( filteredView->verticalScrollBar()->maximum() > 0 );
+
+    // The tail of the last row is reachable at the bottom of the range.
+    filteredView->verticalScrollBar()->setValue( filteredView->verticalScrollBar()->maximum() );
+    QTest::qWait( 50 );
+    widget.grab();
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+    REQUIRE( Access::drawingTopOffset( filteredView ) < 0 );
 }

--- a/tests/unit/colorlabelsmanager_test.cpp
+++ b/tests/unit/colorlabelsmanager_test.cpp
@@ -81,6 +81,155 @@ SCENARIO( "color labels keep their stored match options", "[colorlabels]" )
     }
 }
 
+SCENARIO( "color labels apply to several texts at once", "[colorlabels]" )
+{
+    ColorLabelsManager colorLabelsManager;
+
+    WHEN( "several texts are labelled in one action" )
+    {
+        auto labels = colorLabelsManager.setColorLabel(
+            0, QStringList{ QStringLiteral( "alpha" ), QStringLiteral( "beta" ) },
+            { false, true } );
+
+        THEN( "each text gets its own entry with the given options" )
+        {
+            REQUIRE( labels[ 0 ].size() == 2 );
+            CHECK( labels[ 0 ].at( 0 ).text == QStringLiteral( "alpha" ) );
+            CHECK( labels[ 0 ].at( 1 ).text == QStringLiteral( "beta" ) );
+            CHECK( labels[ 0 ].at( 0 ).wholeWord );
+            CHECK( labels[ 0 ].at( 1 ).wholeWord );
+        }
+    }
+
+    WHEN( "the bulk input contains duplicates and empty texts" )
+    {
+        auto labels = colorLabelsManager.setColorLabel(
+            0,
+            QStringList{ QStringLiteral( "alpha" ), QStringLiteral( "alpha" ), QString(),
+                         QStringLiteral( "beta" ), QStringLiteral( "alpha" ) },
+            { false, false } );
+
+        THEN( "duplicates collapse and empty texts are skipped" )
+        {
+            REQUIRE( labels[ 0 ].size() == 2 );
+            CHECK( labels[ 0 ].at( 0 ).text == QStringLiteral( "alpha" ) );
+            CHECK( labels[ 0 ].at( 1 ).text == QStringLiteral( "beta" ) );
+        }
+    }
+
+    WHEN( "one of several labelled texts is moved to another label" )
+    {
+        colorLabelsManager.setColorLabel(
+            0, QStringList{ QStringLiteral( "alpha" ), QStringLiteral( "beta" ) },
+            { false, true } );
+        auto labels
+            = colorLabelsManager.setColorLabel( 1, QStringList{ QStringLiteral( "alpha" ) },
+                                                { true, false } );
+
+        THEN( "only that text moves, keeping its stored options" )
+        {
+            REQUIRE( labels[ 0 ].size() == 1 );
+            CHECK( labels[ 0 ].front().text == QStringLiteral( "beta" ) );
+            REQUIRE( labels[ 1 ].size() == 1 );
+            CHECK( labels[ 1 ].front().text == QStringLiteral( "alpha" ) );
+            CHECK_FALSE( labels[ 1 ].front().ignoreCase );
+            CHECK( labels[ 1 ].front().wholeWord );
+        }
+    }
+
+    WHEN( "removing by several texts at once" )
+    {
+        colorLabelsManager.setColorLabel(
+            0, QStringList{ QStringLiteral( "alpha" ), QStringLiteral( "beta" ) },
+            { false, false } );
+        colorLabelsManager.setColorLabel( 1, QStringList{ QStringLiteral( "gamma" ) },
+                                          { false, false } );
+
+        auto labels = colorLabelsManager.removeColorLabel(
+            QStringList{ QStringLiteral( "alpha" ), QStringLiteral( "gamma" ) } );
+
+        THEN( "every matching entry is removed from all labels" )
+        {
+            REQUIRE( labels[ 0 ].size() == 1 );
+            CHECK( labels[ 0 ].front().text == QStringLiteral( "beta" ) );
+            CHECK( labels[ 1 ].isEmpty() );
+        }
+    }
+
+    WHEN( "a bulk selection exceeds the entry cap" )
+    {
+        QStringList many;
+        for ( int i = 0; i < static_cast<int>( ColorLabelsManager::MaxBulkLabelTexts ) + 10;
+              ++i ) {
+            many.append( QStringLiteral( "line %1" ).arg( i ) );
+        }
+
+        auto labels = colorLabelsManager.setColorLabel( 0, many, { false, false } );
+
+        THEN( "entries are truncated to the cap" )
+        {
+            CHECK( labels[ 0 ].size()
+                   == static_cast<int>( ColorLabelsManager::MaxBulkLabelTexts ) );
+        }
+    }
+}
+
+SCENARIO( "next color label applies one label to the whole selection", "[colorlabels]" )
+{
+    // The cycle is read from HighlighterSetCollection: initialize the
+    // persistable and seed a deterministic 3-label cycle IN MEMORY ONLY (no
+    // save), restoring the previous configuration on exit.
+    auto& highlighterCollection = HighlighterSetCollection::getSynced();
+    struct QuickHighlightersGuard {
+        ~QuickHighlightersGuard()
+        {
+            HighlighterSetCollection::get().setQuickHighlighters( saved );
+        }
+        QList<QuickHighlighter> saved;
+    } guard{ highlighterCollection.quickHighlighters() };
+
+    QList<QuickHighlighter> cycleConfig;
+    for ( int i = 0; i < 3; ++i ) {
+        cycleConfig.append(
+            QuickHighlighter{ QStringLiteral( "ql%1" ).arg( i ), HighlightColor{}, true } );
+    }
+    highlighterCollection.setQuickHighlighters( cycleConfig );
+
+    ColorLabelsManager colorLabelsManager;
+
+    WHEN( "cycling with several texts" )
+    {
+        const QStringList texts{ QStringLiteral( "alpha" ), QStringLiteral( "beta" ) };
+        auto labels = colorLabelsManager.setNextColorLabel( texts, { false, false } );
+
+        THEN( "all texts land under the first cycle label" )
+        {
+            REQUIRE( labels[ 0 ].size() == 2 );
+            CHECK( labels[ 1 ].isEmpty() );
+            CHECK( labels[ 2 ].isEmpty() );
+        }
+
+        AND_THEN( "cycling again moves the whole selection together by one step" )
+        {
+            labels = colorLabelsManager.setNextColorLabel( texts, { false, false } );
+
+            CHECK( labels[ 0 ].isEmpty() );
+            REQUIRE( labels[ 1 ].size() == 2 );
+            CHECK( labels[ 2 ].isEmpty() );
+
+            AND_THEN( "the cycle wraps around for the whole selection" )
+            {
+                labels = colorLabelsManager.setNextColorLabel( texts, { false, false } );
+                labels = colorLabelsManager.setNextColorLabel( texts, { false, false } );
+
+                REQUIRE( labels[ 0 ].size() == 2 );
+                CHECK( labels[ 1 ].isEmpty() );
+                CHECK( labels[ 2 ].isEmpty() );
+            }
+        }
+    }
+}
+
 SCENARIO( "quick color label defaults persist in highlighter settings", "[colorlabels]" )
 {
     QTemporaryDir temporaryDir;

--- a/tests/unit/quicklabelpattern_test.cpp
+++ b/tests/unit/quicklabelpattern_test.cpp
@@ -42,3 +42,16 @@ TEST_CASE( "Whole-word quick label still matches plain word tokens",
     CHECK( hasMatch( plainWord, QStringLiteral( "warn disk pressure high" ) ) );
     CHECK_FALSE( hasMatch( plainWord, QStringLiteral( "prewarning from daemon" ) ) );
 }
+
+TEST_CASE( "A quick label entry never matches across line boundaries",
+           "[colorlabels][quicklabel]" )
+{
+    // Highlighters match one log line at a time, so an entry whose text
+    // contains a line feed can never match anything. This pins why multi-line
+    // selections must be split into per-line entries by the controller/manager
+    // (storing the LF-joined blob was the multi-line color-label defect).
+    const QuickLabelEntry multiLineBlob{ QStringLiteral( "line a\nline b" ), false, false };
+    CHECK_FALSE( hasMatch( multiLineBlob, QStringLiteral( "line a" ) ) );
+    CHECK_FALSE( hasMatch( multiLineBlob, QStringLiteral( "line b" ) ) );
+    CHECK_FALSE( hasMatch( multiLineBlob, QStringLiteral( "x line a" ) ) );
+}


### PR DESCRIPTION
## Summary
- **Color labels now work on multi-line selections**: selecting several lines and pressing a digit key (1-9) labels every selected line, mirroring what M already did for marks; Key 0 removes them again. Root cause: the LF-joined selection blob was stored as one label entry whose regex could never match a single log line. Fixed by splitting per line at the Selection layer and adding bulk QStringList overloads to ColorLabelsManager (dedup, empty-skip, 1000-entry paint-cost cap, cycle resolves once per action; single-QString overloads delegate).
- **Wrap mode no longer strands tail lines below the viewport**: with few long lines (e.g. a filtered window whose matches fit without a scrollbar), enabling wrap used to leave the range at (0,0) so overflowed rows were unreachable. Root cause: updateScrollBars gated the range on logical line count, ignoring wrapped visual height; the bottom-up count could also yield scrollMax 0 with content still overflowing by a partial line. Fixed by deriving the range from the bottom-frame composition (frame lines + overflow flag) with no logical-count gate.
- Both fixes live in shared layers (ColorLabelsController, AbstractLogView), so single-file, folder, and live-stream tabs are all covered; folder group-header rows can never become label entries. Non-wrap behavior is unchanged.

## Background
- Introduced by: labels -- the text-based quick-label mechanism (joined selection text as one entry); scroll -- the logical-count gate in AbstractLogView::updateScrollBars.
- Use case: (1) multi-line selection + digit key to color-label; (2) wrap mode with fewer logical lines than viewport rows.
- How to reproduce: (1) select 3 lines, press 1: nothing highlights; (2) filter to a few long lines, enable wrap: tail lines pushed below the window bottom, no scrolling possible.
- Root cause: (1) per-line regex matching can never match an entry containing a line feed; (2) range forced to (0,0) when totalLines < visibleLines regardless of wrapped overflow, plus the equality-with-overshoot hole.
- How to fix: per-line selection texts end-to-end (Selection -> View -> Manager -> Controller); wrap range = totalLines - bottomFrameLines (+1 when content overflows with all lines counted), signed-clamped pre-paint fallback.

## Tests
- New: bulk manager unit tests (add/move/remove/dedup/cap/cycle-once), quicklabelpattern characterization, UI regressions in crawlerwidget_test (3-line range label/unlabel in both views; main+filtered wrap overflow with tail reachability; fits-guard; partial-overshoot hole) and foldercrawler_test (range spanning a non-copyable group header; wrapped folder results pane).
- Updated: the wrapped-single-line scenario now pins the new contract (range opens, EOF anchoring preserved).
- Ran: full klogg_tests (unit), klogg_itests (134 cases, 3198 assertions), vectorscan tests, smoke test, scripts/lint_platform_fragile.py -- all green. The label commit boundary was additionally built and tested standalone.
- Adversarial multi-agent review of the diff: 0 confirmed findings (2 minor design points reviewed and accepted: empty next-label no longer consumes a cycle step; bulk cap is documented + visible via paint state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color labels can now be applied to, cycled across, or removed from multiple selected lines individually.
  * Multi-line selections are handled as separate line entries, while ignoring non-copyable rows.
* **Bug Fixes**
  * Improved wrapped-text scrolling, bottom alignment, and scrollbar behavior when content partially overflows.
  * Prevented quick-label matches from spanning line boundaries.
* **Tests**
  * Added regression coverage for multi-line labeling and wrapped-text scrolling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->