### PR TITLE
Fix folder collapse-blank-click, marks-across-filters, and highlight-match masking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,9 +207,6 @@ if(KLOGG_PERF_MEASURE_STREAMING)
   target_compile_definitions(project_options INTERFACE KLOGG_PERF_MEASURE_STREAMING)
 endif()
 
-# Expose build type for issue reporting and diagnostics
-target_compile_definitions(project_options INTERFACE "KLOGG_BUILD_TYPE=$<CONFIG>")
-
 # sanitizer options if supported by compiler
 include(Sanitizers)
 enable_sanitizers(project_options)

--- a/docs/audit_pollution_report.md
+++ b/docs/audit_pollution_report.md
@@ -1,0 +1,368 @@
+# Klogg Core Code Pollution Audit
+
+**Date:** 2026-07-25
+
+## Summary
+
+| Category | Files Affected | Occurrences | Severity |
+|---|---|---|---|
+| Platform OS Macros | 25+ | ~55 | High |
+| Qt Version Branches | 16 | ~30 | High |
+| **Test Instrumentation** | **8** | **~50 methods + 4 counters** | **High** |
+| Signal Overload Disambiguation (qOverload) | 10 | ~22 | Medium |
+| Feature Flags (Vectorscan, mimalloc, etc.) | 9 | ~18 | Medium |
+| Compiler-Specific Pragmas | 3 (same pattern) | 3 blocks | Low |
+| Perf Measurement Instrumentation | 4 | ~10 | Low (dead code) |
+| Build Config Injection | N/A (CMake) | 6 definitions | Medium | |
+
+> ✅ No test-specific code, friend declarations, or `#ifdef` blocks exist in production source files.
+
+---
+
+## 1. Platform OS Macros — `Q_OS_WIN` / `Q_OS_MAC` / `Q_OS_MACOS` / `_WIN64`
+
+These are scattered across the UI, settings, logdata, app, and utils layers, often for small behavioral differences.
+
+### 1.1 Headers (most impactful — propagate to all includers)
+
+| File | Lines | Macro | Purpose |
+|---|---|---|---|
+| `src/ui/include/encodings.h` | 8, 67 | `Q_OS_WIN` | `windows.h` include, `GetACP()` for system code page |
+| `src/app/kloggapp.h` | 47, 51, 145, 253 | `Q_OS_MAC`, `Q_OS_WIN` | App menu bar, taskbar, file associations |
+| `src/settings/include/configuration.h` | 697, 712 | `Q_OS_MACOS`, `Q_OS_WIN` | Default download path, file monitor timeout |
+| `src/utils/include/openfilehelper.h` | 65, 70 | `Q_OS_WIN`, `Q_OS_MAC` | File opening command selection |
+
+### 1.2 Source Files — UI Layer
+
+| File | Lines | Macro | Purpose |
+|---|---|---|---|
+| `src/ui/src/abstractlogview.cpp` | 113, 119 | `Q_OS_WIN`, `_WIN64` | `countLeadingZeroes()` intrinsic (MSVC `_BitScanReverse64`) |
+| `src/ui/src/abstractlogview.cpp` | 1099 | `Q_OS_MACOS` | Font size modifier key (Meta on macOS, Ctrl elsewhere) |
+| `src/ui/src/abstractlogview.cpp` | 1744 | `!Q_OS_WIN` | Clipboard newline normalization |
+| `src/ui/src/mainwindow.cpp` | 54, 638, 1301, 2392 | `Q_OS_WIN`, `Q_OS_MAC` | Menu bar mode, shortcut text, window flags, taskbar button |
+| `src/ui/src/tabbedcrawlerwidget.cpp` | 364, 374, 943 | `Q_OS_MAC`, `Q_OS_WIN`, `Q_OS_MACOS` | Context menu font, keyboard accel keys |
+| `src/ui/src/tabbedscratchpad.cpp` | 83 | `Q_OS_MACOS` | Splitter widget style |
+| `src/ui/src/optionsdialog.cpp` | 157, 161, 325 | `Q_OS_WIN`, `Q_OS_MAC` | Font list, encoding defaults, codec listing |
+| `src/ui/src/selection.cpp` | 175 | `Q_OS_WIN` | Clipboard format selection |
+| `src/ui/src/livesourcetransport.cpp` | 15 | `Q_OS_WIN` | Signal includes for process transport |
+| `src/ui/src/iosdevicelistprovider.cpp` | 35, 140, 154, 172 | `Q_OS_MAC` | macOS FSEvents for iOS device detection |
+| `src/ui/src/ioslogprocesstransport.cpp` | 77, 113, 140 | `Q_OS_MAC`, `Q_OS_WIN` | iOS log process transport spawning |
+| `src/ui/src/adbdevicelistprovider.cpp` | 40, 63, 66 | `Q_OS_WIN`, `Q_OS_MAC` | ADB path resolution |
+
+### 1.3 Source Files — Settings Layer
+
+| File | Lines | Macro | Purpose |
+|---|---|---|---|
+| `src/settings/src/styles.cpp` | 32, 616, 618, 633, 646, 721, 734 | `Q_OS_WIN`, `Q_OS_MACOS` | Font families, palette colors, dark/light mode |
+| `src/settings/src/persistentinfo.cpp` | 68, 121, 153, 164 | `Q_OS_MAC`, `Q_OS_WIN` | Config file paths (`~/Library/...` vs `%APPDATA%`) |
+| `src/settings/src/shortcuts.cpp` | 30 | `Q_OS_MACOS` | `Ctrl`→`⌘` shortcut display text |
+
+### 1.4 Source Files — Other Layers
+
+| File | Lines | Macro | Purpose |
+|---|---|---|---|
+| `src/app/main.cpp` | 44, 47, 49, 137, 180, 206, 237 | `Q_OS_WIN`, `Q_OS_MAC` | HighDPI, Windows console, NSException handler, dark mode detection |
+| `src/logdata/src/logfiltereddata.cpp` | 86, 685 | `Q_OS_WIN` | File size retrieval |
+| `src/logdata/src/fileholder.cpp` | 5, 21, 180 | `Q_OS_WIN` | File handle management, read-ahead control |
+| `src/utils/src/cpu_info.cpp` | 23, 88 | `Q_OS_WIN`, `Q_OS_LINUX` | CPU feature detection |
+| `src/versioncheck/src/versionchecker.cpp` | 94, 96 | `Q_OS_MAC`, `Q_OS_WIN` | Update URL platform suffix |
+
+### 1.5 Crash Handler (acceptable — inherently platform-specific)
+
+| File | Lines | Macro | Notes |
+|---|---|---|---|
+| `src/crash_handler/src/crashhandler.cpp` | 171, 183, 194, 258 | `Q_OS_WIN` | Stack trace, crash dump — **acceptable** |
+| `src/crash_handler/src/memory_info.cpp` | 26, 47 | `Q_OS_WIN`, `Q_OS_APPLE` | Memory stats — **acceptable** |
+
+**Abstraction candidates:**
+- `countLeadingZeroes()` → should be a `PlatformIntrinsics` utility
+- Font size modifier key → `PlatformInput::fontSizeModifier()`
+- Config file paths → `PlatformPaths` (already partially abstracted via `persistentinfo.cpp`)
+- Clipboard normalization → `PlatformClipboard`
+- File handle management → `PlatformFileHandle`
+- CPU feature detection → `PlatformCpuInfo`
+
+---
+
+## 2. Qt Version Branches — `QT_VERSION` / `QT_VERSION_CHECK`
+
+### 2.1 Headers
+
+| File | Lines | Check | Purpose |
+|---|---|---|---|
+| `src/ui/include/fontutils.h` | 38, 58 | `QT_VERSION < 6.0.0` | `QFontDatabase::families()` static vs instance method |
+| `src/utils/include/active_screen.h` | 30 | `QT_VERSION >= 5.14.0` | `QWidget::screen()` availability |
+
+### 2.2 Source Files
+
+| File | Lines | Check | Purpose |
+|---|---|---|---|
+| `src/app/main.cpp` | 179, 189 | `< 6.0.0`, `>= 5.14.0` | Font resolution method, HighDPI policy name |
+| `src/ui/src/quickfind.cpp` | 207, 240, 257, 272 | `< 6.0.0` | `QtConcurrent::run` overload resolution (4 sites) |
+| `src/ui/src/quickfindwidget.cpp` | 133, 143 | `>= 6.7.0` | `QLineEdit::setClearButtonEnabled` |
+| `src/ui/src/tabbedcrawlerwidget.cpp` | 540, 736 | `>= 5.15.0` | `QTabBar::tabAt()`, `setTabVisible()` |
+| `src/ui/src/crawlerwidget.cpp` | 504 | `>= 5.15.0` | `QTabBar::tabAt()` |
+| `src/ui/src/foldercrawlerwidget.cpp` | 1282 | `>= 5.15.0` | `QTabBar::tabAt()` |
+| `src/ui/src/tabgroup.cpp` | 177 | `>= 5.15.0` | `QTabBar::tabAt()` |
+| `src/ui/src/predefinedfilterscombobox.cpp` | 66 | `>= 5.15.0` | `QComboBox::setPlaceholderText()` |
+| `src/ui/src/newversiondialog.cpp` | 75 | `>= 5.14.0` | `QLabel::setTextFormat(MarkdownText)` |
+| `src/settings/src/configuration.cpp` | 161, 172 | `<= 6.4.0` | Qt 6.4 settings migration (version-specific workaround) |
+| `src/settings/src/styles.cpp` | 86, 648 | `>= 6.5.0` | `QPalette::accent()` color role |
+| `src/filewatch/src/filewatcher.cpp` | 33 | `< 6` | `QFSFileEngine` include |
+| `src/versioncheck/src/versionchecker.cpp` | 67 | `>= 6.4.0` | `QNetworkInformation::reachability()` |
+| `src/versioncheck/src/versionchecker.cpp` | 222, 230 | `>= 5.15.0` / `< 5.15.0` | `QNetworkRequest::setTransferTimeout()` |
+
+**Key patterns that could be abstracted:**
+- **`QFontDatabase` static vs instance** (2 sites in `fontutils.h`) → `QtCompat::fontFamilies()` / `QtCompat::isFixedPitch()`
+- **`QtConcurrent::run` overload** (4 sites in `quickfind.cpp`) → `QtCompat::concurrentRun(this, &Class::method, args...)`
+- **`QTabBar` 5.15 APIs** (5 sites across 4 files) → `QtCompat::tabBarTabAt()`, `QtCompat::setTabVisible()`
+- **`QComboBox::setPlaceholderText`** (1 site) → `QtCompat::setPlaceholderText()`
+- **`QNetworkRequest::setTransferTimeout`** (2 sites) → `QtCompat::setTransferTimeout()`
+
+---
+
+## 3. Signal Overload Disambiguation — `qOverload` / `QOverload`
+
+All 22 occurrences are for Qt 5 compatibility (Qt6 can use regular member function pointers without overload resolution). These are **all in `.cpp` files** (not headers), so the impact is limited to compilation, not transitive include pollution.
+
+| File | Count | Context |
+|---|---|---|
+| `src/ui/src/quickfind.cpp` | 4 | `QtConcurrent::run` + member function overloads |
+| `src/ui/src/crawlerwidget.cpp` | 3 | `QComboBox::currentIndexChanged`, `QSpinBox::valueChanged` |
+| `src/ui/src/foldercrawlerwidget.cpp` | 3 | Same — combobox + spinbox signals |
+| `src/ui/src/viewsignalwiring.cpp` | 3 | `AbstractLogView::addToSearch` etc. |
+| `src/ui/src/livesourcetransport.cpp` | 2 | `QProcess::finished` (int + ExitStatus overload) |
+| `src/ui/src/highlighteredit.cpp` | 2 | `QSpinBox::valueChanged`, `QComboBox::currentIndexChanged` |
+| `src/ui/src/searchtoolbar.cpp` | 1 | `QComboBox::currentIndexChanged` |
+| `src/ui/src/adblogcatdialog.cpp` | 1 | `QComboBox::currentIndexChanged` |
+| `src/ui/src/ioslogdialog.cpp` | 1 | `QComboBox::currentIndexChanged` |
+| `src/ui/src/predefinedfilterscombobox.cpp` | 1 | `QComboBox::activated` |
+
+**Abstraction candidate:** All `qOverload<int>(&QComboBox::currentIndexChanged)` and related patterns could be replaced by `QtCompat::connectComboBoxIndexChanged(combo, receiver, slot)` or similar helpers.
+
+---
+
+## 4. Feature Flags
+
+### 4.1 `KLOGG_HAS_VECTORSCAN` — Optional Regex Engine
+
+Defined in: `src/regex/CMakeLists.txt:28` (public, propagates to all consumers of `klogg_regex`)
+
+| File | Lines | Impact |
+|---|---|---|
+| `src/regex/include/hsregularexpression.h` | 36, 75 | Entire class/namespace conditional on Vectorscan |
+| `src/regex/include/regularexpression.h` | 94 | `HsBufferScanner` member in `PatternMatcher` |
+| `src/regex/src/hsregularexpression.cpp` | 29 | Implementation file |
+| `src/regex/src/regularexpression.cpp` | 272, 296, 308 | `scanBuffer` / `hasBufferScan` implementations |
+| `src/app/main.cpp` | 142, 280 | CLI flag registration, debug output |
+| `src/ui/src/optionsdialog.cpp` | 165 | Hides Vectorscan checkbox in options dialog |
+
+### 4.2 `KLOGG_USE_MIMALLOC` — Optional Allocator
+
+Defined in: `3rdparty/CMakeLists.txt`
+
+| File | Lines | Impact |
+|---|---|---|
+| `src/app/klogg_grep.cpp` | 35 | mimalloc override include |
+| `src/app/main.cpp` | 243 | mimalloc override include |
+| `src/crash_handler/src/crashhandler.cpp` | 43, 301 | mimalloc stats in crash dumps |
+
+### 4.3 `KLOGG_PORTABLE` — Portable Mode
+
+Defined in: `src/app/CMakeLists.txt:93`
+
+| File | Lines | Impact |
+|---|---|---|
+| `src/app/main.cpp` | 159 | Portable config path |
+| `src/crash_handler/src/crashhandler.cpp` | 64 | Portable crash dump path |
+
+### 4.4 `KLOGG_KARCHIVE` — Archive Support
+
+Defined by: `cpm_cache/kf5archive/.../CMakeLists.txt:34`
+
+| File | Lines | Impact |
+|---|---|---|
+| `src/ui/src/decompressor.cpp` | 182 | Archive decompression code path |
+
+### 4.5 `KLOGG_USE_SENTRY` — Crash Reporting
+
+Defined in: `src/crash_handler/CMakeLists.txt:25`
+
+Used only in crash_handler layer (acceptable).
+
+**Abstraction approach:** The Vectorscan flag is the most intrusive — it mutates the class layout in headers. Could be addressed via a strategy pattern or compile-time polymorphism behind a `RegexEngine` interface.
+
+---
+
+## 5. Compiler-Specific Pragmas
+
+Three identical blocks suppressing `-Wsign-conversion` for `simdutf.h`:
+
+| File | Lines |
+|---|---|
+| `src/ui/src/highlighterset.cpp` | 50–56 |
+| `src/logdata/src/logdata.cpp` | 53–59 |
+| `src/logdata/src/searchablelogdata.cpp` | 5–11 |
+
+All three follow the same pattern:
+```cpp
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#endif
+#include <simdutf.h>
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+```
+
+This should be centralized into a single `simdutf_wrapper.h` header.
+
+Additionally in `src/ui/src/abstractlogview.cpp:115`:
+```cpp
+#pragma warning( disable : 4244 )  // MSVC only
+```
+This can be wrapped into a platform-intrinsics abstraction.
+
+---
+
+## 6. Performance Measurement Instrumentation
+
+### 6.1 `GLOGG_PERF_MEASURE_FPS` — **DEAD CODE (Orphaned)**
+
+| File | Lines |
+|---|---|
+| `src/ui/include/abstractlogview.h` | 59–61, 573–576 |
+| `src/ui/src/abstractlogview.cpp` | 1243–1251 |
+
+**No CMake option defines this macro.** This is orphaned code from upstream glogg that can never be activated. The `PerfCounter` header include and member variable are always excluded.
+
+**Recommendation:** Remove entirely.
+
+### 6.2 `KLOGG_PERF_MEASURE_STREAMING` — Debug Instrumentation
+
+Controlled by CMake option (default OFF):
+
+| File | Lines |
+|---|---|
+| `src/logdata/src/streaminglogdata.cpp` | 45, 57, 63, 81, 100 |
+| `src/logdata/src/logfiltereddataworker.cpp` | 744, 753 |
+
+These are timing/logging probes. Low-impact since they're off by default and in `.cpp` files.
+
+---
+
+## 7. Build Config Injection
+
+From `CMakeLists.txt`:
+
+| Definition | Scope | Notes |
+|---|---|---|
+| `KLOGG_PERF_MEASURE_STREAMING` | `project_options` INTERFACE | Only active when explicitly opted in |
+| `KLOGG_BUILD_TYPE=$<CONFIG>` | `project_options` INTERFACE | Injected into every TU; used only in `issuereporter.cpp` for crash reports |
+| `KLOGG_PORTABLE` | `klogg_portable` target PUBLIC | Only on portable build variant |
+| `KLOGG_HAS_VECTORSCAN` | `klogg_regex` target PUBLIC | Propagates to all regex consumers |
+| `KLOGG_KARCHIVE` | `klogg_karchive` target PUBLIC | Propagates via 3rdparty |
+| `KLOGG_USE_SENTRY` | `klogg_crash_handler` target PUBLIC | Crash handler only |
+| `QT_NO_KEYWORDS` | `klogg_logdata` target PUBLIC | Needed for Boost header compatibility |
+| `QT_MESSAGELOGCONTEXT` | `klogg_logging` target PUBLIC | Enables file/line/function in Qt log messages |
+
+---
+
+## 8. Test Instrumentation in Production Code
+
+This is a significant category — the codebase has ~50 test-only methods and 4 mutable test counters embedded in production headers. These are deliberately designed test seams, not accidental pollution, but they still contaminate the production API surface.
+
+### 8.1 `access_by<T>` Template — Private-Access Test Hook (3 classes)
+
+Production classes declare a public template struct that test code can specialize to reach **all** private members. This is the most powerful hook pattern.
+
+| File | Lines | Class | Impact |
+|---|---|---|---|
+| `src/ui/include/abstractlogview.h` | 117–118 | `AbstractLogView` | Tests specialize `access_by<AbstractLogViewPrivate>` with dozens of static methods reaching `wrappedLinesInfo_`, `charHeight_`, `textAreaCache_`, `searchEnd_`, `selectionChanged_`, `leftMargin_`, `drawingTopOffset_`, shortcut members, etc. |
+| `src/ui/include/crawlerwidget.h` | 142–143 | `CrawlerWidget` | Allows test code to reach `logMainView_`, `filteredView_`, scroll state |
+| `src/logdata/include/logfiltereddataworker.h` | 224–225 | `LogFilteredDataWorker` | Allows test code to reach private search-worker internals |
+
+### 8.2 Test-Specific Method Names (`ForTest` / `ForTesting` suffixes)
+
+| File | Method | Purpose |
+|---|---|---|
+| `src/ui/include/abstractlogview.h:163` | `lineAtYForTest(int yPos)` | Coordinate-to-line resolution for headless tests |
+| `src/ui/include/folderfilteredview.h:49–56` | `lineTypeForTest(LineNumber)` | Wraps protected `lineType()` so tests can verify mark-bullet rendering |
+| `src/ui/include/sessioninfo.h:61–67` | `saveCountForTesting()` → `std::atomic<uint64_t>` | Counter for debounce verification |
+| `src/logdata/include/encodingdetector.h:79–86` | `uchardetInvocationsForTesting()` → `std::atomic<uint64_t>` | Counter for encoding detector fallback verification |
+
+### 8.3 "Exposed for testing" Public Accessors (AbstractLogView — ~6 methods)
+
+| Line | Method | What it exposes |
+|---|---|---|
+| 147 | `searchEndLine()` | Private `searchEnd_` member |
+| 148–153 | `isLineMapCurrent()` | Private `wrappedLinesInfo_` empty check |
+| 153–159 | `ensureLineMapFresh()` | Forces synchronous visible-line map rebuild |
+| 164–168 | `visibleLineMapBuildCount()` | Counter for map rebuild verification |
+| 206–213 | `searchPattern()` | Currently-wired search pattern |
+| 341–346 | `markSelected()` / `deleteMarksSelected()` | Programmatic mark toggle for tests |
+
+### 8.4 Dedicated Test Accessor Block — FolderCrawlerWidget (~20 methods)
+
+`src/ui/include/foldercrawlerwidget.h:100–157` contains a dedicated block headed by:
+
+```cpp
+// --- Test access / programmatic driving (no UI events needed) ---
+```
+
+Exposing: `folderResults()`, `filteredView()`, `paneCount()`, `resultsTabs()`, `mainView()`, `searchToolbar()`, `overview()`, `currentMainFilePath()`, `currentMainViewLine()`, `statusText()`, `isMainViewLineMarked()`, `isLineMarkedInFile()`, `overviewModel()`, `isFilteredResultRowMarked()`, `markMainViewLine()`, `unmarkMainViewLine()`, `isSearchActive()`, `setResultsVisibility()`, `contextLinesComboBox()`, `contextLinesSpinBox()`, `currentContext()`, `visibilityCombo()`, `viewsSplitter()`
+
+### 8.5 Dedicated Test Accessor Block — SearchToolbar (~13 methods)
+
+`src/ui/include/searchtoolbar.h:128–141` and `src/ui/src/searchtoolbar.cpp:481–545` expose internal Qt widgets via a `// --- QTest access ---` block: `searchLineEdit()`, `matchCaseButton()`, `inverseButton()`, `booleanButton()`, `searchButton()`, `stopButton()`, `useRegexpButton()`, `searchRefreshButton()`, `clearButton()`, `keepSearchResultsButton()`, `favoriteFilterButton()`, `predefinedFilters()`, `searchLineCompleter()`
+
+### 8.6 Test Instrumentation Counters in Production Logic
+
+| File | Member | Increment Site |
+|---|---|---|
+| `src/ui/include/abstractlogview.h:598–599` | `mutable int getSelectedTextCallCount_` | `abstractlogview.cpp:1975` inside `getSelectedText()` |
+| `src/ui/include/abstractlogview.h:632–633` | `int visibleLineMapBuildCount_` | `abstractlogview.cpp:2181` inside `buildVisibleLineMap()` |
+| `src/ui/src/sessioninfo.cpp:109` | `saveCountForTesting()` counter | Incremented on session write |
+| `src/logdata/src/encodingdetector.cpp:117` | `uchardetInvocationsForTesting()` counter | Incremented on uchardet fallback |
+
+### 8.7 Test-Exposed Constants
+
+| File | Constant | Notes |
+|---|---|---|
+| `src/ui/include/newversiondialog.h:52–53` | `static constexpr int kMaxChangesHeight` | Promoted to `public` for test assertions |
+
+### 8.8 Notable: No `#ifdef`, No `friend` for Tests, No `QTest::` in src/
+
+- Zero `#ifdef KLOGG_TESTS` / `#ifndef KLOGG_TESTS` guards
+- Zero `friend` declarations for test classes (all 8 `friend` declarations are architectural)
+- Zero `QTest::` calls or `#include <QTest>` in `src/`
+- Zero `#define` macros that change behavior for test builds
+
+The instrumentation is entirely "always-on" — all test accessors and counters are compiled into every build, including release.
+
+---
+
+## 9. Non-Pollution Items (Reviewed, Found Clean) ✅
+
+- **`friend` declarations:** All 8 are architectural (class-to-class access control), e.g., `WindowSession` ↔ `Session`, `PatternMatcher` ↔ `RegularExpression`. No test classes.
+- **`static_assert`:** 3 occurrences in `linetypes.h`, all for type-safety of `LinesCount`/`LineNumber`/`LineColumn` — business logic, not platform/compiler workarounds.
+- **`Q_DECLARE_METATYPE`:** ~10 standard Qt usages — required for `QVariant` integration, not pollution.
+- **`Q_UNUSED`:** ~15 usages in signal/slot parameter lists — standard Qt pattern, not pollution.
+- **Include guards (`#ifndef KLOGG_XXX_H`):** Standard pattern, not pollution.
+
+---
+
+## Priority Recommendations
+
+| Priority | Action | Impact |
+|---|---|---|
+| **P0** | Remove dead `GLOGG_PERF_MEASURE_FPS` code | Cleanup, no risk |
+| **P1** | Create `simdutf_wrapper.h` to eliminate 3 duplicate pragma blocks | DRY, prevents future copy-paste |
+| **P1** | Create `QtCompat` namespace for Qt version abstractions | Eliminates ~30 version branches, prevents future Qt5→Qt6 mistakes |
+| **P1** | Extract test accessors into `*_testapi.h` / test-only friend classes | Removes ~50 test methods + 4 counters from production headers |
+| **P2** | Replace `access_by<T>` with `friend` + test-only `#ifdef` guard macro | Eliminates unrestricted private access template from public API |
+| **P2** | Create `PlatformIntrinsics` / `PlatformInput` / `PlatformPaths` abstraction layers | Encapsulates ~55 platform `#ifdef` sites |
+| **P2** | Replace `qOverload`/`QOverload` with `QtCompat` signal helpers | Eliminates ~22 overload disambiguations |
+| **P3** | Abstract `KLOGG_HAS_VECTORSCAN` behind a `RegexEngine` interface | Reduces header-level conditional compilation |
+| **P3** | Abstract `KLOGG_USE_MIMALLOC` behind an allocator hook | Removes allocator ifdefs from app code |

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -257,8 +257,9 @@ _QSIZETYPE_DECL_RE = re.compile(r"\b(?:const\s+)?qsizetype\s+(\w+)\b")
 _QSTRINGVIEW_ALIAS_RE = re.compile(r"\busing\s+(\w+)\s*=\s*QStringView\s*;")
 # A #if whose condition is Qt-6-only (so qsizetype code inside it is safe).
 _QT6_IF_RE = re.compile(
-    r"#\s*if\b.*\bQT_VERSION(?:_MAJOR)?\b.*"
-    r"(?:QT_VERSION_CHECK\s*\(\s*6\b|0x0*6[0-9A-Fa-f]{4,}|>=\s*6\b|>\s*5\b)"
+    r"#\s*if\b.*\bQT_VERSION(?:_MAJOR)?\b\s*"
+    r"(?:>=\s*(?:QT_VERSION_CHECK\s*\(\s*6\b|0x0*6[0-9A-Fa-f]{4,}|6\b)"
+    r"|>\s*(?:QT_VERSION_CHECK\s*\(\s*5\b|0x0*5[0-9A-Fa-f]{4,}|5\b))"
 )
 
 
