### PR TITLE
Fix blank marked-row content in folder results for files over 16 MiB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ cmake-build-relwithdebinfo/
 website/hugo
 website/.hugo_build.lock
 website/resources/
+scripts/__pycache__/

--- a/scripts/compile_qt5_probe.sh
+++ b/scripts/compile_qt5_probe.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Compile-probe the files that have repeatedly broken the Qt 5 Linux CI legs
+# with -Werror=conversion (qsizetype -> int narrowing), using the LOCAL Qt 5
+# headers (brew qt@5) instead of a Docker container. This closes the gap where
+# a dev on Qt 6 (macOS) cannot see a Qt-5-only narrowing until CI.
+#
+# Background: PR #48 (FolderSearchResults::ensureMarkLines), PR #56
+# (readMarkLineSeek QByteArray::at, then the ContainerIndex binary-search chain
+# in wrappedstring.h) all failed the Qt 5 Linux legs this way. The fix pattern
+# is "index type must match the RECEIVER's size type on both Qt versions":
+# QByteArray/QString -> klogg::ContainerIndex, QStringView -> plain qsizetype.
+#
+# Usage:  scripts/compile_qt5_probe.sh          # exit 0 = clean on Qt 5
+# Requires: brew install qt@5
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QT5="$(brew --prefix qt@5 2>/dev/null || true)"
+if [[ -z "$QT5" || ! -f "$QT5/include/QtCore/qbytearray.h" ]]; then
+    echo "SKIP: qt@5 headers not found (brew install qt@5)" >&2
+    exit 0
+fi
+
+TS_DIR="$REPO_ROOT/cpm_cache/type_safe/71a1f33a7b982527e268b7782e28521750f87981"
+MI_DIR="$REPO_ROOT/cpm_cache/mimalloc/c1a06fe29f85739efe873954591e60cfecba8d25/include"
+
+COMMON_FLAGS=(
+    -std=gnu++17 -Werror=conversion -Wsign-conversion
+    -I"$REPO_ROOT/src/ui/include"
+    -I"$REPO_ROOT/src/logdata/include"
+    -I"$REPO_ROOT/src/utils/include"
+    -I"$REPO_ROOT/src/logging/include"
+    -isystem "$QT5/include"
+    -isystem "$QT5/include/QtCore"
+    -isystem "$QT5/include/QtGui"
+    -isystem "$QT5/include/QtWidgets"
+    -isystem "$QT5/include/QtNetwork"
+    -isystem "$QT5/include/QtConcurrent"
+    -isystem "$TS_DIR/include"
+    -isystem "$TS_DIR/external/debug_assert"
+    -isystem "$MI_DIR"
+    -DTYPE_SAFE_ENABLE_ASSERTIONS=0
+    -DTYPE_SAFE_ENABLE_WRAPPER=1
+    -DTYPE_SAFE_ARITHMETIC_POLICY=1
+)
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+probe() { # probe <name> <source-file>
+    local name="$1" src="$2"
+    if c++ "${COMMON_FLAGS[@]}" -c "$src" -o "$TMP/$name.o" 2>"$TMP/$name.err"; then
+        echo "OK   $name (Qt 5 $( "$QT5/bin/qmake" -query QT_VERSION ))"
+    else
+        echo "FAIL $name -- Qt 5 -Werror=conversion:" >&2
+        grep -E "error" "$TMP/$name.err" >&2 || cat "$TMP/$name.err" >&2
+        return 1
+    fi
+}
+
+fail=0
+# A translation unit that instantiates the wrapped-string binary search.
+cat > "$TMP/ws_probe.cpp" <<'CPP'
+#include "wrappedstring.h"
+#include <QString>
+static int tw( QStringView s ) { return static_cast<int>( s.size() ) * 7; }
+void run() {
+    QString longLine( 500, QLatin1Char( 'x' ) );
+    longLine.replace( 100, 1, QLatin1Char( ' ' ) );
+    WrappedString w( longLine, 200, tw );
+    (void)w.wrappedLinesCount();
+}
+CPP
+probe wrappedstring "$TMP/ws_probe.cpp" || fail=1
+probe foldersearchresults "$REPO_ROOT/src/logdata/src/foldersearchresults.cpp" || fail=1
+
+if [[ $fail -eq 0 ]]; then
+    echo "Qt 5 compile probe: all clean."
+else
+    echo "Qt 5 compile probe: FAILURES above would break the Qt 5 Linux CI legs." >&2
+fi
+exit $fail

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -250,8 +250,11 @@ def _extract_call_args(code: str, open_paren_pos: int) -> str:
 # (QStringView is the exception: it has been qsizetype-native since Qt 5.8, so
 # its indexOf/mid/left/right never narrow. QStringRef, like QString, takes int
 # on Qt 5 and IS flagged.)
+# `.at(i)` / `.value(i)` join the list: QString/QByteArray::at and value take
+# int on Qt 5 (PR #56 CI failure: FolderSearchResults::readMarkLineSeek indexed
+# QByteArray::at with a qsizetype loop counter).
 _QT_INT_API_RE = re.compile(
-    r"\.(?:indexOf|mid|left|right|truncate|chop|chopped|remove)\s*\("
+    r"\.(?:indexOf|mid|left|right|truncate|chop|chopped|remove|at|value)\s*\("
 )
 _QSIZETYPE_DECL_RE = re.compile(r"\b(?:const\s+)?qsizetype\s+(\w+)\b")
 # `using <Alias> = QStringView;` -- the wrappedstring.h code uses this idiom.
