### PR TITLE
Fix release download on .dockerbuild artifacts + macOS CI ccache

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -536,9 +536,18 @@ jobs:
         if: ${{ matrix.config.sanitizer == 'thread' }}
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # DOCKER_BUILD_SUMMARY=0 (env on both build-push steps below) stops
+      # docker/build-push-action from uploading the per-leg
+      # "<owner>~<repo>~<id>.dockerbuild" build-record/provenance artifact.
+      # Those records are never consumed here, and because they are not zips
+      # they broke the unfiltered cross-run download in ci-release (run
+      # 31241902650, "No END header found"). The ci-release download is now
+      # name-filtered as well; this removes the useless artifact at the source.
       - name: Build cached TSan Qt container
         if: ${{ matrix.config.sanitizer == 'thread' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          DOCKER_BUILD_SUMMARY: "0"
         with:
           context: ${{ matrix.config.container_root }}
           load: true
@@ -553,6 +562,8 @@ jobs:
       - name: Build cached Linux container
         if: ${{ matrix.config.sanitizer != 'thread' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        env:
+          DOCKER_BUILD_SUMMARY: "0"
         with:
           context: ${{ matrix.config.container_root }}
           load: true
@@ -796,7 +807,11 @@ jobs:
             arch: x64
             label: intel-qt6-first-party-tsan
             package_tag: tsan
-            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON
+            # KLOGG_CI_LIGHT_DEBUG=ON (-g1 instead of -g): same treatment as the
+            # asan-ubsan leg and the Linux tsan leg. Line tables suffice to
+            # symbolize TSan reports, and the smaller DWARF shrinks both compile
+            # time (vectorscan dominates) and the ccache entry footprint.
+            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON -DKLOGG_CI_LIGHT_DEBUG=ON
             sanitizer: thread
             package: false
 
@@ -825,7 +840,24 @@ jobs:
 
       - name: Brew deps
         run: |
-          brew install ragel
+          # ccache is a build dep on macOS too: the sanitizer legs rebuild
+          # vectorscan + tbb + kf5archive from source (all pinned third-party
+          # deps) on every run, which the run-31240298189 timeline shows is
+          # the critical path (~11 min of a 27-30 min build). A warm ccache
+          # collapses that to near zero. brew install is idempotent and fast
+          # (~1s) when the formula is already present.
+          brew install ragel ccache
+
+      - name: Restore ccache for the macOS build
+        id: restore-ccache
+        uses: actions/cache/restore@v4
+        with:
+          # Same keying strategy as the Linux legs: stable label key +
+          # restore-keys prefix so a PR restores master's warm cache, and the
+          # run_id-suffixed save key refreshes it on master pushes only.
+          path: ${{ github.workspace }}/.ccache
+          key: ${{ matrix.config.label }}-ccache-v1
+          restore-keys: ${{ matrix.config.label }}-ccache-v1-
 
       - uses: actions/download-artifact@v4
         with:
@@ -862,6 +894,17 @@ jobs:
           # all of which support AVX2 / NEON.  Use GENERIC_CPU=OFF to enable
           # hardware-specific optimizations (AVX2 for Intel, NEON for ARM64).
           echo "KLOGG_CMAKE_OPTS=-G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DKLOGG_GENERIC_CPU=OFF -DKLOGG_USE_SENTRY=OFF -DCMAKE_INSTALL_PREFIX=/usr -DFETCHCONTENT_FULLY_DISCONNECTED=ON ${{ matrix.config.cmake_opts }}" >> $GITHUB_ENV
+
+      - name: Enable ccache compiler launcher
+        shell: sh
+        run: |
+          # Same pattern as the Linux legs (see "Enable ccache compiler
+          # launcher" there). CCACHE_BASEDIR strips the workspace prefix from
+          # debug info so a cache entry restored under a different runner
+          # workspace path still hits.
+          echo "KLOGG_CMAKE_OPTS=$KLOGG_CMAKE_OPTS -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
       
       - name: Set sanitizer env
         if: ${{ matrix.config.sanitizer }}
@@ -874,6 +917,20 @@ jobs:
           echo "TSAN_OPTIONS=halt_on_error=1" >> $GITHUB_ENV
 
       - uses: ./.github/actions/agent-build
+
+      - name: Show ccache statistics
+        shell: sh
+        run: ccache -s 2>/dev/null || echo "ccache stats unavailable"
+
+      - name: Save ccache for the macOS build
+        if: ${{ success() && github.event_name == 'push' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          # run_id-suffixed save key (same as Linux): refreshes the shared
+          # cache on each master push while the label-ccache-v1- restore-keys
+          # prefix keeps PR restores hitting the most recent master entry.
+          key: ${{ matrix.config.label }}-ccache-v1-${{ github.run_id }}
 
       - name: Verify ASan/UBSan-instrumented test binaries
         if: ${{ matrix.config.sanitizer == 'address-undefined' }}

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -27,6 +27,15 @@ jobs:
         workflow: ci-build.yml
         workflow_conclusion: success
         check_artifacts: true
+        # Download only the artifacts the release consumes. Without a filter,
+        # dawidd6 downloads ALL run artifacts, including the
+        # "<owner>~<repo>~<id>.dockerbuild" build records that
+        # docker/build-push-action uploads alongside the docker `type=gha`
+        # cache (added in 1ddee61d). Those are gzipped OCI tarballs, not
+        # zips, so dawidd6's unzip step fails the release with "Invalid or
+        # unsupported zip format. No END header found" (run 31241902650).
+        name: '^(packages-.*|klogg_version)$'
+        name_is_regexp: true
 
     - name: Download artifacts for CI workflow with provided run id
       if: ${{ github.event.inputs.ci-run-id }}
@@ -34,6 +43,9 @@ jobs:
       with:
         workflow: ci-build.yml
         run_id: ${{ github.event.inputs.ci-run-id }}
+        # Same filter as the default-path download above; keep both in sync.
+        name: '^(packages-.*|klogg_version)$'
+        name_is_regexp: true
 
     # Package artifacts are uploaded as single-file tarballs (not raw
     # multi-file directories) to avoid GitHub's artifact backend intermittently

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -958,6 +958,69 @@ def _check_ci_tarball_into_build_root(text: str, path: Path) -> list[tuple[int, 
     return findings
 
 
+def _check_unfiltered_cross_run_artifact_download(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag workflow YAML steps that download artifacts from another workflow
+    run without restricting which artifacts they fetch.
+
+    Release run 31241902650 failed with "Invalid or unsupported zip format.
+    No END header found" because ci-release.yml used
+    dawidd6/action-download-artifact with no ``name`` filter, so it pulled
+    every artifact of the source CI run. Since 1ddee61d added docker
+    ``type=gha`` layer caching, docker/build-push-action also uploads a
+    ``<owner>~<repo>~<id>.dockerbuild`` build-record artifact per build leg;
+    those are gzipped OCI tarballs, not zips, and dawidd6 aborts when its
+    unzip step reaches one.
+
+    Any cross-run download step (``workflow:`` / ``run_id:`` inputs — i.e. it
+    can see artifacts produced by OTHER jobs, not just the current one) must
+    set an explicit artifact selector:
+      - dawidd6/action-download-artifact: ``name:`` (optionally with
+        ``name_is_regexp: true``)
+      - actions/download-artifact@v4: ``name:`` or ``pattern:``
+    """
+    findings: list[tuple[int, str]] = []
+    lines = text.splitlines()
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "uses:" in line and (
+            "dawidd6/action-download-artifact" in line
+            or "actions/download-artifact" in line
+        ):
+            # Scan the step block (until the next step or a dedent to column 0)
+            # for a cross-run marker and for an artifact selector.
+            block: list[str] = []
+            j = i + 1
+            while j < len(lines) and not (
+                lines[j].lstrip().startswith("- ")
+                and (len(lines[j]) - len(lines[j].lstrip())) <= 6
+            ):
+                block.append(lines[j])
+                j += 1
+            joined = "\n".join(block)
+            cross_run = "workflow:" in joined or "run_id:" in joined
+            has_selector = any(
+                b.lstrip().startswith(("name:", "pattern:")) for b in block
+            )
+            if cross_run and not has_selector:
+                findings.append(
+                    (
+                        i + 1,
+                        "cross-run artifact download without a name:/pattern: "
+                        "filter fetches every artifact of the source run, "
+                        "including docker/build-push-action *.dockerbuild "
+                        "build records (not zips), which breaks the unzip "
+                        "step (release run 31241902650). Add a restrictive "
+                        "name:/pattern: filter.",
+                    )
+                )
+            i = j
+        else:
+            i += 1
+    return findings
+
+
 def lint_file(path: Path) -> int:
     try:
         text = path.read_text(encoding="utf-8", errors="replace")
@@ -967,13 +1030,21 @@ def lint_file(path: Path) -> int:
 
     if path.suffix in (".yml", ".yaml"):
         # CI workflow/action YAML has its own platform-fragile class: package
-        # uploads must not write into the docker-root-owned build root.
-        for line_num, message in _check_ci_tarball_into_build_root(text, path):
-            print(f"[platform-fragile] ci-tarball-into-build-root")
-            print(f"  at {path}:{line_num}")
-            print(f"  {message}")
-            print()
-            issues += 1
+        # uploads must not write into the docker-root-owned build root, and
+        # cross-run artifact downloads must be name-filtered.
+        for rule_name, check in (
+            ("ci-tarball-into-build-root", _check_ci_tarball_into_build_root),
+            (
+                "unfiltered-cross-run-artifact-download",
+                _check_unfiltered_cross_run_artifact_download,
+            ),
+        ):
+            for line_num, message in check(text, path):
+                print(f"[platform-fragile] {rule_name}")
+                print(f"  at {path}:{line_num}")
+                print(f"  {message}")
+                print()
+                issues += 1
         return issues
 
     # Single-line patterns.


### PR DESCRIPTION
## Summary
- **Fix the failing "Make CI Release" workflow** (run [31241902650](https://github.com/ZEACENT/klogg/actions/runs/31241902650)): the artifact download step aborted with `Invalid or unsupported zip format. No END header found` because it pulled docker/build-push-action `*.dockerbuild` build-record artifacts, which are not zips.
- **Speed up the macOS CI legs** (the longest pole in CI Build run [31240298189](https://github.com/ZEACENT/klogg/actions/runs/31240298189): intel tsan 38 min, intel asan-ubsan 39 min) by adding ccache, matching what the Linux legs already have.
- Suppress the `*.dockerbuild` artifacts at the source (`DOCKER_BUILD_SUMMARY=0`) and add a lint rule so unfiltered cross-run artifact downloads are caught before CI.

## Background
- Introduced by: `1ddee61d` (docker `type=gha` layer caching, PR #52). Since then, every Linux leg's docker/build-push-action step uploads a `<owner>~<repo>~<id>.dockerbuild` build-record artifact (present in master runs 31058347635 and 31240298189).
- Use case: dispatching "Make CI Release" after a successful CI Build run.
- How to reproduce: dispatch the release workflow against any CI Build run since `1ddee61d`; the download step fails as in run 31241902650.
- Root cause: `ci-release.yml` uses `dawidd6/action-download-artifact` with no `name` filter, so it downloads **all** artifacts and unzips each one. The `.dockerbuild` records are gzipped OCI blob tarballs (verified by downloading artifact 9016966613: `blobs/sha256/…` + `oci-layout`), so the unzip step dies. This is a different failure class from the multi-file `packages-*` zip64 corruption fixed in #54 (`c620dfa4`): that was server-side archive truncation, this is a non-zip artifact reaching an unzip-everything downloader. Native `actions/download-artifact` doesn't unzip, so `CreatePreRelease`'s `pattern: packages-*` path was never affected.
- How to fix:
  - `ci-release.yml`: filter both dawidd6 steps with `name: '^(packages-.*|klogg_version)$'` + `name_is_regexp: true` (validated against all 20 real artifact names — matches exactly the 8 the release consumes).
  - `ci-build.yml` (Mac job): add ccache (brew install, per-label restore/save with the same keying as the Linux legs, compiler launcher, `CCACHE_BASEDIR`). The ninja timeline shows pinned third-party deps (vectorscan = 208 heavy -O2 objects, ~11 min) are the critical path and are rebuilt from scratch every run; a warm cache collapses that.
  - `ci-build.yml` (Mac TSan leg): add `KLOGG_CI_LIGHT_DEBUG=ON` (`-g1`), aligning with the asan-ubsan and Linux-tsan legs — smaller DWARF, smaller cache entries, same symbolization quality for sanitizer reports.
  - `ci-build.yml` (Linux container steps): `DOCKER_BUILD_SUMMARY=0` so the unused `.dockerbuild` records are no longer uploaded at all.
  - `scripts/lint_platform_fragile.py`: new `unfiltered-cross-run-artifact-download` rule flags any cross-run download step missing a `name:`/`pattern:` selector.

## Tests
- Lint rule: RED against the pre-fix `ci-release.yml` (2 findings, one per download step), GREEN on the fixed tree; full `python3 scripts/lint_platform_fragile.py` clean.
- `actionlint` on both workflows: no new issues (the 4 SC10xx shellcheck errors on the pre-existing pwsh openssl step are unchanged from master).
- Ruby YAML parse passes on both workflows.
- Not run (CI-only paths): the release download itself — it will be exercised by the next "Make CI Release" dispatch; ccache effectiveness will be visible in the new "Show ccache statistics" step on the next CI Build run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release Improvements**
  * Improved CI reliability by reducing unnecessary build artifacts and enabling faster macOS builds through caching.
  * Refined release artifact selection to prevent unrelated files from causing extraction failures.
* **Quality Improvements**
  * Added validation to detect insufficient filtering when downloading artifacts across workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->