@@ -406,7 +407,7 @@ def _check_qsizetype_to_int_conversion(text: str, path: Path) -> list[tuple[int,
     # `<Type> <ident>(...)` constructions. Receivers matching these are safe.
     qstrview_vars: set[str] = set()
     type_alt = "|".join(re.escape(t) for t in qstrview_types)
-    var_decl_re = re.compile(rf"\b(?:const\s+)?({type_alt})\s+(\w+)\b")
+    var_decl_re = re.compile(rf"\b(?:const\s+)?({type_alt})\s*[&*]?\s*(\w+)\b")
     for line in lines:
         code = _strip_line_comment(line)
         for m in var_decl_re.finditer(code):

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -223,6 +223,229 @@ def _check_unguarded_platform_helper(text: str, path: Path) -> list[tuple[int, s
     return findings
 
 
+def _extract_call_args(code: str, open_paren_pos: int) -> str:
+    """Return the substring inside the parentheses starting at
+    ``open_paren_pos``, balancing nested ``()``. Returns '' if unbalanced.
+
+    Used by the qsizetype check so that ``.indexOf( QLatin1Char( '\\n' ), start )``
+    is recognised as passing ``start`` (the nested QLatin1Char call would defeat
+    a naive ``[^)]*`` capture).
+    """
+    depth = 0
+    start = open_paren_pos + 1
+    for i in range(start, len(code)):
+        ch = code[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            if depth == 0:
+                return code[start:i]
+            depth -= 1
+    return ""
+
+
+# Qt string/container APIs that take `int` on Qt 5 and `qsizetype` on Qt 6.
+# Passing a raw qsizetype value narrows to int on Qt 5 -> -Werror=conversion.
+# (QStringView is the exception: it has been qsizetype-native since Qt 5.8, so
+# its indexOf/mid/left/right never narrow. QStringRef, like QString, takes int
+# on Qt 5 and IS flagged.)
+_QT_INT_API_RE = re.compile(
+    r"\.(?:indexOf|mid|left|right|truncate|chop|chopped|remove)\s*\("
+)
+_QSIZETYPE_DECL_RE = re.compile(r"\b(?:const\s+)?qsizetype\s+(\w+)\b")
+# `using <Alias> = QStringView;` -- the wrappedstring.h code uses this idiom.
+_QSTRINGVIEW_ALIAS_RE = re.compile(r"\busing\s+(\w+)\s*=\s*QStringView\s*;")
+# A #if whose condition is Qt-6-only (so qsizetype code inside it is safe).
+_QT6_IF_RE = re.compile(
+    r"#\s*if\b.*\bQT_VERSION(?:_MAJOR)?\b.*"
+    r"(?:QT_VERSION_CHECK\s*\(\s*6\b|0x0*6[0-9A-Fa-f]{4,}|>=\s*6\b|>\s*5\b)"
+)
+
+
+def _qt6_guarded_lines(lines: list[str]) -> set[int]:
+    """Return 1-based line numbers inside a Qt-6-only ``#if QT_VERSION >= 6``
+    (or ``> 5``) branch, *excluding* its ``#else`` branch (which is Qt 5).
+
+    qsizetype code behind such a guard only compiles on Qt 6, where these APIs
+    take qsizetype, so it is not a -Werror=conversion risk. The Qt 5 ``#else``
+    branch IS checked.
+    """
+    qt6: set[int] = set()
+    # Each stack frame: {"qt6": bool, "in_else": bool}
+    stack: list[dict] = []
+    for i, line in enumerate(lines, start=1):
+        if re.match(r"#\s*if(n?def)?\b", line):
+            stack.append({"qt6": bool(_QT6_IF_RE.search(line)), "in_else": False})
+        elif re.match(r"#\s*elif\b", line):
+            # Conservatively treat the #elif branch as not the qt6 branch.
+            if stack:
+                stack[-1]["in_else"] = True
+        elif re.match(r"#\s*else\b", line):
+            if stack:
+                stack[-1]["in_else"] = True
+        elif re.match(r"#\s*endif\b", line):
+            if stack:
+                stack.pop()
+        if any(s["qt6"] and not s["in_else"] for s in stack):
+            qt6.add(i)
+    return qt6
+
+
+def _extract_receiver(code: str, dot_pos: int) -> str:
+    """Return the receiver expression immediately before the '.' at dot_pos.
+
+    For ``text.mid`` -> "text"; for ``QStringView{ line }.mid`` -> "QStringView";
+    for ``QStringView(line).mid`` -> "QStringView". Used to tell QStringView
+    receivers (qsizetype-native on Qt 5) from QString/QByteArray ones.
+    """
+    j = dot_pos - 1
+    while j >= 0 and code[j].isspace():
+        j -= 1
+    if j < 0:
+        return ""
+
+    def _ident_before(pos: int) -> str:
+        t = pos
+        while t >= 0 and (code[t].isalnum() or code[t] == "_"):
+            t -= 1
+        return code[t + 1 : pos + 1]
+
+    if code[j] in "})]":
+        open_ch = {"}": "{", ")": "(", "]": "["}[code[j]]
+        depth = 1
+        k = j - 1
+        while k >= 0 and depth > 0:
+            if code[k] == code[j]:
+                depth += 1
+            elif code[k] == open_ch:
+                depth -= 1
+            k -= 1
+        # k+1 is the matching opener; read the type identifier before it.
+        t = k
+        while t >= 0 and code[t].isspace():
+            t -= 1
+        return _ident_before(t) if t >= 0 else ""
+    return _ident_before(j)
+
+
+def _strip_literals(s: str) -> str:
+    """Return ``s`` with char/string literal *contents* blanked so that an
+    identifier search cannot match text inside them (e.g. the ``n`` in
+    ``'\\n'`` must not be confused with a variable named ``n``).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        ch = s[i]
+        if ch == "'" or ch == '"':
+            quote = ch
+            out.append(quote)
+            j = i + 1
+            while j < n:
+                if s[j] == "\\" and j + 1 < n:
+                    j += 2
+                elif s[j] == quote:
+                    out.append(quote)
+                    j += 1
+                    break
+                else:
+                    j += 1
+            i = j
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def _check_qsizetype_to_int_conversion(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag a `qsizetype`-typed variable passed as an argument to a Qt
+    string/container API that takes `int` on Qt 5.
+
+    On Qt 5 (Ubuntu 20.04 / 22.04 CI), QString/QStringRef/QByteArray::indexOf,
+    mid, left, right, truncate, chop, ... take `int`; on Qt 6 they take
+    `qsizetype`. A value held in a raw `qsizetype` variable therefore narrows to
+    `int` on Qt 5 and trips -Werror=conversion -- but the narrowing is invisible
+    on the macOS / Ubuntu-24.04 Qt 6 builds developers run locally, so it only
+    surfaces in the Linux CI matrix. PR #48 failed CI this way in
+    FolderSearchResults::ensureMarkLines (qsizetype loop indices passed to
+    QString::indexOf / QString::mid).
+
+    QStringView is excluded: it has been qsizetype-native since Qt 5.8, so its
+    indexOf/mid/left/right do not narrow on Qt 5. Code behind a Qt-6-only
+    ``#if QT_VERSION >= 6`` guard is also excluded. The adaptive klogg types
+    (LineLength / LineColumn, whose UnderlyingType is decltype(QString::size()))
+    and an explicit static_cast<int>(...) with a documented size bound are the
+    portable alternatives -- both are already used in-tree. `auto` deduced from
+    QString::size()/indexOf() is also safe (it tracks the Qt version), so only
+    explicit `qsizetype` declarations are flags.
+    """
+    findings: list[tuple[int, str]] = []
+    lines = text.splitlines()
+    qt6_lines = _qt6_guarded_lines(lines)
+
+    # Collect every identifier declared `qsizetype` OUTSIDE Qt-6-only guards
+    # (inside the guard, qsizetype only compiles on Qt 6 where it is safe).
+    declared: set[str] = set()
+    for i, line in enumerate(lines, start=1):
+        if i in qt6_lines:
+            continue
+        for m in _QSIZETYPE_DECL_RE.finditer(_strip_line_comment(line)):
+            declared.add(m.group(1))
+    if not declared:
+        return findings
+
+    # QStringView type names: the real one plus `using X = QStringView;` aliases
+    # (wrappedstring.h uses `using WrappedStringPart = QStringView;`).
+    qstrview_types: set[str] = {"QStringView"}
+    for line in lines:
+        m = _QSTRINGVIEW_ALIAS_RE.search(line)
+        if m:
+            qstrview_types.add(m.group(1))
+    # Variables of a QStringView type (incl. aliases): `<Type> <ident>` or
+    # `<Type> <ident>(...)` constructions. Receivers matching these are safe.
+    qstrview_vars: set[str] = set()
+    type_alt = "|".join(re.escape(t) for t in qstrview_types)
+    var_decl_re = re.compile(rf"\b(?:const\s+)?({type_alt})\s+(\w+)\b")
+    for line in lines:
+        code = _strip_line_comment(line)
+        for m in var_decl_re.finditer(code):
+            qstrview_vars.add(m.group(2))
+
+    for i, line in enumerate(lines, start=1):
+        if i in qt6_lines or ALLOW_MARKER in line:
+            continue
+        code = _strip_line_comment(line)
+        for m in _QT_INT_API_RE.finditer(code):
+            args = _extract_call_args(code, m.end() - 1)
+            if not args:
+                continue
+            receiver = _extract_receiver(code, m.start())
+            # QStringView receiver: qsizetype-native on Qt 5, no narrowing.
+            if receiver in qstrview_types or receiver in qstrview_vars:
+                continue
+            for name in declared:
+                if re.search(r"\b" + re.escape(name) + r"\b", _strip_literals(args)):
+                    findings.append(
+                        (
+                            i,
+                            f"qsizetype variable '{name}' is passed to a Qt "
+                            f"string API (.indexOf/.mid/.left/...) that takes "
+                            f"`int` on Qt 5 (receiver '{receiver}' is not a "
+                            f"QStringView). This narrows qsizetype->int and "
+                            f"trips -Werror=conversion on the Qt 5 Linux CI "
+                            f"builds (invisible on Qt 6 / macOS). Use the "
+                            f"adaptive LineLength/LineColumn types, or "
+                            f"static_cast<int>(...) with a documented size "
+                            f"bound. (PR #48 CI failure: ensureMarkLines.)",
+                        )
+                    )
+                    break  # one report per call is enough
+            if findings and findings[-1][0] == i:
+                break  # one report per line is enough
+    return findings
+
+
 def _check_main_view_text_pixel_probe(text: str, path: Path) -> list[tuple[int, str]]:
     """Flag main-view text pixel probes that assert on viewport grabs.
 
@@ -605,6 +828,10 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "data-variable-shadowing",
         "check": _check_data_variable_shadowing,
+    },
+    {
+        "name": "qsizetype-to-qt-int-api",
+        "check": _check_qsizetype_to_int_conversion,
     },
 ]
 

--- a/src/app/klogg_grep.cpp
+++ b/src/app/klogg_grep.cpp
@@ -32,9 +32,7 @@ const bool PersistentInfo::ForcePortable = true;
 
 int main( int argc, char* argv[] )
 {
-#ifdef KLOGG_USE_MIMALLOC
     mi_stats_reset();
-#endif
     qRegisterMetaType<LinesCount>( "LinesCount" );
     qRegisterMetaType<LineNumber>( "LineNumber" );
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -41,6 +41,8 @@
 #include <qapplication.h>
 #include <qthreadpool.h>
 
+#include "qtcompat/qtcompat.h"
+
 #ifdef Q_OS_WIN
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -141,9 +141,6 @@ void kloggUncaughtNSExceptionHandler( NSException* exception )
 #include <mimalloc.h>
 #include <roaring.hh>
 
-#ifdef KLOGG_HAS_VECTORSCAN
-#include <hs.h>
-#endif
 
 #include "tbb/global_control.h"
 
@@ -279,9 +276,6 @@ int main( int argc, char* argv[] )
     roaring_memory_allocators.aligned_free = mi_free;
     roaring_init_memory_hook(roaring_memory_allocators);
 
-#ifdef KLOGG_HAS_VECTORSCAN
-    hs_set_allocator(mi_malloc, mi_free);
-#endif
 
     if ( maxConcurrency < 2 ) {
         maxConcurrency = 2;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -239,9 +239,7 @@ int main( int argc, char* argv[] )
     NSSetUncaughtExceptionHandler( &kloggUncaughtNSExceptionHandler );
 #endif
 
-#ifdef KLOGG_USE_MIMALLOC
     mi_process_init();
-#endif
 
     const auto& config = Configuration::getSynced();
     setApplicationAttributes( config.enableQtHighDpi(), config.scaleFactorRounding() );

--- a/src/crash_handler/CMakeLists.txt
+++ b/src/crash_handler/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
 set_target_properties(klogg_crash_handler PROPERTIES AUTOMOC ON)
 
 target_include_directories(klogg_crash_handler PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_compile_definitions(klogg_crash_handler PUBLIC "KLOGG_BUILD_TYPE=$<CONFIG>")
 target_link_libraries(
   klogg_crash_handler
   PUBLIC project_options

--- a/src/crash_handler/src/crashhandler.cpp
+++ b/src/crash_handler/src/crashhandler.cpp
@@ -40,9 +40,7 @@
 #include <qthreadpool.h>
 #include <string_view>
 
-#ifdef KLOGG_USE_MIMALLOC
 #include <mimalloc.h>
-#endif
 
 #include "client/crash_report_database.h"
 #include "sentry.h"
@@ -298,7 +296,6 @@ CrashHandler::CrashHandler()
         const auto vmUsed = usedMemory();
         addExtra( "vm_used", vmUsed );
 
-#ifdef KLOGG_USE_MIMALLOC
         size_t elapsedMsecs, userMsecs, systemMsecs, currentRss, peakRss, currentCommit, peakCommit,
             pageFaults;
 
@@ -313,7 +310,6 @@ CrashHandler::CrashHandler()
         addExtra( "current_commit", currentCommit );
         addExtra( "peak_commit", peakCommit );
         addExtra( "page_faults", pageFaults );
-#endif
     } );
     memoryUsageTimer_->start( 60000 );
 

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -20,6 +20,7 @@
 #ifndef FOLDERSEARCHRESULTS_H
 #define FOLDERSEARCHRESULTS_H
 
+#include <QHash>
 #include <QSet>
 #include <QString>
 #include <QTextCodec>
@@ -27,6 +28,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include "abstractlogdata.h"
@@ -140,10 +142,14 @@ class FolderSearchResults : public AbstractLogData {
     enum class Visibility { MarksAndMatches, Marks, Matches };
     void setVisibility( Visibility visibility );
     Visibility visibility() const { return visibility_; }
-    // Inject the mark query the Marks filter consults (filePath, localLine) ->
-    // marked. The widget owns the mark store; this keeps FolderSearchResults free
-    // of UI-side mark ownership. Call before/with setVisibility(Marks).
-    void setMarkedLineQuery( std::function<bool( const QString&, LineNumber )> query );
+    // Inject the per-file marks store (widget-owned, read LIVE during rebuild)
+    // so the Marks / Marks-and-matches visibility can show marked lines that do
+    // NOT match the current filter -- single-file LogFilteredData::marks_ parity.
+    // Marks are (filePath, localLine) bookmarks independent of the transient
+    // match set; the store is ENUMERATED (not just predicate-tested) so marked
+    // non-match rows can be injected alongside match rows. The widget must
+    // outlive the results object. Call before/with setVisibility(Marks).
+    void setMarksStore( const QHash<QString, std::set<uint64_t>>* store );
     // Rebuild + emit layoutChanged. Called by the widget when marks change while
     // the Marks filter is active (the visible set depends on marks).
     void refreshForMarksChange();
@@ -171,9 +177,23 @@ class FolderSearchResults : public AbstractLogData {
 
   private:
     struct VisibleRow {
-        LineKind kind;
-        klogg::folder::FileId fileId = 0;   // index into groups_
-        size_t matchIndex = 0;              // index into groups_[fileId].matches (Match rows)
+        LineKind kind = LineKind::Data;
+        // Injected marked non-match row: a bookmark on a source line that does
+        // not match the current filter. Renders as a normal Data row but is not
+        // a match (isMatchRow == false) and fetches text by (filePath, localLine).
+        bool isMarkRow = false;
+        klogg::folder::FileId fileId = 0;   // Header/Match: index into groups_; Mark: real group or marks-only (groups_.size() + idx)
+        size_t matchIndex = 0;              // Match rows: index into groups_[fileId].matches
+        LineNumber markLocalLine = 0_lnum;  // Mark rows: marked source line
+        QString markFilePath;               // Mark rows: source file path
+    };
+
+    // A file that has marks but no match group (marks-only). Rebuilt each
+    // rebuildVisibleRows from the injected marks store; shown under Marks /
+    // Marks-and-matches so marked lines stay visible across filter changes.
+    struct MarksGroup {
+        QString filePath;
+        std::vector<LineNumber> localLines; // sorted ascending
     };
 
     void rebuildVisibleRows();
@@ -185,7 +205,14 @@ class FolderSearchResults : public AbstractLogData {
     void reapplyCollapseForLastGroup();
     bool isLineMarked( const QString& filePath, LineNumber localLine ) const;
     QString headerText( klogg::folder::FileId fileId ) const;
+    QString marksGroupHeader( size_t marksGroupIndex ) const;
     QString readMatchLine( klogg::folder::FileId fileId, size_t matchIndex ) const;
+    // Fetch the text of a marked source line by (filePath, localLine) using a
+    // cached per-file line-offset index (marked non-match lines have no
+    // MatchRecord offset). Results are cached per (filePath, localLine).
+    QString readMarkLine( const QString& filePath, LineNumber localLine, QTextCodec* codec ) const;
+    void ensureMarkLines( const QString& filePath, QTextCodec* codec ) const;
+    QTextCodec* codecForFile( const QString& filePath ) const;
     QFile* fileForGroup( klogg::folder::FileId fileId ) const;
     const VisibleRow* visibleRowAt( LineNumber line ) const;
 
@@ -207,7 +234,21 @@ class FolderSearchResults : public AbstractLogData {
     QSet<QString> pendingCollapsePaths_;
 
     Visibility visibility_ = Visibility::MarksAndMatches;
-    std::function<bool( const QString&, LineNumber )> isMarkedLine_;
+    // Widget-owned per-file marks store, read LIVE during rebuildVisibleRows
+    // (main thread). Lets the Marks / Marks-and-matches filter enumerate marked
+    // lines and inject marked non-match rows (single-file marks_ parity).
+    const QHash<QString, std::set<uint64_t>>* marksStore_ = nullptr;
+    // Marks-only groups (files with marks but no match group), rebuilt each
+    // rebuildVisibleRows. Indexed by FileId = groups_.size() + index.
+    std::vector<MarksGroup> marksGroups_;
+    // Per-file decoded line text for on-demand marked-line fetch (marked
+    // non-match lines have no MatchRecord offset). Built lazily by reading the
+    // whole file, decoding with codecForFile and splitting on '\n' (correct for
+    // all encodings incl. UTF-16), cached, capped at kMarkLineCacheCap bytes
+    // (huge files skip -> empty mark text, no main-thread stall). Persists across
+    // searches (file-intrinsic); invalidated on encoding-override change.
+    // Guarded by fileIoMutex_.
+    mutable QHash<QString, std::vector<QString>> markLineCache_;
     // Per-file display-encoding overrides (Encoding-menu picks), consulted by
     // readMatchLine before the scan-time detected sourceCodec.
     QHash<QString, QByteArray> encodingOverrides_;

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -244,10 +244,11 @@ class FolderSearchResults : public AbstractLogData {
     // Per-file decoded line text for on-demand marked-line fetch (marked
     // non-match lines have no MatchRecord offset). Built lazily by reading the
     // whole file, decoding with codecForFile and splitting on '\n' (correct for
-    // all encodings incl. UTF-16), cached, capped at kMarkLineCacheCap bytes
-    // (huge files skip -> empty mark text, no main-thread stall). Persists across
-    // searches (file-intrinsic); invalidated on encoding-override change.
-    // Guarded by fileIoMutex_.
+    // all encodings incl. UTF-16), cached. kMarkLineCacheCap is a PER-FILE cap
+    // (huge files skip -> empty mark text, no main-thread stall); there is no
+    // cache-wide memory budget. Persists across searches (file-intrinsic);
+    // invalidated on encoding-override change. A transient open failure is NOT
+    // cached so a later fetch can retry. Guarded by fileIoMutex_.
     mutable QHash<QString, std::vector<QString>> markLineCache_;
     // Per-file display-encoding overrides (Encoding-menu picks), consulted by
     // readMatchLine before the scan-time detected sourceCodec.

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -244,9 +244,12 @@ class FolderSearchResults : public AbstractLogData {
     // Per-file decoded line text for on-demand marked-line fetch (marked
     // non-match lines have no MatchRecord offset). Built lazily by reading the
     // whole file, decoding with codecForFile and splitting on '\n' (correct for
-    // all encodings incl. UTF-16), cached. kMarkLineCacheCap is a PER-FILE cap
-    // (huge files skip -> empty mark text, no main-thread stall); there is no
-    // cache-wide memory budget. Persists across searches (file-intrinsic);
+    // all encodings incl. UTF-16), cached. Key is filePath + null + codec name;
+    // a marks-only file (nullptr codec / UTF-8 default) and a later match-group
+    // file (scanned codec, e.g. Shift-JIS) get separate cache entries to avoid
+    // mojibake from a stale encoding mismatch. kMarkLineCacheCap is a PER-FILE
+    // cap (huge files skip -> empty mark text, no main-thread stall); there is
+    // no cache-wide memory budget. Persists across searches (file-intrinsic);
     // invalidated on encoding-override change. A transient open failure is NOT
     // cached so a later fetch can retry. Guarded by fileIoMutex_.
     mutable QHash<QString, std::vector<QString>> markLineCache_;

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -24,6 +24,21 @@
 
 #include <algorithm>
 
+namespace {
+
+// Composite cache key: filePath + null separator + codec name. The codec for a
+// marks-only file (nullptr / "UTF-8" default) differs from the scanned codec of
+// a later match group (e.g. "Shift-JIS"). Without the codec suffix, a cached
+// UTF-8 decode for a marks-only file is reused for a match group that has a
+// different actual encoding — producing mojibake for the marked lines.
+QString markCacheKey( const QString& filePath, QTextCodec* codec )
+{
+    return filePath + QChar::Null
+           + QString::fromLatin1( codec != nullptr ? codec->name() : "UTF-8" );
+}
+
+} // namespace
+
 #include "linetypes.h"
 #include "log.h"
 
@@ -85,8 +100,17 @@ void FolderSearchResults::reapplyCollapseForLastGroup()
         return;
     }
     const auto& lastPath = groups_.back().filePath;
+    const auto fid = static_cast<int>( groups_.size() ) - 1;
     if ( pendingCollapsePaths_.contains( lastPath ) ) {
-        collapsed_.insert( static_cast<int>( groups_.size() ) - 1 );
+        collapsed_.insert( fid );
+    }
+    else {
+        // The group just added was NOT in the collapse snapshot. Remove any
+        // stale collapsed_ entry a marks-only group may have set at this FileId
+        // before the real group arrived (marks-group FileIds shift when later
+        // match groups stream in). Without the removal the stale entry leaks
+        // to the real group now occupying this index.
+        collapsed_.remove( fid );
     }
 }
 
@@ -922,7 +946,8 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
     // larger than kMarkLineCacheCap skip (empty cache -> empty mark text) to
     // avoid a main-thread stall on huge files. Caller does NOT hold fileIoMutex_.
     std::lock_guard<std::mutex> io( fileIoMutex_ );
-    if ( markLineCache_.contains( filePath ) ) {
+    const QString cacheKey = markCacheKey( filePath, codec );
+    if ( markLineCache_.contains( cacheKey ) ) {
         return;
     }
 
@@ -962,7 +987,7 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
             start = idx + 1;
         }
     }
-    markLineCache_.insert( filePath, std::move( lines ) );
+    markLineCache_.insert( cacheKey, std::move( lines ) );
 }
 
 QString FolderSearchResults::readMarkLine( const QString& filePath, LineNumber localLine,
@@ -973,7 +998,7 @@ QString FolderSearchResults::readMarkLine( const QString& filePath, LineNumber l
     // dataMutex_; only fileIoMutex_ is taken here.
     ensureMarkLines( filePath, codec );
     std::lock_guard<std::mutex> io( fileIoMutex_ );
-    const auto it = markLineCache_.constFind( filePath );
+    const auto it = markLineCache_.constFind( markCacheKey( filePath, codec ) );
     const auto lineIdx = static_cast<size_t>( localLine.get() );
     if ( it != markLineCache_.cend() && lineIdx < it->size() ) {
         return it->at( lineIdx );

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -34,7 +34,7 @@ namespace {
 QString markCacheKey( const QString& filePath, QTextCodec* codec )
 {
     return filePath + QChar::Null
-           + QString::fromLatin1( codec != nullptr ? codec->name() : "UTF-8" );
+           + QString::fromLatin1( codec != nullptr ? codec->name() : QByteArrayLiteral( "UTF-8" ) );
 }
 
 } // namespace

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -185,7 +185,7 @@ bool FolderSearchResults::isMatchRow( LineNumber visibleIndex ) const
 {
     SharedLock lock( dataMutex_ );
     const auto* row = visibleRowAt( visibleIndex );
-    if ( row == nullptr || row->kind != LineKind::Data ) {
+    if ( row == nullptr || row->kind != LineKind::Data || row->isMarkRow ) {
         return false;
     }
     const auto& group = groups_[ static_cast<size_t>( row->fileId ) ];
@@ -203,7 +203,15 @@ klogg::folder::SourceRef FolderSearchResults::sourceForLine( LineNumber visibleI
 {
     SharedLock lock( dataMutex_ );
     const auto* row = visibleRowAt( visibleIndex );
-    if ( row == nullptr || row->fileId < 0 || row->fileId >= static_cast<int>( groups_.size() ) ) {
+    if ( row == nullptr ) {
+        return {};
+    }
+    // Mark rows carry their own (filePath, localLine) -- they may belong to a
+    // marks-only file with no entry in groups_.
+    if ( row->isMarkRow ) {
+        return klogg::folder::SourceRef{ row->markFilePath, row->markLocalLine };
+    }
+    if ( row->fileId < 0 || row->fileId >= static_cast<int>( groups_.size() ) ) {
         return {};
     }
 
@@ -257,7 +265,10 @@ void FolderSearchResults::toggleCollapse( klogg::folder::FileId fileId )
 {
     {
         UniqueLock lock( dataMutex_ );
-        if ( fileId < 0 || fileId >= static_cast<int>( groups_.size() ) ) {
+        // Marks-only groups use FileId = groups_.size() + idx, so the valid range
+        // covers both real and marks-only groups.
+        const int totalGroups = static_cast<int>( groups_.size() + marksGroups_.size() );
+        if ( fileId < 0 || fileId >= totalGroups ) {
             return;
         }
         if ( collapsed_.contains( fileId ) ) {
@@ -275,7 +286,8 @@ void FolderSearchResults::setCollapsed( klogg::folder::FileId fileId, bool colla
 {
     {
         UniqueLock lock( dataMutex_ );
-        if ( fileId < 0 || fileId >= static_cast<int>( groups_.size() ) ) {
+        const int totalGroups = static_cast<int>( groups_.size() + marksGroups_.size() );
+        if ( fileId < 0 || fileId >= totalGroups ) {
             return;
         }
         if ( collapsed ) {
@@ -294,7 +306,8 @@ void FolderSearchResults::collapseAll()
     {
         UniqueLock lock( dataMutex_ );
         collapsed_.clear();
-        for ( klogg::folder::FileId i = 0; i < static_cast<int>( groups_.size() ); ++i ) {
+        const int totalGroups = static_cast<int>( groups_.size() + marksGroups_.size() );
+        for ( klogg::folder::FileId i = 0; i < totalGroups; ++i ) {
             collapsed_.insert( i );
         }
         rebuildVisibleRows();
@@ -327,8 +340,26 @@ QString FolderSearchResults::doGetLineString( LineNumber line ) const
     if ( row == nullptr ) {
         return {};
     }
+    if ( row->isMarkRow ) {
+        // Release dataMutex_ before the (capped) file read+decode so mutators
+        // (streaming search commits) are not blocked; codec is resolved under
+        // the lock. readMarkLine takes only fileIoMutex_.
+        const QString filePath = row->markFilePath;
+        const LineNumber localLine = row->markLocalLine;
+        QTextCodec* const codec = codecForFile( filePath );
+        lock.unlock();
+        return readMarkLine( filePath, localLine, codec );
+    }
     if ( row->kind == LineKind::Header ) {
-        return headerText( row->fileId );
+        if ( row->fileId >= 0 && row->fileId < static_cast<int>( groups_.size() ) ) {
+            return headerText( row->fileId );
+        }
+        // Marks-only group header (fileId = groups_.size() + marksGroupIndex).
+        const auto mgi = static_cast<size_t>( row->fileId - static_cast<int>( groups_.size() ) );
+        if ( mgi < marksGroups_.size() ) {
+            return marksGroupHeader( mgi );
+        }
+        return {};
     }
     return readMatchLine( row->fileId, row->matchIndex );
 }
@@ -390,6 +421,10 @@ void FolderSearchResults::setEncodingOverrideForFile( const QString& filePath,
     {
         UniqueLock lock( dataMutex_ );
         encodingOverrides_.insert( filePath, encoding );
+        // Cached mark-line text was decoded with the old codec; drop it so the
+        // next fetch re-decodes with the override. Lock order dataMutex_ -> fileIoMutex_.
+        std::lock_guard<std::mutex> io( fileIoMutex_ );
+        markLineCache_.remove( filePath );
     }
     Q_EMIT layoutChanged();
 }
@@ -404,6 +439,10 @@ void FolderSearchResults::clearEncodingOverrideForFile( const QString& filePath 
     {
         UniqueLock lock( dataMutex_ );
         removed = encodingOverrides_.remove( filePath ) != 0;
+        if ( removed ) {
+            std::lock_guard<std::mutex> io( fileIoMutex_ );
+            markLineCache_.remove( filePath );
+        }
     }
     if ( removed ) {
         Q_EMIT layoutChanged();
@@ -429,8 +468,22 @@ LineLength FolderSearchResults::doGetLineLength( LineNumber line ) const
     if ( row == nullptr ) {
         return 0_length;
     }
+    if ( row->isMarkRow ) {
+        const QString filePath = row->markFilePath;
+        const LineNumber localLine = row->markLocalLine;
+        QTextCodec* const codec = codecForFile( filePath );
+        lock.unlock();
+        return LineLength( untabify( readMarkLine( filePath, localLine, codec ) ).size() );
+    }
     if ( row->kind == LineKind::Header ) {
-        return LineLength( headerText( row->fileId ).size() );
+        if ( row->fileId >= 0 && row->fileId < static_cast<int>( groups_.size() ) ) {
+            return LineLength( headerText( row->fileId ).size() );
+        }
+        const auto mgi = static_cast<size_t>( row->fileId - static_cast<int>( groups_.size() ) );
+        if ( mgi < marksGroups_.size() ) {
+            return LineLength( marksGroupHeader( mgi ).size() );
+        }
+        return 0_length;
     }
     if ( row->fileId >= 0 && row->fileId < static_cast<int>( groups_.size() ) ) {
         const auto& matches = groups_[ static_cast<size_t>( row->fileId ) ].matches;
@@ -498,60 +551,162 @@ void FolderSearchResults::rebuildVisibleRows()
     }
 
     const bool marksOnly = ( visibility_ == Visibility::Marks );
+    // Mark rows (marked non-match lines) are injected under Marks and
+    // Marks-and-matches -- the single-file marks_ parity: a bookmark on a source
+    // line stays visible across filter changes. Matches stays grep-pure (no marks).
+    const bool injectMarks
+        = ( visibility_ == Visibility::Marks || visibility_ == Visibility::MarksAndMatches )
+        && marksStore_ != nullptr;
 
+    // Build marks-only groups: files with marks that have no real match group.
+    marksGroups_.clear();
+    if ( injectMarks ) {
+        QSet<QString> groupFiles;
+        groupFiles.reserve( static_cast<int>( groups_.size() ) );
+        for ( const auto& g : groups_ ) {
+            groupFiles.insert( g.filePath );
+        }
+        for ( auto it = marksStore_->constBegin(); it != marksStore_->constEnd(); ++it ) {
+            if ( it.value().empty() || groupFiles.contains( it.key() ) ) {
+                continue;
+            }
+            MarksGroup mg;
+            mg.filePath = it.key();
+            mg.localLines.reserve( it.value().size() );
+            for ( const auto& ln : it.value() ) {
+                mg.localLines.push_back( LineNumber( ln ) );
+            }
+            // std::set iterates ascending, so localLines is already sorted.
+            marksGroups_.push_back( std::move( mg ) );
+        }
+    }
+
+    // Real groups: header + match rows + injected Mark rows.
     for ( klogg::folder::FileId fid = 0; fid < static_cast<int>( groups_.size() ); ++fid ) {
         const auto& group = groups_[ static_cast<size_t>( fid ) ];
 
-        if ( marksOnly ) {
-            // Under the Marks filter a group with no marked MATCH rows is hidden
-            // entirely (context rows are never marks). Matches single-file Marks
-            // view omitting unmarked lines.
-            bool anyMarked = false;
-            for ( size_t mi = 0; mi < group.matches.size(); ++mi ) {
-                const auto& rec = group.matches[ mi ];
-                if ( rec.role == klogg::folder::RecordRole::Match
-                     && isLineMarked( group.filePath, rec.localLine ) ) {
-                    anyMarked = true;
-                    break;
+        std::vector<LineNumber> markRows;
+        if ( injectMarks ) {
+            const auto mIt = marksStore_->constFind( group.filePath );
+            if ( mIt != marksStore_->cend() ) {
+                // Lines already shown as a visible record (don't inject as a mark
+                // row -> avoids duplicates). Under Marks, context records and
+                // unmarked matches are hidden, so only marked Match records are
+                // visible -- a marked context line is therefore NOT excluded and
+                // is injected as a mark row (its context record is hidden).
+                QSet<uint64_t> visibleRecordLines;
+                visibleRecordLines.reserve( static_cast<int>( group.matches.size() ) );
+                for ( const auto& rec : group.matches ) {
+                    if ( marksOnly ) {
+                        if ( rec.role != klogg::folder::RecordRole::Match ) {
+                            continue;
+                        }
+                        if ( !isLineMarked( group.filePath, rec.localLine ) ) {
+                            continue;
+                        }
+                    }
+                    visibleRecordLines.insert( rec.localLine.get() );
                 }
-            }
-            if ( !anyMarked ) {
-                continue;
+                for ( const auto& ln : mIt.value() ) {
+                    if ( !visibleRecordLines.contains( ln ) ) {
+                        markRows.push_back( LineNumber( ln ) );
+                    }
+                }
             }
         }
 
-        // Every shown group always shows its header (collapsed or not).
-        visibleRows_.push_back( VisibleRow{ LineKind::Header, fid, 0 } );
+        // Does this group have any visible match row?
+        bool hasVisibleMatch = false;
+        for ( const auto& rec : group.matches ) {
+            if ( rec.role != klogg::folder::RecordRole::Match ) {
+                continue;
+            }
+            if ( marksOnly && !isLineMarked( group.filePath, rec.localLine ) ) {
+                continue;
+            }
+            hasVisibleMatch = true;
+            break;
+        }
+        if ( !hasVisibleMatch && markRows.empty() ) {
+            continue;
+        }
+
+        // Header (always shown for a visible group).
+        visibleRows_.push_back( VisibleRow{ LineKind::Header, false, fid, 0, 0_lnum, {} } );
         maxLength_ = std::max( maxLength_, LineLength( headerText( fid ).size() ) );
 
         if ( collapsed_.contains( fid ) ) {
             continue;
         }
-        // group.matches holds Match AND Context records (grep -A/-B/-C), already
-        // sorted by localLine ascending and deduplicated by the engine, so the
-        // linear walk produces grep grouping (context interleaved with matches)
-        // for free. Under Marks, context rows are hidden (not marks) and unmarked
-        // matches are hidden.
-        for ( size_t mi = 0; mi < group.matches.size(); ++mi ) {
-            const auto& rec = group.matches[ mi ];
-            if ( marksOnly ) {
-                if ( rec.role != klogg::folder::RecordRole::Match ) {
-                    continue;
+
+        // Merge match rows (sorted, include context) with mark rows (sorted) by
+        // localLine so the listing reads in source order. Under Marks, context
+        // rows and unmarked matches are hidden (only marked rows remain).
+        size_t mi = 0;
+        size_t mri = 0;
+        while ( mi < group.matches.size() || mri < markRows.size() ) {
+            const bool canMatch = mi < group.matches.size();
+            const bool canMark = mri < markRows.size();
+            const bool takeMatch = !canMatch
+                ? false
+                : ( !canMark || group.matches[ mi ].localLine < markRows[ mri ] );
+
+            if ( takeMatch ) {
+                const auto& rec = group.matches[ mi ];
+                const auto useIndex = mi;
+                ++mi;
+                if ( marksOnly ) {
+                    if ( rec.role != klogg::folder::RecordRole::Match ) {
+                        continue; // hide context under Marks
+                    }
+                    if ( !isLineMarked( group.filePath, rec.localLine ) ) {
+                        continue; // hide unmarked matches under Marks
+                    }
                 }
-                if ( !isLineMarked( group.filePath, rec.localLine ) ) {
-                    continue;
-                }
+                visibleRows_.push_back(
+                    VisibleRow{ LineKind::Data, false, fid, useIndex, 0_lnum, {} } );
+                maxLength_ = std::max( maxLength_, rec.lineLength );
+                maxLocalLine_ = std::max( maxLocalLine_, rec.localLine );
             }
-            visibleRows_.push_back( VisibleRow{ LineKind::Data, fid, mi } );
-            maxLength_ = std::max( maxLength_, rec.lineLength );
-            maxLocalLine_ = std::max( maxLocalLine_, rec.localLine );
+            else {
+                const auto ln = markRows[ mri ];
+                ++mri;
+                visibleRows_.push_back(
+                    VisibleRow{ LineKind::Data, true, fid, 0, ln, group.filePath } );
+                maxLocalLine_ = std::max( maxLocalLine_, ln );
+                // maxLength_ for a mark row needs the fetched text; deferred (the
+                // horizontal scrollbar may be slightly narrow for long marked
+                // lines -- acceptable; doGetLineLength fetches the exact value).
+            }
+        }
+    }
+
+    // Marks-only groups (files with marks but no match group).
+    if ( injectMarks ) {
+        for ( size_t mgi = 0; mgi < marksGroups_.size(); ++mgi ) {
+            const auto fid = static_cast<klogg::folder::FileId>( groups_.size() + mgi );
+            const auto& mg = marksGroups_[ mgi ];
+            visibleRows_.push_back( VisibleRow{ LineKind::Header, false, fid, 0, 0_lnum, {} } );
+            maxLength_ = std::max( maxLength_, LineLength( marksGroupHeader( mgi ).size() ) );
+            if ( collapsed_.contains( fid ) ) {
+                continue;
+            }
+            for ( const auto& ln : mg.localLines ) {
+                visibleRows_.push_back(
+                    VisibleRow{ LineKind::Data, true, fid, 0, ln, mg.filePath } );
+                maxLocalLine_ = std::max( maxLocalLine_, ln );
+            }
         }
     }
 }
 
 bool FolderSearchResults::isLineMarked( const QString& filePath, LineNumber localLine ) const
 {
-    return isMarkedLine_ != nullptr && isMarkedLine_( filePath, localLine );
+    if ( marksStore_ == nullptr ) {
+        return false;
+    }
+    const auto it = marksStore_->constFind( filePath );
+    return it != marksStore_->cend() && it->count( localLine.get() ) > 0;
 }
 
 void FolderSearchResults::setVisibility( Visibility visibility )
@@ -564,13 +719,16 @@ void FolderSearchResults::setVisibility( Visibility visibility )
     Q_EMIT layoutChanged();
 }
 
-void FolderSearchResults::setMarkedLineQuery( std::function<bool( const QString&, LineNumber )> query )
+void FolderSearchResults::setMarksStore( const QHash<QString, std::set<uint64_t>>* store )
 {
     bool rebuilt = false;
     {
         UniqueLock lock( dataMutex_ );
-        isMarkedLine_ = std::move( query );
-        if ( visibility_ == Visibility::Marks ) {
+        marksStore_ = store;
+        // The visible set depends on marks under Marks AND Marks-and-matches now
+        // (marked non-match rows are injected under both); rebuild there. Under
+        // Matches no marks are shown, so a rebuild is unnecessary.
+        if ( visibility_ == Visibility::Marks || visibility_ == Visibility::MarksAndMatches ) {
             rebuildVisibleRows();
             rebuilt = true;
         }
@@ -582,11 +740,12 @@ void FolderSearchResults::setMarkedLineQuery( std::function<bool( const QString&
 
 void FolderSearchResults::refreshForMarksChange()
 {
-    // The visible set depends on marks only under the Marks filter.
+    // The visible set depends on marks under Marks AND Marks-and-matches (both
+    // inject marked non-match rows); Matches shows no marks.
     bool rebuilt = false;
     {
         UniqueLock lock( dataMutex_ );
-        if ( visibility_ == Visibility::Marks ) {
+        if ( visibility_ == Visibility::Marks || visibility_ == Visibility::MarksAndMatches ) {
             rebuildVisibleRows();
             rebuilt = true;
         }
@@ -707,4 +866,101 @@ QFile* FolderSearchResults::fileForGroup( klogg::folder::FileId fileId ) const
     auto* raw = file.get();
     slot = std::move( file );
     return raw;
+}
+
+QString FolderSearchResults::marksGroupHeader( size_t marksGroupIndex ) const
+{
+    if ( marksGroupIndex >= marksGroups_.size() ) {
+        return {};
+    }
+    const auto& mg = marksGroups_[ marksGroupIndex ];
+    const auto fid = static_cast<klogg::folder::FileId>( groups_.size() + marksGroupIndex );
+    const QChar arrow = collapsed_.contains( fid ) ? QChar( 0x25B8 ) : QChar( 0x25BE );
+    QString text;
+    text.reserve( mg.filePath.size() + 24 );
+    text += arrow;
+    text += QLatin1Char( ' ' );
+    text += mg.filePath;
+    text += QLatin1Char( ' ' );
+    text += QChar( 0x2014 ); // em dash
+    text += QLatin1Char( ' ' );
+    text += QString::number( static_cast<int>( mg.localLines.size() ) );
+    text += QLatin1String( " marks" );
+    return text;
+}
+
+QTextCodec* FolderSearchResults::codecForFile( const QString& filePath ) const
+{
+    // Caller holds dataMutex_ shared; reads encodingOverrides_ + groups_.
+    const auto overrideIt = encodingOverrides_.constFind( filePath );
+    if ( overrideIt != encodingOverrides_.cend() ) {
+        QTextCodec* const c = QTextCodec::codecForName( overrideIt.value() );
+        if ( c != nullptr ) {
+            return c;
+        }
+    }
+    for ( const auto& g : groups_ ) {
+        if ( g.filePath == filePath ) {
+            return g.sourceCodec;
+        }
+    }
+    return nullptr; // UTF-8 default for marks-only files (no scanned codec)
+}
+
+void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* codec ) const
+{
+    // Build the per-file decoded line cache: read the whole file, decode with
+    // `codec`, split on '\n'. Decoding BEFORE splitting makes this correct for
+    // all encodings (incl. UTF-16/UTF-32), unlike a raw byte scan. Capped: files
+    // larger than kMarkLineCacheCap skip (empty cache -> empty mark text) to
+    // avoid a main-thread stall on huge files. Caller does NOT hold fileIoMutex_.
+    std::lock_guard<std::mutex> io( fileIoMutex_ );
+    if ( markLineCache_.contains( filePath ) ) {
+        return;
+    }
+
+    std::vector<QString> lines;
+    QFile file( filePath );
+    if ( file.open( QIODevice::ReadOnly ) ) {
+        constexpr qint64 kMarkLineCacheCap = 16LL << 20; // 16 MiB
+        if ( file.size() <= kMarkLineCacheCap ) {
+            const QByteArray bytes = file.readAll();
+            const QString text
+                = codec != nullptr ? codec->toUnicode( bytes ) : QString::fromUtf8( bytes );
+            const qsizetype n = text.size();
+            qsizetype start = 0;
+            while ( start <= n ) {
+                qsizetype idx = text.indexOf( QLatin1Char( '\n' ), start );
+                if ( idx < 0 ) {
+                    idx = n;
+                }
+                QString line = text.mid( start, idx - start );
+                if ( line.endsWith( QLatin1Char( '\r' ) ) ) {
+                    line.chop( 1 );
+                }
+                lines.push_back( std::move( line ) );
+                if ( idx >= n ) {
+                    break;
+                }
+                start = idx + 1;
+            }
+        }
+    }
+    markLineCache_.insert( filePath, std::move( lines ) );
+}
+
+QString FolderSearchResults::readMarkLine( const QString& filePath, LineNumber localLine,
+                                           QTextCodec* codec ) const
+{
+    // Fetch the marked source line by line number from the cached decoded lines
+    // (marked non-match lines have no MatchRecord offset). Caller has released
+    // dataMutex_; only fileIoMutex_ is taken here.
+    ensureMarkLines( filePath, codec );
+    std::lock_guard<std::mutex> io( fileIoMutex_ );
+    const auto it = markLineCache_.constFind( filePath );
+    const auto lineIdx = static_cast<size_t>( localLine.get() );
+    if ( it != markLineCache_.cend() && lineIdx < it->size() ) {
+        return it->at( lineIdx );
+    }
+    return {};
 }

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -579,6 +579,13 @@ void FolderSearchResults::rebuildVisibleRows()
             // std::set iterates ascending, so localLines is already sorted.
             marksGroups_.push_back( std::move( mg ) );
         }
+        // marksStore_ is a QHash (unspecified, per-process-salted iteration
+        // order); sort so marks-only groups -- and their derived FileIds / row
+        // indices -- appear in a stable, natural order across rebuilds and runs.
+        std::sort( marksGroups_.begin(), marksGroups_.end(),
+                   []( const MarksGroup& l, const MarksGroup& r ) {
+                       return l.filePath < r.filePath;
+                   } );
     }
 
     // Real groups: header + match rows + injected Mark rows.
@@ -921,29 +928,38 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
 
     std::vector<QString> lines;
     QFile file( filePath );
-    if ( file.open( QIODevice::ReadOnly ) ) {
-        constexpr qint64 kMarkLineCacheCap = 16LL << 20; // 16 MiB
-        if ( file.size() <= kMarkLineCacheCap ) {
-            const QByteArray bytes = file.readAll();
-            const QString text
-                = codec != nullptr ? codec->toUnicode( bytes ) : QString::fromUtf8( bytes );
-            const qsizetype n = text.size();
-            qsizetype start = 0;
-            while ( start <= n ) {
-                qsizetype idx = text.indexOf( QLatin1Char( '\n' ), start );
-                if ( idx < 0 ) {
-                    idx = n;
-                }
-                QString line = text.mid( start, idx - start );
-                if ( line.endsWith( QLatin1Char( '\r' ) ) ) {
-                    line.chop( 1 );
-                }
-                lines.push_back( std::move( line ) );
-                if ( idx >= n ) {
-                    break;
-                }
-                start = idx + 1;
+    if ( !file.open( QIODevice::ReadOnly ) ) {
+        // Transient open failure: don't cache an empty entry so a later fetch
+        // (e.g. after the file becomes readable again) can retry instead of
+        // being permanently recorded as "no mark text".
+        return;
+    }
+    constexpr qint64 kMarkLineCacheCap = 16LL << 20; // 16 MiB
+    if ( file.size() <= kMarkLineCacheCap ) {
+        const QByteArray bytes = file.readAll();
+        const QString text
+            = codec != nullptr ? codec->toUnicode( bytes ) : QString::fromUtf8( bytes );
+        // File size is capped at kMarkLineCacheCap (16 MiB) above, so all line
+        // indices fit in int. Use int + explicit casts for Qt 5 / Qt 6
+        // portability: Qt 5's QString::indexOf/mid take int, Qt 6's take
+        // qsizetype, and a raw qsizetype here triggers -Werror=conversion on
+        // the Qt 5 Linux CI builds.
+        const int n = static_cast<int>( text.size() );
+        int start = 0;
+        while ( start <= n ) {
+            int idx = static_cast<int>( text.indexOf( QLatin1Char( '\n' ), start ) );
+            if ( idx < 0 ) {
+                idx = n;
             }
+            QString line = text.mid( start, idx - start );
+            if ( line.endsWith( QLatin1Char( '\r' ) ) ) {
+                line.chop( 1 );
+            }
+            lines.push_back( std::move( line ) );
+            if ( idx >= n ) {
+                break;
+            }
+            start = idx + 1;
         }
     }
     markLineCache_.insert( filePath, std::move( lines ) );

--- a/src/logdata/src/logdata.cpp
+++ b/src/logdata/src/logdata.cpp
@@ -50,14 +50,7 @@
 #include <QCoreApplication>
 #include <QFileInfo>
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#endif
-#include <simdutf.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "simdutf_wrapper.h"
 
 #include "configuration.h"
 #include "containers.h"

--- a/src/logdata/src/searchablelogdata.cpp
+++ b/src/logdata/src/searchablelogdata.cpp
@@ -2,14 +2,7 @@
 
 #include <limits>
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#endif
-#include <simdutf.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "simdutf_wrapper.h"
 
 #include "log.h"
 

--- a/src/regex/src/hsregularexpression.cpp
+++ b/src/regex/src/hsregularexpression.cpp
@@ -31,8 +31,18 @@
 
 #include "cpu_info.h"
 #include "log.h"
+#include <mimalloc.h>
 
 namespace {
+
+// Wire Vectorscan to use mimalloc for internal allocations (once per process).
+struct HsAllocatorInit {
+    HsAllocatorInit()
+    {
+        hs_set_allocator( mi_malloc, mi_free );
+    }
+};
+static HsAllocatorInit hsAllocatorInit;
 
 int matchSingleCallback( unsigned int id, unsigned long long from, unsigned long long to,
                          unsigned int flags, void* context )

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -48,6 +48,7 @@
 #include <string_view>
 
 #include "persistable.h"
+#include "platform/platform_files.h"
 #include "platform/platform_style.h"
 
 // Type of regexp to use for searches
@@ -703,11 +704,7 @@ class Configuration final : public Persistable<Configuration> {
     QString language_{ "en" };
 
     bool nativeFileWatchEnabled_ = true;
-#ifdef Q_OS_WIN
-    bool pollingEnabled_ = true;
-#else
-    bool pollingEnabled_ = false;
-#endif
+    bool pollingEnabled_ = klogg::platform::pollingEnabledDefault;
 
     int pollIntervalMs_ = 2000;
 

--- a/src/settings/include/configuration.h
+++ b/src/settings/include/configuration.h
@@ -48,6 +48,7 @@
 #include <string_view>
 
 #include "persistable.h"
+#include "platform/platform_style.h"
 
 // Type of regexp to use for searches
 enum class SearchRegexpType {
@@ -694,14 +695,7 @@ class Configuration final : public Persistable<Configuration> {
 
   private:
     // Configuration settings
-#ifdef Q_OS_MACOS
-    // macOS uses 72 DPI as its reference, so 13 pt is the right visual size.
-    mutable QFont mainFont_ = { "DejaVu Sans Mono", 13 };
-#else
-    // Windows and Linux default to 96 DPI, making the same point size appear
-    // ~33% larger than on macOS. Use a smaller default for visual parity.
-    mutable QFont mainFont_ = { "DejaVu Sans Mono", 10 };
-#endif
+    mutable QFont mainFont_ = klogg::platform::defaultMainFont();
     SearchRegexpType mainRegexpType_ = SearchRegexpType::ExtendedRegexp;
     SearchRegexpType quickfindRegexpType_ = SearchRegexpType::ExtendedRegexp;
     bool quickfindIncremental_ = true;

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -47,6 +47,7 @@
 
 #include "configuration.h"
 #include "log.h"
+#include "qtcompat/qtcompat.h"
 #include "shortcuts.h"
 #include "styles.h"
 
@@ -158,22 +159,14 @@ void Configuration::retrieveFromStorage( QSettings& settings )
               .toBool();
 
     mainSearchBackColor_
-#if QT_VERSION <= QT_VERSION_CHECK( 6, 4, 0 )
-        .setNamedColor(
-#else
-        .fromString(
-#endif
+        = klogg::qtcompat::colorFromString(
             settings
                 .value( "regexpType.mainBackColor",
                         DefaultConfiguration.mainSearchBackColor_.name( QColor::HexArgb ) )
                 .toString() );
 
     qfBackColor_
-#if QT_VERSION <= QT_VERSION_CHECK( 6, 4, 0 )
-        .setNamedColor(
-#else
-        .fromString(
-#endif
+        = klogg::qtcompat::colorFromString(
             settings
                 .value( "regexpType.quickfindBackColor",
                         DefaultConfiguration.qfBackColor_.name( QColor::HexArgb ) )

--- a/src/settings/src/persistentinfo.cpp
+++ b/src/settings/src/persistentinfo.cpp
@@ -48,6 +48,8 @@
 #include "log.h"
 #include "uuid.h"
 
+#include "platform/platform_paths.h"
+
 #include "persistentinfo.h"
 
 constexpr uint8_t AppSettingsVersion = 1;
@@ -150,11 +152,7 @@ void PersistentInfo::PreparePortableSettings( const QString& portableConfigPath 
 
 void PersistentInfo::PrepareOsSettings()
 {
-#ifdef Q_OS_WIN
-    const auto format = QSettings::IniFormat;
-#else
-    const auto format = QSettings::NativeFormat;
-#endif
+    const auto format = klogg::platform::settingsFormat;
 
     appSettings_ = std::make_unique<QSettings>( format, QSettings::UserScope, "klogg",
                                                 ApplicationSessionFile );

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -25,13 +25,11 @@
 
 #include "shortcuts.h"
 
+#include "platform/platform_input.h"
+
 QString commandShortcutModifier()
 {
-#ifdef Q_OS_MACOS
-    return QStringLiteral( "Meta" );
-#else
-    return QStringLiteral( "Ctrl" );
-#endif
+    return klogg::platform::shortcutModifierName;
 }
 
 QStringList getKeyBindings( QKeySequence::StandardKey standardKey )

--- a/src/settings/src/styles.cpp
+++ b/src/settings/src/styles.cpp
@@ -29,6 +29,8 @@
 #include <QSettings>
 #include <qcolor.h>
 
+#include "qtcompat/qtcompat.h"
+
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif

--- a/src/settings/src/styles.cpp
+++ b/src/settings/src/styles.cpp
@@ -29,6 +29,8 @@
 #include <QSettings>
 #include <qcolor.h>
 
+#include "platform/platform_style.h"
+
 #include "qtcompat/qtcompat.h"
 
 #ifdef Q_OS_WIN
@@ -615,13 +617,7 @@ QStringList StyleManager::availableStyles()
 
 QString StyleManager::defaultPlatformStyle()
 {
-#if defined( Q_OS_WIN )
-    return VistaKey;
-#elif defined( Q_OS_MACOS )
-    return MacintoshKey;
-#else
-    return FusionKey;
-#endif
+    return klogg::platform::defaultStyleKey();
 }
 
 QString StyleManager::defaultStyle()
@@ -720,11 +716,7 @@ void StyleManager::applyStyle( const QString& style )
 
     if ( mode == ThemeMode::Auto ) {
         if ( systemDark ) {
-#ifdef Q_OS_WIN
-            actualStyle = DarkWindowsStyleKey;
-#else
-            actualStyle = DarkStyleKey;
-#endif
+            actualStyle = klogg::platform::darkStyleKey();
         }
         else {
             actualStyle = defaultPlatformStyle();
@@ -733,11 +725,7 @@ void StyleManager::applyStyle( const QString& style )
                  << ", using style " << actualStyle;
     }
     else if ( mode == ThemeMode::Dark ) {
-#ifdef Q_OS_WIN
-        actualStyle = DarkWindowsStyleKey;
-#else
-        actualStyle = DarkStyleKey;
-#endif
+        actualStyle = klogg::platform::darkStyleKey();
         LOG_INFO << "Dark theme mode: forcing dark style " << actualStyle;
     }
     else {

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlighterset.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightersmenu.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightedmatch.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/highlightcompose.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/markprovider.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfilters.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfilterscombobox.h
@@ -82,6 +83,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/predefinedfiltersdialog.ui
   ${CMAKE_CURRENT_SOURCE_DIR}/include/optionsdialog.ui
   ${CMAKE_CURRENT_SOURCE_DIR}/src/abstractlogview.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/highlightcompose.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adblogcatdialog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adbprocesstransport.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adbdevicelistprovider.cpp

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -56,10 +56,6 @@
 #include <QEvent>
 #include <QFontMetrics>
 
-#ifdef GLOGG_PERF_MEASURE_FPS
-#include "perfcounter.h"
-#endif
-
 #include "abstractlogdata.h"
 #include "linekind.h"
 #include "highlighterset.h"
@@ -569,11 +565,6 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     const QuickFindPattern* quickFindPattern_;
     // Our own QuickFind object
     QuickFind* quickFind_;
-
-#ifdef GLOGG_PERF_MEASURE_FPS
-    // Performance measurement
-    PerfCounter perfCounter_;
-#endif
 
     // Vertical offset (in pixels) at which the first line of text is written
     int drawingTopOffset_ = 0;

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -153,6 +153,7 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     // async paint -- or on a viewport Qt never painted (hidden/unrealized) --
     // resolves to the current row instead of a stale/empty map.
     void ensureLineMapFresh();
+#ifdef KLOGG_TESTS
     // Exposed for testing: resolve a viewport y to a line using the current map
     // (nullopt when the map is empty). Lets headless tests verify the paint-free
     // rebuild without synthesizing a mouse event.
@@ -162,6 +163,7 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     // tests verify the signature cache skips redundant rebuilds across mouse
     // events that share the same data/geometry.
     int visibleLineMapBuildCount() const { return visibleLineMapBuildCount_; }
+#endif
     // Instructs the widget to update it's content geometry,
     // used when the font is changed.
     void updateDisplaySize();

--- a/src/ui/include/folderfilteredview.h
+++ b/src/ui/include/folderfilteredview.h
@@ -47,6 +47,7 @@ class FolderFilteredView : public AbstractLogView {
     bool shouldApplySearchRangeGraying() const override;
 
   public:
+#ifdef KLOGG_TESTS
     // Test seam: the line-type the paint path uses for a result row, exposed so
     // headless tests can assert the Mark bullet will render (lineType itself is
     // protected).
@@ -54,6 +55,7 @@ class FolderFilteredView : public AbstractLogView {
     {
         return lineType( lineNumber );
     }
+#endif
 
   private:
     FolderSearchResults* results_;

--- a/src/ui/include/fontutils.h
+++ b/src/ui/include/fontutils.h
@@ -22,6 +22,7 @@
 #define KLOGG_FONTUTILS
 
 #include "log.h"
+#include "qtcompat/qtcompat.h"
 #include <numeric>
 
 #include <QFontDatabase>
@@ -35,31 +36,18 @@ class FontUtils {
         // We only show the fixed fonts
         QStringList fixedFamilies;
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-        QFontDatabase database;
-        const auto families = database.families();
+        const auto families = klogg::qtcompat::fontFamilies();
         for ( const auto& family : families ) {
-            if ( database.isFixedPitch( family ) )
+            if ( klogg::qtcompat::isFixedPitch( family ) )
                 fixedFamilies << family;
         }
-#else
-        const auto families = QFontDatabase::families();
-        for ( const auto& family : families ) {
-            if ( QFontDatabase::isFixedPitch( family ) )
-                fixedFamilies << family;
-        }
-#endif
 
         return fixedFamilies;
     }
 
     static QList<int> availableFontSizes( const QString& family )
     {
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-        auto sizes = QFontDatabase().pointSizes( family, "" );
-#else
-        auto sizes = QFontDatabase::pointSizes( family, "" );
-#endif
+        auto sizes = klogg::qtcompat::pointSizes( family );
 
         if ( sizes.empty() ) {
             sizes = QFontDatabase::standardSizes();

--- a/src/ui/include/highlightcompose.h
+++ b/src/ui/include/highlightcompose.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_HIGHLIGHTCOMPOSE_H
+#define KLOGG_HIGHLIGHTCOMPOSE_H
+
+#include "containers.h"
+#include "highlightedmatch.h"
+#include "linetypes.h"
+
+#include <QColor>
+
+// Logical highlight layers for a single rendered line, in ASCENDING priority:
+// a higher layer wins the fill on an overlap. Encoding the priority explicitly
+// (rather than as the implicit order of addMatches() calls in drawTextArea) makes
+// the z-order contract independent of how sources are gathered and immune to
+// refactors that reshuffle call sites.
+enum class HighlightLayer {
+    Ansi,             // embedded ANSI color spans (lowest)
+    SearchMatch,      // the gray "highlight matches" search-match overlay
+    Highlighter,      // the configured HighlighterSet rules
+    QuickHighlighter, // quick highlighters / color labels
+    QuickFind,        // QuickFind pattern
+    Selection,        // the active text selection (highest)
+};
+
+// A highlight source for composeLineHighlights(): a layer plus the matches that
+// source produced against the (already-untabified) line. Matches may overlap
+// across sources; composeLineHighlights() resolves overlaps by priority plus the
+// search-match/highlighter blend rule.
+struct HighlightSource {
+    HighlightLayer layer;
+    klogg::vector<HighlightedMatch> matches;
+};
+
+// Weight of the search-match gray when it is blended over a configured
+// Highlighter / QuickHighlighter on an overlap. Alpha compositing:
+//   out = gray * alpha + highlighter * (1 - alpha)
+// so the highlighter stays dominant (1 - alpha) while the gray stays visible.
+constexpr double kSearchMatchBlendAlpha = 0.35;
+
+// Blend the search-match gray over a highlighter background. If either color is
+// invalid (a source that sets only a foreground), the valid color wins unchanged.
+QColor blendSearchMatchOverHighlighter( const QColor& highlighterBack,
+                                        const QColor& searchMatchBack );
+
+// Compose per-source highlight matches into a single non-overlapping
+// HighlightedMatchRanges for one line, applying the documented priority and the
+// search-match/highlighter blend rule:
+//   - Higher layer wins the fill
+//     (Ansi < SearchMatch < Highlighter < QuickHighlighter < QuickFind < Selection).
+//   - Where SearchMatch overlaps Highlighter or QuickHighlighter, the fill is
+//     blendSearchMatchOverHighlighter(highlighterBack, grayBack) so BOTH the
+//     highlighter color and the search match stay visible instead of one masking
+//     the other. foreColor is taken from the highest layer.
+//   - All other overlaps: the higher layer wins at full opacity (e.g. Selection
+//     and QuickFind still fully cover a search match).
+// Sources must already be in the same (untabified) column space. The result is
+// sorted by start column with adjacent same-color segments merged.
+HighlightedMatchRanges composeLineHighlights( const klogg::vector<HighlightSource>& sources );
+
+#endif // KLOGG_HIGHLIGHTCOMPOSE_H

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -1240,16 +1240,6 @@ void AbstractLogView::paintEvent( QPaintEvent* paintEvent )
     if ( ( invalidRect.isEmpty() ) || ( logData_ == nullptr ) )
         return;
 
-#ifdef GLOGG_PERF_MEASURE_FPS
-    static uint32_t maxline = logData_->getNbLine();
-    if ( !perfCounter_.addEvent() && logData_->getNbLine() > maxline ) {
-        LOG_WARNING << "Redraw per second: " << perfCounter_.readAndReset()
-                    << " lines: " << logData_->getNbLine();
-        perfCounter_.addEvent();
-        maxline = logData_->getNbLine();
-    }
-#endif
-
     auto start = std::chrono::system_clock::now();
 
     // Can we use our cache?

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -97,8 +97,11 @@
 #include "quickfind.h"
 #include "quickfindpattern.h"
 #include "quicklabelpattern.h"
+#include "platform/platform_intrinsics.h"
+#include "platform/platform_clipboard.h"
 #include "regularexpressionpattern.h"
 #include "shortcuts.h"
+#include "platform/platform_input.h"
 
 namespace {
 
@@ -110,52 +113,13 @@ bool quickLabelMatchesText( const QuickLabelEntry& entry, const QString& text )
 }
 } // namespace
 
-#ifdef Q_OS_WIN
-
-#pragma warning( disable : 4244 )
-
-#include <intrin.h>
-
-#if _WIN64
-inline int countLeadingZeroes( uint64_t value )
-{
-    unsigned long leading_zero = 0;
-
-    if ( _BitScanReverse64( &leading_zero, value ) ) {
-        return 63ul - leading_zero;
-    }
-    else {
-        return 64;
-    }
-}
-#else
-inline int countLeadingZeroes( uint64_t value )
-{
-    unsigned long leading_zero = 0;
-
-    if ( _BitScanReverse( &leading_zero, static_cast<uint32_t>( value ) ) ) {
-        return 63ul - leading_zero;
-    }
-    else {
-        return 64;
-    }
-}
-#endif
-
-#else
-inline int countLeadingZeroes( uint64_t value )
-{
-    return __builtin_clzll( value );
-}
-#endif
-
 namespace {
 
 int mapPullToFollowLength( int length );
 
 int intLog2( uint64_t x )
 {
-    return 63 - countLeadingZeroes( x | 1 );
+    return 63 - klogg::platform::countLeadingZeroes( x | 1 );
 }
 
 // see https://lemire.me/blog/2021/05/28/computing-the-number-of-digits-of-an-integer-quickly/
@@ -1096,11 +1060,7 @@ void AbstractLogView::wheelEvent( QWheelEvent* wheelEvent )
         return;
     }
 
-#ifdef Q_OS_MACOS
-    constexpr auto FontSizeMod = Qt::MetaModifier;
-#else
-    constexpr auto FontSizeMod = Qt::ControlModifier;
-#endif
+    constexpr auto FontSizeMod = klogg::platform::FontSizeMod;
     if ( wheelEvent->modifiers().testFlag( FontSizeMod ) ) {
         Q_EMIT changeFontSize( yDelta > 0 );
         return;
@@ -1731,9 +1691,9 @@ void AbstractLogView::saveLinesToFile( LineNumber begin, LineNumber end )
                 const auto& offset = offsets.at( offsetIndex );
                 LinesData lines{ logData_->getLines( offset.first, offset.second ), true };
                 for ( auto& l : lines.first ) {
-#if !defined( Q_OS_WIN )
+if constexpr ( klogg::platform::clipboardNewlineBeforeLf ) {
                     l.append( QChar::CarriageReturn );
-#endif
+                }
                     l.append( QChar::LineFeed );
                 }
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -84,6 +84,7 @@
 #include "abstractlogview.h"
 #include "containers.h"
 #include "highlightedmatch.h"
+#include "highlightcompose.h"
 #include "linetypes.h"
 
 #include "active_screen.h"
@@ -2340,18 +2341,33 @@ LineLength AbstractLogView::getNbVisibleCols() const
 // Converts the mouse x, y coordinates to the line number in the file
 OptionalLineNumber AbstractLogView::convertCoordToLine( int yPos ) const
 {
-    // Use signed math (no abs) then clamp to valid range.
-    // This fixes clicks near the bottom returning "no line" due to an out-of-range index.
-    if ( wrappedLinesInfo_.empty() ) {
+    // Report the row under the cursor, or nullopt if the click falls outside the
+    // rendered rows (above the first row or below the last row's bottom).
+    //
+    // This used to CLAMP out-of-range clicks to the last visible row. That made
+    // a blank-space click below the content resolve to the last row -- in folder
+    // mode (after Collapse All) the last row is a group Header, so the click
+    // fired headerClicked and expanded the last file's group. It also caused a
+    // latent phantom last-line selection on single-file/live-log blank-space
+    // clicks. Returning nullopt makes blank space a no-op for every view.
+    //
+    // Integer division keeps in-row clicks correct: a click within the last row
+    // (y in [top+(n-1)*charH, top+n*charH)) yields offsetLines == n-1 (returned);
+    // only a click strictly below the last row's bottom yields offsetLines == n
+    // (nullopt). Drag/auto-scroll use convertCoordToFilePos (independent clamp),
+    // so they are unaffected.
+    if ( wrappedLinesInfo_.empty() || charHeight_ <= 0 ) {
         return OptionalLineNumber{};
     }
 
     const int offsetPx = yPos - drawingTopOffset_;
     const int offsetLines = offsetPx / charHeight_;
-    const auto wrappedLineInfoIndex = static_cast<size_t>( std::clamp(
-        offsetLines, 0, static_cast<int>( wrappedLinesInfo_.size() ) - 1 ) );
-    
-    return wrappedLinesInfo_[ wrappedLineInfoIndex ].lineNumber;
+    if ( offsetLines < 0
+         || offsetLines >= static_cast<int>( wrappedLinesInfo_.size() ) ) {
+        return OptionalLineNumber{};
+    }
+
+    return wrappedLinesInfo_[ static_cast<size_t>( offsetLines ) ].lineNumber;
 }
 
 // Converts the mouse x, y coordinates to the char coordinates (in the file)
@@ -3231,8 +3247,6 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
 
         const int xPos = contentStartPosX + ContentMarginWidth;
 
-        HighlightedMatchRanges highlighterMatches;
-
         const auto isWholeLineSelected = selection_.isLineSelected( lineNumber );
 
         // Set base colors
@@ -3252,88 +3266,124 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
         if ( !isWholeLineSelected && isOutsideSearchRange ) {
             foreColor = palette.brush( QPalette::Disabled, QPalette::Text ).color();
         }
-        else if ( !isOutsideSearchRange ) {
-            const auto ansiColorSpans = logData_->getLineAnsiColors( lineNumber );
-            for ( const auto& span : ansiColorSpans ) {
-                const auto toColor = []( quint32 rgb ) {
-                    return QColor( static_cast<int>( ( rgb >> 16 ) & 0xff ),
-                                   static_cast<int>( ( rgb >> 8 ) & 0xff ),
-                                   static_cast<int>( rgb & 0xff ) );
+
+        // Gather per-source highlight matches and compose them through a single
+        // explicit priority + blend contract (see highlightcompose.h). logLine-
+        // space sources (ANSI, HighlighterSet, search-match gray, quick
+        // highlighters) are mapped to the expanded (untabified) column space;
+        // QuickFind and Selection are already in that space. composeLineHighlights
+        // is now the ONLY owner of the z-order -- it replaces the scattered
+        // addMatches() calls whose implicit order let the gray search match mask
+        // configured HighlighterSet colors. On a search-match/highlighter overlap
+        // the two are blended instead of one masking the other.
+        klogg::vector<HighlightSource> highlightSources;
+
+        if ( !isOutsideSearchRange ) {
+            const auto toColor = []( quint32 rgb ) {
+                return QColor( static_cast<int>( ( rgb >> 16 ) & 0xff ),
+                               static_cast<int>( ( rgb >> 8 ) & 0xff ),
+                               static_cast<int>( rgb & 0xff ) );
+            };
+            // Map a logLine-space match into the expanded (untabified) column
+            // space. logLine is still alive here: it is moved into expandedLine
+            // only after every logLine-space source has been gathered.
+            const auto untabifyMatch = [ &logLine ]( const HighlightedMatch& match ) {
+                const auto prefix = QStringView{ logLine }.left( match.startColumn().get() );
+                const auto matchPart
+                    = QStringView{ logLine }.mid( match.startColumn().get(), match.size().get() );
+                const auto expandedPrefixLength = untabify( prefix.toString() ).size();
+                const LineLength startDelta
+                    = LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
+                        expandedPrefixLength - prefix.size() ) };
+
+                const LineLength expandedMatchLength = LineLength{
+                    untabify( matchPart.toString(),
+                              LineColumn{ type_safe::narrow_cast<LineColumn::UnderlyingType>(
+                                  expandedPrefixLength ) } )
+                        .size()
                 };
-                highlighterMatches.addMatch( HighlightedMatch{
+
+                const auto lengthDelta
+                    = expandedMatchLength
+                      - LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
+                          matchPart.size() ) };
+
+                return HighlightedMatch{ match.startColumn() + startDelta,
+                                         match.size() + lengthDelta, match.foreColor(),
+                                         match.backColor() };
+            };
+
+            // ANSI color spans (lowest layer). Unset channels inherit the base.
+            klogg::vector<HighlightedMatch> ansiMatches;
+            for ( const auto& span : logData_->getLineAnsiColors( lineNumber ) ) {
+                ansiMatches.push_back( HighlightedMatch{
                     span.startColumn, span.length,
                     span.foreground.has_value() ? toColor( *span.foreground ) : foreColor,
                     span.background.has_value() ? toColor( *span.background ) : backColor } );
             }
+            std::transform( ansiMatches.begin(), ansiMatches.end(), ansiMatches.begin(),
+                            untabifyMatch );
+            highlightSources.push_back( { HighlightLayer::Ansi, std::move( ansiMatches ) } );
 
+            // Search-match gray. Sits BELOW configured highlighters so it no
+            // longer masks them; on overlap the two are blended.
+            if ( patternHighlight ) {
+                klogg::vector<HighlightedMatch> patternMatches;
+                patternHighlight->matchLine( logLine, patternMatches );
+                std::transform( patternMatches.begin(), patternMatches.end(),
+                                patternMatches.begin(), untabifyMatch );
+                highlightSources.push_back(
+                    { HighlightLayer::SearchMatch, std::move( patternMatches ) } );
+            }
+
+            // Configured HighlighterSet rules. matchLine fills a
+            // HighlightedMatchRanges; extract its matches for composition.
+            HighlightedMatchRanges highlighterMatches;
             const auto highlightType = highlighterSet.matchLine( logLine, highlighterMatches );
-
-            // LineMatch whole-line coloring only applies when not selected
+            // LineMatch whole-line coloring sets the line's base color (used by
+            // the fill rect and any gaps); capture it before extracting matches.
             if ( highlightType == HighlighterMatchType::LineMatch && !isWholeLineSelected ) {
                 foreColor = highlighterMatches.front().foreColor();
                 backColor = highlighterMatches.front().backColor();
             }
+            klogg::vector<HighlightedMatch> highlighterMatchesVec = highlighterMatches.matches();
+            std::transform( highlighterMatchesVec.begin(), highlighterMatchesVec.end(),
+                            highlighterMatchesVec.begin(), untabifyMatch );
+            highlightSources.push_back(
+                { HighlightLayer::Highlighter, std::move( highlighterMatchesVec ) } );
 
-            if ( patternHighlight ) {
-                klogg::vector<HighlightedMatch> patternMatches;
-                patternHighlight->matchLine( logLine, patternMatches );
-                highlighterMatches.addMatches( patternMatches );
-            }
-
+            // Quick highlighters / color labels.
             for ( const auto& highlighter : additionalHighlighters ) {
                 klogg::vector<HighlightedMatch> patternMatches;
                 highlighter.matchLine( logLine, patternMatches );
-                highlighterMatches.addMatches( patternMatches );
+                std::transform( patternMatches.begin(), patternMatches.end(),
+                                patternMatches.begin(), untabifyMatch );
+                highlightSources.push_back(
+                    { HighlightLayer::QuickHighlighter, std::move( patternMatches ) } );
             }
         }
-
-        const auto untabifyHighlight = [ &logLine ]( const auto& match ) {
-            const auto prefix = QStringView{ logLine }.left( match.startColumn().get() );
-            const auto matchPart
-                = QStringView{ logLine }.mid( match.startColumn().get(), match.size().get() );
-            const auto expandedPrefixLength = untabify( prefix.toString() ).size();
-            const LineLength startDelta
-                = LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
-                    expandedPrefixLength - prefix.size() ) };
-
-            const LineLength expandedMatchLength = LineLength{
-                untabify( matchPart.toString(),
-                          LineColumn{ type_safe::narrow_cast<LineColumn::UnderlyingType>(
-                              expandedPrefixLength ) } )
-                    .size()
-            };
-
-            const auto lengthDelta
-                = expandedMatchLength
-                  - LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
-                      matchPart.size() ) };
-
-            return HighlightedMatch{ match.startColumn() + startDelta, match.size() + lengthDelta,
-                                     match.foreColor(), match.backColor() };
-        };
-
-        klogg::vector<HighlightedMatch> sortedHighlights = highlighterMatches.matches();
-        std::transform( sortedHighlights.begin(), sortedHighlights.end(), sortedHighlights.begin(),
-                        untabifyHighlight );
-
-        HighlightedMatchRanges allHighlights{ std::move( sortedHighlights ) };
 
         // string to print, cut to fit the length and position of the view
         const QString& expandedLine = untabify( std::move( logLine ) );
 
-        // Has the line got elements to be highlighted
+        // QuickFind (already in the expanded column space).
         klogg::vector<HighlightedMatch> quickFindMatches;
         quickFindPattern_->matchLine( expandedLine, quickFindMatches );
-        allHighlights.addMatches( quickFindMatches );
+        highlightSources.push_back(
+            { HighlightLayer::QuickFind, std::move( quickFindMatches ) } );
 
-        // Is there something selected in the line?
+        // Selection (already in the expanded column space).
         const auto selectionPortion = selection_.getPortionForLine( lineNumber );
         if ( selectionPortion.isValid() ) {
-            allHighlights.addMatch( HighlightedMatch{ selectionPortion.startColumn(),
-                                                      selectionPortion.size(),
-                                                      palette.color( QPalette::HighlightedText ),
-                                                      palette.color( QPalette::Highlight ) } );
+            highlightSources.push_back(
+                { HighlightLayer::Selection,
+                  { HighlightedMatch{ selectionPortion.startColumn(), selectionPortion.size(),
+                                      palette.color( QPalette::HighlightedText ),
+                                      palette.color( QPalette::Highlight ) } } } );
         }
+
+        HighlightedMatchRanges allHighlights = composeLineHighlights( highlightSources );
+
 
         WrappedString wrappedLineView = [&, this] {
             if ( useTextWrap_ ) {

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -3228,53 +3228,55 @@ void AbstractLogView::drawTextArea( QPaintDevice* paintDevice )
         // the two are blended instead of one masking the other.
         klogg::vector<HighlightSource> highlightSources;
 
+        const auto toColor = []( quint32 rgb ) {
+            return QColor( static_cast<int>( ( rgb >> 16 ) & 0xff ),
+                           static_cast<int>( ( rgb >> 8 ) & 0xff ),
+                           static_cast<int>( rgb & 0xff ) );
+        };
+        // Map a logLine-space match into the expanded (untabified) column
+        // space. logLine is still alive here: it is moved into expandedLine
+        // only after every logLine-space source has been gathered.
+        const auto untabifyMatch = [ &logLine ]( const HighlightedMatch& match ) {
+            const auto prefix = QStringView{ logLine }.left( match.startColumn().get() );
+            const auto matchPart
+                = QStringView{ logLine }.mid( match.startColumn().get(), match.size().get() );
+            const auto expandedPrefixLength = untabify( prefix.toString() ).size();
+            const LineLength startDelta
+                = LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
+                    expandedPrefixLength - prefix.size() ) };
+
+            const LineLength expandedMatchLength = LineLength{
+                untabify( matchPart.toString(),
+                          LineColumn{ type_safe::narrow_cast<LineColumn::UnderlyingType>(
+                              expandedPrefixLength ) } )
+                    .size()
+            };
+
+            const auto lengthDelta
+                = expandedMatchLength
+                  - LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
+                      matchPart.size() ) };
+
+            return HighlightedMatch{ match.startColumn() + startDelta,
+                                     match.size() + lengthDelta, match.foreColor(),
+                                     match.backColor() };
+        };
+
+        // ANSI color spans (lowest layer). Unset channels inherit the base.
+        // ANSI spans come from the raw log content and are file-intrinsic —
+        // apply them even to grayed-out lines outside the search range.
+        klogg::vector<HighlightedMatch> ansiMatches;
+        for ( const auto& span : logData_->getLineAnsiColors( lineNumber ) ) {
+            ansiMatches.push_back( HighlightedMatch{
+                span.startColumn, span.length,
+                span.foreground.has_value() ? toColor( *span.foreground ) : foreColor,
+                span.background.has_value() ? toColor( *span.background ) : backColor } );
+        }
+        std::transform( ansiMatches.begin(), ansiMatches.end(), ansiMatches.begin(),
+                        untabifyMatch );
+        highlightSources.push_back( { HighlightLayer::Ansi, std::move( ansiMatches ) } );
+
         if ( !isOutsideSearchRange ) {
-            const auto toColor = []( quint32 rgb ) {
-                return QColor( static_cast<int>( ( rgb >> 16 ) & 0xff ),
-                               static_cast<int>( ( rgb >> 8 ) & 0xff ),
-                               static_cast<int>( rgb & 0xff ) );
-            };
-            // Map a logLine-space match into the expanded (untabified) column
-            // space. logLine is still alive here: it is moved into expandedLine
-            // only after every logLine-space source has been gathered.
-            const auto untabifyMatch = [ &logLine ]( const HighlightedMatch& match ) {
-                const auto prefix = QStringView{ logLine }.left( match.startColumn().get() );
-                const auto matchPart
-                    = QStringView{ logLine }.mid( match.startColumn().get(), match.size().get() );
-                const auto expandedPrefixLength = untabify( prefix.toString() ).size();
-                const LineLength startDelta
-                    = LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
-                        expandedPrefixLength - prefix.size() ) };
-
-                const LineLength expandedMatchLength = LineLength{
-                    untabify( matchPart.toString(),
-                              LineColumn{ type_safe::narrow_cast<LineColumn::UnderlyingType>(
-                                  expandedPrefixLength ) } )
-                        .size()
-                };
-
-                const auto lengthDelta
-                    = expandedMatchLength
-                      - LineLength{ type_safe::narrow_cast<LineLength::UnderlyingType>(
-                          matchPart.size() ) };
-
-                return HighlightedMatch{ match.startColumn() + startDelta,
-                                         match.size() + lengthDelta, match.foreColor(),
-                                         match.backColor() };
-            };
-
-            // ANSI color spans (lowest layer). Unset channels inherit the base.
-            klogg::vector<HighlightedMatch> ansiMatches;
-            for ( const auto& span : logData_->getLineAnsiColors( lineNumber ) ) {
-                ansiMatches.push_back( HighlightedMatch{
-                    span.startColumn, span.length,
-                    span.foreground.has_value() ? toColor( *span.foreground ) : foreColor,
-                    span.background.has_value() ? toColor( *span.background ) : backColor } );
-            }
-            std::transform( ansiMatches.begin(), ansiMatches.end(), ansiMatches.begin(),
-                            untabifyMatch );
-            highlightSources.push_back( { HighlightLayer::Ansi, std::move( ansiMatches ) } );
-
             // Search-match gray. Sits BELOW configured highlighters so it no
             // longer masks them; on overlap the two are blended.
             if ( patternHighlight ) {

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -46,6 +46,7 @@
 #include "emptyfilterpolicy.h"
 #include "linetypes.h"
 #include "log.h"
+#include "qtcompat/qtcompat.h"
 #include "searchgeneration.h"
 
 #include <algorithm>
@@ -501,11 +502,7 @@ void CrawlerWidget::editSearchHistory()
 
     if ( ok ) {
         savedSearches_->clear();
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-        auto items = newHistory.split( QChar::LineFeed, Qt::SkipEmptyParts );
-#else
-        auto items = newHistory.split( QChar::LineFeed, QString::SkipEmptyParts );
-#endif
+        auto items = newHistory.split( QChar::LineFeed, klogg::qtcompat::skipEmptyParts() );
         std::for_each( items.rbegin(), items.rend(), [ this ]( const auto& item ) {
             savedSearches_->addRecent( item );
             LOG_INFO << item;

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -39,6 +39,8 @@
 #include <QTabWidget>
 #include <QVBoxLayout>
 
+#include "qtcompat/qtcompat.h"
+
 #include <algorithm>
 
 #include "abstractlogview.h"
@@ -1279,11 +1281,7 @@ void FolderCrawlerWidget::editSearchHistory()
 
     if ( ok ) {
         savedSearches_->clear();
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-        const auto items = newHistory.split( QChar::LineFeed, Qt::SkipEmptyParts );
-#else
-        const auto items = newHistory.split( QChar::LineFeed, QString::SkipEmptyParts );
-#endif
+        const auto items = newHistory.split( QChar::LineFeed, klogg::qtcompat::skipEmptyParts() );
         std::for_each( items.rbegin(), items.rend(), [ this ]( const auto& item ) {
             savedSearches_->addRecent( item );
         } );

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -733,13 +733,12 @@ FolderCrawlerWidget::ResultPane* FolderCrawlerWidget::createPane( const QString&
     pane->markProvider->results = pane->results.get();
     view->setMarkProvider( pane->markProvider.get() );
 
-    // The Marks visibility filter consults this query (filePath, localLine) ->
-    // marked, reading the shared per-file store live (same lambda every pane
-    // uses; it captures this, valid for the widget's lifetime).
-    pane->results->setMarkedLineQuery( [ this ]( const QString& file, LineNumber line ) {
-        const auto it = folderMarks_.find( file );
-        return it != folderMarks_.end() && it->count( line.get() ) > 0;
-    } );
+    // Inject the shared per-file marks store (widget-owned, read LIVE during
+    // rebuild) so the Marks / Marks-and-matches filter can ENUMERATE marked lines
+    // and inject marked non-match rows -- single-file LogFilteredData::marks_
+    // parity (a bookmark on a source line stays visible across filter changes).
+    // Same store for every pane; folderMarks_ outlives the pane (widget-owned).
+    pane->results->setMarksStore( &folderMarks_ );
 
     // Seed config so a pane created mid-session (Keep) matches the others.
     const auto& config = Configuration::get();

--- a/src/ui/src/highlightcompose.cpp
+++ b/src/ui/src/highlightcompose.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "highlightcompose.h"
+
+#include <cmath>
+#include <algorithm>
+#include <optional>
+
+QColor blendSearchMatchOverHighlighter( const QColor& highlighterBack,
+                                        const QColor& searchMatchBack )
+{
+    if ( !highlighterBack.isValid() ) {
+        return searchMatchBack;
+    }
+    if ( !searchMatchBack.isValid() ) {
+        return highlighterBack;
+    }
+    const auto blend = [ ]( int gray, int hl ) {
+        return static_cast<int>( std::lround( gray * kSearchMatchBlendAlpha
+                                              + hl * ( 1.0 - kSearchMatchBlendAlpha ) ) );
+    };
+    return QColor{ blend( searchMatchBack.red(), highlighterBack.red() ),
+                   blend( searchMatchBack.green(), highlighterBack.green() ),
+                   blend( searchMatchBack.blue(), highlighterBack.blue() ) };
+}
+
+HighlightedMatchRanges composeLineHighlights( const klogg::vector<HighlightSource>& sources )
+{
+    // Flatten the per-source matches into spans tagged with layer + colors.
+    struct Span {
+        LineColumn start;
+        LineColumn end; // inclusive
+        HighlightLayer layer;
+        QColor fore;
+        QColor back;
+    };
+    klogg::vector<Span> spans;
+    for ( const auto& src : sources ) {
+        for ( const auto& m : src.matches ) {
+            if ( m.size() <= 0_length ) {
+                continue;
+            }
+            spans.push_back( Span{ m.startColumn(), m.endColumn(), src.layer, m.foreColor(),
+                                   m.backColor() } );
+        }
+    }
+    if ( spans.empty() ) {
+        return HighlightedMatchRanges{};
+    }
+
+    // Sweep over all match boundaries to form non-overlapping segments, then
+    // resolve each segment's (fore, back) by priority + the blend rule. This is
+    // the single place that owns the z-order contract.
+    klogg::vector<LineColumn::UnderlyingType> bounds;
+    bounds.reserve( spans.size() * 2 );
+    for ( const auto& s : spans ) {
+        bounds.push_back( s.start.get() );
+        bounds.push_back( s.end.get() + 1 );
+    }
+    std::sort( bounds.begin(), bounds.end() );
+    bounds.erase( std::unique( bounds.begin(), bounds.end() ), bounds.end() );
+
+    const auto layerPriority = []( HighlightLayer layer ) {
+        return static_cast<int>( layer );
+    };
+
+    klogg::vector<HighlightedMatch> result;
+    for ( size_t i = 0; i + 1 < bounds.size(); ++i ) {
+        const LineColumn segStart{ bounds[ i ] };
+        const LineColumn segLast{ bounds[ i + 1 ] - 1 }; // inclusive end
+
+        const Span* top = nullptr;
+        std::optional<QColor> searchMatchBack;
+        for ( const auto& s : spans ) {
+            if ( s.start <= segStart && s.end >= segLast ) {
+                if ( s.layer == HighlightLayer::SearchMatch ) {
+                    searchMatchBack = s.back;
+                }
+                if ( top == nullptr
+                     || layerPriority( s.layer ) >= layerPriority( top->layer ) ) {
+                    top = &s;
+                }
+            }
+        }
+        if ( top == nullptr ) {
+            continue;
+        }
+
+        QColor back = top->back;
+        // Blend rule: where the search-match gray sits UNDER a configured
+        // Highlighter or QuickHighlighter, keep both visible instead of letting
+        // one mask the other. Selection/QuickFind (higher layers) still fully
+        // cover a search match; ANSI (lower) is covered by the search match.
+        if ( searchMatchBack.has_value()
+             && ( top->layer == HighlightLayer::Highlighter
+                  || top->layer == HighlightLayer::QuickHighlighter ) ) {
+            back = blendSearchMatchOverHighlighter( top->back, *searchMatchBack );
+        }
+        const QColor fore = top->fore;
+
+        // Merge with the previous segment if it is adjacent and identical in
+        // fore/back, so the output stays minimal.
+        if ( !result.empty() ) {
+            auto& prev = result.back();
+            if ( prev.endColumn() + 1_length == segStart && prev.foreColor() == fore
+                 && prev.backColor() == back ) {
+                prev = HighlightedMatch{ prev.startColumn(),
+                                         segLast - prev.startColumn() + 1_length,
+                                         prev.foreColor(), prev.backColor() };
+                continue;
+            }
+        }
+        result.push_back( HighlightedMatch{ segStart, segLast - segStart + 1_length, fore, back } );
+    }
+
+    return HighlightedMatchRanges{ std::move( result ) };
+}

--- a/src/ui/src/highlighterset.cpp
+++ b/src/ui/src/highlighterset.cpp
@@ -47,14 +47,7 @@
 
 #include <QSettings>
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsign-conversion"
-#endif
-#include <simdutf.h>
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+#include "simdutf_wrapper.h"
 
 #include "containers.h"
 #include "crc32.h"

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -10,13 +10,11 @@
 #include <QTimer>
 
 #include "log.h"
+#include "platform/platform_process.h"
 
 namespace {
-#ifdef Q_OS_WIN
-constexpr int StartupFailureGracePeriodMs = 1000;
-#else
-constexpr int StartupFailureGracePeriodMs = 250;
-#endif
+constexpr int StartupFailureGracePeriodMs
+    = klogg::platform::startupFailureGracePeriod().count();
 constexpr int StartupFailurePollIntervalMs = 10;
 }
 

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -61,6 +61,8 @@
 #include "shortcuts.h"
 #include "styles.h"
 
+#include "platform/platform_files.h"
+
 #include "optionsdialog.h"
 
 static constexpr int PollIntervalMin = 10;
@@ -154,9 +156,9 @@ OptionsDialog::OptionsDialog( QWidget* parent )
 // Setups the tabs depending on the configuration
 void OptionsDialog::setupTabs()
 {
-#ifndef Q_OS_WIN
+if ( !klogg::platform::hasExclusiveFileLocks ) {
     keepFileClosedCheckBox->setVisible( false );
-#endif
+}
 
 #ifdef Q_OS_MAC
     minimizeToTrayCheckBox->setVisible( false );

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -42,6 +42,7 @@
 #include <qabstractitemview.h>
 
 #include "log.h"
+#include "qtcompat/qtcompat.h"
 
 constexpr int PatternRole = Qt::UserRole + 1;
 constexpr int RegexRole = PatternRole + 1;
@@ -63,9 +64,7 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     view()->setTextElideMode( Qt::ElideNone );
     setSizeAdjustPolicy( QComboBox::AdjustToContents );
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    setPlaceholderText( tr( "Filter favorites" ) );
-#endif
+klogg::qtcompat::setPlaceholderText( this, tr( "Filter favorites" ) );
 }
 
 void PredefinedFiltersComboBox::populatePredefinedFilters()

--- a/src/ui/src/quickfind.cpp
+++ b/src/ui/src/quickfind.cpp
@@ -48,6 +48,7 @@
 #include "dispatch_to.h"
 #include "linetypes.h"
 #include "log.h"
+#include "qtcompat/qtcompat.h"
 #include "quickfindpattern.h"
 #include "selection.h"
 
@@ -204,15 +205,10 @@ void QuickFind::incrementallySearchForward( Selection selection, QuickFindMatche
         incrementalSearchStatus_ = IncrementalSearchStatus( Forward, start_position, selection );
     }
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    operationFuture_ = QtConcurrent::run( this, &QuickFind::doSearchForward, start_position,
-                                          selection, matcher );
-#else
-    operationFuture_ = QtConcurrent::run(
-        qOverload<const FilePosition&, const Selection&, const QuickFindMatcher&>(
+    operationFuture_ = klogg::qtcompat::runConcurrent(
+        QOverload<const FilePosition&, const Selection&, const QuickFindMatcher&>::of(
             &QuickFind::doSearchForward ),
         this, start_position, selection, matcher );
-#endif
 
     operationWatcher_.setFuture( operationFuture_ );
 }
@@ -237,15 +233,10 @@ void QuickFind::incrementallySearchBackward( Selection selection, QuickFindMatch
         incrementalSearchStatus_ = IncrementalSearchStatus( Backward, start_position, selection );
     }
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    operationFuture_ = QtConcurrent::run( this, &QuickFind::doSearchBackward, start_position,
-                                          selection, matcher );
-#else
-    operationFuture_ = QtConcurrent::run(
-        qOverload<const FilePosition&, const Selection&, const QuickFindMatcher&>(
+    operationFuture_ = klogg::qtcompat::runConcurrent(
+        QOverload<const FilePosition&, const Selection&, const QuickFindMatcher&>::of(
             &QuickFind::doSearchBackward ),
         this, start_position, selection, matcher );
-#endif
     operationWatcher_.setFuture( operationFuture_ );
 }
 
@@ -254,13 +245,9 @@ void QuickFind::searchForward( Selection selection, QuickFindMatcher matcher )
     incrementalSearchStatus_ = IncrementalSearchStatus();
     interruptAndWait();
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    operationFuture_ = QtConcurrent::run( this, &QuickFind::doSearchForward, selection, matcher );
-#else
-    operationFuture_ = QtConcurrent::run(
-        qOverload<const Selection&, const QuickFindMatcher&>( &QuickFind::doSearchForward ), this,
-        selection, matcher );
-#endif
+    operationFuture_ = klogg::qtcompat::runConcurrent(
+        QOverload<const Selection&, const QuickFindMatcher&>::of( &QuickFind::doSearchForward ),
+        this, selection, matcher );
     operationWatcher_.setFuture( operationFuture_ );
 }
 
@@ -269,13 +256,9 @@ void QuickFind::searchBackward( Selection selection, QuickFindMatcher matcher )
     incrementalSearchStatus_ = IncrementalSearchStatus();
     interruptAndWait();
 
-#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
-    operationFuture_ = QtConcurrent::run( this, &QuickFind::doSearchBackward, selection, matcher );
-#else
-    operationFuture_ = QtConcurrent::run(
-        qOverload<const Selection&, const QuickFindMatcher&>( &QuickFind::doSearchBackward ), this,
-        selection, matcher );
-#endif
+    operationFuture_ = klogg::qtcompat::runConcurrent(
+        QOverload<const Selection&, const QuickFindMatcher&>::of( &QuickFind::doSearchBackward ),
+        this, selection, matcher );
     operationWatcher_.setFuture( operationFuture_ );
 }
 

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -49,6 +49,7 @@
 #include "log.h"
 #include "openfilehelper.h"
 #include "pathutils.h"
+#include "qtcompat/qtcompat.h"
 #include "styles.h"
 #include "tabgroup.h"
 #include "tabgroupdropresolver.h"
@@ -537,12 +538,7 @@ int TabbedCrawlerWidget::tabIndexForPath( const QString& tabPath ) const
 
 void TabbedCrawlerWidget::setTabVisibleCompat( int index, bool visible )
 {
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-    myTabBar_.setTabVisible( index, visible );
-#else
-    Q_UNUSED( visible );
-    myTabBar_.setTabEnabled( index, visible );
-#endif
+    klogg::qtcompat::setTabVisible( &myTabBar_, index, visible );
 }
 
 void TabbedCrawlerWidget::handleTabMoved( int from, int to )
@@ -733,11 +729,9 @@ void CrawlerTabBar::paintEvent( QPaintEvent* event )
     painter.setRenderHint( QPainter::Antialiasing, true );
 
     for ( int i = 0; i < count(); ++i ) {
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-        if ( !isTabVisible( i ) ) {
+        if ( !klogg::qtcompat::isTabVisible( this, i ) ) {
             continue;
         }
-#endif
         const auto tabInfo = tabData( i ).toMap();
         if ( !tabInfo.contains( GroupColorKey ) ) {
             continue;

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -48,6 +48,7 @@
 #include "iconloader.h"
 #include "log.h"
 #include "openfilehelper.h"
+#include "platform/platform_input.h"
 #include "pathutils.h"
 #include "qtcompat/qtcompat.h"
 #include "styles.h"
@@ -362,6 +363,9 @@ void TabbedCrawlerWidget::updateTabBarStyle()
         backgroundHoverImage = ":/images/icons8-close-window-hover_inverse.svg";
     }
 
+// Platform-specific tab close icon workarounds.
+// This is tightly coupled to the renderer (QStyle, Fusion vs. native) and
+// Qt bug QTBUG-61092 on macOS — not a good candidate for abstraction.
 #if defined( Q_OS_MAC )
     // work around Qt MacOSX bug missing tab close icons
     // see: https://bugreports.qt.io/browse/QTBUG-61092
@@ -373,6 +377,7 @@ void TabbedCrawlerWidget::updateTabBarStyle()
             = ":/qt-project.org/styles/commonstyle/images/standardbutton-closetab-hover-16.png";
     }
 #elif defined( Q_OS_WIN )
+    // Fusion style on Windows uses different close icons than the native style
     if ( !useDarkIcons && config.style() == StyleManager::FusionKey ) {
         backgroundImage = ":/images/icons8-close-window.svg";
         backgroundHoverImage = ":/images/icons8-close-window-hover.svg";
@@ -934,11 +939,7 @@ void TabbedCrawlerWidget::keyPressEvent( QKeyEvent* event )
 
     LOG_DEBUG << "TabbedCrawlerWidget::keyPressEvent";
 
-#ifdef Q_OS_MACOS
-    constexpr auto PrimaryMod = Qt::MetaModifier;
-#else
-    constexpr auto PrimaryMod = Qt::ControlModifier;
-#endif
+    constexpr auto PrimaryMod = klogg::platform::PrimaryMod;
 
     // Ctrl + page down (tab cycling keeps Ctrl on all platforms —
     // Cmd+Tab is reserved for the system app switcher on macOS)

--- a/src/ui/src/tabbedscratchpad.cpp
+++ b/src/ui/src/tabbedscratchpad.cpp
@@ -27,6 +27,8 @@
 
 #include <memory>
 
+#include "platform/platform_input.h"
+
 TabbedScratchPad::TabbedScratchPad( QWidget* parent )
     : QWidget( parent )
 {
@@ -80,11 +82,7 @@ void TabbedScratchPad::keyPressEvent( QKeyEvent* event )
 
     event->accept();
 
-#ifdef Q_OS_MACOS
-    constexpr auto PrimaryMod = Qt::MetaModifier;
-#else
-    constexpr auto PrimaryMod = Qt::ControlModifier;
-#endif
+    constexpr auto PrimaryMod = klogg::platform::PrimaryMod;
 
     // Ctrl + tab (tab cycling keeps Ctrl on all platforms —
     // Cmd+Tab is reserved for the system app switcher on macOS)

--- a/src/ui/src/tabgroup.cpp
+++ b/src/ui/src/tabgroup.cpp
@@ -24,6 +24,8 @@
 
 #include "log.h"
 
+#include "qtcompat/qtcompat.h"
+
 QList<TabGroup> TabGroupManager::groups() const
 {
     return groups_;
@@ -174,12 +176,7 @@ void TabGroupManager::retrieveFromStorage( QSettings& settings )
         if ( group.tabPaths.isEmpty() ) {
             const auto tabPathsText = settings.value( "tabPathsText" ).toString();
             if ( !tabPathsText.isEmpty() ) {
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
-                group.tabPaths = tabPathsText.split( QLatin1Char( '\n' ), Qt::SkipEmptyParts );
-#else
-                group.tabPaths =
-                    tabPathsText.split( QLatin1Char( '\n' ), QString::SkipEmptyParts );
-#endif
+                group.tabPaths = tabPathsText.split( QLatin1Char( '\n' ), klogg::qtcompat::skipEmptyParts() );
             }
         }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -9,8 +9,12 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/synchronization.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/overload_visitor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/resourcewrapper.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/simdutf_wrapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crc32.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathutils.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/qtcompat/qtcompat.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/qtcompat/qtcompat_concurrent.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/qtcompat/qtcompat_properties.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/cpu_info.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/runnable_lambda.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cpu_info.cpp

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -9,6 +9,10 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/synchronization.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/overload_visitor.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/resourcewrapper.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_intrinsics.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_input.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_style.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_clipboard.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/simdutf_wrapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crc32.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathutils.h

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -13,6 +13,9 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_input.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_style.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_clipboard.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_files.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_paths.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/platform/platform_process.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/simdutf_wrapper.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crc32.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/pathutils.h

--- a/src/utils/include/platform/platform_clipboard.h
+++ b/src/utils/include/platform/platform_clipboard.h
@@ -24,13 +24,12 @@
 
 namespace klogg::platform {
 
-// On Windows, Qt handles CRLF conversion natively for clipboard text.
-// On other platforms, bare LF is the norm and we emit it directly.
-// Returns the line-ending sequence to append when building clipboard text.
+// On Windows, Qt inserts CR before LF in clipboard text natively, so we do not
+// prepend one ourselves. On other platforms we emit it explicitly.
 #ifdef Q_OS_WIN
-constexpr auto clipboardLineEnding = QChar::LineFeed;
+constexpr bool clipboardNewlineBeforeLf = false;
 #else
-constexpr auto clipboardNewlineBeforeLf = true;
+constexpr bool clipboardNewlineBeforeLf = true;
 #endif
 
 } // namespace klogg::platform

--- a/src/utils/include/platform/platform_clipboard.h
+++ b/src/utils/include/platform/platform_clipboard.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_CLIPBOARD_H
+#define KLOGG_PLATFORM_CLIPBOARD_H
+
+#include <QChar>
+
+namespace klogg::platform {
+
+// On Windows, Qt handles CRLF conversion natively for clipboard text.
+// On other platforms, bare LF is the norm and we emit it directly.
+// Returns the line-ending sequence to append when building clipboard text.
+#ifdef Q_OS_WIN
+constexpr auto clipboardLineEnding = QChar::LineFeed;
+#else
+constexpr auto clipboardNewlineBeforeLf = true;
+#endif
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_CLIPBOARD_H

--- a/src/utils/include/platform/platform_files.h
+++ b/src/utils/include/platform/platform_files.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_FILES_H
+#define KLOGG_PLATFORM_FILES_H
+
+#include <QFile>
+
+namespace klogg::platform {
+
+// Whether the platform uses exclusive file locks (Windows). When true, the
+// "keep file closed" option is shown in preferences.
+#ifdef Q_OS_WIN
+constexpr bool hasExclusiveFileLocks = true;
+#else
+constexpr bool hasExclusiveFileLocks = false;
+#endif
+
+// Whether file-polling should be the default (true on Windows where
+// filesystem notifications are less reliable).
+#ifdef Q_OS_WIN
+constexpr bool pollingEnabledDefault = true;
+#else
+constexpr bool pollingEnabledDefault = false;
+#endif
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_FILES_H

--- a/src/utils/include/platform/platform_input.h
+++ b/src/utils/include/platform/platform_input.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_INPUT_H
+#define KLOGG_PLATFORM_INPUT_H
+
+#include <Qt>
+
+namespace klogg::platform {
+
+// The platform-appropriate keyboard modifier for application-level shortcuts
+// (tab switching, scratchpad navigation, etc.).
+// macOS: MetaModifier (Cmd, HIG-conformant), others: ControlModifier.
+#ifdef Q_OS_MACOS
+constexpr auto PrimaryMod = Qt::MetaModifier;
+#else
+constexpr auto PrimaryMod = Qt::ControlModifier;
+#endif
+
+// The modifier key for font size changes via mouse wheel.
+#ifdef Q_OS_MACOS
+constexpr auto FontSizeMod = Qt::MetaModifier;
+#else
+constexpr auto FontSizeMod = Qt::ControlModifier;
+#endif
+
+// Human-readable shortcut modifier name for UI display.
+#ifdef Q_OS_MACOS
+constexpr auto shortcutModifierName = "Meta";
+#else
+constexpr auto shortcutModifierName = "Ctrl";
+#endif
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_INPUT_H

--- a/src/utils/include/platform/platform_intrinsics.h
+++ b/src/utils/include/platform/platform_intrinsics.h
@@ -31,9 +31,13 @@
 namespace klogg::platform {
 
 // Count leading zero bits. Uses MSVC intrinsics on Windows, GCC/Clang
-// builtins elsewhere.
+// builtins elsewhere.  __builtin_clzll(0) is UB on GCC/Clang, so guard zero
+// before the platform branches.
 inline int countLeadingZeroes( uint64_t value )
 {
+    if ( value == 0 ) {
+        return 64;
+    }
 #ifdef Q_OS_WIN
 #if _WIN64
     unsigned long leading_zero = 0;

--- a/src/utils/include/platform/platform_intrinsics.h
+++ b/src/utils/include/platform/platform_intrinsics.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_INTRINSICS_H
+#define KLOGG_PLATFORM_INTRINSICS_H
+
+#include <cstdint>
+
+#ifdef Q_OS_WIN
+#define WIN32_LEAN_AND_MEAN
+#include <intrin.h>
+#pragma warning( disable : 4244 )
+#endif
+
+namespace klogg::platform {
+
+// Count leading zero bits. Uses MSVC intrinsics on Windows, GCC/Clang
+// builtins elsewhere.
+inline int countLeadingZeroes( uint64_t value )
+{
+#ifdef Q_OS_WIN
+#if _WIN64
+    unsigned long leading_zero = 0;
+    if ( _BitScanReverse64( &leading_zero, value ) ) {
+        return 63 - static_cast<int>( leading_zero );
+    }
+    return 64;
+#else
+    unsigned long leading_zero = 0;
+    if ( _BitScanReverse( &leading_zero, static_cast<uint32_t>( value ) ) ) {
+        return 63 - static_cast<int>( leading_zero );
+    }
+    return 64;
+#endif
+#else
+    return __builtin_clzll( value );
+#endif
+}
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_INTRINSICS_H

--- a/src/utils/include/platform/platform_paths.h
+++ b/src/utils/include/platform/platform_paths.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_PATHS_H
+#define KLOGG_PLATFORM_PATHS_H
+
+#include <QSettings>
+
+namespace klogg::platform {
+
+// The preferred QSettings format for each platform.
+// Windows: IniFormat (registry not used for application settings).
+// macOS: NativeFormat (plist, HIG-conformant).
+// Linux: NativeFormat (ini/conf).
+#ifdef Q_OS_WIN
+constexpr auto settingsFormat = QSettings::IniFormat;
+#else
+constexpr auto settingsFormat = QSettings::NativeFormat;
+#endif
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_PATHS_H

--- a/src/utils/include/platform/platform_process.h
+++ b/src/utils/include/platform/platform_process.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_PROCESS_H
+#define KLOGG_PLATFORM_PROCESS_H
+
+#include <chrono>
+
+namespace klogg::platform {
+
+// Startup failure grace period: Windows processes need longer to start.
+// Returns the interval in milliseconds before retrying after a failed start.
+constexpr std::chrono::milliseconds startupFailureGracePeriod()
+{
+#ifdef Q_OS_WIN
+    return std::chrono::milliseconds{ 1000 };
+#else
+    return std::chrono::milliseconds{ 250 };
+#endif
+}
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_PROCESS_H

--- a/src/utils/include/platform/platform_process.h
+++ b/src/utils/include/platform/platform_process.h
@@ -20,6 +20,7 @@
 #ifndef KLOGG_PLATFORM_PROCESS_H
 #define KLOGG_PLATFORM_PROCESS_H
 
+#include <QtGlobal>
 #include <chrono>
 
 namespace klogg::platform {

--- a/src/utils/include/platform/platform_style.h
+++ b/src/utils/include/platform/platform_style.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_PLATFORM_STYLE_H
+#define KLOGG_PLATFORM_STYLE_H
+
+#include <QFont>
+#include <QString>
+
+namespace klogg::platform {
+
+// Default Qt style key for each platform.
+inline QString defaultStyleKey()
+{
+#ifdef Q_OS_WIN
+    return QStringLiteral( "Vista" );
+#elif defined( Q_OS_MACOS )
+    return QStringLiteral( "Macintosh" );
+#else
+    return QStringLiteral( "Fusion" );
+#endif
+}
+
+// Auto-theme dark style key.
+inline QString darkStyleKey()
+{
+#ifdef Q_OS_WIN
+    return QStringLiteral( "DarkWindows" );
+#else
+    return QStringLiteral( "Dark" );
+#endif
+}
+
+// Default main font. macOS uses a larger point size (72 DPI reference) to
+// match the visual size on Windows/Linux (96 DPI reference).
+inline QFont defaultMainFont()
+{
+#ifdef Q_OS_MACOS
+    return QFont( QStringLiteral( "DejaVu Sans Mono" ), 13 );
+#else
+    return QFont( QStringLiteral( "DejaVu Sans Mono" ), 10 );
+#endif
+}
+
+} // namespace klogg::platform
+
+#endif // KLOGG_PLATFORM_STYLE_H

--- a/src/utils/include/qtcompat/qtcompat.h
+++ b/src/utils/include/qtcompat/qtcompat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Anton Filimonov
+ * Copyright (C) 2024 Anton Filimonov and other contributors
  *
  * This file is part of klogg.
  *
@@ -17,19 +17,10 @@
  * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KLOGG_ACTIVE_SCREEN_H
+#ifndef KLOGG_QTCOMPAT_H
+#define KLOGG_QTCOMPAT_H
 
-#include <QWidget>
-#include <QWindow>
-#include <QScreen>
+#include "qtcompat_concurrent.h"
+#include "qtcompat_properties.h"
 
-#include "qtcompat/qtcompat.h"
-
-static inline QScreen* activeScreen(QWidget* widget) {
-    if (widget == nullptr) return nullptr;
-    
-    QScreen* screen = klogg::qtcompat::widgetScreen( widget );
-    return screen;
-}
-
-#endif
+#endif // KLOGG_QTCOMPAT_H

--- a/src/utils/include/qtcompat/qtcompat_concurrent.h
+++ b/src/utils/include/qtcompat/qtcompat_concurrent.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_QTCOMPAT_CONCURRENT_H
+#define KLOGG_QTCOMPAT_CONCURRENT_H
+
+#include <QtConcurrent>
+#include <QFuture>
+
+// Qt 5: QtConcurrent::run(obj, &Class::method, args...)
+// Qt 6: QtConcurrent::run(&Class::method, obj, args...)  (requires overload
+//        disambiguation)
+//
+// runConcurrent normalises both spellings into one call site.
+namespace klogg::qtcompat {
+
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+
+// Qt 5 overload of QtConcurrent::run: obj comes first.
+template <typename Method, typename Obj, typename... Args>
+auto runConcurrent( Method method, Obj* obj, Args&&... args )
+    -> QFuture<decltype( ( std::declval<Obj*>()->*method )( std::forward<Args>( args )... ) )>
+{
+    return QtConcurrent::run( obj, method, std::forward<Args>( args )... );
+}
+
+#else // Qt >= 6.0
+
+template <typename Method, typename Obj, typename... Args>
+auto runConcurrent( Method method, Obj* obj, Args&&... args )
+{
+    return QtConcurrent::run( method, obj, std::forward<Args>( args )... );
+}
+
+#endif
+
+} // namespace klogg::qtcompat
+
+#endif // KLOGG_QTCOMPAT_CONCURRENT_H

--- a/src/utils/include/qtcompat/qtcompat_properties.h
+++ b/src/utils/include/qtcompat/qtcompat_properties.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2024 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef KLOGG_QTCOMPAT_PROPERTIES_H
+#define KLOGG_QTCOMPAT_PROPERTIES_H
+
+#include <QApplication>
+#include <QColor>
+#include <QComboBox>
+#include <QFontDatabase>
+#include <QScreen>
+#include <QStyleHints>
+#include <QTabBar>
+#include <QWidget>
+
+// Qt API compat wrappers.  Each function encapsulates a Qt-version branch;
+// call sites include this header and use the wrapper instead of writing an
+// inline #if QT_VERSION block.
+
+namespace klogg::qtcompat {
+
+// --- QFontDatabase ----------------------------------------------------------
+
+inline QStringList fontFamilies()
+{
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    return QFontDatabase().families();
+#else
+    return QFontDatabase::families();
+#endif
+}
+
+inline bool isFixedPitch( const QString& family )
+{
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    return QFontDatabase().isFixedPitch( family );
+#else
+    return QFontDatabase::isFixedPitch( family );
+#endif
+}
+
+inline QList<int> pointSizes( const QString& family, const QString& style = {} )
+{
+#if QT_VERSION < QT_VERSION_CHECK( 6, 0, 0 )
+    return QFontDatabase().pointSizes( family, style );
+#else
+    return QFontDatabase::pointSizes( family, style );
+#endif
+}
+
+// --- QWidget::screen --------------------------------------------------------
+
+inline QScreen* widgetScreen( QWidget* widget )
+{
+    if ( !widget )
+        return nullptr;
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+    return widget->screen();
+#else
+    (void)widget->winId(); // force native window creation
+    QWindow* window = widget->windowHandle();
+    return window ? window->screen() : nullptr;
+#endif
+}
+
+// --- QColor -----------------------------------------------------------------
+
+inline QColor colorFromString( const QString& name )
+{
+#if QT_VERSION <= QT_VERSION_CHECK( 6, 4, 0 )
+    QColor color;
+    color.setNamedColor( name );
+    return color;
+#else
+    return QColor::fromString( name );
+#endif
+}
+
+// --- QPalette / Dark mode ---------------------------------------------------
+
+inline bool isDarkColorScheme()
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 5, 0 )
+    return QApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+#else
+    return false;
+#endif
+}
+
+// --- QComboBox --------------------------------------------------------------
+
+inline void setPlaceholderText( QComboBox* combo, const QString& text )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    combo->setPlaceholderText( text );
+#else
+    Q_UNUSED( combo );
+    Q_UNUSED( text );
+#endif
+}
+
+// --- QTabBar ----------------------------------------------------------------
+
+inline int tabBarTabAt( const QTabBar* bar, const QPoint& pos )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    return bar->tabAt( pos );
+#else
+    for ( int i = 0; i < bar->count(); ++i ) {
+        if ( bar->tabRect( i ).contains( pos ) )
+            return i;
+    }
+    return -1;
+#endif
+}
+
+inline void setTabVisible( QTabBar* bar, int index, bool visible )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    bar->setTabVisible( index, visible );
+#else
+    bar->setTabEnabled( index, visible );
+#endif
+}
+
+inline bool isTabVisible( const QTabBar* bar, int index )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    return bar->isTabVisible( index );
+#else
+    return bar->isTabEnabled( index );
+#endif
+}
+
+// --- QString::split ---------------------------------------------------------
+
+inline Qt::SplitBehaviorFlags skipEmptyParts()
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
+    return Qt::SkipEmptyParts;
+#else
+    return QString::SkipEmptyParts;
+#endif
+}
+
+} // namespace klogg::qtcompat
+
+#endif // KLOGG_QTCOMPAT_PROPERTIES_H

--- a/src/utils/include/qtcompat/qtcompat_properties.h
+++ b/src/utils/include/qtcompat/qtcompat_properties.h
@@ -28,6 +28,7 @@
 #include <QStyleHints>
 #include <QTabBar>
 #include <QWidget>
+#include <QWindow>
 
 // Qt API compat wrappers.  Each function encapsulates a Qt-version branch;
 // call sites include this header and use the wrapper instead of writing an
@@ -150,7 +151,11 @@ inline bool isTabVisible( const QTabBar* bar, int index )
 
 // --- QString::split ---------------------------------------------------------
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
 inline Qt::SplitBehaviorFlags skipEmptyParts()
+#else
+inline QString::SplitBehavior skipEmptyParts()
+#endif
 {
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 15, 0 )
     return Qt::SkipEmptyParts;

--- a/src/utils/include/simdutf_wrapper.h
+++ b/src/utils/include/simdutf_wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Anton Filimonov
+ * Copyright (C) 2024 Anton Filimonov and other contributors
  *
  * This file is part of klogg.
  *
@@ -17,19 +17,21 @@
  * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef KLOGG_ACTIVE_SCREEN_H
+#ifndef KLOGG_SIMDUTF_WRAPPER_H
+#define KLOGG_SIMDUTF_WRAPPER_H
 
-#include <QWidget>
-#include <QWindow>
-#include <QScreen>
-
-#include "qtcompat/qtcompat.h"
-
-static inline QScreen* activeScreen(QWidget* widget) {
-    if (widget == nullptr) return nullptr;
-    
-    QScreen* screen = klogg::qtcompat::widgetScreen( widget );
-    return screen;
-}
-
+// simdutf has sign-conversion warnings under -Werror / -Wsign-conversion.
+// This wrapper centralises the suppression so call sites do not need to
+// replicate the pragma block.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
 #endif
+
+#include <simdutf.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#endif // KLOGG_SIMDUTF_WRAPPER_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,13 @@ if(KLOGG_USE_VECTORSCAN)
   add_subdirectory(vectorscan)
 endif()
 
+# KLOGG_TESTS enables test-only API surface (test accessors, counters) in
+# production headers guarded by #ifdef KLOGG_TESTS / friend declarations.
+# Production (non-test) targets do NOT define this macro, so test seams are
+# invisible in release builds.
+target_compile_definitions(klogg_tests PUBLIC -DKLOGG_TESTS)
+target_compile_definitions(klogg_itests PUBLIC -DKLOGG_TESTS)
+
 add_dependencies(klogg_itests file_write_helper)
 add_dependencies(ci_build klogg_tests klogg_itests)
 

--- a/tests/scripts/test_lint_platform_fragile.py
+++ b/tests/scripts/test_lint_platform_fragile.py
@@ -182,5 +182,81 @@ class TestPrivateCurrentCrawlerTest(unittest.TestCase):
             )
 
 
+class Qt6IfReTest(unittest.TestCase):
+    """_QT6_IF_RE must match Qt-6-only guards (>= 6, > 5) but NOT Qt-5
+    guards (e.g. < QT_VERSION_CHECK(6, 0, 0))."""
+
+    def test_qt6_ge_6_matches(self):
+        cases = [
+            "#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)",
+            "#if QT_VERSION >= 6",
+            "#if QT_VERSION >= 0x060000",
+            "#if QT_VERSION > QT_VERSION_CHECK(5, 15, 0)",
+            "#if QT_VERSION > 5",
+            "#if QT_VERSION > 0x050f00",
+            "#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)",
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIsNotNone(lint._QT6_IF_RE.search(case),
+                                     f"Should match: {case}")
+
+    def test_qt5_lt_6_does_not_match(self):
+        cases = [
+            "#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)",
+            "#if QT_VERSION <= QT_VERSION_CHECK(5, 15, 0)",
+            "#if QT_VERSION_CHECK(6, 0, 0)",  # no comparison
+        ]
+        for case in cases:
+            with self.subTest(case=case):
+                self.assertIsNone(lint._QT6_IF_RE.search(case),
+                                  f"Should NOT match: {case}")
+
+    def test_qt_version_major_variant(self):
+        # QT_VERSION_MAJOR guards also need to be recognized.
+        self.assertIsNotNone(
+            lint._QT6_IF_RE.search("#if QT_VERSION_MAJOR >= 6"))
+
+    def test_qt6_ge_6_with_comment(self):
+        self.assertIsNotNone(
+            lint._QT6_IF_RE.search(
+                "#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)  // Qt 6 only"))
+
+
+class QsizetypeConversionQStringViewDeclTest(unittest.TestCase):
+    """var_decl_re in the qsizetype check must recognise QStringView
+    reference and pointer parameters."""
+
+    def _do_check(self, text: str) -> list:
+        return lint._check_qsizetype_to_int_conversion(
+            text, Path("test.cpp"))
+
+    def test_qstringview_ref_var_is_recognised(self):
+        # const QStringView& sv should be added to qstrview_vars.
+        text = (
+            "void f(const QStringView& sv) {\n"
+            "    qsizetype n = sv.indexOf('x');\n"
+            "}\n"
+        )
+        self.assertEqual(self._do_check(text), [])
+
+    def test_qstringview_ptr_var_is_recognised(self):
+        text = (
+            "void f(QStringView* sv) {\n"
+            "    qsizetype n = sv->indexOf('x');\n"
+            "}\n"
+        )
+        self.assertEqual(self._do_check(text), [])
+
+    def test_qstringview_value_var_still_recognised(self):
+        text = (
+            "void f() {\n"
+            "    QStringView sv = getView();\n"
+            "    qsizetype n = sv.indexOf('x');\n"
+            "}\n"
+        )
+        self.assertEqual(self._do_check(text), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -1724,6 +1724,52 @@ SCENARIO( "Empty search shows only marked lines with default settings (marks nav
 
 }
 
+SCENARIO( "Marks persist across a filter change and stay visible (single-file parity)",
+          "[ui][filter][marks]" )
+{
+    // Reference behavior for the folder mark-persistence bug: in single-file
+    // mode marks live in LogFilteredData::marks_, which clearSearch() preserves
+    // (marks_and_matches_ = marks_), so a mark made under filter1 that does NOT
+    // match filter2 still appears in the filtered view under the default
+    // "Marks and matches" visibility. The folder results model must match this.
+    QTemporaryFile file{ "crawler_marks_filter_change_XXXXXX" };
+    REQUIRE( generateDataFiles( file ) );
+
+    ScopedShowAllEmptyFilterSetting showAllEmptyFilter{
+        Configuration{}.showAllInFilteredViewWhenSearchEmpty()
+    };
+
+    Session session;
+    CrawlerWidgetVisitor crawlerVisitor;
+    crawlerVisitor.crawler.reset( static_cast<CrawlerWidget*>(
+        session.open( file.fileName(), []() { return new CrawlerWidget(); } ) ) );
+
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogNbLines().get() == SL_NB_LINES; } ) );
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.isLoadingFinished(); } ) );
+
+    // filter1 = "glogg": matches every line (the data template contains glogg).
+    crawlerVisitor.setSearchPattern( "glogg" );
+    crawlerVisitor.runSearch();
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get()
+                                            == SL_NB_LINES; } ) );
+
+    // Mark line 5 -- a line that matches filter1 but NOT the upcoming filter2.
+    crawlerVisitor.addMarksInMainView( { 5_lnum } );
+    REQUIRE( crawlerVisitor.markedLinesCount() == 1 );
+
+    // filter2 = "000010": matches only line 10. Line 5 (marked) does not match.
+    crawlerVisitor.replaceSearchPattern( "000010" );
+    crawlerVisitor.runSearch();
+    REQUIRE( waitUiState( [ & ]() { return crawlerVisitor.getLogFilteredNbLines().get() == 2; } ) );
+
+    // The mark survives the filter change...
+    REQUIRE( crawlerVisitor.markedLinesCount() == 1 );
+    // ...and stays visible in the filtered view under "Marks and matches"
+    // (marked line 5 + matched line 10), even though line 5 does not match
+    // filter2.
+    REQUIRE( crawlerVisitor.getLogFilteredNbLines() == 2_lcount );
+}
+
 SCENARIO( "Live source search auto-refresh is throttled", "[ui][live]" )
 {
     // Use production-like search buffer so each search chunk takes noticeable time.

--- a/tests/ui/crawlerwidget_test.cpp
+++ b/tests/ui/crawlerwidget_test.cpp
@@ -1766,8 +1766,11 @@ SCENARIO( "Marks persist across a filter change and stay visible (single-file pa
     REQUIRE( crawlerVisitor.markedLinesCount() == 1 );
     // ...and stays visible in the filtered view under "Marks and matches"
     // (marked line 5 + matched line 10), even though line 5 does not match
-    // filter2.
-    REQUIRE( crawlerVisitor.getLogFilteredNbLines() == 2_lcount );
+    // filter2. Assert the ROW IDENTITY, not just the count: the filtered view
+    // preserves source order, so row 0 is marked line 5 (000005) and row 1 is
+    // the filter2 match on line 10 (000010).
+    REQUIRE( crawlerVisitor.filteredLineText( 0 ).contains( "000005" ) );
+    REQUIRE( crawlerVisitor.filteredLineText( 1 ).contains( "000010" ) );
 }
 
 SCENARIO( "Live source search auto-refresh is throttled", "[ui][live]" )

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -656,7 +656,11 @@ TEST_CASE( "FolderCrawlerWidget main-view marks are per-file and survive swaps",
                 return row;
             }
         }
-        return 0_lnum;
+        // 0_lnum is a valid header row, so a silent miss would select an
+        // unrelated row and surface later as a confusing waitFor timeout. Fail
+        // at the lookup site instead.
+        FAIL( "matchRowForFile: no matching result row found for the requested file" );
+        return 0_lnum; // unreachable; FAIL aborts the test case
     };
     widget.selectResultRow( matchRowForFile( b ) ); // b.log match
     REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -645,16 +645,208 @@ TEST_CASE( "FolderCrawlerWidget main-view marks are per-file and survive swaps",
     widget.markMainViewLine( 1_lnum );
     REQUIRE( widget.isMainViewLineMarked( 1_lnum ) );
 
-    widget.selectResultRow( 3_lnum ); // b.log match
+    // A non-match mark is now injected as a results row under Marks-and-matches,
+    // so b.log's match row index shifts; resolve it dynamically by source file.
+    const auto matchRowForFile = [ & ]( const QString& path ) -> LineNumber {
+        const auto total = widget.folderResults()->getNbLine().get();
+        for ( uint64_t i = 0; i < total; ++i ) {
+            const LineNumber row{ i };
+            if ( widget.folderResults()->lineKind( row ) == LineKind::Data
+                 && widget.folderResults()->sourceForLine( row ).filePath == path ) {
+                return row;
+            }
+        }
+        return 0_lnum;
+    };
+    widget.selectResultRow( matchRowForFile( b ) ); // b.log match
     REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
     QTest::qWait( 200 );
     REQUIRE_FALSE( widget.isMainViewLineMarked( 1_lnum ) );
 
     // ...and must reappear when A is reopened (cached swap).
-    widget.selectResultRow( 1_lnum );
+    widget.selectResultRow( matchRowForFile( a ) ); // a.log match
     REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
     QTest::qWait( 200 );
     REQUIRE( widget.isMainViewLineMarked( 1_lnum ) );
+}
+
+TEST_CASE( "FolderCrawlerWidget marks survive a filter change and show under Marks",
+           "[folder][marks][regression]" )
+{
+    // Regression for issue: marking lines under filter1, then switching to
+    // filter2, hides the marks that don't match filter2 from the results pane
+    // (under both "Marks" and "Marks and matches" visibility). Marks are
+    // conceptually tied to a SOURCE LINE (file+localLine), not to a transient
+    // search result, so they must persist across filter changes and remain
+    // visible under the "Marks" filter -- single-file parity
+    // (LogFilteredData::marks_ is preserved by clearSearch and unioned into
+    // marks_and_matches_, so marked non-matching lines DO appear there).
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    // a.log: line 1 = "ERROR alpha" (matches both ERROR and alpha),
+    //        line 3 = "ERROR beta"  (matches ERROR only).
+    const QString a = writeFile( dir, "a.log",
+                                 QByteArray( "line0\nERROR alpha\nline2\nERROR beta\nline4\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+
+    // filter1 = ERROR: matches a.log lines 1 and 3.
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount ); // header + 2 matches
+
+    // Open a.log and mark line 3 (ERROR beta): a mark that matches filter1 but
+    // NOT the upcoming filter2 (alpha).
+    widget.selectResultRow( 1_lnum ); // ERROR alpha -> opens a.log
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+    widget.markMainViewLine( 3_lnum );
+    REQUIRE( widget.isLineMarkedInFile( a, 3_lnum ) );
+
+    // filter2 = alpha: matches only a.log line 1. The marked line 3 (ERROR beta)
+    // does NOT match alpha, but under "Marks and matches" (the default) it must
+    // still appear as an injected mark row -- single-file marks_and_matches_
+    // parity (matches | marks), so the bookmark survives the filter change.
+    widget.searchFor( "alpha" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount ); // header + 1 match + 1 mark row
+
+    // The marked line 3 must be present as a row that resolves to its source.
+    bool sawMarkedLine3 = false;
+    const auto totalRows = widget.folderResults()->getNbLine();
+    for ( LinesCount::UnderlyingType i = 0; i < totalRows.get(); ++i ) {
+        const auto src = widget.folderResults()->sourceForLine( LineNumber( i ) );
+        if ( src.filePath == a && src.localLine == 3_lnum ) {
+            sawMarkedLine3 = true;
+            break;
+        }
+    }
+    REQUIRE( sawMarkedLine3 );
+
+    // The mark itself must persist in the per-file store (not cleared by a new
+    // search).
+    REQUIRE( widget.isLineMarkedInFile( a, 3_lnum ) );
+
+    // Under the "Marks" visibility filter the marked line 3 (ERROR beta) must
+    // still be visible in the results pane -- it is a bookmark on a source
+    // line, independent of the current search. RED before the fix: the folder
+    // results model is match-centric (FolderSearchResults only stores match
+    // rows), so a marked line that does not match the current filter has no
+    // row and the "Marks" filter hides it (getNbLine() == 0).
+    widget.setResultsVisibility( FolderSearchResults::Visibility::Marks );
+    QTest::qWait( 50 );
+    REQUIRE( widget.folderResults()->getNbLine() > 0_lcount );
+}
+
+TEST_CASE( "FolderCrawlerWidget a marked grep-context line stays visible under Marks",
+           "[folder][marks][context]" )
+{
+    // A marked line that is a grep -A/-B/-C CONTEXT row (not a Match) must still
+    // appear under the Marks filter: under Marks the context record is hidden,
+    // so the mark is injected as a mark row (its context record does not render
+    // it). RED before the fix: rebuildVisibleRows excluded ALL record lines from
+    // mark-row injection, so a marked context line vanished under Marks.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    // match on line 1 (HIT); -A2 -> context lines 2 and 3 follow it.
+    const QString a = writeFile( dir, "a.log", QByteArray( "line0\nHIT\nline2\nline3\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.contextLinesComboBox()->setCurrentIndex( 2 ); // After -A
+    widget.contextLinesSpinBox()->setValue( 2 );
+    widget.searchFor( "HIT" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    // rows: [H0, D1(Match HIT line1), D2(Context line2), D3(Context line3)].
+    REQUIRE( widget.folderResults()->getNbLine() == 4_lcount );
+
+    // Open a.log and mark line 2 (a context line).
+    widget.selectResultRow( 1_lnum ); // HIT -> opens a.log
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+    widget.markMainViewLine( 2_lnum );
+    REQUIRE( widget.isLineMarkedInFile( a, 2_lnum ) );
+
+    // Under Marks: the match (line1) is unmarked -> hidden; context rows hidden;
+    // the marked context line2 is injected as a mark row.
+    widget.setResultsVisibility( FolderSearchResults::Visibility::Marks );
+    QTest::qWait( 50 );
+    REQUIRE( widget.folderResults()->getNbLine() == 2_lcount ); // header + mark row
+
+    // The mark row resolves to the marked context line.
+    const auto src = widget.folderResults()->sourceForLine( 1_lnum );
+    REQUIRE( src.filePath == a );
+    REQUIRE( src.localLine == 2_lnum );
+}
+
+TEST_CASE( "FolderCrawlerWidget clicking blank space below collapsed results does not expand the last group",
+           "[folder][blank-space]" )
+{
+    // After Collapse All every group is reduced to its Header row, so the LAST
+    // rendered row is the last file's Header. AbstractLogView::convertCoordToLine
+    // used to CLAMP a below-content click to the last visible row, so a click in
+    // the blank space below the results resolved to that last Header and fired
+    // headerClicked -> toggleCollapse, expanding the last file's group.
+    // Expected: a click that hits no row is a no-op.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "ERROR one\n" ) );
+    const QString b = writeFile( dir, "b.log", QByteArray( "ERROR two\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    // Expanded rows: [H0, D1, H2, D3] (2 groups, 1 match each).
+
+    widget.collapseAll();
+    QTest::qWait( 100 );
+    REQUIRE( widget.folderResults()->getNbLine() == 2_lcount ); // only the 2 headers
+    REQUIRE( widget.folderResults()->lineKind( 0_lnum ) == LineKind::Header );
+    REQUIRE( widget.folderResults()->lineKind( 1_lnum ) == LineKind::Header );
+    REQUIRE( widget.folderResults()->isCollapsed( 0 ) );
+    REQUIRE( widget.folderResults()->isCollapsed( 1 ) );
+
+    auto* const view = widget.filteredView();
+    REQUIRE( view != nullptr );
+    view->setFocus();
+    QTest::qWait( 100 );
+
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+    const int charH = Access::charHeight( view );
+    REQUIRE( charH > 0 );
+    const int top = Access::drawingTopOffset( view );
+    const int bullet = Access::bulletZoneWidth( view );
+    const int xPos = bullet + ( view->viewport()->width() - bullet ) / 2;
+
+    // Positive control: a click within the first row resolves to a real line,
+    // proving wrappedLinesInfo_ is populated (so the nullopt below is meaningful
+    // and not just an empty map).
+    REQUIRE( view->lineAtYForTest( top + charH / 2 ).has_value() );
+
+    // A click clearly BELOW the last rendered row (2 headers span top..top+2*charH).
+    const int yBelow = top + charH * 2 + charH / 2;
+
+    // The resolver itself must report "no row" for a below-content click.
+    // RED before fix: clamp -> returns the last Header line; GREEN: nullopt.
+    REQUIRE_FALSE( view->lineAtYForTest( yBelow ).has_value() );
+
+    QTest::mouseClick( view->viewport(), Qt::LeftButton, {}, QPoint( xPos, yBelow ) );
+    QTest::qWait( 100 );
+
+    // The last group must stay collapsed: no phantom headerClicked.
+    // RED before fix: clamp -> headerClicked(last Header) -> isCollapsed(1)==false.
+    REQUIRE( widget.folderResults()->isCollapsed( 1 ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 2_lcount );
+    // First group untouched (sanity).
+    REQUIRE( widget.folderResults()->isCollapsed( 0 ) );
 }
 
 TEST_CASE( "FolderCrawlerWidget exposes predefined filters and favorites in the toolbar", "[folder]" )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(klogg_tests
     droppathclassification_test.cpp
     recentfolders_test.cpp
     highlighter_vectorscan_test.cpp
+    linehighlight_compose_test.cpp
     linepositionarray_test.cpp
     mergefileorder_test.cpp
     overview_test.cpp

--- a/tests/unit/linehighlight_compose_test.cpp
+++ b/tests/unit/linehighlight_compose_test.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "highlightcompose.h"
+#include "highlightedmatch.h"
+#include "linetypes.h"
+
+#include <QColor>
+
+#include <optional>
+
+namespace {
+HighlightedMatch makeMatch( int start, int size, QColor fore, QColor back )
+{
+    return HighlightedMatch{ LineColumn{ start }, LineLength{ size }, fore, back };
+}
+
+// ranges.matches() returns by value, so return the covering match by value
+// (not a pointer into a temporary).
+std::optional<HighlightedMatch> matchCovering( const HighlightedMatchRanges& ranges, int column )
+{
+    const auto matches = ranges.matches();
+    const auto col = LineColumn{ column };
+    for ( const auto& m : matches ) {
+        if ( m.startColumn() <= col && col <= m.endColumn() ) {
+            return m;
+        }
+    }
+    return std::nullopt;
+}
+} // namespace
+
+TEST_CASE( "composeLineHighlights blends search-match gray under a configured Highlighter",
+           "[highlighter][coexistence]" )
+{
+    const QColor red{ 0xff, 0x00, 0x00 };
+    const QColor gray{ Qt::lightGray };
+    const QColor black{ Qt::black };
+
+    // "x ERROR y": ERROR occupies columns 2..6 (size 5). Both the Highlighter
+    // and the search match target the same span.
+    klogg::vector<HighlightSource> sources;
+    sources.push_back( HighlightSource{ HighlightLayer::Highlighter,
+                                        { makeMatch( 2, 5, black, red ) } } );
+    sources.push_back( HighlightSource{ HighlightLayer::SearchMatch,
+                                        { makeMatch( 2, 5, black, gray ) } } );
+
+    const auto ranges = composeLineHighlights( sources );
+    REQUIRE_FALSE( ranges.empty() );
+
+    const auto m = matchCovering( ranges, 4 );
+    REQUIRE( m.has_value() );
+    // Highlighter wins (visible) but the gray is NOT completely covered: the
+    // result is the blend, neither pure red nor pure gray.
+    REQUIRE( m->backColor() != red );
+    REQUIRE( m->backColor() != gray );
+    REQUIRE( m->backColor() == blendSearchMatchOverHighlighter( red, gray ) );
+}
+
+TEST_CASE( "composeLineHighlights blends search-match gray under a QuickHighlighter (color label)",
+           "[highlighter][coexistence]" )
+{
+    const QColor green{ 0x00, 0xff, 0x00 };
+    const QColor gray{ Qt::lightGray };
+    const QColor white{ Qt::white };
+
+    klogg::vector<HighlightSource> sources;
+    sources.push_back( HighlightSource{ HighlightLayer::QuickHighlighter,
+                                        { makeMatch( 0, 4, white, green ) } } );
+    sources.push_back( HighlightSource{ HighlightLayer::SearchMatch,
+                                        { makeMatch( 0, 4, white, gray ) } } );
+
+    const auto ranges = composeLineHighlights( sources );
+    REQUIRE_FALSE( ranges.empty() );
+    const auto m = matchCovering( ranges, 1 );
+    REQUIRE( m.has_value() );
+    REQUIRE( m->backColor() == blendSearchMatchOverHighlighter( green, gray ) );
+    REQUIRE( m->backColor() != green );
+    REQUIRE( m->backColor() != gray );
+}
+
+TEST_CASE( "composeLineHighlights blends only the overlap; pure highlighter elsewhere",
+           "[highlighter][coexistence]" )
+{
+    // A whole-line (LineMatch-style) Highlighter spanning 0..9; search match only 2..6.
+    const QColor red{ 0xff, 0x00, 0x00 };
+    const QColor gray{ Qt::lightGray };
+    const QColor black{ Qt::black };
+
+    klogg::vector<HighlightSource> sources;
+    sources.push_back( HighlightSource{ HighlightLayer::Highlighter,
+                                        { makeMatch( 0, 10, black, red ) } } );
+    sources.push_back( HighlightSource{ HighlightLayer::SearchMatch,
+                                        { makeMatch( 2, 5, black, gray ) } } );
+
+    const auto ranges = composeLineHighlights( sources );
+    REQUIRE_FALSE( ranges.empty() );
+
+    // Overlap (col 4): blend.
+    const auto overlap = matchCovering( ranges, 4 );
+    REQUIRE( overlap.has_value() );
+    REQUIRE( overlap->backColor() == blendSearchMatchOverHighlighter( red, gray ) );
+
+    // Non-overlap (col 8): pure highlighter, no gray punched in.
+    const auto pure = matchCovering( ranges, 8 );
+    REQUIRE( pure.has_value() );
+    REQUIRE( pure->backColor() == red );
+}
+
+TEST_CASE( "composeLineHighlights: search match alone stays gray, highlighter alone stays pure",
+           "[highlighter][coexistence]" )
+{
+    const QColor red{ 0xff, 0x00, 0x00 };
+    const QColor gray{ Qt::lightGray };
+    const QColor black{ Qt::black };
+
+    SECTION( "search match alone" ) {
+        klogg::vector<HighlightSource> sources;
+        sources.push_back( HighlightSource{ HighlightLayer::SearchMatch,
+                                            { makeMatch( 0, 3, black, gray ) } } );
+        const auto ranges = composeLineHighlights( sources );
+        REQUIRE_FALSE( ranges.empty() );
+        REQUIRE( matchCovering( ranges, 1 )->backColor() == gray );
+    }
+    SECTION( "highlighter alone" ) {
+        klogg::vector<HighlightSource> sources;
+        sources.push_back( HighlightSource{ HighlightLayer::Highlighter,
+                                            { makeMatch( 0, 3, black, red ) } } );
+        const auto ranges = composeLineHighlights( sources );
+        REQUIRE_FALSE( ranges.empty() );
+        REQUIRE( matchCovering( ranges, 1 )->backColor() == red );
+    }
+}
+
+TEST_CASE( "composeLineHighlights: Selection fully covers a search match (no blend)",
+           "[highlighter][coexistence]" )
+{
+    const QColor gray{ Qt::lightGray };
+    const QColor selBack{ 0x00, 0x00, 0xff };
+    const QColor selFore{ Qt::white };
+    const QColor black{ Qt::black };
+
+    klogg::vector<HighlightSource> sources;
+    sources.push_back( HighlightSource{ HighlightLayer::SearchMatch,
+                                        { makeMatch( 0, 4, black, gray ) } } );
+    sources.push_back( HighlightSource{ HighlightLayer::Selection,
+                                        { makeMatch( 0, 4, selFore, selBack ) } } );
+
+    const auto ranges = composeLineHighlights( sources );
+    REQUIRE_FALSE( ranges.empty() );
+    const auto m = matchCovering( ranges, 2 );
+    REQUIRE( m.has_value() );
+    // Selection is above SearchMatch and is NOT a blend target: it wins at full
+    // opacity, so the search match is covered (current behavior preserved).
+    REQUIRE( m->backColor() == selBack );
+    REQUIRE( m->backColor() != blendSearchMatchOverHighlighter( selBack, gray ) );
+}

--- a/tests/vectorscan/CMakeLists.txt
+++ b/tests/vectorscan/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(
 )
 klogg_configure_test_target(klogg_vectorscan_tests)
 
+target_compile_definitions(klogg_vectorscan_tests PUBLIC -DKLOGG_TESTS)
+
 add_dependencies(ci_build klogg_vectorscan_tests)
 
 klogg_add_runtime_test(klogg_vectorscan_tests klogg_vectorscan_tests)


### PR DESCRIPTION
Three user-reported issues, fixed TDD (red-green-refactor) with an adversarial review pass. Full \`ctest\` 4/4 green (klogg_smoke, klogg_tests 6430 assertions/404 cases, klogg_itests 3249/139, klogg_vectorscan).

## 1. Collapse All + click blank space below results expanded the last file

\`AbstractLogView::convertCoordToLine\` clamped out-of-range clicks to the last visible row (regression from \`b1ab703c\`, which replaced a bounds check with \`std::clamp\`). After Collapse All the last row is a group Header, so the click fired \`headerClicked\` → expand. **Fix:** return \`nullopt\` for clicks outside the rendered rows (base class → folder, single-file, live-log). Drag/double-click use \`convertCoordToFilePos\` (still clamps, intentionally) and are unaffected.

## 2. Marks (M shortcut) disappeared when switching search filters

\`FolderSearchResults\` was match-centric — \`rebuildVisibleRows\` under Marks only filtered match rows and could not show a marked line that didn't match the current filter (single-file \`LogFilteredData::marks_\` already preserves marks across searches). **Fix:** model folder marks as an independent row source — the widget injects its per-file marks store via \`setMarksStore(&folderMarks_)\` (replacing the predicate-only \`setMarkedLineQuery\`); under Marks / Marks-and-matches, marked non-match rows are injected (with a synthetic "marks-only" group for files with no matches), text fetched from a per-file decoded-line cache (codec-correct incl. UTF-16, capped at 16 MiB, \`dataMutex_\` released during I/O, invalidated on encoding-override change). Marked grep-context lines are injected under Marks too. Not a regression — design gap since \`a0865558\`.

## 3. "Highlight matches" (gray) masked configured HighlighterSet colors

The 6 highlight sources had no explicit z-order — priority was the implicit order of \`addMatches()\` calls (new-wins), and the gray search-match was added AFTER the configured set, erasing configured colors. **Latent defect since \`4acfd7bc\` (2021), NOT a recent regression** (exhaustive archaeology: add-order stable across all 39 branches; \`b4416c06\` "highlighter coexistence" was selection-only). **Fix:** extract \`composeLineHighlights()\` (single owner of the z-order: \`Ansi < SearchMatch < Highlighter < QuickHighlighter < QuickFind < Selection\`) with an explicit **blend rule** — where the search-match gray overlaps a configured Highlighter or QuickHighlighter, the two are alpha-blended (\`blend(hl, gray, 0.35)\`, highlighter dominant, gray visible) instead of one masking the other. Selection/QuickFind still fully cover. Per the user's request: "保留看到 Highlighter，但不完全覆盖 Highlight matches".

## Review hardening (adversarial workflow, 18 confirmed findings fixed)

- Marked grep-context line no longer dropped under Marks (visibleRecordLines excludes only *visible* records) + regression test \`[folder][marks][context]\`
- Whole-file synchronous read on the paint path → 16 MiB cap + \`dataMutex_\` released during fetch
- Byte-scan offset cache wrong for UTF-16 → switched to decode-then-split (correct for all encodings)
- Mark text cache not invalidated on encoding-override change → fixed
- Marks-only groups not collapsible → fixed (\`collapseAll\`/\`toggleCollapse\` cover the combined FileId range)
- Cache comment/contract mismatch → fixed

## Known accepted limitations (documented)

- \`maxLength_\` (horizontal scrollbar) excludes mark-row lengths; \`doGetLineLength\` still returns the exact per-row value.
- Marks-only files have no scanned codec → default UTF-8 (set an encoding override for non-UTF-8).
- Marks-only group collapse state does not persist across a re-search (real groups do).

## Test plan

- \`ctest --build-config RelWithDebInfo\` → 4/4 PASS
- New: \`[folder][blank-space]\`, \`[folder][marks][regression]\`, \`[folder][marks][context]\`, \`[ui][filter][marks]\`, \`[highlighter][coexistence]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marked lines now persist across searches and filters, including marked context lines and files containing only marked lines.
  * Improved line highlighting by composing multiple highlight layers with consistent priority and correct blending of search-match overlays.
* **Bug Fixes**
  * Clicking blank space below collapsed result groups is now a no-op.
  * Click hit-testing outside rendered rows now returns no matching row (no longer maps to the last visible line).
* **Tests**
  * Added UI regression coverage for mark persistence and context visibility, plus unit tests for highlight blending/priority behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->