### PR TITLE
Fix live-save output file being cleared on restart

### DIFF
--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -79,7 +79,10 @@ class CaptureStore {
     TrimResult trimToLimits();
     TrimResult lastTrimResult() const;
     void clearTrimResult();
-    bool bindOutputFile( const QString& outputPath );
+    // Reopen the bound output file. When preserveExisting is true the file is
+    // opened append-only and the current capture is NOT replayed into it, so
+    // previously streamed content already on disk is kept (session restore).
+    bool bindOutputFile( const QString& outputPath, bool preserveExisting = false );
     void setOutputFlushedCallback( std::function<void()> callback );
     void setLimits( Limits limits );
     QString boundOutputFile() const;

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -20,6 +20,20 @@ enum class LiveLogSaveAnsiMode {
     Preserve,
 };
 
+// How bindOutputFile treats an existing destination file.
+enum class OutputBindMode {
+    // User-initiated "Save Live Log As": truncate the destination and rewrite
+    // it from the current capture. The Save dialog has already confirmed any
+    // overwrite, so destroying prior content is the user's explicit intent.
+    FreshSave,
+    // Session restore: the destination already holds previously streamed
+    // content. Preserve it and only append data that arrives after the
+    // restore. The capture store is volatile (it lives in the OS temp dir),
+    // so rewriting from it on restart can silently empty the file when the
+    // temp dir has been cleared (computer restart, logout, crash, cleanup).
+    Restore,
+};
+
 class StreamingLogData : public SearchableLogData {
     Q_OBJECT
 
@@ -33,6 +47,7 @@ class StreamingLogData : public SearchableLogData {
     void setCaptureLimits( CaptureStore::Limits limits );
     bool bindOutputFile( const QString& outputPath );
     bool bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode );
+    bool bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode, OutputBindMode mode );
     QString boundOutputFile() const;
     QString captureId() const;
     QString capturePath() const;
@@ -81,7 +96,7 @@ class StreamingLogData : public SearchableLogData {
     CaptureStore::TrimResult consumeTrimResult();
     void startOutputFlushTimer();
     void stopOutputFlushTimer();
-    bool openDisplayOutputFile( const QString& outputPath );
+    bool openDisplayOutputFile( const QString& outputPath, bool preserveExisting = false );
     void closeDisplayOutputFile();
     bool writeDisplayLinesToOutput( LineNumber first, LinesCount count );
     // Writes the lines appended in `appendResult` to the Strip-mode display

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -476,7 +476,7 @@ void CaptureStore::clearTrimResult()
     lastTrimResult_ = {};
 }
 
-bool CaptureStore::bindOutputFile( const QString& outputPath )
+bool CaptureStore::bindOutputFile( const QString& outputPath, bool preserveExisting )
 {
     const std::lock_guard<std::recursive_mutex> lock( mutex_ );
     rollingOutput_.close();
@@ -490,17 +490,23 @@ bool CaptureStore::bindOutputFile( const QString& outputPath )
 
     rollingOutput_ = RollingFileManager( boundOutputFile_, limits_.rollingMaxFileSize,
                                          limits_.rollingBackupCount );
-    if ( !rollingOutput_.open( true ) ) {
+    // FreshSave truncates and replays the capture; Restore opens append-only so
+    // previously streamed content already on disk is never destroyed (the
+    // capture is volatile — it lives in the OS temp dir and may be empty on
+    // restart, which would otherwise empty the file).
+    if ( !rollingOutput_.open( /*truncate=*/!preserveExisting ) ) {
         boundOutputFile_.clear();
         return false;
     }
 
-    // Write existing segments to the rolling file
-    for ( const auto& segment : segments_ ) {
-        if ( !writeSegmentToDevice( segment, rollingOutput_.currentFile() ) ) {
-            boundOutputFile_.clear();
-            rollingOutput_.close();
-            return false;
+    if ( !preserveExisting ) {
+        // Write existing segments to the rolling file
+        for ( const auto& segment : segments_ ) {
+            if ( !writeSegmentToDevice( segment, rollingOutput_.currentFile() ) ) {
+                boundOutputFile_.clear();
+                rollingOutput_.close();
+                return false;
+            }
         }
     }
     // Replay writes directly to QFile, bypassing RollingFileManager::write().

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -195,10 +195,16 @@ void StreamingLogData::setCaptureLimits( CaptureStore::Limits limits )
 
 bool StreamingLogData::bindOutputFile( const QString& outputPath )
 {
-    return bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip );
+    return bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip, OutputBindMode::FreshSave );
 }
 
 bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode )
+{
+    return bindOutputFile( outputPath, ansiMode, OutputBindMode::FreshSave );
+}
+
+bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAnsiMode ansiMode,
+                                       OutputBindMode mode )
 {
     stopOutputFlushTimer();
     outputSaveAnsiMode_ = ansiMode;
@@ -209,15 +215,23 @@ bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAns
         return true;
     }
 
+    // FreshSave truncates the destination and replays the current capture
+    // (user-initiated "Save As" — overwrite was already confirmed by the
+    // dialog). Restore opens the destination append-only and never replays, so
+    // content already streamed to the file survives a restart even when the
+    // volatile capture (OS temp dir) has been cleared and would otherwise
+    // rewrite the file empty.
+    const bool preserveExisting = ( mode == OutputBindMode::Restore );
+
     bool result = false;
     if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Preserve ) {
         closeDisplayOutputFile();
-        result = captureStore_.bindOutputFile( outputPath );
+        result = captureStore_.bindOutputFile( outputPath, preserveExisting );
         boundOutputFile_ = result ? outputPath : QString{};
     }
     else {
         captureStore_.bindOutputFile( QString{} );
-        result = openDisplayOutputFile( outputPath );
+        result = openDisplayOutputFile( outputPath, preserveExisting );
     }
 
     if ( !outputPath.isEmpty() && result ) {
@@ -446,7 +460,7 @@ void StreamingLogData::stopOutputFlushTimer()
     outputFlushTimer_.stop();
 }
 
-bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
+bool StreamingLogData::openDisplayOutputFile( const QString& outputPath, bool preserveExisting )
 {
     const auto outputPathCopy = outputPath;
     closeDisplayOutputFile();
@@ -461,12 +475,15 @@ bool StreamingLogData::openDisplayOutputFile( const QString& outputPath )
     // Use CaptureStore's rolling settings for the display file
     rollingDisplayOutput_ = RollingFileManager( boundOutputFile_, rollingMaxFileSize_,
                                                  rollingBackupCount_ );
-    if ( !rollingDisplayOutput_.open( true ) ) {
+    // FreshSave truncates and dumps the current capture; Restore opens
+    // append-only so existing on-disk content is preserved.
+    if ( !rollingDisplayOutput_.open( /*truncate=*/!preserveExisting ) ) {
         boundOutputFile_.clear();
         return false;
     }
 
-    if ( !writeDisplayLinesToOutput( 0_lnum, captureStore_.lineCount() ) ) {
+    if ( !preserveExisting
+         && !writeDisplayLinesToOutput( 0_lnum, captureStore_.lineCount() ) ) {
         closeDisplayOutputFile();
         return false;
     }

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -30,6 +30,11 @@ struct AdbLogcatSessionData {
     int maxReconnectAttempts = 0; // 0 = unlimited
     qint64 captureMaxFileSize = 0; // bytes, 0 = unlimited
     int captureBackupCount = 0; // 0 = keep all rotated files
+    // Mode used when the bound output file was last saved / rebound. Persisted
+    // so a session restore reopens the file in the same mode and appends
+    // format-consistent data (Strip-stripped vs Preserve-raw bytes). Kept last
+    // so existing positional aggregate initializers keep mapping correctly.
+    LiveLogSaveAnsiMode outputAnsiMode = LiveLogSaveAnsiMode::Strip;
 
     QString displayName() const;
     QString documentId() const;

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -112,6 +112,8 @@ QJsonObject AdbLogcatSessionData::toJson() const
         { QStringLiteral( "extraArgs" ), extraArgs },
         { QStringLiteral( "captureId" ), captureId },
         { QStringLiteral( "boundOutputFile" ), boundOutputFile },
+        { QStringLiteral( "outputPreserveAnsi" ),
+          outputAnsiMode == LiveLogSaveAnsiMode::Preserve },
         { QStringLiteral( "ansiOutputEnabled" ), ansiOutputEnabled },
         { QStringLiteral( "autoReconnectEnabled" ), autoReconnectEnabled },
         { QStringLiteral( "maxReconnectAttempts" ), maxReconnectAttempts },
@@ -130,6 +132,9 @@ AdbLogcatSessionData AdbLogcatSessionData::fromJson( const QString& json )
     data.extraArgs = jsonObject.value( QStringLiteral( "extraArgs" ) ).toString();
     data.captureId = jsonObject.value( QStringLiteral( "captureId" ) ).toString();
     data.boundOutputFile = jsonObject.value( QStringLiteral( "boundOutputFile" ) ).toString();
+    data.outputAnsiMode = jsonObject.value( QStringLiteral( "outputPreserveAnsi" ) ).toBool( false )
+                              ? LiveLogSaveAnsiMode::Preserve
+                              : LiveLogSaveAnsiMode::Strip;
     data.sourceType
         = sourceTypeFromString( jsonObject.value( QStringLiteral( "sourceType" ) ).toString() );
     data.ansiOutputEnabled
@@ -295,6 +300,7 @@ bool AdbLogcatSource::bindOutputFile( const QString& outputPath, LiveLogSaveAnsi
     }
 
     sessionData_.boundOutputFile = outputPath;
+    sessionData_.outputAnsiMode = ansiMode;
     return true;
 }
 

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -322,7 +322,9 @@ ViewInterface* Session::openAdbAlways( const AdbLogcatSessionData& sessionData,
     auto restoredSessionData = sessionData;
     auto logData = std::make_shared<StreamingLogData>( restoredSessionData.captureId );
     if ( !restoredSessionData.boundOutputFile.isEmpty()
-         && !logData->bindOutputFile( restoredSessionData.boundOutputFile ) ) {
+         && !logData->bindOutputFile( restoredSessionData.boundOutputFile,
+                                      restoredSessionData.outputAnsiMode,
+                                      OutputBindMode::Restore ) ) {
         LOG_WARNING << "Failed to restore ADB output file binding "
                     << restoredSessionData.boundOutputFile;
         restoredSessionData.boundOutputFile.clear();

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -2292,3 +2292,28 @@ TEST_CASE( "DeviceListProvider async enumeration is safe against provider destru
     REQUIRE( future.result().isEmpty() );
 #endif
 }
+
+TEST_CASE( "AdbLogcatSessionData round-trips the bound output file and ANSI save mode",
+           "[live-save-restore]" )
+{
+    AdbLogcatSessionData data;
+    data.captureId = QStringLiteral( "cap-1234" );
+    data.boundOutputFile = QStringLiteral( "/tmp/saved.log" );
+    data.outputAnsiMode = LiveLogSaveAnsiMode::Preserve;
+
+    const auto json = QString::fromUtf8(
+        QJsonDocument( data.toJson() ).toJson( QJsonDocument::Compact ) );
+    const auto restored = AdbLogcatSessionData::fromJson( json );
+
+    REQUIRE( restored.captureId == QStringLiteral( "cap-1234" ) );
+    REQUIRE( restored.boundOutputFile == QStringLiteral( "/tmp/saved.log" ) );
+    REQUIRE( restored.outputAnsiMode == LiveLogSaveAnsiMode::Preserve );
+
+    // A session serialized by an older klogg (before the mode was persisted)
+    // must default to Strip so restore reopens in the historical default mode.
+    const auto legacyJson
+        = QStringLiteral( R"({"captureId":"cap-old","boundOutputFile":"/tmp/old.log"})" );
+    const auto legacy = AdbLogcatSessionData::fromJson( legacyJson );
+    REQUIRE( legacy.boundOutputFile == QStringLiteral( "/tmp/old.log" ) );
+    REQUIRE( legacy.outputAnsiMode == LiveLogSaveAnsiMode::Strip );
+}

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -843,3 +843,125 @@ TEST_CASE( "StreamingLogData finishInput emits Truncated on single-line rotation
     const auto tailLine = logData.getLinesRaw( LineNumber( tail ), 1_lcount );
     REQUIRE( tailLine.endOfLines.size() == 1 );
 }
+
+TEST_CASE( "StreamingLogData Restore preserves a Strip-saved file when capture is empty",
+           "[live-save-restore]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+    const QByteArray savedBytes = QByteArrayLiteral( "line1\nline2\nline3\n" );
+
+    // A prior session streamed content and saved it (FreshSave, Strip mode).
+    {
+        StreamingLogData logDataA( makeCaptureId(), tempDir.path() );
+        SafeQSignalSpy loadingSpy( &logDataA, SIGNAL( loadingFinished( LoadingStatus ) ) );
+        REQUIRE( loadingSpy.safeWait() );
+
+        logDataA.appendUtf8( QByteArrayLiteral( "line1\nline2\nline3\n" ) );
+        REQUIRE( loadingSpy.safeWait() );
+        REQUIRE( logDataA.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+    }
+
+    QFile before( outputPath );
+    REQUIRE( before.open( QIODevice::ReadOnly ) );
+    REQUIRE( before.readAll() == savedBytes );
+    before.close();
+
+    // Simulate a restart where the temp capture was wiped (computer restart,
+    // OS temp cleanup, or a crash before segments spilled to disk). A fresh
+    // captureId loads nothing, so the in-memory capture is empty.
+    StreamingLogData logDataB( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpyB( &logDataB, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpyB.safeWait() );
+    REQUIRE( logDataB.getNbLine().get() == 0 );
+
+    // Restoring the binding must NOT clear the previously saved file.
+    REQUIRE( logDataB.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip,
+                                      OutputBindMode::Restore ) );
+
+    QFile after( outputPath );
+    REQUIRE( after.open( QIODevice::ReadOnly ) );
+    CHECK( after.readAll() == savedBytes );
+}
+
+TEST_CASE( "StreamingLogData Restore preserves a Preserve-saved file when capture is empty",
+           "[live-save-restore]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+    const QByteArray savedBytes
+        = QByteArrayLiteral( "\x1b[32mI/App\x1b[0m line1\n\x1b[31mE/App\x1b[0m line2\n" );
+
+    {
+        StreamingLogData logDataA( makeCaptureId(), tempDir.path() );
+        SafeQSignalSpy loadingSpy( &logDataA, SIGNAL( loadingFinished( LoadingStatus ) ) );
+        REQUIRE( loadingSpy.safeWait() );
+
+        logDataA.appendUtf8( QByteArrayLiteral( "\x1b[32mI/App\x1b[0m line1\n"
+                                                "\x1b[31mE/App\x1b[0m line2\n" ) );
+        REQUIRE( loadingSpy.safeWait() );
+        REQUIRE( logDataA.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Preserve ) );
+    }
+
+    QFile before( outputPath );
+    REQUIRE( before.open( QIODevice::ReadOnly ) );
+    REQUIRE( before.readAll() == savedBytes );
+    before.close();
+
+    // Restart with a wiped temp capture.
+    StreamingLogData logDataB( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpyB( &logDataB, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpyB.safeWait() );
+    REQUIRE( logDataB.getNbLine().get() == 0 );
+
+    REQUIRE( logDataB.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Preserve,
+                                      OutputBindMode::Restore ) );
+
+    QFile after( outputPath );
+    REQUIRE( after.open( QIODevice::ReadOnly ) );
+    CHECK( after.readAll() == savedBytes );
+}
+
+TEST_CASE( "StreamingLogData Restore appends new data without duplicating existing content",
+           "[live-save-restore]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+
+    // First session saves three lines.
+    const auto captureId = makeCaptureId();
+    {
+        StreamingLogData logDataA( captureId, tempDir.path() );
+        SafeQSignalSpy loadingSpy( &logDataA, SIGNAL( loadingFinished( LoadingStatus ) ) );
+        REQUIRE( loadingSpy.safeWait() );
+
+        logDataA.appendUtf8( QByteArrayLiteral( "line1\nline2\nline3\n" ) );
+        REQUIRE( loadingSpy.safeWait() );
+        REQUIRE( logDataA.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+    }
+
+    // Graceful restart: same captureId, temp intact, so the capture reloads.
+    StreamingLogData logDataB( captureId, tempDir.path() );
+    SafeQSignalSpy loadingSpyB( &logDataB, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpyB.safeWait() );
+    REQUIRE( logDataB.getNbLine().get() == 3 );
+
+    REQUIRE( logDataB.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip,
+                                      OutputBindMode::Restore ) );
+
+    // New data after restore must be appended exactly once — the reloaded
+    // capture content must not be rewritten/duplicated.
+    loadingSpyB.clear();
+    logDataB.appendUtf8( QByteArrayLiteral( "line4\nline5\n" ) );
+    REQUIRE( loadingSpyB.safeWait() );
+
+    QFile after( outputPath );
+    REQUIRE( after.open( QIODevice::ReadOnly ) );
+    CHECK( after.readAll() == QByteArrayLiteral( "line1\nline2\nline3\nline4\nline5\n" ) );
+}


### PR DESCRIPTION
## Summary
- Live log streams (ADB/iOS) bound to a save file via **"Save Live Log As"** no longer have their saved file emptied on restart. The destination is reopened **append-only** on session restore instead of being truncated and replayed from the volatile temp capture.
- Adds `OutputBindMode { FreshSave, Restore }`: `FreshSave` (user "Save As") keeps the existing truncate+replay; `Restore` (session reopen) preserves existing content and appends only new data.
- Persists the Strip/Preserve save mode in `AdbLogcatSessionData` so a restored Preserve file keeps receiving format-consistent raw bytes.
- New `[live-save-restore]` tests + session round-trip test.

## Background
- **Introduced by:** the original live-save design — `bindOutputFile` always truncated the destination and replayed the in-memory `CaptureStore` into it.
- **Use case:** bind a live stream to a save file, restart klogg/computer, expect the file to keep its content.
- **How to reproduce:** start a live stream → "Save Live Log As" → stop → close & reopen klogg. The saved file drops to 0 bytes, then slowly regrows (slow, lossy replay); if temp was wiped it stays empty.
- **Root cause:** the capture's source of truth lives in `$TMPDIR/klogg_live`, which is cleared on computer restart / logout / crash / capture cleanup. On restart `bindOutputFile` truncated the file, then replayed zero lines → empty file.
- **How to fix:** `Restore` opens the destination append-only and skips the replay, so on-disk content survives regardless of temp state; only data arriving after the restore is appended. Also removes the slow/lossy restart replay entirely.

## Tests
- `cmake --build build_root --target klogg_tests` + `./output/klogg_tests -platform offscreen` → **6456 assertions / 407 cases pass**.
- `./output/klogg_itests -platform offscreen` → **3250 assertions / 139 cases pass**.
- New `[live-save-restore]` cases: Strip & Preserve file preserved when capture empty; append-without-duplication when capture intact; `AdbLogcatSessionData` round-trip incl. legacy-JSON default Strip.
- `python3 scripts/lint_platform_fragile.py` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restoring live log output files without overwriting existing content.
  * Preserved log formatting preferences across session restores.
  * New saves continue to create fresh output files, while restored sessions append only newly captured data.

* **Bug Fixes**
  * Prevented existing saved logs from being cleared or duplicated during session restoration.

* **Tests**
  * Added coverage for output restoration, formatting persistence, backward compatibility, and appending new log data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->