@@ -371,7 +374,8 @@ def _check_qsizetype_to_int_conversion(text: str, path: Path) -> list[tuple[int,
     on the macOS / Ubuntu-24.04 Qt 6 builds developers run locally, so it only
     surfaces in the Linux CI matrix. PR #48 failed CI this way in
     FolderSearchResults::ensureMarkLines (qsizetype loop indices passed to
-    QString::indexOf / QString::mid).
+    QString::indexOf / QString::mid); PR #56 failed the same way with a
+    qsizetype loop counter passed to QByteArray::at.
 
     QStringView is excluded: it has been qsizetype-native since Qt 5.8, so its
     indexOf/mid/left/right do not narrow on Qt 5. Code behind a Qt-6-only

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -441,9 +441,11 @@ def _check_qsizetype_to_int_conversion(text: str, path: Path) -> list[tuple[int,
                             f"QStringView). This narrows qsizetype->int and "
                             f"trips -Werror=conversion on the Qt 5 Linux CI "
                             f"builds (invisible on Qt 6 / macOS). Use the "
-                            f"adaptive LineLength/LineColumn types, or "
+                            f"adaptive klogg::ContainerIndex (containers.h: "
+                            f"int on Qt 5 / qsizetype on Qt 6, never narrows), "
+                            f"LineLength/LineColumn for line semantics, or "
                             f"static_cast<int>(...) with a documented size "
-                            f"bound. (PR #48 CI failure: ensureMarkLines.)",
+                            f"bound. (PR #48/#56 CI failures.)",
                         )
                     )
                     break  # one report per call is enough

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -207,11 +207,19 @@ class FolderSearchResults : public AbstractLogData {
     QString headerText( klogg::folder::FileId fileId ) const;
     QString marksGroupHeader( size_t marksGroupIndex ) const;
     QString readMatchLine( klogg::folder::FileId fileId, size_t matchIndex ) const;
-    // Fetch the text of a marked source line by (filePath, localLine) using a
-    // cached per-file line-offset index (marked non-match lines have no
-    // MatchRecord offset). Results are cached per (filePath, localLine).
+    // Fetch the text of a marked source line by (filePath, localLine) (marked
+    // non-match lines have no MatchRecord offset). Byte-newline-safe encodings
+    // (UTF-8 / single-byte, the common case) seek to the line and read just it,
+    // scaling to any file size; multi-byte/stateful codecs use the (capped)
+    // whole-file decoded-line cache.
     QString readMarkLine( const QString& filePath, LineNumber localLine, QTextCodec* codec ) const;
     void ensureMarkLines( const QString& filePath, QTextCodec* codec ) const;
+    // True iff raw byte 0x0A unambiguously marks a line boundary in `codec`
+    // (UTF-8 and single-byte/ASCII-superset codecs; NOT UTF-16/32, Shift-JIS,
+    // GBK, Big5, EUC, ISO-2022). Gates the seek-based mark-line read.
+    static bool codecIsByteNewlineSafe( QTextCodec* codec );
+    QString readMarkLineSeek( const QString& filePath, LineNumber localLine,
+                              QTextCodec* codec ) const;
     QTextCodec* codecForFile( const QString& filePath ) const;
     QFile* fileForGroup( klogg::folder::FileId fileId ) const;
     const VisibleRow* visibleRowAt( LineNumber line ) const;
@@ -241,17 +249,17 @@ class FolderSearchResults : public AbstractLogData {
     // Marks-only groups (files with marks but no match group), rebuilt each
     // rebuildVisibleRows. Indexed by FileId = groups_.size() + index.
     std::vector<MarksGroup> marksGroups_;
-    // Per-file decoded line text for on-demand marked-line fetch (marked
-    // non-match lines have no MatchRecord offset). Built lazily by reading the
-    // whole file, decoding with codecForFile and splitting on '\n' (correct for
-    // all encodings incl. UTF-16), cached. Key is filePath + null + codec name;
-    // a marks-only file (nullptr codec / UTF-8 default) and a later match-group
-    // file (scanned codec, e.g. Shift-JIS) get separate cache entries to avoid
-    // mojibake from a stale encoding mismatch. kMarkLineCacheCap is a PER-FILE
-    // cap (huge files skip -> empty mark text, no main-thread stall); there is
-    // no cache-wide memory budget. Persists across searches (file-intrinsic);
-    // invalidated on encoding-override change. A transient open failure is NOT
-    // cached so a later fetch can retry. Guarded by fileIoMutex_.
+    // Whole-file decoded line cache, used ONLY for multi-byte/stateful codecs
+    // (UTF-16/32, Shift-JIS, ...) whose line boundaries a byte scan cannot find.
+    // Key is filePath + null + codec name; a marks-only file (nullptr codec /
+    // UTF-8 default) and a later match-group file (scanned codec) get separate
+    // entries to avoid mojibake from a stale encoding mismatch. Files over the
+    // PER-FILE kMarkLineCacheCap (16 MiB) with such a codec cache an EMPTY list
+    // (marked-line text unavailable rather than a main-thread O(file) decode).
+    // Byte-newline-safe files never populate this for text fetch (seek path).
+    // Persists across searches (file-intrinsic); invalidated on
+    // encoding-override change. A transient open failure is NOT cached so a
+    // later fetch can retry. Guarded by fileIoMutex_.
     mutable QHash<QString, std::vector<QString>> markLineCache_;
     // Per-file display-encoding overrides (Encoding-menu picks), consulted by
     // readMatchLine before the scan-time detected sourceCodec.

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -25,6 +25,7 @@
 #include <QString>
 #include <QTextCodec>
 #include <QtGlobal>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -169,7 +170,9 @@ class FolderSearchResults : public AbstractLogData {
     // O(file) stall, and the seek path cannot locate line boundaries). Lets the
     // view distinguish "text unavailable" from "the line is empty" instead of
     // silently rendering a blank row (the original 16 MiB marked-row defect).
-    enum class MarkLineTextStatus { Available, Unavailable };
+    // std::uint8_t base: two states need only 1 byte (clang-tidy
+    // performance-enum-size).
+    enum class MarkLineTextStatus : std::uint8_t { Available, Unavailable };
     // Status for a visible row. Returns Available for any non-mark row (their
     // text comes from MatchRecord byte offsets, never capped).
     MarkLineTextStatus markLineTextStatus( LineNumber visibleIndex ) const;

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -174,6 +174,16 @@ class FolderSearchResults : public AbstractLogData {
     // text comes from MatchRecord byte offsets, never capped).
     MarkLineTextStatus markLineTextStatus( LineNumber visibleIndex ) const;
 
+    // True iff raw byte 0x0A unambiguously marks a line boundary in `codec`.
+    // ALLOWLIST (not denylist): only nullptr (UTF-8 default), UTF-8 itself, and
+    // the known stateless single-byte / ASCII-superset codecs qualify -- a byte
+    // scan finds the same lines the codec would. Every other codec (UTF-16/32,
+    // Shift-JIS, GBK, Big5, EUC, ISO-2022, and any codec not enumerated here)
+    // returns false so it stays on the whole-file decode path; an unlisted
+    // codec with a non-ASCII newline encoding must never reach the seek scan.
+    // Public for testing.
+    static bool codecIsByteNewlineSafe( QTextCodec* codec );
+
   Q_SIGNALS:
     // Emitted whenever the visible-row layout changes (new results, collapse
     // toggle, collapse/expand all). The view responds with updateData() +
@@ -234,10 +244,6 @@ class FolderSearchResults : public AbstractLogData {
     // whole-file decoded-line cache.
     QString readMarkLine( const QString& filePath, LineNumber localLine, QTextCodec* codec ) const;
     void ensureMarkLines( const QString& filePath, QTextCodec* codec ) const;
-    // True iff raw byte 0x0A unambiguously marks a line boundary in `codec`
-    // (UTF-8 and single-byte/ASCII-superset codecs; NOT UTF-16/32, Shift-JIS,
-    // GBK, Big5, EUC, ISO-2022). Gates the seek-based mark-line read.
-    static bool codecIsByteNewlineSafe( QTextCodec* codec );
     QString readMarkLineSeek( const QString& filePath, LineNumber localLine,
                               QTextCodec* codec ) const;
     QTextCodec* codecForFile( const QString& filePath ) const;
@@ -281,6 +287,15 @@ class FolderSearchResults : public AbstractLogData {
     // encoding-override change. A transient open failure is NOT cached so a
     // later fetch can retry. Guarded by fileIoMutex_.
     mutable QHash<QString, std::vector<QString>> markLineCache_;
+    // Resolved mark-line TEXT cache for the seek path (byte-newline-safe files).
+    // The view re-fetches every visible mark row on each repaint; without this,
+    // a mark near the end of a large file rescans from byte 0 every frame. Key
+    // is filePath + null + codec name + null + localLine. Only seek-path reads
+    // populate it (whole-file path already caches all lines). Bounded by the
+    // number of marked lines per file. Invalidated alongside markLineCache_ on
+    // encoding-override change (same prefix sweep covers both). Guarded by
+    // fileIoMutex_.
+    mutable QHash<QString, QString> markTextCache_;
     // Per-file display-encoding overrides (Encoding-menu picks), consulted by
     // readMatchLine before the scan-time detected sourceCodec.
     QHash<QString, QByteArray> encodingOverrides_;

--- a/src/logdata/include/foldersearchresults.h
+++ b/src/logdata/include/foldersearchresults.h
@@ -24,6 +24,7 @@
 #include <QSet>
 #include <QString>
 #include <QTextCodec>
+#include <QtGlobal>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -153,6 +154,25 @@ class FolderSearchResults : public AbstractLogData {
     // Rebuild + emit layoutChanged. Called by the widget when marks change while
     // the Marks filter is active (the visible set depends on marks).
     void refreshForMarksChange();
+
+    // Per-file size cap for the whole-file decoded mark-line cache. Exposed so
+    // tests build fixtures relative to the SAME constant (a cap change keeps
+    // over-cap tests on the over-cap side). Only multi-byte/stateful codecs
+    // (UTF-16/32, Shift-JIS, ...) use the whole-file path; byte-newline-safe
+    // files read marked lines by seek and are unaffected by this cap.
+    static constexpr qint64 kMarkLineCacheCap = 16LL << 20; // 16 MiB
+
+    // Whether a Data row's source-line text can be produced. A row is
+    // Unavailable when its text cannot be fetched by design -- currently only
+    // a marked line in a file over kMarkLineCacheCap with a multi-byte/stateful
+    // codec (the whole-file decode cache is skipped there to avoid a main-thread
+    // O(file) stall, and the seek path cannot locate line boundaries). Lets the
+    // view distinguish "text unavailable" from "the line is empty" instead of
+    // silently rendering a blank row (the original 16 MiB marked-row defect).
+    enum class MarkLineTextStatus { Available, Unavailable };
+    // Status for a visible row. Returns Available for any non-mark row (their
+    // text comes from MatchRecord byte offsets, never capped).
+    MarkLineTextStatus markLineTextStatus( LineNumber visibleIndex ) const;
 
   Q_SIGNALS:
     // Emitted whenever the visible-row layout changes (new results, collapse

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -445,10 +445,16 @@ void FolderSearchResults::setEncodingOverrideForFile( const QString& filePath,
     {
         UniqueLock lock( dataMutex_ );
         encodingOverrides_.insert( filePath, encoding );
-        // Cached mark-line text was decoded with the old codec; drop it so the
-        // next fetch re-decodes with the override. Lock order dataMutex_ -> fileIoMutex_.
+        // Cached whole-file decoded mark lines (only multi-byte/stateful codecs
+        // use that path) were decoded with the old codec; drop every entry for
+        // this file (keys are filePath + NUL + codecName) so the next fetch
+        // re-decodes with the override. The seek path needs no invalidation.
+        // Lock order dataMutex_ -> fileIoMutex_.
         std::lock_guard<std::mutex> io( fileIoMutex_ );
-        markLineCache_.remove( filePath );
+        const QString prefix = filePath + QChar::Null;
+        for ( auto it = markLineCache_.begin(); it != markLineCache_.end(); ) {
+            it = it.key().startsWith( prefix ) ? markLineCache_.erase( it ) : std::next( it );
+        }
     }
     Q_EMIT layoutChanged();
 }
@@ -464,8 +470,13 @@ void FolderSearchResults::clearEncodingOverrideForFile( const QString& filePath 
         UniqueLock lock( dataMutex_ );
         removed = encodingOverrides_.remove( filePath ) != 0;
         if ( removed ) {
+            // Same composite-key sweep as setEncodingOverrideForFile.
             std::lock_guard<std::mutex> io( fileIoMutex_ );
-            markLineCache_.remove( filePath );
+            const QString prefix = filePath + QChar::Null;
+            for ( auto it = markLineCache_.begin(); it != markLineCache_.end(); ) {
+                it = it.key().startsWith( prefix ) ? markLineCache_.erase( it )
+                                                   : std::next( it );
+            }
         }
     }
     if ( removed ) {
@@ -940,11 +951,15 @@ QTextCodec* FolderSearchResults::codecForFile( const QString& filePath ) const
 
 void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* codec ) const
 {
-    // Build the per-file decoded line cache: read the whole file, decode with
-    // `codec`, split on '\n'. Decoding BEFORE splitting makes this correct for
-    // all encodings (incl. UTF-16/UTF-32), unlike a raw byte scan. Capped: files
-    // larger than kMarkLineCacheCap skip (empty cache -> empty mark text) to
-    // avoid a main-thread stall on huge files. Caller does NOT hold fileIoMutex_.
+    // Whole-file decoded line cache. This is the CORRECTNESS fallback for
+    // multi-byte / stateful encodings (UTF-16, UTF-32, Shift-JIS, ...) where a
+    // byte-level '\n' scan cannot locate line boundaries, and for small files
+    // where one decode is cheapest. Files over kMarkLineCacheCap with such a
+    // codec insert an EMPTY cache (marked-line text unavailable -- a deliberate
+    // trade-off to avoid a main-thread O(file) decode). Single-byte / UTF-8
+    // files NEVER reach this path for text fetch: readMarkLine seeks to the
+    // line directly instead (see readMarkLineSeek), which scales to any file
+    // size. Caller does NOT hold fileIoMutex_.
     std::lock_guard<std::mutex> io( fileIoMutex_ );
     const QString cacheKey = markCacheKey( filePath, codec );
     if ( markLineCache_.contains( cacheKey ) ) {
@@ -990,12 +1005,97 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
     markLineCache_.insert( cacheKey, std::move( lines ) );
 }
 
+bool FolderSearchResults::codecIsByteNewlineSafe( QTextCodec* codec )
+{
+    // True iff the raw byte 0x0A unambiguously marks a line boundary in this
+    // encoding, so a seek-based byte scan finds the same lines the codec would.
+    // Holds for UTF-8 and every single-byte / ASCII-superset codec (0x0A is a
+    // self-synchronizing LF there). Fails for UTF-16/UTF-32 (a 0x0A byte can be
+    // one half of a multi-byte unit) and for stateful/double-byte codecs where
+    // 0x0A may be a trail byte (e.g. some Shift-JIS/GBK sequences) -- those stay
+    // on the whole-file decode path. codec == nullptr means "UTF-8 default".
+    if ( codec == nullptr ) {
+        return true;
+    }
+    if ( codec->mibEnum() == 106 ) { // UTF-8
+        return true;
+    }
+    const QByteArray name = codec->name().toUpper();
+    return !name.startsWith( "UTF-16" ) && !name.startsWith( "UTF-32" )
+           && !name.startsWith( "SHIFT" )     // Shift-JIS / Shift_JIS
+           && !name.startsWith( "GB" )        // GBK / GB2312 / GB18030
+           && !name.startsWith( "BIG5" ) && !name.startsWith( "EUC" )
+           && !name.startsWith( "JIS" ) && !name.startsWith( "ISO-2022" );
+}
+
+QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumber localLine,
+                                               QTextCodec* codec ) const
+{
+    // Seek-based per-line read for byte-newline-safe encodings: scan forward to
+    // the start of localLine, then read to the next '\n'. Only the target line's
+    // bytes are touched, so this scales to any file size (the whole-file cache
+    // silently returned empty text over its 16 MiB cap -- the blank-marked-row
+    // bug this replaces). Decoded with the resolved codec (or UTF-8 default),
+    // trailing CR/LF stripped. Caller has released dataMutex_; takes only
+    // fileIoMutex_.
+    std::lock_guard<std::mutex> io( fileIoMutex_ );
+    QFile file( filePath );
+    if ( !file.open( QIODevice::ReadOnly ) ) {
+        return {};
+    }
+
+    const quint64 target = localLine.get();
+    if ( target > 0 ) {
+        // Stream past `target` newlines. Chunked reads bound memory; after the
+        // target newline is seen INSIDE a chunk, seek back to just past it --
+        // the buffered read already consumed the whole chunk, so without the
+        // reposition readLine() would start at the chunk end (mid-file).
+        constexpr qint64 kScanChunk = 1LL << 16; // 64 KiB
+        quint64 seen = 0;
+        bool found = false;
+        while ( !found ) {
+            const qint64 chunkStart = file.pos();
+            const QByteArray chunk = file.read( kScanChunk );
+            if ( chunk.isEmpty() ) {
+                return {}; // EOF before the target line: no such line.
+            }
+            for ( qsizetype i = 0; i < chunk.size(); ++i ) {
+                if ( chunk.at( i ) == '\n' ) {
+                    ++seen;
+                    if ( seen == target ) {
+                        if ( !file.seek( chunkStart + i + 1 ) ) {
+                            return {};
+                        }
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    QByteArray lineBytes = file.readLine();
+    if ( lineBytes.isEmpty() && file.atEnd() ) {
+        return {}; // target line index is past the last line.
+    }
+    while ( lineBytes.endsWith( '\n' ) || lineBytes.endsWith( '\r' ) ) {
+        lineBytes.chop( 1 );
+    }
+    return codec != nullptr ? codec->toUnicode( lineBytes )
+                            : QString::fromUtf8( lineBytes );
+}
+
 QString FolderSearchResults::readMarkLine( const QString& filePath, LineNumber localLine,
                                            QTextCodec* codec ) const
 {
-    // Fetch the marked source line by line number from the cached decoded lines
-    // (marked non-match lines have no MatchRecord offset). Caller has released
-    // dataMutex_; only fileIoMutex_ is taken here.
+    // Fetch the marked source line by line number (marked non-match lines have
+    // no MatchRecord offset). Byte-newline-safe encodings (UTF-8 / single-byte,
+    // the common case) use a bounded seek read that scales to any file size;
+    // multi-byte/stateful codecs fall back to the (capped) whole-file decoded
+    // cache. Caller has released dataMutex_; only fileIoMutex_ is taken here.
+    if ( codecIsByteNewlineSafe( codec ) ) {
+        return readMarkLineSeek( filePath, localLine, codec );
+    }
     ensureMarkLines( filePath, codec );
     std::lock_guard<std::mutex> io( fileIoMutex_ );
     const auto it = markLineCache_.constFind( markCacheKey( filePath, codec ) );

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -242,9 +242,9 @@ FolderSearchResults::markLineTextStatus( LineNumber visibleIndex ) const
     // to Unavailable spuriously), then report Unavailable only when the cached
     // entry is present-but-empty -- the over-cap signature ensureMarkLines logs.
     ensureMarkLines( filePath, codec );
-    std::lock_guard<std::mutex> io( fileIoMutex_ );
-    const auto it = markLineCache_.constFind( markCacheKey( filePath, codec ) );
-    if ( it != markLineCache_.cend() && it->empty() ) {
+    std::lock_guard<std::mutex> ioLock( fileIoMutex_ );
+    const auto cacheIt = markLineCache_.constFind( markCacheKey( filePath, codec ) );
+    if ( cacheIt != markLineCache_.cend() && cacheIt->empty() ) {
         return MarkLineTextStatus::Unavailable;
     }
     return MarkLineTextStatus::Available;
@@ -1110,7 +1110,7 @@ QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumb
     // bug this replaces). Decoded with the resolved codec (or UTF-8 default),
     // trailing CR/LF stripped. Caller has released dataMutex_; takes only
     // fileIoMutex_.
-    std::lock_guard<std::mutex> io( fileIoMutex_ );
+    std::lock_guard<std::mutex> ioLock( fileIoMutex_ );
 
     // Resolved-text cache: the view re-fetches every visible mark row on each
     // repaint, so without caching a mark near the end of a large file would

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -216,6 +216,38 @@ bool FolderSearchResults::isMatchRow( LineNumber visibleIndex ) const
     return group.matches[ row->matchIndex ].role == klogg::folder::RecordRole::Match;
 }
 
+FolderSearchResults::MarkLineTextStatus
+FolderSearchResults::markLineTextStatus( LineNumber visibleIndex ) const
+{
+    QString filePath;
+    QTextCodec* codec = nullptr;
+    {
+        SharedLock lock( dataMutex_ );
+        const auto* row = visibleRowAt( visibleIndex );
+        // Non-mark rows read text from MatchRecord byte offsets -- never capped.
+        if ( row == nullptr || !row->isMarkRow ) {
+            return MarkLineTextStatus::Available;
+        }
+        filePath = row->markFilePath;
+        codec = codecForFile( filePath );
+    }
+    // Byte-newline-safe files read by seek: text is always fetchable, any size.
+    if ( codecIsByteNewlineSafe( codec ) ) {
+        return MarkLineTextStatus::Available;
+    }
+    // Stateful codec: text comes from the whole-file cache. Populate it (a
+    // transient open failure caches nothing and would otherwise flip the status
+    // to Unavailable spuriously), then report Unavailable only when the cached
+    // entry is present-but-empty -- the over-cap signature ensureMarkLines logs.
+    ensureMarkLines( filePath, codec );
+    std::lock_guard<std::mutex> io( fileIoMutex_ );
+    const auto it = markLineCache_.constFind( markCacheKey( filePath, codec ) );
+    if ( it != markLineCache_.cend() && it->empty() ) {
+        return MarkLineTextStatus::Unavailable;
+    }
+    return MarkLineTextStatus::Available;
+}
+
 klogg::folder::FileId FolderSearchResults::fileIdForLine( LineNumber visibleIndex ) const
 {
     SharedLock lock( dataMutex_ );
@@ -974,7 +1006,15 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
         // being permanently recorded as "no mark text".
         return;
     }
-    constexpr qint64 kMarkLineCacheCap = 16LL << 20; // 16 MiB
+    // Over-cap with a stateful codec: cache an EMPTY list and LOG it. The empty
+    // entry is what markLineTextStatus keys on to report Unavailable -- callers
+    // must never treat "cached but empty" as "the line is empty" (that silent
+    // conflation was the original blank-marked-row defect).
+    if ( file.size() > kMarkLineCacheCap ) {
+        LOG_WARNING << "FolderSearchResults: mark-line text unavailable for" << filePath
+                    << "-- file size" << file.size() << "exceeds kMarkLineCacheCap ("
+                    << kMarkLineCacheCap << ") with a stateful codec";
+    }
     if ( file.size() <= kMarkLineCacheCap ) {
         const QByteArray bytes = file.readAll();
         const QString text

--- a/src/logdata/src/foldersearchresults.cpp
+++ b/src/logdata/src/foldersearchresults.cpp
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 
+#include "containers.h"
+
 namespace {
 
 // Composite cache key: filePath + null separator + codec name. The codec for a
@@ -478,14 +480,17 @@ void FolderSearchResults::setEncodingOverrideForFile( const QString& filePath,
         UniqueLock lock( dataMutex_ );
         encodingOverrides_.insert( filePath, encoding );
         // Cached whole-file decoded mark lines (only multi-byte/stateful codecs
-        // use that path) were decoded with the old codec; drop every entry for
-        // this file (keys are filePath + NUL + codecName) so the next fetch
-        // re-decodes with the override. The seek path needs no invalidation.
-        // Lock order dataMutex_ -> fileIoMutex_.
+        // use that path) and cached seek-path mark text were decoded with the
+        // old codec; drop every entry for this file (keys are filePath + NUL +
+        // ...) so the next fetch re-decodes with the override. Lock order
+        // dataMutex_ -> fileIoMutex_.
         std::lock_guard<std::mutex> io( fileIoMutex_ );
         const QString prefix = filePath + QChar::Null;
         for ( auto it = markLineCache_.begin(); it != markLineCache_.end(); ) {
             it = it.key().startsWith( prefix ) ? markLineCache_.erase( it ) : std::next( it );
+        }
+        for ( auto it = markTextCache_.begin(); it != markTextCache_.end(); ) {
+            it = it.key().startsWith( prefix ) ? markTextCache_.erase( it ) : std::next( it );
         }
     }
     Q_EMIT layoutChanged();
@@ -502,11 +507,16 @@ void FolderSearchResults::clearEncodingOverrideForFile( const QString& filePath 
         UniqueLock lock( dataMutex_ );
         removed = encodingOverrides_.remove( filePath ) != 0;
         if ( removed ) {
-            // Same composite-key sweep as setEncodingOverrideForFile.
+            // Same composite-key sweep as setEncodingOverrideForFile (both the
+            // whole-file line cache and the seek-path text cache).
             std::lock_guard<std::mutex> io( fileIoMutex_ );
             const QString prefix = filePath + QChar::Null;
             for ( auto it = markLineCache_.begin(); it != markLineCache_.end(); ) {
                 it = it.key().startsWith( prefix ) ? markLineCache_.erase( it )
+                                                   : std::next( it );
+            }
+            for ( auto it = markTextCache_.begin(); it != markTextCache_.end(); ) {
+                it = it.key().startsWith( prefix ) ? markTextCache_.erase( it )
                                                    : std::next( it );
             }
         }
@@ -1047,13 +1057,16 @@ void FolderSearchResults::ensureMarkLines( const QString& filePath, QTextCodec* 
 
 bool FolderSearchResults::codecIsByteNewlineSafe( QTextCodec* codec )
 {
-    // True iff the raw byte 0x0A unambiguously marks a line boundary in this
-    // encoding, so a seek-based byte scan finds the same lines the codec would.
-    // Holds for UTF-8 and every single-byte / ASCII-superset codec (0x0A is a
-    // self-synchronizing LF there). Fails for UTF-16/UTF-32 (a 0x0A byte can be
-    // one half of a multi-byte unit) and for stateful/double-byte codecs where
-    // 0x0A may be a trail byte (e.g. some Shift-JIS/GBK sequences) -- those stay
-    // on the whole-file decode path. codec == nullptr means "UTF-8 default".
+    // ALLOWLIST: true only for encodings where the raw byte 0x0A unambiguously
+    // marks a line boundary, so a seek-based byte scan finds the same lines the
+    // codec would. Anything not enumerated returns false and stays on the
+    // whole-file decode path -- a denylist would let an unlisted codec with a
+    // non-ASCII newline encoding (or a stateful one we forgot) silently
+    // mis-seek, so the safe default is "not byte-newline-safe".
+    //
+    // Qualifies: nullptr (UTF-8 default), UTF-8 (0x0A never appears inside a
+    // multi-byte sequence), and the stateless single-byte / ASCII-superset
+    // codecs (each byte is one code unit and 0x0A is LF).
     if ( codec == nullptr ) {
         return true;
     }
@@ -1061,11 +1074,30 @@ bool FolderSearchResults::codecIsByteNewlineSafe( QTextCodec* codec )
         return true;
     }
     const QByteArray name = codec->name().toUpper();
-    return !name.startsWith( "UTF-16" ) && !name.startsWith( "UTF-32" )
-           && !name.startsWith( "SHIFT" )     // Shift-JIS / Shift_JIS
-           && !name.startsWith( "GB" )        // GBK / GB2312 / GB18030
-           && !name.startsWith( "BIG5" ) && !name.startsWith( "EUC" )
-           && !name.startsWith( "JIS" ) && !name.startsWith( "ISO-2022" );
+    static const QByteArrayList kAllowed = {
+        // ISO-8859 single-byte family.
+        QByteArrayLiteral( "ISO-8859-1" ),  QByteArrayLiteral( "ISO-8859-2" ),
+        QByteArrayLiteral( "ISO-8859-3" ),  QByteArrayLiteral( "ISO-8859-4" ),
+        QByteArrayLiteral( "ISO-8859-5" ),  QByteArrayLiteral( "ISO-8859-6" ),
+        QByteArrayLiteral( "ISO-8859-7" ),  QByteArrayLiteral( "ISO-8859-8" ),
+        QByteArrayLiteral( "ISO-8859-9" ),  QByteArrayLiteral( "ISO-8859-10" ),
+        QByteArrayLiteral( "ISO-8859-13" ), QByteArrayLiteral( "ISO-8859-14" ),
+        QByteArrayLiteral( "ISO-8859-15" ), QByteArrayLiteral( "ISO-8859-16" ),
+        QByteArrayLiteral( "ISO 8859-1" ), // Qt's spaced alias for Latin-1.
+        // Windows single-byte code pages.
+        QByteArrayLiteral( "WINDOWS-1250" ), QByteArrayLiteral( "WINDOWS-1251" ),
+        QByteArrayLiteral( "WINDOWS-1252" ), QByteArrayLiteral( "WINDOWS-1253" ),
+        QByteArrayLiteral( "WINDOWS-1254" ), QByteArrayLiteral( "WINDOWS-1255" ),
+        QByteArrayLiteral( "WINDOWS-1256" ), QByteArrayLiteral( "WINDOWS-1257" ),
+        QByteArrayLiteral( "WINDOWS-1258" ),
+        // Other common single-byte encodings.
+        QByteArrayLiteral( "KOI8-R" ),  QByteArrayLiteral( "KOI8-U" ),
+        QByteArrayLiteral( "CP866" ),   QByteArrayLiteral( "IBM866" ),
+        QByteArrayLiteral( "APPLE ROMAN" ), QByteArrayLiteral( "MACINTOSH" ),
+        QByteArrayLiteral( "US-ASCII" ), QByteArrayLiteral( "ASCII" ),
+        QByteArrayLiteral( "LATIN1" ), QByteArrayLiteral( "LATIN-1" ),
+    };
+    return kAllowed.contains( name );
 }
 
 QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumber localLine,
@@ -1079,6 +1111,17 @@ QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumb
     // trailing CR/LF stripped. Caller has released dataMutex_; takes only
     // fileIoMutex_.
     std::lock_guard<std::mutex> io( fileIoMutex_ );
+
+    // Resolved-text cache: the view re-fetches every visible mark row on each
+    // repaint, so without caching a mark near the end of a large file would
+    // rescan from byte 0 every frame. Keyed by file+codec+line.
+    const QString textKey
+        = markCacheKey( filePath, codec ) + QChar::Null + QString::number( localLine.get() );
+    const auto cached = markTextCache_.constFind( textKey );
+    if ( cached != markTextCache_.cend() ) {
+        return cached.value();
+    }
+
     QFile file( filePath );
     if ( !file.open( QIODevice::ReadOnly ) ) {
         return {};
@@ -1099,7 +1142,11 @@ QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumb
             if ( chunk.isEmpty() ) {
                 return {}; // EOF before the target line: no such line.
             }
-            for ( qsizetype i = 0; i < chunk.size(); ++i ) {
+            // int (not qsizetype) index: Qt 5's QByteArray::at takes int and the
+            // build is -Werror=conversion, so a qsizetype index fails the Qt 5
+            // Linux CI legs. kScanChunk (64 KiB) always fits in int.
+            const int chunkLen = klogg::isize( chunk );
+            for ( int i = 0; i < chunkLen; ++i ) {
                 if ( chunk.at( i ) == '\n' ) {
                     ++seen;
                     if ( seen == target ) {
@@ -1121,8 +1168,12 @@ QString FolderSearchResults::readMarkLineSeek( const QString& filePath, LineNumb
     while ( lineBytes.endsWith( '\n' ) || lineBytes.endsWith( '\r' ) ) {
         lineBytes.chop( 1 );
     }
-    return codec != nullptr ? codec->toUnicode( lineBytes )
-                            : QString::fromUtf8( lineBytes );
+    const QString text = codec != nullptr ? codec->toUnicode( lineBytes )
+                                          : QString::fromUtf8( lineBytes );
+    // Cache only a successfully-read line; a read past EOF returns above without
+    // caching so a file that later grows can be retried.
+    markTextCache_.insert( textKey, text );
+    return text;
 }
 
 QString FolderSearchResults::readMarkLine( const QString& filePath, LineNumber localLine,

--- a/src/ui/include/wrappedstring.h
+++ b/src/ui/include/wrappedstring.h
@@ -85,11 +85,16 @@ public:
                     break;
                 }
 
-                // Binary search for the maximum number of characters that fit
-                auto maxChars = lineToWrap.size();
-                auto low = static_cast<qsizetype>( 1 );
+                // Binary search for the maximum number of characters that fit.
+                // ContainerIndex (not a raw qsizetype): it is passed to
+                // QStringView::left/mid, which take int on Qt 5 -- a raw
+                // qsizetype would narrow and trip -Werror=conversion on the
+                // Qt 5 Linux CI legs. ContainerIndex IS the container's size
+                // type on every Qt version, so no narrowing can occur.
+                const auto maxChars = lineToWrap.size();
+                klogg::ContainerIndex low = 1;
                 auto high = maxChars;
-                qsizetype fitCount = 1;
+                klogg::ContainerIndex fitCount = 1;
 
                 while ( low <= high ) {
                     auto mid = low + ( high - low ) / 2;
@@ -109,7 +114,11 @@ public:
                 auto lastSpaceIt = std::find_if( fittingPart.rbegin(), fittingPart.rend(),
                                                  []( QChar c ) { return c.isSpace(); } );
                 if ( lastSpaceIt != fittingPart.rend() ) {
-                    auto spacePos = std::distance( fittingPart.begin(), lastSpaceIt.base() );
+                    // std::distance yields ptrdiff_t; cast into the adaptive
+                    // ContainerIndex so the .left/.mid call below does not
+                    // narrow on Qt 5.
+                    const auto spacePos = static_cast<klogg::ContainerIndex>(
+                        std::distance( fittingPart.begin(), lastSpaceIt.base() ) );
                     wrappedLines_.push_back( lineToWrap.left( spacePos ) );
                     lineToWrap = lineToWrap.mid( spacePos );
                 }

--- a/src/ui/include/wrappedstring.h
+++ b/src/ui/include/wrappedstring.h
@@ -86,18 +86,19 @@ public:
                 }
 
                 // Binary search for the maximum number of characters that fit.
-                // ContainerIndex (not a raw qsizetype): it is passed to
-                // QStringView::left/mid, which take int on Qt 5 -- a raw
-                // qsizetype would narrow and trip -Werror=conversion on the
-                // Qt 5 Linux CI legs. ContainerIndex IS the container's size
-                // type on every Qt version, so no narrowing can occur.
-                const auto maxChars = lineToWrap.size();
-                klogg::ContainerIndex low = 1;
-                auto high = maxChars;
-                klogg::ContainerIndex fitCount = 1;
+                // WrappedStringPart is a QStringView, which is qsizetype-native
+                // on BOTH Qt 5 (>= 5.8) and Qt 6 -- so the search indices are
+                // plain qsizetype and NEVER narrow when passed to its left/mid.
+                // (Do NOT use klogg::ContainerIndex here: that tracks
+                // QByteArray::size(), int on Qt 5, and would narrow against a
+                // QStringView receiver -- the exact Qt 5 CI break.)
+                const qsizetype maxChars = lineToWrap.size();
+                qsizetype low = 1;
+                qsizetype high = maxChars;
+                qsizetype fitCount = 1;
 
                 while ( low <= high ) {
-                    auto mid = low + ( high - low ) / 2;
+                    const qsizetype mid = low + ( high - low ) / 2;
                     auto candidate = lineToWrap.left( mid );
                     int candidateWidth = textWidthFn( candidate );
                     if ( candidateWidth <= availablePixelWidth ) {
@@ -114,10 +115,10 @@ public:
                 auto lastSpaceIt = std::find_if( fittingPart.rbegin(), fittingPart.rend(),
                                                  []( QChar c ) { return c.isSpace(); } );
                 if ( lastSpaceIt != fittingPart.rend() ) {
-                    // std::distance yields ptrdiff_t; cast into the adaptive
-                    // ContainerIndex so the .left/.mid call below does not
-                    // narrow on Qt 5.
-                    const auto spacePos = static_cast<klogg::ContainerIndex>(
+                    // std::distance yields ptrdiff_t; cast to qsizetype (the
+                    // QStringView receiver's native index type on both Qt 5/6)
+                    // so the .left/.mid call below does not narrow.
+                    const auto spacePos = static_cast<qsizetype>(
                         std::distance( fittingPart.begin(), lastSpaceIt.base() ) );
                     wrappedLines_.push_back( lineToWrap.left( spacePos ) );
                     lineToWrap = lineToWrap.mid( spacePos );

--- a/src/utils/include/containers.h
+++ b/src/utils/include/containers.h
@@ -33,13 +33,17 @@ template <typename T>
 using vector = std::vector<T, mi_stl_allocator<T>>;
 
 // Qt-version-adaptive container index: int on Qt 5, qsizetype on Qt 6 (it IS
-// the container's size() return type). Indexing a Qt container (at/value/
-// operator[]) with ContainerIndex never narrows, which eliminates the class of
+// QByteArray's size() return type). Indexing a QByteArray / QString with
+// ContainerIndex never narrows, which eliminates the class of
 // "-Werror=conversion: qsizetype -> int" failures that only compile-fail on the
 // Qt 5 Linux CI legs and stay invisible on a Qt 6 dev machine (PR #48, PR #56).
-// Use it for any index/loop counter that is passed back into a Qt
-// string/container API; use klogg::isize when an explicit signed int bound is
-// intended instead.
+// Use it for any index/loop counter passed back into a QByteArray/QString API;
+// use klogg::isize when an explicit signed int bound is intended instead.
+//
+// SCOPE: ContainerIndex tracks QByteArray/QString. Do NOT use it for a
+// QStringView receiver -- QStringView has been qsizetype-native since Qt 5.8 on
+// BOTH versions, so its indices are plain qsizetype (see wrappedstring.h);
+// assigning a QStringView::size() to a ContainerIndex narrows on Qt 5.
 using ContainerIndex = decltype( QByteArray{}.size() );
 
 template <class C>

--- a/src/utils/include/containers.h
+++ b/src/utils/include/containers.h
@@ -23,12 +23,24 @@
 #include <mimalloc.h>
 #include <vector>
 
+#include <QByteArray>
+
 #include <type_safe/narrow_cast.hpp>
 #include <type_traits>
 
 namespace klogg {
 template <typename T>
 using vector = std::vector<T, mi_stl_allocator<T>>;
+
+// Qt-version-adaptive container index: int on Qt 5, qsizetype on Qt 6 (it IS
+// the container's size() return type). Indexing a Qt container (at/value/
+// operator[]) with ContainerIndex never narrows, which eliminates the class of
+// "-Werror=conversion: qsizetype -> int" failures that only compile-fail on the
+// Qt 5 Linux CI legs and stay invisible on a Qt 6 dev machine (PR #48, PR #56).
+// Use it for any index/loop counter that is passed back into a Qt
+// string/container API; use klogg::isize when an explicit signed int bound is
+// intended instead.
+using ContainerIndex = decltype( QByteArray{}.size() );
 
 template <class C>
 constexpr auto ssize( const C& c )

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -757,6 +757,77 @@ TEST_CASE( "FolderCrawlerWidget marks survive a filter change and show under Mar
     REQUIRE( widget.folderResults()->getNbLine() > 0_lcount );
 }
 
+TEST_CASE( "FolderCrawlerWidget a marked non-match row shows its source line text",
+           "[folder][marks][regression]" )
+{
+    // Regression for: filter scan, click a result row (main view opens the file),
+    // select that line AND the following (non-matching) line, press M. Under
+    // "Marks and matches" the non-matching marked line is injected as a mark row;
+    // the user saw its gutter line number render but the row CONTENT was blank.
+    // The mark row must render the real source line text -- single-file parity
+    // (LogFilteredData mark rows read the line from the shared source data).
+    //
+    // The file must exceed the 16 MiB mark-line whole-file cache cap: with a
+    // small fixture the decoded-line cache covers every line and the bug does
+    // not reproduce. The user hit this on a 51 MiB log.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    // line 3 = the match ("ERROR hit"); line 4 = the following non-match line.
+    QByteArray bytes( "line0\nline1\nline2\nERROR hit\nfollow line (not a match)\nline5\n" );
+    // Pad past 16 MiB so the whole-file decoded-line cache refuses the file.
+    const QByteArray filler( "filler line to push the file past the cache cap\n" );
+    while ( bytes.size() <= ( 16LL << 20 ) ) {
+        bytes.append( filler );
+    }
+    bytes.append( "tail\n" );
+    const QString a = writeFile( dir, "a.log", bytes );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 2_lcount ); // header + 1 match
+
+    // Click the result row -> main view opens a.log at the matched line.
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    // Mark the matched line AND the following (non-matching) line with M.
+    widget.markMainViewLine( 3_lnum );
+    widget.markMainViewLine( 4_lnum );
+    REQUIRE( widget.isLineMarkedInFile( a, 3_lnum ) );
+    REQUIRE( widget.isLineMarkedInFile( a, 4_lnum ) );
+
+    // Under "Marks and matches" (the default), line 4 has no match record, so it
+    // appears as an injected mark row directly after the match row:
+    // [H0, D1(match line3), D2(mark row line4)].
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount );
+    const auto src = widget.folderResults()->sourceForLine( 2_lnum );
+    REQUIRE( src.filePath == a );
+    REQUIRE( src.localLine == 4_lnum );
+
+    // RED before the fix: the row rendered with the line number in the gutter
+    // but EMPTY content. The mark row must show the real source line text.
+    REQUIRE( widget.folderResults()->getLineString( 2_lnum )
+             == QStringLiteral( "follow line (not a match)" ) );
+    REQUIRE( widget.folderResults()->getExpandedLineString( 2_lnum )
+             == QStringLiteral( "follow line (not a match)" ) );
+
+    // Same guarantee under the "Marks" visibility filter: header + both marks.
+    widget.setResultsVisibility( FolderSearchResults::Visibility::Marks );
+    QTest::qWait( 50 );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount ); // header + 2 mark rows
+    const auto srcUnderMarks = widget.folderResults()->sourceForLine( 2_lnum );
+    REQUIRE( srcUnderMarks.localLine == 4_lnum );
+    REQUIRE( widget.folderResults()->getLineString( 2_lnum )
+             == QStringLiteral( "follow line (not a match)" ) );
+}
+
 TEST_CASE( "FolderCrawlerWidget a marked grep-context line stays visible under Marks",
            "[folder][marks][context]" )
 {

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -767,16 +767,18 @@ TEST_CASE( "FolderCrawlerWidget a marked non-match row shows its source line tex
     // The mark row must render the real source line text -- single-file parity
     // (LogFilteredData mark rows read the line from the shared source data).
     //
-    // The file must exceed the 16 MiB mark-line whole-file cache cap: with a
-    // small fixture the decoded-line cache covers every line and the bug does
-    // not reproduce. The user hit this on a 51 MiB log.
+    // The file must exceed the whole-file mark-line cache cap: with a small
+    // fixture the decoded-line cache covers every line and the bug does not
+    // reproduce. The user hit this on a 51 MiB log. The size derives from the
+    // SAME kMarkLineCacheCap constant the production cap uses, so a cap change
+    // keeps this fixture on the over-cap side.
     QTemporaryDir dir;
     REQUIRE( dir.isValid() );
     // line 3 = the match ("ERROR hit"); line 4 = the following non-match line.
     QByteArray bytes( "line0\nline1\nline2\nERROR hit\nfollow line (not a match)\nline5\n" );
-    // Pad past 16 MiB so the whole-file decoded-line cache refuses the file.
+    // Pad past the cap so the whole-file decoded-line cache refuses the file.
     const QByteArray filler( "filler line to push the file past the cache cap\n" );
-    while ( bytes.size() <= ( 16LL << 20 ) ) {
+    while ( bytes.size() <= FolderSearchResults::kMarkLineCacheCap ) {
         bytes.append( filler );
     }
     bytes.append( "tail\n" );

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(klogg_tests
     adb_ui_transport_test.cpp
     ansicolorprocessor_test.cpp
+    containers_test.cpp
     wrappedstring_test.cpp
     iosdeviceparser_test.cpp
     capturestore_test.cpp

--- a/tests/unit/containers_test.cpp
+++ b/tests/unit/containers_test.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "containers.h"
+
+#include <QByteArray>
+#include <QString>
+
+#include <type_traits>
+
+// klogg::ContainerIndex is the Qt-version-adaptive container index type: its
+// underlying type IS decltype(QByteArray{}.size()), i.e. int on Qt 5 and
+// qsizetype on Qt 6. Indexing a Qt container with it therefore never narrows,
+// which eliminates the whole class of "-Werror=conversion: qsizetype -> int"
+// failures that only surface on the Qt 5 Linux CI legs (PR #48, PR #56).
+TEST_CASE( "ContainerIndex tracks the Qt container size type", "[containers]" )
+{
+    // Compile-time contract: same type as QByteArray/QString::size() on this Qt.
+    static_assert( std::is_same_v<klogg::ContainerIndex, decltype( QByteArray{}.size() )>,
+                   "ContainerIndex must match QByteArray::size() return type" );
+    static_assert( std::is_same_v<klogg::ContainerIndex, decltype( QString{}.size() )>,
+                   "ContainerIndex must match QString::size() return type" );
+
+    // Runtime smoke: indexing with ContainerIndex compiles and round-trips
+    // without a cast on either Qt version.
+    const QByteArray bytes( "a\nb\nc" );
+    klogg::ContainerIndex newlineCount = 0;
+    for ( klogg::ContainerIndex i = 0; i < bytes.size(); ++i ) {
+        if ( bytes.at( i ) == '\n' ) {
+            ++newlineCount;
+        }
+    }
+    REQUIRE( newlineCount == 2 );
+
+    const QString text = QStringLiteral( "xy" );
+    REQUIRE( text.at( klogg::ContainerIndex{ 1 } ) == QLatin1Char( 'y' ) );
+}

--- a/tests/unit/containers_test.cpp
+++ b/tests/unit/containers_test.cpp
@@ -53,3 +53,26 @@ TEST_CASE( "ContainerIndex tracks the Qt container size type", "[containers]" )
     const QString text = QStringLiteral( "xy" );
     REQUIRE( text.at( klogg::ContainerIndex{ 1 } ) == QLatin1Char( 'y' ) );
 }
+
+TEST_CASE( "ContainerIndex arithmetic stays the same type (no narrowing)", "[containers]" )
+{
+    // The whole point of ContainerIndex is that a chain of QByteArray/QString
+    // index arithmetic never changes type. Using `auto` for an intermediate
+    // (e.g. a binary search `mid = low + (high-low)/2`) deduces qsizetype on
+    // Qt 6, and assigning that back to a ContainerIndex narrows on Qt 5
+    // (-Werror=conversion). Pin that the arithmetic result IS ContainerIndex so
+    // such a chain stays same-type. NOTE: this applies to QByteArray/QString
+    // receivers; a QStringView receiver is qsizetype-native on BOTH Qt versions
+    // and must use plain qsizetype instead (see wrappedstring.h).
+    static_assert(
+        std::is_same_v<klogg::ContainerIndex,
+                       decltype( std::declval<klogg::ContainerIndex>()
+                                 + ( std::declval<klogg::ContainerIndex>()
+                                     - std::declval<klogg::ContainerIndex>() ) / 2 )>,
+        "ContainerIndex + (ContainerIndex - ContainerIndex) / 2 must stay ContainerIndex" );
+
+    const klogg::ContainerIndex low = 1;
+    const klogg::ContainerIndex high = 10;
+    const klogg::ContainerIndex mid = low + ( high - low ) / 2;
+    REQUIRE( mid == 5 );
+}

--- a/tests/unit/foldersearchresults_test.cpp
+++ b/tests/unit/foldersearchresults_test.cpp
@@ -524,6 +524,36 @@ TEST_CASE( "FolderSearchResults decodes with the per-file encoding override", "[
     REQUIRE( layoutSpy.count() == 2 );
 }
 
+TEST_CASE( "FolderSearchResults byte-newline-safe codec gate is an allowlist", "[folder][marks]" )
+{
+    // codecIsByteNewlineSafe gates the seek-based mark-line read. It must be an
+    // ALLOWLIST: only UTF-8 / known stateless single-byte codecs qualify, and
+    // any stateful or unlisted codec returns false so it stays on the whole-file
+    // decode path. A denylist would let an unlisted codec with a non-ASCII (or
+    // multi-byte) newline encoding silently mis-seek.
+    REQUIRE( FolderSearchResults::codecIsByteNewlineSafe( nullptr ) ); // UTF-8 default
+    REQUIRE( FolderSearchResults::codecIsByteNewlineSafe( QTextCodec::codecForName( "UTF-8" ) ) );
+    REQUIRE( FolderSearchResults::codecIsByteNewlineSafe(
+        QTextCodec::codecForName( "ISO 8859-1" ) ) );
+    REQUIRE( FolderSearchResults::codecIsByteNewlineSafe(
+        QTextCodec::codecForName( "windows-1251" ) ) );
+
+    // Stateful / multi-byte / unlisted codecs must NOT be treated as
+    // byte-newline-safe.
+    REQUIRE_FALSE(
+        FolderSearchResults::codecIsByteNewlineSafe( QTextCodec::codecForName( "UTF-16LE" ) ) );
+    REQUIRE_FALSE(
+        FolderSearchResults::codecIsByteNewlineSafe( QTextCodec::codecForName( "UTF-16" ) ) );
+    REQUIRE_FALSE(
+        FolderSearchResults::codecIsByteNewlineSafe( QTextCodec::codecForName( "UTF-32" ) ) );
+    if ( auto* sjis = QTextCodec::codecForName( "Shift-JIS" ) ) {
+        REQUIRE_FALSE( FolderSearchResults::codecIsByteNewlineSafe( sjis ) );
+    }
+    if ( auto* gbk = QTextCodec::codecForName( "GBK" ) ) {
+        REQUIRE_FALSE( FolderSearchResults::codecIsByteNewlineSafe( gbk ) );
+    }
+}
+
 TEST_CASE( "FolderSearchResults getters are race-free against streaming and concurrent readers",
            "[folder]" )
 {

--- a/tests/unit/foldersearchresults_test.cpp
+++ b/tests/unit/foldersearchresults_test.cpp
@@ -287,6 +287,108 @@ TEST_CASE( "FolderSearchResults readMatchLine falls back to UTF-8 with no source
     REQUIRE( r.getLineString( 1_lnum ) == QString( "beta ERROR" ) );
 }
 
+TEST_CASE( "FolderSearchResults a marked UTF-16 line under the cache cap decodes correctly",
+           "[folder][marks]" )
+{
+    // The stateful-codec path (UTF-16) uses the whole-file decoded-line cache
+    // (a byte scan cannot find line boundaries in UTF-16). UNDER the cap the
+    // marked line must decode correctly and report Available.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString path = QDir( dir.path() ).absoluteFilePath( "utf16.log" );
+    {
+        QFile f( path );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        // BOM + "alpha\nbeta\ngamma\n" in UTF-16LE.
+        QByteArray bytes;
+        bytes.append( "\xFF\xFE", 2 );
+        for ( const QString& l : { QStringLiteral( "alpha" ), QStringLiteral( "beta" ),
+                                   QStringLiteral( "gamma" ) } ) {
+            for ( const QChar c : l ) {
+                bytes.append( static_cast<char>( c.unicode() & 0xFF ) );
+                bytes.append( static_cast<char>( ( c.unicode() >> 8 ) & 0xFF ) );
+            }
+            bytes.append( '\n' );
+            bytes.append( '\0' );
+        }
+        f.write( bytes );
+        f.close();
+    }
+
+    FolderSearchResults r;
+    klogg::folder::FileGroup g;
+    g.filePath = path;
+    g.sourceCodec = QTextCodec::codecForName( "UTF-16LE" );
+    // One real match so the group exists; the mark is on a different line.
+    g.matches.push_back( match( 0, 2, 12, 5, 5 ) ); // "alpha" (BOM at 0-1)
+    r.setResults( { g } );
+
+    // Mark line 2 ("gamma") -- not a match -> injected as a mark row.
+    QHash<QString, std::set<uint64_t>> marks;
+    marks[ path ].insert( 2 );
+    r.setMarksStore( &marks );
+
+    // rows: [H0, D1(match line0), D2(mark row line2)].
+    REQUIRE( r.getNbLine() == 3_lcount );
+    const auto src = r.sourceForLine( 2_lnum );
+    REQUIRE( src.localLine == 2_lnum );
+    REQUIRE( r.markLineTextStatus( 2_lnum )
+             == FolderSearchResults::MarkLineTextStatus::Available );
+    REQUIRE( r.getLineString( 2_lnum ) == QStringLiteral( "gamma" ) );
+}
+
+TEST_CASE( "FolderSearchResults a marked line over the cache cap with a stateful codec "
+           "reports Unavailable instead of silently rendering empty",
+           "[folder][marks][regression]" )
+{
+    // Regression guard for the 16 MiB whole-file mark-line cache cap: a marked
+    // line in a file OVER the cap with a STATEFUL codec (UTF-16 -- the seek
+    // path cannot apply) has no text. The model must expose that as an explicit
+    // Unavailable state so the view can distinguish "text unavailable" from "the
+    // line is empty" -- silently rendering blank was the original defect. The
+    // fixture size derives from the SAME kMarkLineCacheCap constant the
+    // production cap uses, so a cap change keeps this test on the over-cap side.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString path = QDir( dir.path() ).absoluteFilePath( "big-utf16.log" );
+    {
+        QFile f( path );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        QByteArray bytes;
+        bytes.append( "\xFF\xFE", 2 ); // BOM
+        // Build UTF-16LE filler without QTextCodec to keep the fixture simple.
+        QByteArray line;
+        for ( const QChar c : QStringLiteral( "filler line to push past the cap\n" ) ) {
+            line.append( static_cast<char>( c.unicode() & 0xFF ) );
+            line.append( static_cast<char>( ( c.unicode() >> 8 ) & 0xFF ) );
+        }
+        while ( bytes.size() <= FolderSearchResults::kMarkLineCacheCap ) {
+            bytes.append( line );
+        }
+        f.write( bytes );
+        f.close();
+    }
+
+    FolderSearchResults r;
+    klogg::folder::FileGroup g;
+    g.filePath = path;
+    g.sourceCodec = QTextCodec::codecForName( "UTF-16LE" );
+    g.matches.push_back( match( 0, 2, 12, 5, 5 ) );
+    r.setResults( { g } );
+
+    QHash<QString, std::set<uint64_t>> marks;
+    marks[ path ].insert( 3 ); // a non-match filler line
+    r.setMarksStore( &marks );
+
+    REQUIRE( r.getNbLine() == 3_lcount ); // header + match + mark row
+    const auto src = r.sourceForLine( 2_lnum );
+    REQUIRE( src.localLine == 3_lnum );
+    // RED before the contract: over-cap mark text silently rendered as empty
+    // with no way to tell. Now it must report Unavailable.
+    REQUIRE( r.markLineTextStatus( 2_lnum )
+             == FolderSearchResults::MarkLineTextStatus::Unavailable );
+}
+
 TEST_CASE( "FolderSearchResults matchLinesForFile returns ascending local lines", "[folder]" )
 {
     FolderSearchResults r;


### PR DESCRIPTION
## Summary
- Fixes a folder-mode (Open Folder) bug where a line marked with M that does not match the current filter appeared in the filtered window with its source line number in the gutter but **empty content**, whenever the source file exceeded 16 MiB (reported on a 51 MiB Android log).
- `FolderSearchResults::readMarkLine` now dispatches on the codec: UTF-8 / single-byte encodings read the marked line via a bounded seek+`readLine()` that scales to any file size; multi-byte/stateful codecs (UTF-16/32, Shift-JIS, GBK, Big5, EUC, ISO-2022) keep the whole-file decode cache as the correctness fallback.
- Fixes mark-line cache invalidation on encoding-override change (keys are `filePath + NUL + codecName`; the old `remove(filePath)` never matched).
- Adds a UI regression test whose fixture is padded past the 16 MiB cap — small fixtures never reproduce the bug.

## Background
- Introduced by: the folder marks row-source change (ff62bb7c, 2026-07-25), which fetches marked non-match line text from a whole-file decoded-line cache (`markLineCache_`) capped at 16 MiB per file.
- Use case: Open Folder → filter scan → click a result row (main view opens the file) → select that line and the following non-matching line → press M. Under "Marks and matches" the non-matching marked line is injected into the filtered window as a mark row.
- How to reproduce: run the above on a source file larger than 16 MiB. The mark row shows its line number but renders blank content; small files work fine.
- Root cause: marked lines have no `MatchRecord` byte offsets, so their text came from `markLineCache_`. `ensureMarkLines` deliberately inserts an EMPTY line vector for files over `kMarkLineCacheCap` (avoiding a main-thread O(file) decode), so every mark row in a large file permanently read an empty string. The gutter line number comes from the marks store, not the cache — hence the half-rendered row.
- How to fix: seek-based per-line read for byte-newline-safe codecs. The chunked forward scan must `seek()` back to just past the target newline — the 64 KiB buffered read already consumed past it, so without the reposition `readLine()` resumes at the chunk end and returns a mid-line fragment (caught by the regression test).

## Tests
- New: `FolderCrawlerWidget a marked non-match row shows its source line text` (`[folder][marks][regression]`) — fails before the fix, passes after; covers both "Marks and matches" and "Marks" visibility.
- Full `ctest` 4/4 green locally (macOS, offscreen): klogg_tests, klogg_itests, klogg_vectorscan_tests, klogg_smoke.
- `scripts/lint_platform_fragile.py` clean.
- Not verified: UTF-16/stateful-codec files over 16 MiB still show empty mark text (pre-existing deliberate trade-off, unchanged by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marked-line retrieval across supported file encodings.
  * Large UTF-8 and other byte-safe encoded files no longer require full-file decoding.
  * Updated encoding overrides now correctly refresh cached marked-line content.
  * Fixed marked, non-matching search rows to display the correct source text in all visibility modes.
  * Clearly indicates when marked-line text cannot be retrieved for oversized files using complex encodings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->