### PR TITLE
Fix PR #53 review follow-ups and package-artifact zip64 upload corruption

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -724,16 +724,18 @@ jobs:
         if: ${{ matrix.config.package != false }}
         shell: sh
         run: |
-          cd "$KLOGG_BUILD_ROOT"
-          [ -n "$(find ./packages -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
-          tar -czf "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C ./packages .
+          # Write the tarball into $KLOGG_WORKSPACE (runner-owned), not
+          # $KLOGG_BUILD_ROOT: on Linux the build root is created by docker as
+          # root, so the host runner cannot create files inside it.
+          [ -n "$(find "$KLOGG_BUILD_ROOT/packages" -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
+          tar -czf "$KLOGG_WORKSPACE/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C "$KLOGG_BUILD_ROOT/packages" .
 
 # Final upload of all packages
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
+          path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
   Mac:
@@ -913,15 +915,17 @@ jobs:
         if: ${{ matrix.config.package != false }}
         shell: sh
         run: |
-          cd "$KLOGG_BUILD_ROOT"
-          [ -n "$(find ./packages -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
-          tar -czf "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C ./packages .
+          # Write the tarball into $KLOGG_WORKSPACE (runner-owned), not
+          # $KLOGG_BUILD_ROOT: on Linux the build root is created by docker as
+          # root, so the host runner cannot create files inside it.
+          [ -n "$(find "$KLOGG_BUILD_ROOT/packages" -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
+          tar -czf "$KLOGG_WORKSPACE/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C "$KLOGG_BUILD_ROOT/packages" .
 
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
+          path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: warn
 
   Windows:
@@ -1293,7 +1297,9 @@ jobs:
           $tarName = "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz"
           # bsdtar's -C is unhappy with backslash paths; use forward slashes.
           $pkgDir = (Join-Path $env:KLOGG_BUILD_ROOT "packages").Replace("\", "/")
-          $tarPath = (Join-Path $env:KLOGG_BUILD_ROOT $tarName).Replace("\", "/")
+          # Write into $KLOGG_WORKSPACE (runner-owned): on Linux the build root
+          # is created by docker as root, so the host runner cannot write there.
+          $tarPath = (Join-Path $env:KLOGG_WORKSPACE $tarName).Replace("\", "/")
           if (-not (Get-ChildItem -Path $pkgDir -Force | Select-Object -First 1)) {
             Write-Error "packages directory is empty: $pkgDir"
             exit 1
@@ -1305,7 +1311,7 @@ jobs:
         if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
+          path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
   ci-gate:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -714,12 +714,26 @@ jobs:
       - uses: ./.github/actions/docker-package
         if: ${{ matrix.config.package != false }}
 
+# Package artifacts are uploaded as a single-file tarball, not the raw
+# multi-file directory. GitHub's artifact backend intermittently corrupts
+# multi-file zip64 archives ("No END header found" on extract, silent-empty
+# on macOS) — same failure class as the boost-root artifact flake (fe4859ca). Each package dir
+# is pre-packed into one tarball; the release/continuous jobs untar it back
+# into the expected directory layout after download.
+      - name: Package tarball for upload
+        if: ${{ matrix.config.package != false }}
+        shell: sh
+        run: |
+          cd "$KLOGG_BUILD_ROOT"
+          [ -n "$(find ./packages -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
+          tar -czf "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C ./packages .
+
 # Final upload of all packages
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages/*'
+          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
   Mac:
@@ -892,11 +906,22 @@ jobs:
         #   notarization-team: ${{ secrets.NOTARIZATION_TEAM }}
         #   notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
+# Upload packages as a single-file tarball to avoid GitHub's artifact backend
+# intermittently corrupting multi-file zip64 archives (the .app/.dSym tree
+# pushes this artifact over the corruption threshold — same class as fe4859ca).
+      - name: Package tarball for upload
+        if: ${{ matrix.config.package != false }}
+        shell: sh
+        run: |
+          cd "$KLOGG_BUILD_ROOT"
+          [ -n "$(find ./packages -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
+          tar -czf "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C ./packages .
+
       - uses: actions/upload-artifact@v4
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages/*'
+          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: warn
 
   Windows:
@@ -1259,12 +1284,28 @@ jobs:
           $script = Join-Path $env:GITHUB_WORKSPACE "packaging\windows\verify_ssl.ps1"
           & $script -ReleaseDir $releaseDir -QtVersion $env:KLOGG_QT
 
+# Upload packages as a single-file tarball to avoid GitHub's artifact backend
+# intermittently corrupting multi-file zip64 archives (same class as fe4859ca).
+      - name: Package tarball for upload
+        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
+        shell: pwsh
+        run: |
+          $tarName = "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz"
+          # bsdtar's -C is unhappy with backslash paths; use forward slashes.
+          $pkgDir = (Join-Path $env:KLOGG_BUILD_ROOT "packages").Replace("\", "/")
+          $tarPath = (Join-Path $env:KLOGG_BUILD_ROOT $tarName).Replace("\", "/")
+          if (-not (Get-ChildItem -Path $pkgDir -Force | Select-Object -First 1)) {
+            Write-Error "packages directory is empty: $pkgDir"
+            exit 1
+          }
+          tar -czf $tarPath -C $pkgDir .
+
 # Final upload of all packages
       - uses: actions/upload-artifact@v4
         if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
-          path: '${{ env.KLOGG_BUILD_ROOT }}/packages/*'
+          path: '${{ env.KLOGG_BUILD_ROOT }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
   ci-gate:
@@ -1321,6 +1362,18 @@ jobs:
         with:
           pattern: packages-*
           path: ./packages-all
+
+      # Package artifacts are uploaded as single-file tarballs; restore the
+      # per-artifact directory layout the cleanup below expects.
+      - name: Extract package tarballs
+        shell: sh
+        run: |
+          set -e
+          for t in $(find ./packages-all -name 'packages-*.tar.gz' -type f); do
+            echo "Extracting: $t"
+            tar -xzf "$t" -C "$(dirname "$t")"
+            rm -f "$t"
+          done
 
       - name: Clean up package artifacts
         shell: sh

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -35,6 +35,20 @@ jobs:
         workflow: ci-build.yml
         run_id: ${{ github.event.inputs.ci-run-id }}
 
+    # Package artifacts are uploaded as single-file tarballs (not raw
+    # multi-file directories) to avoid GitHub's artifact backend intermittently
+    # corrupting multi-file zip64 archives ("No END header found" on extract).
+    # Restore the ./packages-*/ directory layout the steps below expect.
+    - name: Extract package tarballs
+      shell: sh
+      run: |
+        set -e
+        for t in $(find . -maxdepth 2 -name 'packages-*.tar.gz' -type f); do
+          echo "Extracting: $t"
+          tar -xzf "$t" -C "$(dirname "$t")"
+          rm -f "$t"
+        done
+
     - name: Initialize version
       run: echo "KLOGG_VERSION=`cat klogg_version/klogg_version.txt`" >> $GITHUB_ENV
 

--- a/packaging/windows/klogg.nsi
+++ b/packaging/windows/klogg.nsi
@@ -190,6 +190,11 @@ Section "Uninstall"
 
     Delete "$INSTDIR\klogg.exe"
     Delete "$INSTDIR\klogg_crashpad_handler.exe"
+    ; Keep deleting the retired crash-stackwalker helper. New installs no longer
+    ; stage it (the install File line was removed), but released builds shipped
+    ; it, so uninstalling after an upgrade must still remove the stale copy or
+    ; it blocks RMDir $INSTDIR from cleaning up the install directory.
+    Delete "$INSTDIR\klogg_minidump_dump.exe"
     Delete "$INSTDIR\README.md"
     Delete "$INSTDIR\COPYING"
     Delete "$INSTDIR\NOTICE"

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 Catches platform-fragile patterns that pass on the developer's macOS / Linux
-build but fail on Windows CI.  Run before pushing or as a CI gate.
+build but fail in CI (Windows runners, or Linux-docker packaging).  Run before
+pushing or as a CI gate.
 
 Background: PR #12 surfaced two such patterns -- `startsWith(QLatin1Char('/'))`
 treating the leading-slash convention as portable, and `endsWith("\\adb.exe")`
@@ -887,7 +888,7 @@ def iter_target_files(paths: Iterable[Path]) -> Iterable[Path]:
     for root in paths:
         if not root.exists():
             continue
-        for ext in ("*.cpp", "*.h", "*.hpp", "*.cc"):
+        for ext in ("*.cpp", "*.h", "*.hpp", "*.cc", "*.yml", "*.yaml"):
             yield from root.rglob(ext)
 
 
@@ -901,8 +902,60 @@ def iter_staged_files() -> Iterable[Path]:
     for raw in out.splitlines():
         if not raw.strip():
             continue
-        if raw.endswith((".cpp", ".h", ".hpp", ".cc")):
+        if raw.endswith((".cpp", ".h", ".hpp", ".cc", ".yml", ".yaml")):
             yield Path(raw)
+
+
+def _check_ci_tarball_into_build_root(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag workflow/action YAML that writes package tarballs into
+    ``$KLOGG_BUILD_ROOT``.
+
+    PR #54's package-upload tarball step wrote the archive into the build root
+    and failed on every Linux leg with ``tar: ... Cannot open: Permission
+    denied``. On Linux the build root is created by docker as root (build and
+    packaging steps run in containers with the workspace mounted at
+    ``/usr/local``), so the host runner cannot create files inside it. Upload
+    tarballs must be written to ``$KLOGG_WORKSPACE``, which the runner owns —
+    the ``cpm-cache.tar.gz`` prefetch already followed that rule.
+
+    Two manifestations are caught, both zero-false-positive on the current
+    tree:
+      1. An upload-artifact ``path:`` (or any path line) referencing a
+         ``.tar.gz`` under ``KLOGG_BUILD_ROOT``.
+      2. A host step that ``cd "$KLOGG_BUILD_ROOT"`` and then ``tar -czf``s a
+         file into it (the write lands in the root-owned build root).
+    Reading from the build root (e.g. ``tar ... -C "$KLOGG_BUILD_ROOT/packages"``)
+    is fine and is not flagged.
+    """
+    findings: list[tuple[int, str]] = []
+    lines = text.splitlines()
+
+    for i, line in enumerate(lines, start=1):
+        if "path:" in line and "KLOGG_BUILD_ROOT" in line and ".tar.gz" in line:
+            findings.append(
+                (
+                    i,
+                    "package tarball referenced under $KLOGG_BUILD_ROOT; that "
+                    "directory is root-owned on Linux (docker-created), so the "
+                    "host runner cannot write there. Write/upload tarballs "
+                    "from $KLOGG_WORKSPACE instead.",
+                )
+            )
+        if 'cd "$KLOGG_BUILD_ROOT"' in line:
+            for j in range(i, min(i + 15, len(lines) + 1)):
+                if "tar -czf" in lines[j - 1]:
+                    findings.append(
+                        (
+                            i,
+                            '`cd "$KLOGG_BUILD_ROOT"` followed by `tar -czf` '
+                            "writes the archive into the root-owned build root "
+                            "on Linux (docker-created); the host runner cannot "
+                            "create files there. Write the tarball into "
+                            "$KLOGG_WORKSPACE instead.",
+                        )
+                    )
+                    break
+    return findings
 
 
 def lint_file(path: Path) -> int:
@@ -911,6 +964,17 @@ def lint_file(path: Path) -> int:
     except OSError:
         return 0
     issues = 0
+
+    if path.suffix in (".yml", ".yaml"):
+        # CI workflow/action YAML has its own platform-fragile class: package
+        # uploads must not write into the docker-root-owned build root.
+        for line_num, message in _check_ci_tarball_into_build_root(text, path):
+            print(f"[platform-fragile] ci-tarball-into-build-root")
+            print(f"  at {path}:{line_num}")
+            print(f"  {message}")
+            print()
+            issues += 1
+        return issues
 
     # Single-line patterns.
     for line_num, raw in enumerate(text.splitlines(), start=1):
@@ -944,7 +1008,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--paths",
         nargs="*",
-        default=["src", "tests", "benchmarks"],
+        default=["src", "tests", "benchmarks", ".github"],
         help="Source directories to scan, relative to repo root.",
     )
     parser.add_argument(

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -297,21 +297,35 @@ void RollingFileManager::cleanupOldBackups()
 
 bool RollingFileManager::openNewFile( bool truncate )
 {
-    // Snapshot existence before opening. Append mode auto-creates a missing
-    // file, so a caller that checked existence first would race this open.
-    const auto existedBeforeOpen = QFileInfo::exists( basePath_ );
     currentFile_.setFileName( basePath_ );
-    const auto mode = truncate ? ( QIODevice::WriteOnly | QIODevice::Truncate )
-                               : ( QIODevice::WriteOnly | QIODevice::Append );
-    if ( !currentFile_.open( mode ) ) {
+
+    // A truncating open always starts a fresh file, regardless of whether the
+    // path already exists (FreshSave semantics).
+    if ( truncate ) {
+        if ( !currentFile_.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) {
+            LOG_WARNING << "RollingFileManager: failed to open " << basePath_;
+            return false;
+        }
+        currentBytes_ = 0;
+        openedNewFile_ = true;
+        return true;
+    }
+
+    // Append path: decide "is this a brand-new file" atomically with the open.
+    // NewOnly (O_EXCL) succeeds only when the path did not exist, so the result
+    // cannot race a pre-open QFileInfo::exists() probe. On success the file was
+    // created by this open; on failure it pre-existed, so fall back to append.
+    if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::NewOnly ) ) {
+        currentBytes_ = 0;
+        openedNewFile_ = true;
+        return true;
+    }
+    if ( !currentFile_.open( QIODevice::WriteOnly | QIODevice::Append ) ) {
         LOG_WARNING << "RollingFileManager: failed to open " << basePath_;
         return false;
     }
-    currentBytes_ = truncate ? 0 : currentFile_.size();
-    // A truncating open always starts a fresh file; an append only does when
-    // the path did not exist yet. Callers use this (not their own pre-open
-    // existence check) to decide whether to replay captured content.
-    openedNewFile_ = truncate || !existedBeforeOpen;
+    currentBytes_ = currentFile_.size();
+    openedNewFile_ = false;
     return true;
 }
 

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -314,19 +314,38 @@ bool RollingFileManager::openNewFile( bool truncate )
     // Append path: decide "is this a brand-new file" atomically with the open.
     // NewOnly (O_EXCL) succeeds only when the path did not exist, so the result
     // cannot race a pre-open QFileInfo::exists() probe. On success the file was
-    // created by this open; on failure it pre-existed, so fall back to append.
+    // created by this open.
     if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::NewOnly ) ) {
         currentBytes_ = 0;
         openedNewFile_ = true;
         return true;
     }
-    if ( !currentFile_.open( QIODevice::WriteOnly | QIODevice::Append ) ) {
-        LOG_WARNING << "RollingFileManager: failed to open " << basePath_;
-        return false;
+
+    // The path pre-existed (NewOnly failed with EEXIST). Append to it without
+    // creation (ExistingOnly): a plain Append would silently recreate the file
+    // if another process deleted it in the window since NewOnly failed, leaving
+    // openedNewFile_ = false for a file this open just created. Restore-mode
+    // callers gate capture replay on that flag, so the new file would be left
+    // empty and the buffered content lost.
+    if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::ExistingOnly | QIODevice::Append ) ) {
+        currentBytes_ = currentFile_.size();
+        openedNewFile_ = false;
+        return true;
     }
-    currentBytes_ = currentFile_.size();
-    openedNewFile_ = false;
-    return true;
+
+    // The ExistingOnly append failed, most likely because the path disappeared
+    // after NewOnly's EEXIST (deleted by another process). Recreate it
+    // atomically; the result now correctly reports a brand-new file. A second
+    // NewOnly failure means the path reappeared in the meantime (or a genuine
+    // open error) — surface it.
+    if ( currentFile_.open( QIODevice::WriteOnly | QIODevice::NewOnly ) ) {
+        currentBytes_ = 0;
+        openedNewFile_ = true;
+        return true;
+    }
+
+    LOG_WARNING << "RollingFileManager: failed to open " << basePath_;
+    return false;
 }
 
 bool RollingFileManager::rotateInternal()

--- a/tests/unit/live_save_split_test.cpp
+++ b/tests/unit/live_save_split_test.cpp
@@ -278,3 +278,47 @@ TEST_CASE( "RollingFileManager::openedNewFile reflects the open that created the
         REQUIRE( fm.openedNewFile() );
     }
 }
+
+TEST_CASE( "RollingFileManager::openedNewFile stays consistent across create/delete interleaving",
+           "[rolling][live_save]" )
+{
+    // The append path decides "new file?" atomically with the open (NewOnly
+    // first, Append fallback). Interleaving external create/delete with opens
+    // must keep the flag consistent with what the open actually saw: a created
+    // path is never reported as pre-existing, and a pre-existing path is never
+    // reported as new.
+    const auto rootPath = makeTestDir( "rollingfilemanager_interleave" );
+    const auto path = QDir( rootPath ).filePath( QStringLiteral( "interleave.log" ) );
+
+    // Delete then open: the open creates the file -> new.
+    QFile::remove( path );
+    {
+        RollingFileManager fm( path, 1024, 2 );
+        REQUIRE( fm.open( /*truncate=*/false ) );
+        REQUIRE( fm.openedNewFile() );
+    }
+
+    // External create with content, then open: pre-existing -> not new, and the
+    // pre-existing content must be preserved (append, not truncate).
+    {
+        QFile seed( path );
+        REQUIRE( seed.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        seed.write( "interleaved" );
+        seed.close();
+
+        RollingFileManager fm( path, 1024, 2 );
+        REQUIRE( fm.open( /*truncate=*/false ) );
+        REQUIRE_FALSE( fm.openedNewFile() );
+        REQUIRE( fm.currentFileSize() == 11 ); // "interleaved"
+    }
+
+    // Delete between manager construction and open: the open recreates the
+    // path -> new, and the old content is gone.
+    QFile::remove( path );
+    {
+        RollingFileManager fm( path, 1024, 2 );
+        REQUIRE( fm.open( /*truncate=*/false ) );
+        REQUIRE( fm.openedNewFile() );
+        REQUIRE( fm.currentFileSize() == 0 );
+    }
+}

--- a/tests/unit/optionsdialog_test.cpp
+++ b/tests/unit/optionsdialog_test.cpp
@@ -319,32 +319,57 @@ TEST_CASE( "ConfigurationScope restores the persisted configuration on disk" )
     // later Configuration::getSynced() (which reloads from disk on every call)
     // observes the leaked test configuration and the suite becomes
     // order-dependent.
-    SavedSearches::getSynced();
-    RecentFiles::getSynced();
-
-    // Normalize to a known baseline first so the assertions below are
-    // deterministic regardless of what earlier tests left in the shared store.
-    Configuration::get().setStyle( StyleManager::ModernKey );
-    Configuration::get().setThemeMode( ThemeMode::Light );
-    Configuration::get().setLanguage( QStringLiteral( "baseline_lang" ) );
+    //
+    // Pre-seed a distinct persisted state so any baseline leak is observable:
+    // this case must hand the store back exactly as it found it, not as an
+    // artificial baseline normalized for its own assertions.
+    Configuration::get().setStyle( StyleManager::DarkStyleKey );
+    Configuration::get().setThemeMode( ThemeMode::Dark );
+    Configuration::get().setLanguage( QStringLiteral( "preseed_lang" ) );
     Configuration::get().save();
 
-    const auto originalStyle = Configuration::getSynced().style();
-    const auto originalThemeMode = Configuration::getSynced().themeMode();
-    const auto originalLanguage = Configuration::getSynced().language();
-
     {
-        ConfigurationScope configScope;
+        // Outer scope snapshots the TRUE pre-test persisted state, so the
+        // baseline normalization below is itself rolled back on disk when this
+        // case exits. Without it, the baseline write escapes to the shared
+        // QSettings store and a later Configuration::getSynced() observes it —
+        // the order-dependence this test exists to prevent.
+        ConfigurationScope testIsolation;
 
-        // Simulate the OptionsDialog Apply path: mutate and persist.
-        Configuration::get().setStyle( StyleManager::DarkStyleKey );
-        Configuration::get().setThemeMode( ThemeMode::Auto );
-        Configuration::get().setLanguage( QStringLiteral( "test_language" ) );
+        SavedSearches::getSynced();
+        RecentFiles::getSynced();
+
+        // Normalize to a known baseline first so the assertions below are
+        // deterministic regardless of what earlier tests left in the shared
+        // store.
+        Configuration::get().setStyle( StyleManager::ModernKey );
+        Configuration::get().setThemeMode( ThemeMode::Light );
+        Configuration::get().setLanguage( QStringLiteral( "baseline_lang" ) );
         Configuration::get().save();
+
+        const auto originalStyle = Configuration::getSynced().style();
+        const auto originalThemeMode = Configuration::getSynced().themeMode();
+        const auto originalLanguage = Configuration::getSynced().language();
+
+        {
+            ConfigurationScope configScope;
+
+            // Simulate the OptionsDialog Apply path: mutate and persist.
+            Configuration::get().setStyle( StyleManager::DarkStyleKey );
+            Configuration::get().setThemeMode( ThemeMode::Auto );
+            Configuration::get().setLanguage( QStringLiteral( "test_language" ) );
+            Configuration::get().save();
+        }
+
+        // The disk-backed snapshot must be restored, not the leaked values
+        // above.
+        REQUIRE( Configuration::getSynced().style() == originalStyle );
+        REQUIRE( Configuration::getSynced().themeMode() == originalThemeMode );
+        REQUIRE( Configuration::getSynced().language() == originalLanguage );
     }
 
-    // The disk-backed snapshot must be restored, not the leaked values above.
-    REQUIRE( Configuration::getSynced().style() == originalStyle );
-    REQUIRE( Configuration::getSynced().themeMode() == originalThemeMode );
-    REQUIRE( Configuration::getSynced().language() == originalLanguage );
+    // The pre-test seed, not the artificial baseline, must be what persists.
+    REQUIRE( Configuration::getSynced().style() == StyleManager::DarkStyleKey );
+    REQUIRE( Configuration::getSynced().themeMode() == ThemeMode::Dark );
+    REQUIRE( Configuration::getSynced().language() == QStringLiteral( "preseed_lang" ) );
 }

--- a/tests/unit/optionsdialog_test.cpp
+++ b/tests/unit/optionsdialog_test.cpp
@@ -48,6 +48,11 @@ class ConfigurationScope {
         // updateConfigFromDialog() writes the language from the combo; restore
         // it too so later tests see the same process-wide configuration.
         Configuration::get().setLanguage( language_ );
+        // updateConfigFromDialog() also calls save(), persisting the test's
+        // values to the QSettings store. Persist the restored snapshot too, or
+        // a later getSynced() reloads the leaked test configuration and the
+        // suite becomes order-dependent.
+        Configuration::get().save();
     }
 
     ConfigurationScope( const ConfigurationScope& ) = delete;
@@ -304,4 +309,42 @@ TEST_CASE( "Applying the dialog while Classic Dark is pinned preserves the pre-p
     // so switching away from Classic Dark later can restore the original mode.
     REQUIRE( Configuration::get().style() == StyleManager::DarkStyleKey );
     REQUIRE( Configuration::get().themeMode() == ThemeMode::Auto );
+}
+
+TEST_CASE( "ConfigurationScope restores the persisted configuration on disk" )
+{
+    // updateConfigFromDialog() calls Configuration::save(), which writes the
+    // in-memory state to the QSettings store. ConfigurationScope must restore
+    // not just the in-memory singleton but the on-disk snapshot, otherwise a
+    // later Configuration::getSynced() (which reloads from disk on every call)
+    // observes the leaked test configuration and the suite becomes
+    // order-dependent.
+    SavedSearches::getSynced();
+    RecentFiles::getSynced();
+
+    // Normalize to a known baseline first so the assertions below are
+    // deterministic regardless of what earlier tests left in the shared store.
+    Configuration::get().setStyle( StyleManager::ModernKey );
+    Configuration::get().setThemeMode( ThemeMode::Light );
+    Configuration::get().setLanguage( QStringLiteral( "baseline_lang" ) );
+    Configuration::get().save();
+
+    const auto originalStyle = Configuration::getSynced().style();
+    const auto originalThemeMode = Configuration::getSynced().themeMode();
+    const auto originalLanguage = Configuration::getSynced().language();
+
+    {
+        ConfigurationScope configScope;
+
+        // Simulate the OptionsDialog Apply path: mutate and persist.
+        Configuration::get().setStyle( StyleManager::DarkStyleKey );
+        Configuration::get().setThemeMode( ThemeMode::Auto );
+        Configuration::get().setLanguage( QStringLiteral( "test_language" ) );
+        Configuration::get().save();
+    }
+
+    // The disk-backed snapshot must be restored, not the leaked values above.
+    REQUIRE( Configuration::getSynced().style() == originalStyle );
+    REQUIRE( Configuration::getSynced().themeMode() == originalThemeMode );
+    REQUIRE( Configuration::getSynced().language() == originalLanguage );
 }


### PR DESCRIPTION
## Summary

The branch addresses the live-save rolling-file open, PR #53's review follow-ups, and CI package-artifact upload reliability. After PR CI failed the Linux legs and bots filed review comments, a follow-up round of fixes (commits `60535e30`, `c9e0ea07`, `d91ff7a3`) was added:

1. **PR #53 review follow-ups** (`c117c899`):
   - **Config-store leak** — `ConfigurationScope` persists its restored snapshot to disk so OptionsDialog tests can't leak values into the shared QSettings store.
   - **NSIS upgrade cleanup** — the uninstaller keeps deleting the retired `klogg_minidump_dump.exe` so upgrades uninstall cleanly.
   - **Atomic rolling-file open** — the append path decides "new file?" atomically with the open instead of a racy pre-open `exists()` probe.

2. **Package-artifact zip64 upload hardening** (`c620dfa4`) — package dirs upload as single-file tarballs (GitHub's backend corrupts large multi-file zip64 archives; same class as the boost fix `fe4859ca`).

3. **CI fix + lint guard** (`60535e30`) — the tarball was written into `$KLOGG_BUILD_ROOT`, which is root-owned on Linux (docker-created), so every Linux leg failed "Package tarball for upload" with `Permission denied`. Upload tarballs now go to the runner-owned `$KLOGG_WORKSPACE` on all three platforms. `lint_platform_fragile.py` now scans workflow YAML and flags the two patterns that caused this (upload path under `KLOGG_BUILD_ROOT`, and `cd "$KLOGG_BUILD_ROOT"` + `tar -czf`).

4. **Rolling-file TOCTOU fix** (`c9e0ea07`, CodeRabbit Major / Codex P2) — the `NewOnly` → `Append` fallback recreated a file deleted in the window with `openedNewFile_ = false`, so Restore-mode replay was skipped and capture content lost. Now falls back to `ExistingOnly | Append` (no `O_CREAT`) and retries `NewOnly` if the path disappeared.

5. **Test-leak fix** (`d91ff7a3`, CodeRabbit Major / Codex P2) — the "ConfigurationScope restores the persisted configuration on disk" test wrote its synthetic baseline before creating any scope, leaking `baseline_lang`/Modern/Light into the shared store. The baseline is now wrapped in an outer `ConfigurationScope` that snapshots the true pre-test state.

## Background

- **Introduced by:** PR #53 (`760b98f5`) shipped the first round of Classic Dark / CI / live-save fixes; post-merge review flagged the config-store leak, the stale NSIS uninstall entry, and the `openedNewFile()` TOCTOU (the live-save replay path came from PR #49/#53). The zip64 corruption was first seen on the boost-root artifact (`fe4859ca`); package uploads still used raw multi-file directory paths.
- **Use case:** OptionsDialog test determinism; Windows uninstall-after-upgrade cleanup; live-save users whose capture target is created/deleted concurrently (duplicated replay or lost content); release automation downloading package artifacts (corrupted archives); Linux packaging jobs (root-owned build dir).
- **How to reproduce:** (1) Run an OptionsDialog test that mutates config, then a later test calling `getSynced()` — leaked values surface. (2) Install a pre-#53 release, then a new one, and uninstall — `klogg_minidump_dump.exe` blocks `RMDir`. (3) Open a live-save file while another process creates/rotates it — replay can duplicate or be skipped. (4) Release run 31076322123 failed extracting `packages-macos-intel-qt6-vs-gen.zip` with "No END header found". (5) Pre-fix PR CI: every Linux leg failed the tarball step with `tar: ... Cannot open: Permission denied`.
- **Root cause:** Disk-vs-memory config restore gap; uninstaller dropped the Delete when the install File line was removed; TOCTOU between `exists()` probe and `open(Append)` and between `NewOnly` failure and `Append` open; GitHub backend baking zip64 truncation into stored archives; Linux `build_root` created root-owned by docker while the host-runner upload step wrote into it.
- **How to fix:** Persist the restored config snapshot and scope the test baseline; keep the uninstall Delete for the retired helper; make new-file detection atomic via `O_EXCL` → `ExistingOnly` append → `O_EXCL` retry; upload single-file tarballs from the runner-owned workspace; lint-flag build-root tarball writes.

## Tests

- `RollingFileManager::openedNewFile stays consistent across create/delete interleaving` — deterministic contract test (missing→new, existing→not-new, truncate→new); the TOCTOU window itself is not deterministically unit-testable without a forced thread race.
- "ConfigurationScope restores the persisted configuration on disk" was RED before the outer-scope fix (leaked baseline failed the seed assertions) and GREEN after (6 assertions).
- Full `klogg_tests` pass: 7416 assertions / 503 test cases (macOS, offscreen).
- Full `klogg_itests` pass: 3283 assertions / 142 test cases (macOS, offscreen).
- `python3 scripts/lint_platform_fragile.py` clean; verified it flags a reproduction of the old tarball step (RED) and passes the current tree (GREEN).
- `ci-build.yml` / `ci-release.yml` parse (Ruby psych).
- CI: a new run on `d91ff7a3` is in progress and will exercise the fixed package-tarball path on all platforms, including the previously failing Linux legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
