### PR TITLE
Flip empty-filter default to upstream-parity false (fixes #46)

### DIFF
--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -809,7 +809,9 @@ class Configuration final : public Persistable<Configuration> {
 
     bool allowFollowOnScroll_ = true;
     bool autoRunSearchOnPatternChange_ = false;
-    bool showAllInFilteredViewWhenSearchEmpty_ = true;
+    // Upstream parity (issue #46): an empty filter leaves only marked lines
+    // unless the user opts into the unfiltered mirror mode.
+    bool showAllInFilteredViewWhenSearchEmpty_ = false;
 
     bool optimizeForNotLatinEncodings_ = false;
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/colorlabelsmanager.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/colorlabelscontroller.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crawlershortcuts.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/emptyfilterpolicy.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/viewsignalwiring.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/newversiondialog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighteredit.ui

--- a/src/ui/include/emptyfilterpolicy.h
+++ b/src/ui/include/emptyfilterpolicy.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_EMPTYFILTERPOLICY_H
+#define KLOGG_EMPTYFILTERPOLICY_H
+
+namespace klogg {
+
+// What a filtered/results pane should display while the search filter is
+// empty.  The choice is per pane KIND, and the split is deliberate:
+//
+//  - Single-document lens views (CrawlerWidget: file tabs AND live-source
+//    tabs -- adb logcat / iOS streams share the same widget and a plain
+//    LogFilteredData) honor the user's showAllInFilteredViewWhenSearchEmpty
+//    preference.  MirrorAllLines turns the filtered window into an
+//    unfiltered mirror of the document without launching a search scan;
+//    ClearResults leaves only marked lines (upstream behavior, issue #46).
+//
+//  - Cross-file grep results panes (FolderCrawlerWidget) always use
+//    ClearResults: "every line of every file" is not a meaningful result
+//    set, so an empty search there just clears the pane.
+//
+// Layering: the DECISION lives in the UI layer (it owns the search-text
+// state); the MECHANISM lives in the data layer
+// (LogFilteredData::setAllLinesVisible).  LogFilteredData resets the
+// mechanism on every clearSearch/runSearch/updateSearch, so the widget
+// re-asserts the resolved policy on each search/load/config transition.
+enum class EmptyFilterPolicy {
+    ClearResults,
+    MirrorAllLines,
+};
+
+// Resolves the empty-filter policy for a single-document lens view from the
+// current search text and the user preference.  Pure function with exactly
+// one definition so CrawlerWidget's search/load/config code paths cannot
+// silently diverge (and so the rule is unit-testable without a widget).
+inline EmptyFilterPolicy emptyLensFilterPolicy( bool searchTextEmpty,
+                                                bool showAllWhenEmptyPreferred )
+{
+    return searchTextEmpty && showAllWhenEmptyPreferred ? EmptyFilterPolicy::MirrorAllLines
+                                                        : EmptyFilterPolicy::ClearResults;
+}
+
+} // namespace klogg
+
+#endif // KLOGG_EMPTYFILTERPOLICY_H

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -43,6 +43,7 @@
 
 #include "abstractlogview.h"
 #include "active_screen.h"
+#include "emptyfilterpolicy.h"
 #include "linetypes.h"
 #include "log.h"
 #include "searchgeneration.h"
@@ -872,9 +873,11 @@ void CrawlerWidget::applyEmptyFilterBehavior()
         return;
     }
 
-    const bool showAll = searchToolbar_->currentSearchText().isEmpty()
-        && Configuration::get().showAllInFilteredViewWhenSearchEmpty();
-    logFilteredData_->setAllLinesVisible( showAll );
+    const auto emptyFilterPolicy
+        = klogg::emptyLensFilterPolicy( searchToolbar_->currentSearchText().isEmpty(),
+                                        Configuration::get().showAllInFilteredViewWhenSearchEmpty() );
+    logFilteredData_->setAllLinesVisible( emptyFilterPolicy
+                                          == klogg::EmptyFilterPolicy::MirrorAllLines );
     if ( searchToolbar_->currentSearchText().isEmpty() ) {
         filteredView_->updateData();
     }
@@ -1576,7 +1579,10 @@ void CrawlerWidget::replaceCurrentSearch( const QString& searchText )
 
     // Clear and recompute the content of the filtered window.
     logFilteredData_->clearSearch();
-    if ( searchText.isEmpty() && Configuration::get().showAllInFilteredViewWhenSearchEmpty() ) {
+    if ( klogg::emptyLensFilterPolicy(
+             searchText.isEmpty(),
+             Configuration::get().showAllInFilteredViewWhenSearchEmpty() )
+         == klogg::EmptyFilterPolicy::MirrorAllLines ) {
         logFilteredData_->setAllLinesVisible( true );
     }
     filteredView_->updateData();

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -1486,10 +1486,11 @@ void FolderCrawlerWidget::startSearch()
 
         // Parity with CrawlerWidget::replaceCurrentSearch(""): an empty search
         // clears the results pane instead of leaving stale results behind.
-        // (Single-file additionally honors showAllInFilteredViewWhenSearchEmpty
-        // by dumping the open file unfiltered; that preference is specific to
-        // the single-file lens view and is intentionally not mirrored into the
-        // cross-file grep results pane.)
+        // Folder results panes always use EmptyFilterPolicy::ClearResults --
+        // the showAllInFilteredViewWhenSearchEmpty preference (mirror mode)
+        // only applies to single-document lens views; "every line of every
+        // file" is not a meaningful cross-file result set.
+        // See emptyfilterpolicy.h for the per-pane-kind policy split.
         searchToolbar_->setSearchInProgress( false );
         searchActive_ = false;
         currentSearchPattern_ = {};

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -991,6 +991,11 @@ SCENARIO( "Crawler widget search", "[ui]" )
     QTemporaryFile file{ "crawler_test_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
 
+    // This scenario exercises the populated filtered view (incl. the
+    // empty-filter mirror branch); pin the mirror-mode preference so it does
+    // not depend on the compiled default (issue #46 flipped it to off).
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
+
     Session session;
     session.savedSearches().clear();
 
@@ -1685,6 +1690,40 @@ SCENARIO( "Filtered window can stay empty while the filter is empty",
 
 }
 
+SCENARIO( "Empty search shows only marked lines with default settings (marks navigation)",
+          "[ui][filter][regression]" )
+{
+    QTemporaryFile file{ "crawler_empty_filter_marks_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    // Pin the UI behavior to the COMPILED default (issue #46, upstream parity:
+    // an empty filter must not flood the filtered window).  Seeding the guard
+    // from a default-constructed Configuration keeps the test deterministic
+    // regardless of any persisted user setting.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{
+        Configuration{}.showAllInFilteredViewWhenSearchEmpty()
+    };
+
+    Session session;
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    crawlerVisitor.addMarksInMainView( { 10_lnum, 25_lnum } );
+    REQUIRE( crawlerVisitor.markedLinesCount() == 2 );
+
+    // "Search" with an empty search box: matches are cleared and the filtered
+    // window shows exactly the marked lines (upstream behavior; the reporter's
+    // marks-navigation workflow from issue #46).
+    crawlerVisitor.runSearch();
+
+    REQUIRE( crawlerVisitor.getLogFilteredNbLines() == 2_lcount );
+
+}
+
 SCENARIO( "Live source search auto-refresh is throttled", "[ui][live]" )
 {
     // Use production-like search buffer so each search chunk takes noticeable time.
@@ -1835,6 +1874,10 @@ SCENARIO( "Log views keep the bottom line anchored when non-wrapped height chang
     QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
     REQUIRE( generateLongLineDataFile( file ) );
 
+    // Geometry assertions need a populated filtered view: pin mirror mode so
+    // the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
+
     Session session;
 
     CrawlerWidgetVisitor crawlerVisitor;
@@ -1880,6 +1923,10 @@ SCENARIO( "Log views remain at bottom when viewport height decreases",
 {
     QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
     REQUIRE( generateLongLineDataFile( file ) );
+
+    // Geometry assertions need a populated filtered view: pin mirror mode so
+    // the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
 
     Session session;
 
@@ -1940,6 +1987,10 @@ SCENARIO( "Log views do not clip text rows at top or bottom in bottom alignment"
 {
     QTemporaryFile file{ "crawler_long_lines_XXXXXX" };
     REQUIRE( generateLongLineDataFile( file ) );
+
+    // Geometry assertions need a populated filtered view: pin mirror mode so
+    // the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
 
     Session session;
 
@@ -2839,6 +2890,10 @@ SCENARIO( "Go to top (T) scrolls both views regardless of focus", "[ui][shortcut
     QTemporaryFile file{ "crawler_gototop_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
 
+    // Scroll assertions need a populated filtered view: pin mirror mode so
+    // the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
+
     Session session;
 
     CrawlerWidgetVisitor crawlerVisitor;
@@ -2969,6 +3024,10 @@ SCENARIO( "Crawler widget color labels apply to the selection in all views",
     QTemporaryFile file{ "crawler_colorlabels_test_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
 
+    // The filtered-view selection needs a populated filtered view: pin mirror
+    // mode so the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
+
     Session session;
     session.savedSearches().clear();
 
@@ -3022,6 +3081,10 @@ SCENARIO( "Crawler widget color labels apply to every line of a multi-line selec
     // same per-line semantics marking already has.
     QTemporaryFile file{ "crawler_colorlabels_multiline_XXXXXX" };
     REQUIRE( generateDataFiles( file ) );
+
+    // The filtered-view selection needs a populated filtered view: pin mirror
+    // mode so the scenario does not depend on the compiled empty-filter default.
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{ true };
 
     Session session;
     session.savedSearches().clear();

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -214,11 +214,13 @@ TEST_CASE( "Configuration stores and restores capture rolling settings" )
     REQUIRE( restoredConfig.liveCaptureRollingBackupCount() == 3 );
 }
 
-TEST_CASE( "Configuration defaults empty filters to show all lines in filtered view" )
+TEST_CASE( "Configuration defaults empty filters to an empty filtered view" )
 {
     Configuration config;
 
-    REQUIRE( config.showAllInFilteredViewWhenSearchEmpty() );
+    // Upstream parity (issue #46): an empty filter must NOT flood the
+    // filtered window with every line; users opt into the mirror mode.
+    REQUIRE_FALSE( config.showAllInFilteredViewWhenSearchEmpty() );
 }
 
 TEST_CASE( "Configuration stores and restores empty-filter filtered-view behavior" )
@@ -230,8 +232,10 @@ TEST_CASE( "Configuration stores and restores empty-filter filtered-view behavio
     {
         QSettings settings( settingsPath, QSettings::IniFormat );
 
+        // Store the non-default value so the round-trip stays discriminating
+        // (the compiled default is false since issue #46).
         Configuration config;
-        config.setShowAllInFilteredViewWhenSearchEmpty( false );
+        config.setShowAllInFilteredViewWhenSearchEmpty( true );
         config.saveToStorage( settings );
         settings.sync();
         REQUIRE( settings.status() == QSettings::NoError );
@@ -241,7 +245,7 @@ TEST_CASE( "Configuration stores and restores empty-filter filtered-view behavio
     Configuration restoredConfig;
     restoredConfig.retrieveFromStorage( restoredSettings );
 
-    REQUIRE_FALSE( restoredConfig.showAllInFilteredViewWhenSearchEmpty() );
+    REQUIRE( restoredConfig.showAllInFilteredViewWhenSearchEmpty() );
 }
 
 TEST_CASE( "Configuration live-capture rolling size MB view does not truncate sub-MB values",


### PR DESCRIPTION
## Summary
- Flip `showAllInFilteredViewWhenSearchEmpty` compiled default from `true` to `false` — empty search no longer floods the filtered view with every line; matches upstream klogg and closes issue #46.
- Introduce `klogg::EmptyFilterPolicy` + `emptyLensFilterPolicy()` in a new header `src/ui/include/emptyfilterpolicy.h` as the single decision point, so CrawlerWidget's search/load/config code paths cannot silently diverge.
- FolderCrawlerWidget always uses `ClearResults` (the preference is lens-view-only by design); its inline comment now references the shared policy vocabulary.
- Add marks-navigation regression test and pin seven default-dependent UI test scenarios with `ScopedShowAllEmptyFilterSetting{true}`.
- Configuration roundtrip test now stores the non-default `true` to stay discriminating.

## Background
- **Introduced by:** PR #25 (commit 387aa362) — "make an empty filter show all lines by default without launching a filter scan."
- **Use case:** User clears the search box and presses Enter to navigate marked lines; the old compiled default flooded the filtered view with the entire file.
- **Root cause:** `showAllInFilteredViewWhenSearchEmpty_` defaulted to `true`, diverging from upstream klogg where empty search naturally yields an empty filtered view.
- **How to fix:** Flip default to `false` in `configuration.h`; unify the two consuming call sites in `crawlerwidget.cpp` through a single `emptyLensFilterPolicy()` resolver.

## Existing-user impact
The key is persisted on every config save (Options OK, View-menu toggles, splitter save, etc.), so virtually all existing users already have `true` written to QSettings. Their behavior will NOT change — the flipped default reaches fresh installs only. Existing users who prefer the old behavior keep it; existing users who want marks-navigation uncheck the checkbox (live-apply, no restart).

## Tests
- `ctest --build-config RelWithDebInfo` — **100% passed** (smoke + unit + integration + vectorscan, 4/4 suites)
- `python3 scripts/lint_platform_fragile.py` — **clean**
- Manual GUI verification: open file, mark two lines, empty Enter → filtered view shows exactly two marked lines (no full dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Empty searches now show only marked lines by default in filtered views.
  * Users can enable the option to mirror all lines when the search field is empty.
  * Cross-file search results continue to clear when no search pattern is provided.

* **Bug Fixes**
  * Improved consistency of empty-search behavior across filtered views and search workflows.

* **Tests**
  * Added regression coverage for marked-line navigation and default empty-search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->