### PR TITLE
Folder-tab Go-to-top/Follow support + color-label match options in preferences

### DIFF
--- a/src/ui/include/abstractcrawlerwidget.h
+++ b/src/ui/include/abstractcrawlerwidget.h
@@ -93,6 +93,19 @@ class AbstractCrawlerWidget : public ViewInterface {
     {
         return false;
     }
+    // Scroll to the top of the document (View -> Go to top). Folder tabs top
+    // only their main view: the results view is a cross-file static snapshot,
+    // so topping it is meaningless. Default no-op.
+    virtual void jumpToTop() {}
+    // Toggle follow mode for the tab's document (View -> Follow file). Folder
+    // tabs follow the file shown in their main view only (same rationale as
+    // jumpToTop). Default no-op.
+    virtual void followSet( bool /*checked*/ ) {}
+    // True if follow mode is on (drives the Follow action's checked state).
+    virtual bool isFollowEnabled() const
+    {
+        return false;
+    }
     // QuickFind bar lifecycle: save (entering) and restore (exiting) the view
     // focus. Default no-op.
     virtual void enteringQuickFind() {}

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -112,7 +112,7 @@ class CrawlerWidget : public QSplitter,
     QString encodingText() const;
 
     // Returns whether follow is enabled in this crawler
-    bool isFollowEnabled() const;
+    bool isFollowEnabled() const override;
 
     // Returns whether the initial file load has completed
     bool isFirstLoadDone() const;
@@ -134,7 +134,7 @@ class CrawlerWidget : public QSplitter,
 
     void focusSearchEdit() override;
     void goToLine() override;
-    void jumpToTop();
+    void jumpToTop() override;
 
     // Instructs the widget to reconfigure itself because Config() has changed.
     void applyConfiguration() override;
@@ -170,8 +170,10 @@ class CrawlerWidget : public QSplitter,
     // Sent to the client when the loading has finished
     // whether successful or not.
     void loadingFinished( LoadingStatus status );
-    // Sent when follow mode is enabled/disabled
-    void followSet( bool checked );
+    // Sent when follow mode is enabled/disabled. A signal overriding the
+    // AbstractCrawlerWidget virtual (the textWrapSet pattern below): MainWindow
+    // dispatches through the virtual, the emission fans out to both views.
+    void followSet( bool checked ) override;
     // Sent when text wrap mode is enabled/disabled
     void textWrapSet( bool checked ) override;
     // Sent up to the MainWindow to enable/disable the follow mode

--- a/src/ui/include/foldercrawlerwidget.h
+++ b/src/ui/include/foldercrawlerwidget.h
@@ -206,6 +206,13 @@ class FolderCrawlerWidget : public QWidget,
     void goToLine() override;
     void textWrapSet( bool checked ) override;
     bool isTextWrapEnabled() const override;
+    // View -> Go to top / Follow file, applied to the file shown in the MAIN
+    // view only: the results view is a cross-file static snapshot, so topping
+    // or following it is meaningless (the folder-specific variation of
+    // CrawlerWidget, which drives both views).
+    void jumpToTop() override;
+    void followSet( bool checked ) override;
+    bool isFollowEnabled() const override;
     void enteringQuickFind() override;
     void exitingQuickFind() override;
 
@@ -226,6 +233,12 @@ class FolderCrawlerWidget : public QWidget,
     // pane is created, switched, or closed) so MainWindow re-registers the
     // selector with the QuickFindMux instead of driving a stale/freed pane.
     void searchablesChanged();
+    // Emitted when the main view's follow mode changes (the view's elastic
+    // hook disengages on scroll-up, or re-engages at the bottom). Single-file
+    // parity with CrawlerWidget::followModeChanged: MainWindow direct-connects
+    // this to changeFollowMode so the Follow action's checked state tracks the
+    // view (single-file tabs reach that slot via SignalMux).
+    void followModeChanged( bool follow );
 
   protected:
     // ViewInterface (single-file APIs are no-ops in folder mode).
@@ -273,6 +286,12 @@ class FolderCrawlerWidget : public QWidget,
                              LinesCount nLines = LinesCount( 1 ),
                              LineColumn startCol = LineColumn( 0 ),
                              LineLength nSymbols = LineLength( 0 ) );
+    // (Re)bind the follow/refresh data-flow of the CURRENT currentMainData_ to
+    // the main view: the per-file LogData self-registers with FileWatcher and
+    // re-indexes on growth, but nothing else forwards those notifications to
+    // mainView_, so without this follow mode would set a flag and never track.
+    // Called on every main-view file swap (cache hit and async load).
+    void bindMainViewDataSignals();
     // Select (and display) a line or portion in the main view: whole-line jump
     // for plain row clicks, portion mirror for drag selections (parity with
     // single-file jumpToMatchingLine).
@@ -429,6 +448,14 @@ class FolderCrawlerWidget : public QWidget,
     std::shared_ptr<LogData> placeholderData_;
     std::shared_ptr<LogData> currentMainData_;
     QString currentMainFilePath_;
+    // Connections bound by bindMainViewDataSignals to the CURRENT
+    // currentMainData_. Stored so they can be disconnected before rebinding:
+    // LRU-cached LogDatas keep their FileWatcher registration, so stale
+    // connections would fire mainView_->updateData() (and the truncation
+    // handler) for files that are no longer shown.
+    QMetaObject::Connection mainDataLoadingFinishedConn_;
+    QMetaObject::Connection mainDataLoadingProgressedConn_;
+    QMetaObject::Connection mainDataFileChangedConn_;
     // The last line opened/announced in the main view (jump target). Tracked so
     // MainWindow can restore "Ln: x/y" when switching back to this folder tab.
     LineNumber lastMainViewLine_ = 0_lnum;
@@ -445,6 +472,19 @@ class FolderCrawlerWidget : public QWidget,
     // Pending async load (file clicked before its index finished building).
     std::shared_ptr<LogData> pendingMainData_;
     QString pendingMainFilePath_;
+    // The one-shot loadingFinished connection of the CURRENT pendingMainData_.
+    // Its lifetime is tied to the open it serves: the lambda self-disconnects
+    // when the open completes, and any newer open (async supersede or cached
+    // swap) disconnects it before replacing/abandoning the pending state.
+    // Without this the connection would outlive its open: the completed
+    // LogData moves into the LRU cache and keeps re-indexing on disk changes
+    // (self-registered FileWatcher), so its stale lambda would fire while a
+    // DIFFERENT file's open is in flight (pendingMainData_ non-null) and run
+    // the completion body with the wrong file's half-indexed state --
+    // clobbering currentMainData_/currentMainFilePath_ and consuming the
+    // pending jump, so the real completion early-returns and the new file's
+    // jump/overview/encoding are never applied with the final index state.
+    QMetaObject::Connection pendingMainDataConn_;
     LineNumber pendingJumpLine_ = 0_lnum;
     // Portion to mirror into the main view once the pending file is open
     // (plain row clicks use the defaults -> whole-line selection).

--- a/src/ui/include/highlighterset.h
+++ b/src/ui/include/highlighterset.h
@@ -174,12 +174,12 @@ struct QuickHighlighter {
 
 struct QuickLabelEntry {
     QString text;
-    bool ignoreCase = false;
+    bool ignoreCase = true;
     bool wholeWord = false;
 };
 
 struct QuickHighlighterDefaults {
-    bool ignoreCase = false;
+    bool ignoreCase = true;
     bool wholeWord = false;
 };
 

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -162,7 +162,8 @@ class MainWindow : public QMainWindow {
     void toggleMainLineNumbersVisibility( bool isVisible );
     void toggleFilteredLineNumbersVisibility( bool isVisible );
 
-    // Change the follow mode checkbox and send the followSet signal down
+    // Change the follow mode checkbox (the views report follow-state changes
+    // up; the action's toggled signal carries followSet down to the document)
     void changeFollowMode( bool follow );
 
     // Update the selection information displayed in the status bar.
@@ -199,8 +200,6 @@ class MainWindow : public QMainWindow {
   Q_SIGNALS:
     // Is emitted when new settings must be used
     void optionsChanged();
-    // Is emitted when the 'follow' option is enabled/disabled
-    void followSet( bool checked );
 
     void newWindow();
     void windowActivated();

--- a/src/ui/include/optionsdialog.ui
+++ b/src/ui/include/optionsdialog.ui
@@ -168,6 +168,20 @@
               </property>
              </widget>
             </item>
+            <item row="5" column="0" colspan="2">
+             <widget class="QCheckBox" name="colorLabelsIgnoreCaseCheckBox">
+              <property name="text">
+               <string>Color labels ignore case</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="0" colspan="2">
+             <widget class="QCheckBox" name="colorLabelsWholeWordCheckBox">
+              <property name="text">
+               <string>Color labels whole word</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>

--- a/src/ui/include/viewinterface.h
+++ b/src/ui/include/viewinterface.h
@@ -22,6 +22,8 @@
 
 #include <memory>
 
+#include <QString>
+
 class SearchableLogData;
 class LogFilteredData;
 class SavedSearches;

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -470,6 +470,14 @@ FolderCrawlerWidget::FolderCrawlerWidget( QWidget* parent )
                  refreshAllPanesForMarks();
              } );
 
+    // Follow-mode uplink (single-file parity with CrawlerWidget relaying its
+    // main view's followModeChanged, crawlerwidget.cpp:1409-1410): the view's
+    // follow-state changes (elastic-hook disengage on scroll-up, re-engage at
+    // the bottom) surface at widget level so MainWindow can keep the Follow
+    // action's checked state in sync.
+    connect( mainView_, &AbstractLogView::followModeChanged, this,
+             &FolderCrawlerWidget::followModeChanged );
+
     // Apply Configuration (font, line numbers, overview, view shortcuts) now
     // that both views + the toolbar exist. Also re-applied on every
     // MainWindow::optionsChanged (the folder's applyConfiguration is connected
@@ -1021,6 +1029,9 @@ void FolderCrawlerWidget::applyConfiguration()
     font.setBold( config.useBoldFont() );
 
     mainView_->setLineNumbersVisible( config.mainLineNumbersVisible() );
+    // Follow-mode parity with CrawlerWidget (crawlerwidget.cpp:866-867): the
+    // elastic pull-to-follow hook is only armed while file watching is on.
+    mainView_->allowFollowMode( config.anyFileWatchEnabled() );
     overview_.setVisible( config.isOverviewVisible() );
     mainView_->refreshOverview();
     // Re-feed the minimap when it just became visible: marks/matches changed
@@ -1230,6 +1241,64 @@ void FolderCrawlerWidget::textWrapSet( bool checked )
 bool FolderCrawlerWidget::isTextWrapEnabled() const
 {
     return mainView_->isTextWrapEnabled();
+}
+
+void FolderCrawlerWidget::jumpToTop()
+{
+    // Folder variation of CrawlerWidget::jumpToTop (crawlerwidget.cpp:352):
+    // top ONLY the main view. The results view is a cross-file static snapshot
+    // whose rows do not map to one document, so topping it is meaningless.
+    mainView_->selectAndDisplayLine( 0_lnum );
+}
+
+void FolderCrawlerWidget::followSet( bool checked )
+{
+    // Main view only (same rationale as jumpToTop): the results view is a
+    // static cross-file snapshot, follow mode does not apply to it.
+    mainView_->followSet( checked );
+}
+
+bool FolderCrawlerWidget::isFollowEnabled() const
+{
+    return mainView_ != nullptr && mainView_->isFollowEnabled();
+}
+
+void FolderCrawlerWidget::bindMainViewDataSignals()
+{
+    // Disconnect-before-rebind invariant: LRU-cached LogDatas keep their
+    // FileWatcher registration and keep re-indexing in the background as those
+    // files change on disk; without dropping the old connections, a hidden
+    // cached file's growth would still call mainView_->updateData() (and the
+    // truncation handler below would wipe marks for a file that is not shown).
+    disconnect( mainDataLoadingFinishedConn_ );
+    disconnect( mainDataLoadingProgressedConn_ );
+    disconnect( mainDataFileChangedConn_ );
+
+    if ( currentMainData_ == nullptr ) {
+        return;
+    }
+
+    // The per-file LogData re-indexes itself on file growth (FileWatcher ->
+    // LogData::fileChangedOnDisk), but unlike CrawlerWidget
+    // (crawlerwidget.cpp:1438-1444) nothing forwarded those notifications to
+    // the view -- follow mode set the flag yet the view never tracked the
+    // tail. Mirror the single-file wiring minimally: refresh/track on (re)index
+    // progress + finish, and on truncation clear that file's marks (mirrors
+    // CrawlerWidget::fileChangedHandler clearing all marks on Truncated).
+    mainDataLoadingFinishedConn_
+        = connect( currentMainData_.get(), &SearchableLogData::loadingFinished, this,
+                   [ this ]( LoadingStatus ) { mainView_->updateData(); } );
+    mainDataLoadingProgressedConn_
+        = connect( currentMainData_.get(), &SearchableLogData::loadingProgressed, this,
+                   [ this ]( int ) { mainView_->updateData(); } );
+    mainDataFileChangedConn_
+        = connect( currentMainData_.get(), &SearchableLogData::fileChanged, this,
+                   [ this ]( MonitoredFileStatus status ) {
+                       if ( status == MonitoredFileStatus::Truncated ) {
+                           folderMarks_.remove( currentMainFilePath_ );
+                           refreshAllPanesForMarks();
+                       }
+                   } );
 }
 
 void FolderCrawlerWidget::enteringQuickFind()
@@ -1774,6 +1843,13 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
 
     // Already showing this file -> just jump.
     if ( filePath == currentMainFilePath_ && currentMainData_ != nullptr ) {
+        // Re-selecting the CURRENT file supersedes any in-flight async open of
+        // a different file (the newest open request wins): abandon it like the
+        // async path below does, so its late completion cannot yank the view
+        // away from the file the user just re-confirmed.
+        disconnect( pendingMainDataConn_ );
+        pendingMainData_.reset();
+        pendingMainFilePath_.clear();
         lastMainViewLine_ = localLine;
         // select+announce (not just scroll) so the Ln: field and the selection
         // highlight track the clicked result -- parity with single-file, whose
@@ -1792,12 +1868,22 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
     // so the LRU eviction policy keeps it resident.
     const auto it = mainViewCache_.find( filePath );
     if ( it != mainViewCache_.end() ) {
+        // This swap supersedes any in-flight async open of a different file:
+        // abandon it exactly like the async path below does (disconnect the
+        // one-shot connection FIRST, then drop the shared_ptr), so the
+        // abandoned load's late completion cannot clobber this swap.
+        disconnect( pendingMainDataConn_ );
+        pendingMainData_.reset();
+        pendingMainFilePath_.clear();
         mainViewCacheOrder_.splice( mainViewCacheOrder_.begin(), mainViewCacheOrder_,
                                     it.value().second );
         currentMainData_ = it.value().first;
         currentMainFilePath_ = filePath;
         lastMainViewLine_ = localLine;
         mainView_->setDataSource( currentMainData_.get() );
+        // Re-point the follow/refresh data-flow at the swapped-in file (the
+        // cached file's LogData keeps watching + re-indexing on disk changes).
+        bindMainViewDataSignals();
         // Re-apply the current search pattern so the swapped-in (cached) file
         // highlights its matches at first paint (idempotent: setDataSource does
         // not reset searchPattern_, this is the explicit parity guarantee).
@@ -1811,6 +1897,14 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
     }
 
     // Not loaded yet -> index the file asynchronously, then swap + jump.
+    // Supersede any in-flight async open FIRST: disconnect its one-shot
+    // loadingFinished connection so the abandoned LogData can never run the
+    // completion lambda against THIS open's pending state, then overwrite the
+    // shared_ptr. The abandoned LogData is destroyed by the overwrite (nothing
+    // else retains it); its destructor unhooks it from the FileWatcher
+    // (logdata.cpp:102-115), so no re-index of the abandoned file can fire a
+    // stale completion either.
+    disconnect( pendingMainDataConn_ );
     pendingMainFilePath_ = filePath;
     pendingJumpLine_ = localLine;
     pendingJumpNLines_ = nLines;
@@ -1818,45 +1912,65 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
     pendingJumpLen_ = nSymbols;
     pendingMainData_ = std::make_shared<LogData>();
 
-    connect( pendingMainData_.get(), &SearchableLogData::loadingFinished, this,
-             [ this ]( LoadingStatus ) {
-                 if ( pendingMainData_ == nullptr ) {
-                     return;
-                 }
-                 currentMainData_ = pendingMainData_;
-                 currentMainFilePath_ = pendingMainFilePath_;
-                 lastMainViewLine_ = pendingJumpLine_;
-                 cacheMainViewData( currentMainFilePath_, currentMainData_ );
+    // Store the connection so its lifetime is tied to the open it serves: the
+    // lambda self-disconnects on completion, and the supersede paths above
+    // disconnect it when a newer open replaces this one. A bare connect()
+    // would outlive the open -- the completed LogData goes into the LRU cache
+    // and keeps re-indexing on disk changes (self-registered FileWatcher), so
+    // its stale lambda would fire while ANOTHER file's open is in flight
+    // (pendingMainData_ non-null) and complete that open with this file's
+    // half-indexed state.
+    pendingMainDataConn_
+        = connect( pendingMainData_.get(), &SearchableLogData::loadingFinished, this,
+                   [ this ]( LoadingStatus ) {
+                       if ( pendingMainData_ == nullptr ) {
+                           return;
+                       }
+                       // Self-disconnect: the open this connection served is
+                       // completing right now, so its lifetime ends here
+                       // (disconnecting the currently-executing connection is
+                       // legal -- the slot runs to completion). From here on,
+                       // the only loadingFinished connections on this LogData
+                       // are the long-lived ones bindMainViewDataSignals
+                       // installs below.
+                       disconnect( pendingMainDataConn_ );
+                       currentMainData_ = pendingMainData_;
+                       currentMainFilePath_ = pendingMainFilePath_;
+                       lastMainViewLine_ = pendingJumpLine_;
+                       cacheMainViewData( currentMainFilePath_, currentMainData_ );
 
-                 // Sync the display codec to the indexer-detected encoding
-                 // BEFORE setDataSource renders, so a non-UTF-8 file decodes
-                 // correctly at first paint and the info line reports the right
-                 // encoding (parity with CrawlerWidget::updateEncoding, which
-                 // single-file calls from its own loadingFinished). Idempotent
-                 // for UTF-8 (detected == default codec -> no reload).
-                 applyDetectedEncoding();
-                 // Any override the user picked while this load was in flight
-                 // belonged to the previously displayed file: drop it so the
-                 // encoding menu does not check a codec the new file does not
-                 // actually use.
-                 encodingMibOverride_.reset();
+                       // Sync the display codec to the indexer-detected encoding
+                       // BEFORE setDataSource renders, so a non-UTF-8 file decodes
+                       // correctly at first paint and the info line reports the right
+                       // encoding (parity with CrawlerWidget::updateEncoding, which
+                       // single-file calls from its own loadingFinished). Idempotent
+                       // for UTF-8 (detected == default codec -> no reload).
+                       applyDetectedEncoding();
+                       // Any override the user picked while this load was in flight
+                       // belonged to the previously displayed file: drop it so the
+                       // encoding menu does not check a codec the new file does not
+                       // actually use.
+                       encodingMibOverride_.reset();
 
-                 mainView_->setDataSource( currentMainData_.get() );
-                 // Re-apply the current search pattern so the freshly-indexed
-                 // file highlights its matches at first paint. Runs on the main
-                 // thread (loadingFinished is a queued signal), so threading is
-                 // correct.
-                 mainView_->setSearchPattern( currentSearchPattern_ );
-                 selectInMainView( pendingJumpLine_, pendingJumpNLines_, pendingJumpCol_,
-                                   pendingJumpLen_ );
-                 // getNbLine() is only valid now that indexing finished: the
-                 // overview repoint MUST happen here, not at attachFile time.
-                 refreshFileOverview( pendingMainFilePath_ );
-                 Q_EMIT mainViewFileChanged();
+                       mainView_->setDataSource( currentMainData_.get() );
+                       // Re-point the follow/refresh data-flow at the freshly indexed
+                       // file (its LogData keeps watching + re-indexing on growth).
+                       bindMainViewDataSignals();
+                       // Re-apply the current search pattern so the freshly-indexed
+                       // file highlights its matches at first paint. Runs on the main
+                       // thread (loadingFinished is a queued signal), so threading is
+                       // correct.
+                       mainView_->setSearchPattern( currentSearchPattern_ );
+                       selectInMainView( pendingJumpLine_, pendingJumpNLines_,
+                                         pendingJumpCol_, pendingJumpLen_ );
+                       // getNbLine() is only valid now that indexing finished: the
+                       // overview repoint MUST happen here, not at attachFile time.
+                       refreshFileOverview( pendingMainFilePath_ );
+                       Q_EMIT mainViewFileChanged();
 
-                 pendingMainData_.reset();
-                 pendingMainFilePath_.clear();
-             } );
+                       pendingMainData_.reset();
+                       pendingMainFilePath_.clear();
+                   } );
 
     // The opened file's path/size/date surface in MainWindow's info line; keep
     // the toolbar status focused on search state (no path leak here).

--- a/src/ui/src/highlighterset.cpp
+++ b/src/ui/src/highlighterset.cpp
@@ -550,6 +550,14 @@ void HighlighterSetCollection::saveToStorage( QSettings& settings ) const
     settings.beginGroup( "quick_defaults" );
     settings.setValue( "ignore_case", quickHighlighterDefaults_.ignoreCase );
     settings.setValue( "whole_word", quickHighlighterDefaults_.wholeWord );
+    // Any state written by this build is post-flip by definition, so stamp
+    // the one-shot migration marker alongside the values. Without this the
+    // marker only ever appears when retrieveFromStorage runs the migration
+    // against a pre-flip store: a fresh install's first save (e.g. the user
+    // unchecking ignore-case in OptionsDialog) would leave the marker absent,
+    // and the next retrieve would re-run the migration and wipe that
+    // deliberate ignore_case=false exactly once.
+    settings.setValue( "ignore_case_default_migrated", true );
     settings.endGroup();
     settings.endGroup();
 }
@@ -601,10 +609,25 @@ void HighlighterSetCollection::retrieveFromStorage( QSettings& settings )
             settings.endArray();
 
             settings.beginGroup( "quick_defaults" );
+            // One-shot migration (pre-flip installs): the quick color-label
+            // ignore-case default used to be false and was persisted by
+            // routine saves of the collection, so the case-sensitive behavior
+            // silently stuck forever. The compiled default is now ON (the
+            // convention of the search/quick-find ignore-case defaults, which
+            // are also ON); drop the stale key once so the new default
+            // applies. A deliberate post-migration choice sticks because the
+            // marker suppresses re-migration; saveToStorage also stamps the
+            // marker, so any state last written by a post-flip build is never
+            // re-migrated. whole_word is untouched: its default is unchanged,
+            // so an explicit stored choice must survive.
+            if ( !settings.value( "ignore_case_default_migrated", false ).toBool() ) {
+                settings.remove( "ignore_case" );
+                settings.setValue( "ignore_case_default_migrated", true );
+            }
             quickHighlighterDefaults_.ignoreCase
-                = settings.value( "ignore_case", false ).toBool();
+                = settings.value( "ignore_case", QuickHighlighterDefaults{}.ignoreCase ).toBool();
             quickHighlighterDefaults_.wholeWord
-                = settings.value( "whole_word", false ).toBool();
+                = settings.value( "whole_word", QuickHighlighterDefaults{}.wholeWord ).toBool();
             settings.endGroup();
         }
         else {

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -76,6 +76,7 @@
 #include <QResource>
 #include <QScreen>
 #include <QShortcut>
+#include <QSignalBlocker>
 #include <QSortFilterProxyModel>
 #include <QStringListModel>
 #include <QTemporaryFile>
@@ -226,11 +227,11 @@ MainWindow::MainWindow( WindowSession session )
     // "current" crawlerwidget
 
     // Send actions to the crawlerwidget
-    signalMux_.connect( this, SIGNAL( followSet( bool ) ), SIGNAL( followSet( bool ) ) );
     signalMux_.connect( this, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
-    // textWrapSet / goToLine / enteringQuickFind / exitingQuickFind are NOT
-    // mux-routed: they are dispatched polymorphically via currentDocument()
-    // (AbstractCrawlerWidget virtuals) so folder tabs receive them too.
+    // textWrapSet / goToLine / followSet / jumpToTop / enteringQuickFind /
+    // exitingQuickFind are NOT mux-routed: they are dispatched polymorphically
+    // via currentDocument() (AbstractCrawlerWidget virtuals) so folder tabs
+    // receive them too.
     connect( &quickFindWidget_, &QuickFindWidget::close, this, [ this ] {
         if ( auto* document = currentDocument() ) {
             document->exitingQuickFind();
@@ -795,10 +796,25 @@ void MainWindow::createActions()
     followAction->setObjectName( QStringLiteral( "followAction" ) );
     followAction->setCheckable( true );
     followAction->setEnabled( config.anyFileWatchEnabled() );
-    connect( followAction, &QAction::toggled, this, &MainWindow::followSet );
+    // Dispatched polymorphically so folder tabs follow the file shown in their
+    // main view too (single-file: the CrawlerWidget::followSet signal override
+    // fans out to both views, exactly as the old mux relay did).
+    connect( followAction, &QAction::toggled, this, [ this ]( bool checked ) {
+        if ( auto* document = currentDocument() ) {
+            document->followSet( checked );
+        }
+    } );
 
     goToTopAction = new QAction( tr( action::goToTopText ), this );
-    signalMux_.connect( goToTopAction, SIGNAL( triggered() ), SLOT( jumpToTop() ) );
+    goToTopAction->setObjectName( QStringLiteral( "goToTopAction" ) );
+    // Dispatched polymorphically (the goToLineAction precedent) so folder tabs
+    // top their main view (single-file: CrawlerWidget::jumpToTop tops both
+    // views).
+    connect( goToTopAction, &QAction::triggered, this, [ this ] {
+        if ( auto* document = currentDocument() ) {
+            document->jumpToTop();
+        }
+    } );
 
     textWrapAction = new QAction( tr( action::wrapText ), this );
     textWrapAction->setObjectName( QStringLiteral( "textWrapAction" ) );
@@ -2256,10 +2272,10 @@ void MainWindow::currentTabChanged( int index )
         else {
             // --- Folder tab (FolderCrawlerWidget) ---
             // The folder is NOT registered as the signalMux document: the mux
-            // routes file/live-source slots (reload/stopLoading/follow) the
-            // folder does not implement, and registering it would emit "No
-            // such slot" warnings. Document-level actions (goToLine, wrap,
-            // focus-search, quickfind lifecycle) reach the folder via
+            // routes file/live-source slots (reload/stopLoading) the folder
+            // does not implement, and registering it would emit "No such slot"
+            // warnings. Document-level actions (goToLine, go-to-top, follow,
+            // wrap, focus-search, quickfind lifecycle) reach the folder via
             // currentDocument() virtual dispatch instead; config/view option
             // changes (line numbers, font, overview) are delivered directly
             // to applyConfiguration via the connection below.
@@ -2305,6 +2321,12 @@ void MainWindow::currentTabChanged( int index )
                          &MainWindow::sendToScratchpad, Qt::UniqueConnection );
                 connect( folder_widget, &FolderCrawlerWidget::replaceDataInScratchpad, this,
                          &MainWindow::replaceDataInScratchpad, Qt::UniqueConnection );
+                // Follow-state uplink (single-file parity with the mux-routed
+                // CrawlerWidget::followModeChanged): the folder main view's
+                // follow changes (elastic-hook disengage on scroll-up, ...) keep
+                // the Follow action's checked state in sync.
+                connect( folder_widget, &FolderCrawlerWidget::followModeChanged, this,
+                         &MainWindow::changeFollowMode, Qt::UniqueConnection );
             }
 
             // Routes to the folder via the connection above.
@@ -2317,14 +2339,29 @@ void MainWindow::currentTabChanged( int index )
             const auto* view = dynamic_cast<const ViewInterface*>( widget );
             updateTitleBar( view != nullptr ? session_.getDisplayName( view ) : QString() );
 
-            disableFileSpecificActions();
+            {
+                // Block the forced uncheck inside disableFileSpecificActions:
+                // followAction::toggled is now dispatched to the CURRENT tab,
+                // which is already this folder widget, so an unguarded
+                // setChecked(false) would kill the folder main view's follow
+                // mode before its state can be synced back below.
+                const QSignalBlocker followActionBlocker( followAction );
+                disableFileSpecificActions();
+            }
             // A folder tab has a valid filesystem path (the folder), so Copy
             // Path and Open Containing Folder are meaningful (they operate on
             // the folder path via currentView()). Re-enable them; the other
-            // actions disabled above (follow, live-log save, disconnect/
-            // reconnect, open-in-editor) remain folder-inapplicable.
+            // actions disabled above (live-log save, disconnect/reconnect,
+            // open-in-editor) remain folder-inapplicable.
             copyPathToClipboardAction->setEnabled( true );
             openContainingFolderAction->setEnabled( true );
+
+            // Follow applies to the file shown in the folder main view: sync
+            // the checked state from it, mirroring updateMenuBarFromDocument's
+            // followAction->setChecked( crawler->isFollowEnabled() ) for file
+            // tabs.
+            followAction->setChecked( folder_widget != nullptr
+                                      && folder_widget->isFollowEnabled() );
 
             infoLine->hideGauge();
             // updateInfoLine now owns the folder info line: it shows the file

--- a/src/ui/src/optionsdialog.cpp
+++ b/src/ui/src/optionsdialog.cpp
@@ -51,6 +51,7 @@
 #include "encodings.h"
 #include "fontutils.h"
 #include "highlighteredit.h"
+#include "highlighterset.h"
 #include "ioslogprocesstransport.h"
 #include "log.h"
 #include "logger.h"
@@ -739,6 +740,13 @@ void OptionsDialog::updateDialogFromConfiguration( const Configuration& config )
     logicalCombiningCheckBox->setChecked( config.isSearchLogicalCombiningDefault() );
     autoRefreshCheckBox->setChecked( config.isSearchAutoRefreshDefault() );
 
+    // Color label match defaults live in HighlighterSetCollection (the single
+    // source of truth shared with the context-menu toggles), not in
+    // Configuration; the dialog only mirrors them.
+    const auto colorLabelDefaults = HighlighterSetCollection::get().quickHighlighterDefaults();
+    colorLabelsIgnoreCaseCheckBox->setChecked( colorLabelDefaults.ignoreCase );
+    colorLabelsWholeWordCheckBox->setChecked( colorLabelDefaults.wholeWord );
+
     // Polling
     nativeFileWatchCheckBox->setChecked( config.nativeFileWatchEnabled() );
     fastModificationDetectionCheckBox->setChecked( config.fastModificationDetection() );
@@ -901,6 +909,13 @@ void OptionsDialog::resetGeneralDefaults()
     autoRunSearchOnAddCheckBox->setChecked( defaults.autoRunSearchOnPatternChange() );
     showAllFilteredWhenEmptyCheckBox->setChecked(
         defaults.showAllInFilteredViewWhenSearchEmpty() );
+
+    // Compiled defaults (ignore case on, whole word off) come from the
+    // QuickHighlighterDefaults struct itself, not from the stored collection.
+    const QuickHighlighterDefaults defaultColorLabelDefaults;
+    colorLabelsIgnoreCaseCheckBox->setChecked( defaultColorLabelDefaults.ignoreCase );
+    colorLabelsWholeWordCheckBox->setChecked( defaultColorLabelDefaults.wholeWord );
+
     searchHistorySpinBox->setValue( defaultSavedSearches.historySize() );
 
     loadLastSessionCheckBox->setChecked( defaults.loadLastSession() );
@@ -1258,6 +1273,14 @@ void OptionsDialog::updateConfigFromDialog()
     auto& recentFiles = RecentFiles::get();
     recentFiles.setFilesHistoryMaxItems( filesHistoryMaxItemsSpinBox->value() );
     recentFiles.save();
+
+    // Same non-Configuration-persistable pattern as SavedSearches/RecentFiles
+    // above: HighlighterSetCollection owns the color-label match defaults.
+    auto& highlighterSetCollection = HighlighterSetCollection::get();
+    highlighterSetCollection.setQuickHighlighterDefaults(
+        { colorLabelsIgnoreCaseCheckBox->isChecked(),
+          colorLabelsWholeWordCheckBox->isChecked() } );
+    highlighterSetCollection.save();
 
     if ( restartAppMessage ) {
         QMessageBox::warning(

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -241,6 +241,11 @@ struct AbstractLogView::access_by<FolderViewTestAccess> {
     {
         return view->selection_.getLines();
     }
+
+    static const AbstractLogData* logData( const AbstractLogView* view )
+    {
+        return view->logData_;
+    }
 };
 
 TEST_CASE( "FolderCrawlerWidget plain click on a result row repaints the selection highlight",
@@ -3636,10 +3641,15 @@ TEST_CASE( "FolderCrawlerWidget follow tracks the tail when the file grows", "[f
         return topBefore.get() > 0;
     } ) );
 
-    // Grow the file on disk. The deterministic seam is the FileWatcher the
-    // LogData registered with at indexingFinished (logdata.cpp:242): native
-    // watch on Linux/macOS, 1s polling on Windows (qtests_main.cpp) -- the
-    // generous waitFor timeout covers both.
+    // Grow the file on disk, then deliver the change notification through the
+    // same entry point the FileWatcher uses (queued FileWatcher::fileChanged ->
+    // LogData::fileChangedOnDisk, logdata.cpp:71-72). Invoking the slot
+    // directly keeps the test deterministic: watcher timing (1s polling on
+    // Windows/macOS, efsw on Linux) is too slow on loaded CI runners, and the
+    // watcher -> LogData leg is already covered by the LogData growth unit
+    // tests; what this test pins is the widget wiring this change adds
+    // (bindMainViewDataSignals -> mainView_->updateData() -> follow tracks the
+    // tail).
     {
         QFile f( a );
         REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
@@ -3650,6 +3660,12 @@ TEST_CASE( "FolderCrawlerWidget follow tracks the tail when the file grows", "[f
         f.write( payload );
         f.flush();
     }
+
+    auto* mainData = const_cast<AbstractLogData*>(
+        AbstractLogView::access_by<FolderViewTestAccess>::logData( widget.mainView() ) );
+    REQUIRE( mainData != nullptr );
+    QMetaObject::invokeMethod( mainData, "fileChangedOnDisk", Qt::QueuedConnection,
+                               Q_ARG( QString, widget.currentMainFilePath() ) );
 
     // Follow + refresh => the view tracks the new tail: the top line moves
     // down past its previous at-bottom position.

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -3493,3 +3493,306 @@ TEST_CASE( "FolderCrawlerWidget results view scrolls wrapped overflow beyond the
     using Access = AbstractLogView::access_by<FolderViewTestAccess>;
     REQUIRE( Access::drawingTopOffset( filteredView ) < 0 );
 }
+
+TEST_CASE( "FolderCrawlerWidget jumpToTop dispatch tops the main view only", "[folder]" )
+{
+    // The AbstractCrawlerWidget::jumpToTop hook is what MainWindow's
+    // goToTopAction dispatches to on a folder tab. It must scroll the folder
+    // MAIN view back to the top (the results view is a cross-file static
+    // snapshot and is intentionally left alone).
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "a.log", 200, { 0, 100 } );
+
+    FolderCrawlerWidget widget;
+    widget.resize( 800, 600 );
+    widget.show();
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    // The on-demand index + layout are async: wait until the 200-line file is
+    // actually scrollable, then settle so the worker thread unwinds.
+    REQUIRE( waitFor(
+        [ & ]() { return widget.mainView()->verticalScrollBar()->maximum() > 0; } ) );
+    QTest::qWait( 200 );
+
+    auto* const scrollBar = widget.mainView()->verticalScrollBar();
+    scrollBar->setValue( scrollBar->maximum() );
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->verticalScrollBar()->value() > 0; } ) );
+
+    static_cast<AbstractCrawlerWidget*>( &widget )->jumpToTop();
+
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->verticalScrollBar()->value() == 0; } ) );
+}
+
+TEST_CASE( "FolderCrawlerWidget followSet dispatch toggles follow on the main view",
+           "[folder]" )
+{
+    // The AbstractCrawlerWidget::followSet hook is what MainWindow's
+    // followAction dispatches to on a folder tab. Both directions must reach
+    // the folder main view (and isFollowEnabled must report it back so
+    // MainWindow can sync the action's checked state).
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "line0\nERROR here\nline2\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    auto* const document = static_cast<AbstractCrawlerWidget*>( &widget );
+    REQUIRE_FALSE( document->isFollowEnabled() );
+
+    document->followSet( true );
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->isFollowEnabled(); } ) );
+    REQUIRE( document->isFollowEnabled() );
+
+    document->followSet( false );
+    REQUIRE( waitFor( [ & ]() { return !widget.mainView()->isFollowEnabled(); } ) );
+    REQUIRE_FALSE( document->isFollowEnabled() );
+}
+
+TEST_CASE( "FolderCrawlerWidget re-emits the main view's followModeChanged", "[folder]" )
+{
+    // MainWindow direct-connects FolderCrawlerWidget::followModeChanged to
+    // changeFollowMode (single-file tabs reach that slot via the SignalMux) so
+    // the Follow action unchecks when the user scrolls away from the tail.
+    // The view emits followModeChanged(false) from disableFollow -- scrolling
+    // up while follow is on -- which is the state change driven here.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "line0\nERROR here\nline2\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    bool fired = false;
+    bool followValue = true;
+    QObject::connect( &widget, &FolderCrawlerWidget::followModeChanged, &widget,
+                      [ & ]( bool follow ) {
+                          fired = true;
+                          followValue = follow;
+                      } );
+
+    widget.mainView()->followSet( true );
+    REQUIRE( widget.mainView()->isFollowEnabled() );
+
+    // Scrolling up while following disengages follow (the scrollbar's
+    // actionTriggered -> disableFollow path, abstractlogview.cpp:414-423);
+    // triggerAction emits actionTriggered even when the value cannot move.
+    widget.mainView()->verticalScrollBar()->triggerAction(
+        QAbstractSlider::SliderSingleStepSub );
+
+    REQUIRE( waitFor( [ & ]() { return fired; } ) );
+    REQUIRE_FALSE( followValue );
+}
+
+TEST_CASE( "FolderCrawlerWidget follow tracks the tail when the file grows", "[folder]" )
+{
+    // The follow DATA FLOW: the folder main view's per-file LogData
+    // self-registers with FileWatcher and re-indexes on growth, but follow
+    // only tracks if the view is refreshed -- bindMainViewDataSignals forwards
+    // the current file's loadingFinished/loadingProgressed to
+    // mainView_->updateData(). RED without it: the flag is set, the view never
+    // moves, and the top line stays put when the file grows.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "a.log", 200, { 0, 100 } );
+
+    FolderCrawlerWidget widget;
+    widget.resize( 800, 600 );
+    widget.show();
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    REQUIRE( waitFor(
+        [ & ]() { return widget.mainView()->verticalScrollBar()->maximum() > 0; } ) );
+    QTest::qWait( 200 );
+
+    // Enable follow through the same dispatch MainWindow uses; the view jumps
+    // to the bottom of the 200-line file.
+    static_cast<AbstractCrawlerWidget*>( &widget )->followSet( true );
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->isFollowEnabled(); } ) );
+    LineNumber topBefore = 0_lnum;
+    REQUIRE( waitFor( [ & ]() {
+        topBefore = widget.mainView()->getTopLine();
+        return topBefore.get() > 0;
+    } ) );
+
+    // Grow the file on disk. The deterministic seam is the FileWatcher the
+    // LogData registered with at indexingFinished (logdata.cpp:242): native
+    // watch on Linux/macOS, 1s polling on Windows (qtests_main.cpp) -- the
+    // generous waitFor timeout covers both.
+    {
+        QFile f( a );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
+        QByteArray payload;
+        for ( int i = 0; i < 100; ++i ) {
+            payload.append( "appended line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+        f.flush();
+    }
+
+    // Follow + refresh => the view tracks the new tail: the top line moves
+    // down past its previous at-bottom position.
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->getTopLine() > topBefore; },
+                      15000 ) );
+}
+
+TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending open",
+           "[folder][regression]" )
+{
+    // Regression for the stale pending-load connection in openFileInMainView:
+    // the one-shot loadingFinished connect() stayed attached to the LogData for
+    // its whole lifetime. After file A's open completed, A's LogData went into
+    // the LRU cache and kept re-indexing on disk changes (self-registered
+    // FileWatcher; the follow data-flow makes these re-indexes routine). When
+    // such a re-index finished while a DIFFERENT file B's async open was in
+    // flight, A's stale lambda saw pendingMainData_ != nullptr and ran the
+    // completion body with B's half-indexed state: the jump landed on a
+    // not-yet-indexed B, the next progress-driven updateData cropped the
+    // out-of-range selection away (abstractlogview.cpp:1825, Selection::crop
+    // clears a selected line beyond the indexed range), and B's real
+    // completion early-returned without re-jumping -- so B ended up displayed
+    // with NO selection at the clicked match line. The fix ties the pending
+    // connection's lifetime to the open it serves (self-disconnect on
+    // completion + disconnect on supersede), so A's re-index can no longer
+    // complete B's open.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "ERROR in a\npadding\n" ) );
+    // B is deliberately large so its async index stays in flight long enough
+    // for A's watcher-triggered re-index to complete inside the pending window
+    // (the stale lambda can only clobber while pendingMainData_ is non-null).
+    // The match sits near the END of B so the premature jump targets a line
+    // far beyond whatever prefix of B is indexed when the clobber lands.
+    constexpr int bLines = 2000000;
+    constexpr int bMatchLine = bLines - 10;
+    const QString b = makeFile( dir, "b.log", bLines, { bMatchLine } );
+
+    FolderCrawlerWidget widget;
+    widget.resize( 800, 600 );
+    widget.show();
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.searchFor( "ERROR" );
+    // Wait for the folder scan to COMPLETE (not merely start): searchActive_
+    // flips synchronously inside searchFor(), so waiting for it to become
+    // true returns immediately with an empty results model, and the
+    // matchRowForFile lookups below would find no rows. The scan streams all
+    // ~26MB of B: generous budget for loaded CI.
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); }, 30000 ) );
+
+    // Resolve each file's match row dynamically: group headers shift row
+    // indices, and a hardcoded row would silently select the wrong file.
+    const auto matchRowForFile = [ & ]( const QString& path ) -> LineNumber {
+        const auto total = widget.folderResults()->getNbLine().get();
+        for ( uint64_t i = 0; i < total; ++i ) {
+            const LineNumber row{ i };
+            if ( widget.folderResults()->lineKind( row ) == LineKind::Data
+                 && widget.folderResults()->sourceForLine( row ).filePath == path ) {
+                return row;
+            }
+        }
+        FAIL( "matchRowForFile: no matching result row found for the requested file" );
+        return 0_lnum; // unreachable; FAIL aborts the test case
+    };
+
+    // Open A first (uncached -> async path): after completion A is cached,
+    // bound, and -- before the fix -- still carrying its stale pending lambda.
+    widget.selectResultRow( matchRowForFile( a ) );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
+
+    const LineNumber bRow = matchRowForFile( b );
+    const LineNumber bLocalLine = widget.folderResults()->sourceForLine( bRow ).localLine;
+    REQUIRE( bLocalLine.get() == static_cast<uint64_t>( bMatchLine ) );
+
+    // Append to A on disk and IMMEDIATELY start B's open, then keep nudging A
+    // while B indexes, so at least one re-index of A completes inside B's
+    // pending window regardless of watcher latency (native watcher on
+    // Linux/macOS, 1s polling on Windows -- B's size keeps the window wide on
+    // native watchers; under 1s polling the clobber may not be exercised, but
+    // the healthy end state asserted below must hold either way).
+    const auto appendLine = []( const QString& path ) {
+        QFile f( path );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
+        f.write( "nudge\n" );
+        f.flush();
+    };
+    appendLine( a );
+    widget.selectResultRow( bRow );
+    QElapsedTimer openBudget;
+    openBudget.start();
+    while ( widget.currentMainFilePath() != b && openBudget.elapsed() < 30000 ) {
+        QTest::qWait( 100 );
+        appendLine( a );
+    }
+    REQUIRE( widget.currentMainFilePath() == b );
+
+    // Wait for B's index to actually FINISH (currentMainViewInfo reads the
+    // live indexed line count), then settle so the queued loadingFinished
+    // side effects (pre-fix: the selection crop) have landed.
+    REQUIRE( waitFor(
+        [ & ]() {
+            const auto info = widget.currentMainViewInfo();
+            return info.has_value() && info->path == b
+                   && info->nbLines >= static_cast<uint64_t>( bLines );
+        },
+        30000 ) );
+    QTest::qWait( 200 );
+
+    // The jump must have selected the clicked match line. RED before the fix:
+    // the premature jump selected bLocalLine while B was still mostly
+    // unindexed, the next progress-driven updateData cropped the out-of-range
+    // selection to nothing, and B's real completion early-returned.
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+    const auto selected = Access::selectedLines( widget.mainView() );
+    INFO( "selection must hold exactly the clicked match line, got "
+          << selected.size() << " line(s)" );
+    REQUIRE( selected.size() == 1 );
+    REQUIRE( selected.front() == bLocalLine );
+
+    // B's follow data-flow must be bound (bindMainViewDataSignals at B's real
+    // completion): enable follow through the same dispatch MainWindow uses,
+    // grow B on disk, and the view must track the tail -- mirrors the
+    // follow-tail test above (same FileWatcher seam, same 15s budget for the
+    // 1s polling watcher on Windows).
+    static_cast<AbstractCrawlerWidget*>( &widget )->followSet( true );
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->isFollowEnabled(); } ) );
+    LineNumber topBefore = 0_lnum;
+    REQUIRE( waitFor( [ & ]() {
+        topBefore = widget.mainView()->getTopLine();
+        return topBefore.get() > 0;
+    } ) );
+
+    {
+        QFile f( b );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
+        QByteArray payload;
+        for ( int i = 0; i < 100; ++i ) {
+            payload.append( "appended line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+        f.flush();
+    }
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->getTopLine() > topBefore; },
+                      15000 ) );
+}

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -29,6 +29,7 @@
 #include <QMenuBar>
 #include <QClipboard>
 #include <QLineEdit>
+#include <QScrollBar>
 #include <QSignalSpy>
 #include <QTabBar>
 #include <QTemporaryDir>
@@ -81,6 +82,40 @@ struct TabGroupCleanupGuard {
     {
         clearPersistedTabGroups();
     }
+};
+
+// RAII save/restore of the file-watch flags gating followAction's enabled
+// state. MainWindow reads anyFileWatchEnabled() when the action is created
+// (and on every tab switch via disableFileSpecificActions), so the guard must
+// be installed before the window under test is constructed. Uses the
+// in-memory Configuration singleton so nothing leaks to disk or sibling tests.
+struct FileWatchConfigGuard {
+    FileWatchConfigGuard()
+        : config_( Configuration::get() )
+        , previousNative_( config_.nativeFileWatchEnabled() )
+        , previousPolling_( config_.pollingEnabled() )
+    {
+        // Force polling (not native): anyFileWatchEnabled() is native||polling,
+        // and polling is the watcher the test harness itself keeps enabled on
+        // every platform for determinism (qtests_main disables the flaky
+        // native efsw watcher on Windows -- re-arming it here would put these
+        // scenarios into exactly the configuration the harness avoids).
+        config_.setPollingEnabled( true );
+    }
+
+    ~FileWatchConfigGuard()
+    {
+        config_.setNativeFileWatchEnabled( previousNative_ );
+        config_.setPollingEnabled( previousPolling_ );
+    }
+
+    FileWatchConfigGuard( const FileWatchConfigGuard& ) = delete;
+    FileWatchConfigGuard& operator=( const FileWatchConfigGuard& ) = delete;
+
+  private:
+    Configuration& config_;
+    bool previousNative_;
+    bool previousPolling_;
 };
 
 struct SessionInfoWindowSnapshot {
@@ -1017,6 +1052,9 @@ SCENARIO( "Folder tab in MainWindow does not crash on open/switch/close",
 SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folder]" )
 {
     TabGroupCleanupGuard tabGroupCleanupGuard;
+    // Deterministic followAction enabled state (must precede MainWindow
+    // construction: the action reads anyFileWatchEnabled() at creation).
+    FileWatchConfigGuard fileWatchConfigGuard;
 
     auto appSession = std::make_shared<Session>();
     const auto windowId = QString( "folder-dispatch-%1" ).arg(
@@ -1098,7 +1136,7 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
         auto* follow = mainWindow->findChild<QAction*>( QStringLiteral( "followAction" ) );
         auto* wrap = mainWindow->findChild<QAction*>( QStringLiteral( "textWrapAction" ) );
 
-        THEN( "document actions are enabled, file-only actions are not" )
+        THEN( "document actions are enabled" )
         {
             // The folder branch of currentTabChanged explicitly re-enables the
             // wrap toggle and syncs its checked state from the folder views.
@@ -1108,9 +1146,62 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
             // Go-to-line is routed polymorphically and stays available.
             REQUIRE( goToLine != nullptr );
             REQUIRE( goToLine->isEnabled() );
-            // Follow stays file/live-source-only.
+            // Follow applies to the file shown in the folder main view and
+            // stays available whenever file watching is enabled.
             REQUIRE( follow != nullptr );
-            REQUIRE_FALSE( follow->isChecked() );
+            REQUIRE( follow->isEnabled() );
+        }
+
+        AND_WHEN( "follow is toggled on for the folder tab" )
+        {
+            runInUiThread( [ follow ] {
+                follow->trigger();
+            } );
+
+            THEN( "the folder main view follows and the action shows it" )
+            {
+                // RED: today followSet is routed through the signal mux, whose
+                // current document is null for folder tabs, so the folder main
+                // view never enters follow mode.
+                REQUIRE( waitUiState( [ & ] {
+                    return folderWidget->mainView()->isFollowEnabled();
+                } ) );
+                REQUIRE( follow->isChecked() );
+            }
+
+            AND_WHEN( "switching to a file tab and back to the folder tab" )
+            {
+                const auto filePath = QDir( tempDirPath ).absoluteFilePath( "a.log" );
+                runInUiThread( [ &mainWindow, filePath ] {
+                    mainWindow->loadInitialFile( filePath, false );
+                } );
+                REQUIRE( waitUiState( [ & ] { return tabArea->count() == 2; } ) );
+                // Let the file tab's background load finish (and its worker
+                // thread unwind) before switching away / tearing down.
+                REQUIRE( waitUiState( [ & ] {
+                    auto* crawler = qobject_cast<CrawlerWidget*>( tabArea->widget( 1 ) );
+                    return crawler != nullptr && crawler->isFirstLoadDone();
+                } ) );
+                QTest::qWait( 200 );
+
+                runInUiThread( [ tabArea ] {
+                    tabArea->setCurrentIndex( 0 );
+                } );
+                REQUIRE( waitUiState( [ & ] {
+                    return qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() )
+                           != nullptr;
+                } ) );
+                QTest::qWait( 200 );
+
+                THEN( "the follow action still reflects the folder main view" )
+                {
+                    // RED: today switching to a folder tab forces the action
+                    // unchecked (disableFileSpecificActions) instead of syncing
+                    // the checked state from the folder main view's follow mode.
+                    REQUIRE( waitUiState( [ & ] { return follow->isChecked(); } ) );
+                    REQUIRE( folderWidget->mainView()->isFollowEnabled() );
+                }
+            }
         }
     }
 
@@ -1141,6 +1232,191 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
             REQUIRE( waitUiState( [ & ] {
                 return QApplication::clipboard()->text() == QDir::toNativeSeparators( expectedPath );
             } ) );
+        }
+    }
+}
+
+// F9: "Go to top" and "Follow file" are document-level actions: on a folder
+// tab they must apply to the file shown in the folder MAIN view. Today both
+// are routed through the signal mux, whose current document is null for
+// folder tabs (signalMux_.setCurrentDocument( nullptr ) in currentTabChanged),
+// so they are silent no-ops there.
+SCENARIO( "Folder tab go-to-top and follow actions apply to the main view file",
+          "[ui][folder]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    // Deterministic followAction enabled state (must precede MainWindow
+    // construction: the action reads anyFileWatchEnabled() at creation).
+    FileWatchConfigGuard fileWatchConfigGuard;
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "folder-doc-actions-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+
+    QTest::qWait( 100 );
+    mainWindow->resize( 1600, 900 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+
+    auto* goToTopAction = mainWindow->findChild<QAction*>( QStringLiteral( "goToTopAction" ) );
+    REQUIRE( goToTopAction != nullptr );
+    auto* followAction = mainWindow->findChild<QAction*>( QStringLiteral( "followAction" ) );
+    REQUIRE( followAction != nullptr );
+
+    // 200 matching lines so the folder main view is comfortably scrollable
+    // once the file is opened from a result row.
+    const auto tempDirPath = makeTestDir( "folderdocactions" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto logFilePath = QDir( tempDirPath ).absoluteFilePath( "a.log" );
+    {
+        QFile f( logFilePath );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        QByteArray payload;
+        for ( int i = 0; i < 200; ++i ) {
+            payload.append( "ERROR line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+    }
+
+    GIVEN( "a folder tab with a file opened in the main view" )
+    {
+        runInUiThread( [ &mainWindow, tempDirPath ] {
+            mainWindow->openFolderByPath( tempDirPath );
+        } );
+        REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+        QTest::qWait( 200 );
+        auto* folderWidget = qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() );
+        REQUIRE( folderWidget != nullptr );
+
+        runInUiThread( [ folderWidget ] {
+            folderWidget->searchFor( QStringLiteral( "ERROR" ) );
+        } );
+        REQUIRE( waitUiState( [ & ] { return !folderWidget->isSearchActive(); } ) );
+        REQUIRE( folderWidget->filteredView() != nullptr );
+
+        // Results rows: group header at 0, then one data row per match. Row 2
+        // is a data row; selecting it in the results view opens its file in
+        // the main view (newSelection -> onResultSelected, the same path
+        // FolderCrawlerWidget::selectResultRow drives).
+        runInUiThread( [ folderWidget ] {
+            folderWidget->filteredView()->selectAndDisplayLine( 2_lnum );
+        } );
+        REQUIRE( waitUiState(
+            [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        // The on-demand index + layout of the main-view file are async: wait
+        // until the 200-line file is actually scrollable, then settle so the
+        // worker thread unwinds before the views are driven further.
+        REQUIRE( waitUiState( [ & ] {
+            return folderWidget->mainView()->verticalScrollBar()->maximum() > 0;
+        } ) );
+        QTest::qWait( 200 );
+
+        auto scrollMainViewToBottom = [ & ] {
+            runInUiThread( [ folderWidget ] {
+                auto* scrollBar = folderWidget->mainView()->verticalScrollBar();
+                scrollBar->setValue( scrollBar->maximum() );
+            } );
+            REQUIRE( waitUiState( [ & ] {
+                return folderWidget->mainView()->verticalScrollBar()->value() > 0;
+            } ) );
+        };
+
+        WHEN( "the go-to-top action is triggered" )
+        {
+            scrollMainViewToBottom();
+
+            runInUiThread( [ goToTopAction ] {
+                goToTopAction->trigger();
+            } );
+
+            THEN( "the folder main view scrolls back to the top" )
+            {
+                // RED: jumpToTop is mux-routed; the mux document is null on
+                // folder tabs, so the main view never scrolls.
+                REQUIRE( waitUiState( [ & ] {
+                    return folderWidget->mainView()->verticalScrollBar()->value() == 0;
+                } ) );
+            }
+        }
+
+        WHEN( "the go-to-top shortcut is pressed" )
+        {
+            scrollMainViewToBottom();
+
+            pressConfiguredShortcut( mainWindow.get(), ShortcutAction::MainWindowGoToTop );
+
+            THEN( "the folder main view scrolls back to the top" )
+            {
+                // RED: the shortcut fires the same mux-routed goToTopAction.
+                REQUIRE( waitUiState( [ & ] {
+                    return folderWidget->mainView()->verticalScrollBar()->value() == 0;
+                } ) );
+            }
+        }
+
+        WHEN( "the follow action is toggled on" )
+        {
+            REQUIRE( waitUiState( [ & ] { return followAction->isEnabled(); } ) );
+
+            runInUiThread( [ followAction ] {
+                followAction->trigger();
+            } );
+
+            THEN( "the folder main view enters follow mode" )
+            {
+                // RED: followSet is mux-routed; the mux document is null on
+                // folder tabs, so the main view's follow mode is never set.
+                REQUIRE( waitUiState( [ & ] {
+                    return folderWidget->mainView()->isFollowEnabled();
+                } ) );
+                REQUIRE( followAction->isChecked() );
+            }
+        }
+
+        WHEN( "the results view has focus and go-to-top is triggered" )
+        {
+            scrollMainViewToBottom();
+
+            runInUiThread( [ folderWidget ] {
+                folderWidget->filteredView()->setFocus( Qt::OtherFocusReason );
+            } );
+            REQUIRE( waitUiState( [ & ] {
+                return folderWidget->filteredView()->hasFocus();
+            } ) );
+
+            const auto selectedRowsBefore
+                = folderWidget->filteredView()->getSelectedLinesText();
+            REQUIRE_FALSE( selectedRowsBefore.isEmpty() );
+
+            runInUiThread( [ goToTopAction ] {
+                goToTopAction->trigger();
+            } );
+
+            THEN( "the main view scrolls to top and the results selection is untouched" )
+            {
+                // RED: same null-mux-document no-op regardless of which folder
+                // view holds focus.
+                REQUIRE( waitUiState( [ & ] {
+                    return folderWidget->mainView()->verticalScrollBar()->value() == 0;
+                } ) );
+                // The action targets the folder MAIN view only: the results
+                // (filtered) view's selection must not be moved by it.
+                REQUIRE( folderWidget->filteredView()->getSelectedLinesText()
+                         == selectedRowsBefore );
+            }
         }
     }
 }

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -51,6 +51,7 @@
 #include "adblogcatdialog.h"
 #include "commandargumenttokenizer.h"
 #include "configuration.h"
+#include "highlighterset.h"
 #include "ioslogprocesstransport.h"
 #include "livesourcetransport.h"
 #include "optionsdialog.h"
@@ -110,6 +111,10 @@ class ScopedOptionsDialogConfigurationGuard {
         : config_( Configuration::getSynced() )
         , savedSearches_( SavedSearches::getSynced() )
         , recentFiles_( RecentFiles::getSynced() )
+        // OptionsDialog mirrors and (on Apply) persists the color-label match
+        // defaults through HighlighterSetCollection, so snapshot it alongside
+        // the other non-Configuration persistables the dialog touches.
+        , highlighterSets_( HighlighterSetCollection::getSynced() )
     {
         REQUIRE( snapshotDir_.isValid() );
         snapshotPath_ = snapshotDir_.filePath( QStringLiteral( "settings.ini" ) );
@@ -118,6 +123,7 @@ class ScopedOptionsDialogConfigurationGuard {
         config_.saveToStorage( snapshot );
         savedSearches_.saveToStorage( snapshot );
         recentFiles_.saveToStorage( snapshot );
+        highlighterSets_.saveToStorage( snapshot );
         snapshot.sync();
     }
 
@@ -132,12 +138,16 @@ class ScopedOptionsDialogConfigurationGuard {
 
         recentFiles_.retrieveFromStorage( snapshot );
         recentFiles_.save();
+
+        highlighterSets_.retrieveFromStorage( snapshot );
+        highlighterSets_.save();
     }
 
   private:
     Configuration& config_;
     SavedSearches& savedSearches_;
     RecentFiles& recentFiles_;
+    HighlighterSetCollection& highlighterSets_;
     QTemporaryDir snapshotDir_;
     QString snapshotPath_;
 };
@@ -964,8 +974,13 @@ TEST_CASE( "OptionsDialog loads and persists adb settings" )
     ScopedAdbConfigurationGuard configGuard;
     auto& savedSearches = SavedSearches::getSynced();
     auto& recentFiles = RecentFiles::getSynced();
+    // OptionsDialog also reads the color-label match defaults from
+    // HighlighterSetCollection during construction; initialize the persistable
+    // like the two above so get() does not throw.
+    auto& highlighterSets = HighlighterSetCollection::getSynced();
     Q_UNUSED( savedSearches );
     Q_UNUSED( recentFiles );
+    Q_UNUSED( highlighterSets );
     auto& config = Configuration::getSynced();
     config.setAdbExecutable( QStringLiteral( "/initial/adb" ) );
     config.setAdbLogcatExtraArgs( QStringLiteral( "-v brief" ) );
@@ -1198,8 +1213,13 @@ TEST_CASE( "OptionsDialog adb detect button fills the executable field with the 
     ScopedAdbConfigurationGuard configGuard;
     auto& savedSearches = SavedSearches::getSynced();
     auto& recentFiles = RecentFiles::getSynced();
+    // OptionsDialog also reads the color-label match defaults from
+    // HighlighterSetCollection during construction; initialize the persistable
+    // like the two above so get() does not throw.
+    auto& highlighterSets = HighlighterSetCollection::getSynced();
     Q_UNUSED( savedSearches );
     Q_UNUSED( recentFiles );
+    Q_UNUSED( highlighterSets );
     auto& config = Configuration::getSynced();
     config.setAdbExecutable( QString{} );
     config.save();

--- a/tests/unit/colorlabelsmanager_test.cpp
+++ b/tests/unit/colorlabelsmanager_test.cpp
@@ -264,8 +264,108 @@ SCENARIO( "quick color label defaults persist in highlighter settings", "[colorl
         THEN( "the product defaults are used" )
         {
             const auto defaults = loadedCollection.quickHighlighterDefaults();
-            CHECK_FALSE( defaults.ignoreCase );
+            CHECK( defaults.ignoreCase );
             CHECK_FALSE( defaults.wholeWord );
+        }
+    }
+}
+
+SCENARIO( "flipped ignore-case default reaches existing installs exactly once", "[colorlabels]" )
+{
+    QTemporaryDir temporaryDir;
+    REQUIRE( temporaryDir.isValid() );
+
+    const auto settingsPath = temporaryDir.filePath( QStringLiteral( "highlighters.ini" ) );
+
+    // Migration contract for the GREEN implementation: on retrieve,
+    // HighlighterSetCollection must sweep the stale
+    // HighlighterSetCollection/quick_defaults/ignore_case key exactly once (so
+    // the new compiled default ignoreCase=true applies to installs that
+    // persisted the old false default) and stamp the marker key
+    // HighlighterSetCollection/quick_defaults/ignore_case_default_migrated
+    // (inside the quick_defaults group) so a deliberate post-migration choice
+    // is never swept again. Mirrors the perf.useBlockScan one-shot migration
+    // in Configuration::retrieveFromStorage.
+    GIVEN( "an ini from an install that persisted the old ignore-case default" )
+    {
+        QSettings settings{ settingsPath, QSettings::IniFormat };
+        settings.setValue( QStringLiteral( "HighlighterSetCollection/version" ), 3 );
+        settings.setValue(
+            QStringLiteral( "HighlighterSetCollection/quick_defaults/ignore_case" ), false );
+        settings.setValue(
+            QStringLiteral( "HighlighterSetCollection/quick_defaults/whole_word" ), true );
+        settings.sync();
+
+        WHEN( "a fresh collection retrieves from it" )
+        {
+            HighlighterSetCollection loadedCollection;
+            loadedCollection.retrieveFromStorage( settings );
+
+            THEN( "the new default applies, the explicit whole-word choice is kept, and the "
+                  "marker is stamped" )
+            {
+                const auto defaults = loadedCollection.quickHighlighterDefaults();
+                CHECK( defaults.ignoreCase );
+                CHECK( defaults.wholeWord );
+
+                CHECK( settings
+                           .value( QStringLiteral( "HighlighterSetCollection/quick_defaults/"
+                                                   "ignore_case_default_migrated" ),
+                                   false )
+                           .toBool() );
+            }
+        }
+    }
+
+    GIVEN( "an ini where the migration already ran and ignore-case was set to false" )
+    {
+        QSettings settings{ settingsPath, QSettings::IniFormat };
+        settings.setValue( QStringLiteral( "HighlighterSetCollection/version" ), 3 );
+        settings.setValue(
+            QStringLiteral( "HighlighterSetCollection/quick_defaults/ignore_case" ), false );
+        settings.setValue( QStringLiteral( "HighlighterSetCollection/quick_defaults/"
+                                           "ignore_case_default_migrated" ),
+                           true );
+        settings.sync();
+
+        WHEN( "a fresh collection retrieves from it" )
+        {
+            HighlighterSetCollection loadedCollection;
+            loadedCollection.retrieveFromStorage( settings );
+
+            THEN( "the deliberate post-migration choice sticks" )
+            {
+                CHECK_FALSE( loadedCollection.quickHighlighterDefaults().ignoreCase );
+            }
+        }
+    }
+
+    GIVEN( "a fresh install whose first persisted state is a deliberate ignore-case=false" )
+    {
+        // Fresh-install regression: the marker used to be stamped only inside
+        // retrieveFromStorage (and only when a pre-existing version key made
+        // the migration block reachable), so the first save of a post-flip
+        // build left it absent and the NEXT retrieve re-ran the migration,
+        // wiping the deliberate false exactly once. saveToStorage now stamps
+        // the marker: anything it writes is post-flip by definition.
+        HighlighterSetCollection savedCollection;
+        savedCollection.setQuickHighlighterDefaults( { false, false } );
+
+        QSettings settings{ settingsPath, QSettings::IniFormat };
+        savedCollection.saveToStorage( settings );
+        settings.sync();
+
+        WHEN( "a fresh collection retrieves from it" )
+        {
+            HighlighterSetCollection loadedCollection;
+            loadedCollection.retrieveFromStorage( settings );
+
+            THEN( "the deliberate choice survives the save/retrieve round-trip" )
+            {
+                const auto defaults = loadedCollection.quickHighlighterDefaults();
+                CHECK_FALSE( defaults.ignoreCase );
+                CHECK_FALSE( defaults.wholeWord );
+            }
         }
     }
 }

--- a/tests/unit/optionsdialog_test.cpp
+++ b/tests/unit/optionsdialog_test.cpp
@@ -20,10 +20,12 @@
 #include <catch2/catch.hpp>
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QLabel>
 
+#include "highlighterset.h"
 #include "optionsdialog.h"
 #include "recentfiles.h"
 #include "savedsearches.h"
@@ -63,6 +65,29 @@ class ConfigurationScope {
     ThemeMode themeMode_;
     QString language_;
 };
+
+// Restore the process-wide HighlighterSetCollection quick-defaults when the
+// test ends, for the same reason ConfigurationScope exists: a REQUIRE abort
+// unwinds the stack, and updateConfigFromDialog() also persists the
+// collection, so the on-disk snapshot must be restored too.
+class QuickHighlighterDefaultsScope {
+  public:
+    QuickHighlighterDefaultsScope()
+        : defaults_( HighlighterSetCollection::get().quickHighlighterDefaults() )
+    {
+    }
+    ~QuickHighlighterDefaultsScope()
+    {
+        HighlighterSetCollection::get().setQuickHighlighterDefaults( defaults_ );
+        HighlighterSetCollection::get().save();
+    }
+
+    QuickHighlighterDefaultsScope( const QuickHighlighterDefaultsScope& ) = delete;
+    QuickHighlighterDefaultsScope& operator=( const QuickHighlighterDefaultsScope& ) = delete;
+
+  private:
+    QuickHighlighterDefaults defaults_;
+};
 } // namespace
 
 TEST_CASE( "Theme mode selector is disabled for the fixed Classic Dark style" )
@@ -72,6 +97,9 @@ TEST_CASE( "Theme mode selector is disabled for the fixed Classic Dark style" )
     // other UI tests do so get() does not throw.
     SavedSearches::getSynced();
     RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
 
     // The theme mode (Light/Dark/Auto) governs how "Modern" and "System"
     // adapt to the platform. "Classic Dark" is an inherently dark style, so
@@ -124,6 +152,9 @@ TEST_CASE( "Classic Dark pins the theme mode selector to Dark and restores it on
     // other UI tests do so get() does not throw.
     SavedSearches::getSynced();
     RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
 
     OptionsDialog dialog;
     dialog.show();
@@ -175,6 +206,9 @@ TEST_CASE( "Leaving Classic Dark restores a non-default theme mode selected befo
 {
     SavedSearches::getSynced();
     RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
 
     OptionsDialog dialog;
     dialog.show();
@@ -214,6 +248,9 @@ TEST_CASE( "Dialog initialized with Classic Dark shows the theme mode pinned to 
     // other UI tests do so get() does not throw.
     SavedSearches::getSynced();
     RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
 
     // Open the dialog as if the user had saved Classic Dark + Auto: the theme
     // selector must present itself pinned to Dark, not as the saved Auto mode.
@@ -261,6 +298,9 @@ TEST_CASE( "Applying the dialog while Classic Dark is pinned preserves the pre-p
 {
     SavedSearches::getSynced();
     RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
     ConfigurationScope configScope;
 
     // Deterministic start: saved as Classic Dark + Auto, so the dialog opens
@@ -338,6 +378,9 @@ TEST_CASE( "ConfigurationScope restores the persisted configuration on disk" )
 
         SavedSearches::getSynced();
         RecentFiles::getSynced();
+        // The dialog constructor also mirrors the color-label match defaults
+        // from HighlighterSetCollection; initialize it for the same reason.
+        HighlighterSetCollection::getSynced();
 
         // Normalize to a known baseline first so the assertions below are
         // deterministic regardless of what earlier tests left in the shared
@@ -372,4 +415,57 @@ TEST_CASE( "ConfigurationScope restores the persisted configuration on disk" )
     REQUIRE( Configuration::getSynced().style() == StyleManager::DarkStyleKey );
     REQUIRE( Configuration::getSynced().themeMode() == ThemeMode::Dark );
     REQUIRE( Configuration::getSynced().language() == QStringLiteral( "preseed_lang" ) );
+}
+
+TEST_CASE( "Color label match option defaults are configurable in the options dialog",
+           "[configuration]" )
+{
+    // updateDialogFromConfig() reads these persistables during construction;
+    // initialize them (and the highlighter collection) like the other tests do
+    // so get() does not throw.
+    SavedSearches::getSynced();
+    RecentFiles::getSynced();
+    // The dialog constructor also mirrors the color-label match defaults from
+    // HighlighterSetCollection; initialize it for the same reason.
+    HighlighterSetCollection::getSynced();
+
+    // The Apply path writes and saves both the process-wide Configuration and
+    // the HighlighterSetCollection; the scope guards restore in-memory and
+    // on-disk state so serial sibling tests are unaffected.
+    ConfigurationScope configScope;
+    QuickHighlighterDefaultsScope defaultsScope;
+
+    // Seed known values (the product defaults: ignore case on, whole word
+    // off). HighlighterSetCollection stays the single source of truth; the
+    // dialog only mirrors it.
+    HighlighterSetCollection::get().setQuickHighlighterDefaults( { true, false } );
+
+    OptionsDialog dialog;
+    dialog.show();
+
+    auto* ignoreCaseCheckBox
+        = dialog.findChild<QCheckBox*>( QStringLiteral( "colorLabelsIgnoreCaseCheckBox" ) );
+    auto* wholeWordCheckBox
+        = dialog.findChild<QCheckBox*>( QStringLiteral( "colorLabelsWholeWordCheckBox" ) );
+    REQUIRE( ignoreCaseCheckBox != nullptr );
+    REQUIRE( wholeWordCheckBox != nullptr );
+
+    // Initial state mirrors the stored defaults.
+    REQUIRE( ignoreCaseCheckBox->isChecked() );
+    REQUIRE_FALSE( wholeWordCheckBox->isChecked() );
+
+    // Toggle both, then Apply. Do NOT touch the style/language combos: a
+    // style change pops a modal restart prompt that hangs offscreen.
+    ignoreCaseCheckBox->setChecked( false );
+    wholeWordCheckBox->setChecked( true );
+
+    // Same pattern as the theme-mode Apply test above: invoke the Apply slot
+    // directly because QAbstractButton::click() blocks on the offscreen
+    // platform.
+    REQUIRE( QMetaObject::invokeMethod( &dialog, "updateConfigFromDialog",
+                                        Qt::DirectConnection ) );
+
+    const auto defaults = HighlighterSetCollection::get().quickHighlighterDefaults();
+    REQUIRE_FALSE( defaults.ignoreCase );
+    REQUIRE( defaults.wholeWord );
 }


### PR DESCRIPTION
## Summary
- **Folder tabs: Go to top / Follow file now work.** Both actions (menu, toolbar, T/F shortcuts) apply to the file shown in the folder main view — with focus on the main view or on a selected result row. The results view intentionally gets no effect: it is a cross-file static snapshot, so topping/following it is meaningless.
- **Follow actually tracks in folder mode.** The folder main view's per-file `LogData` already re-indexes on disk growth via FileWatcher, but nothing forwarded those notifications to the view; the current file's `loadingFinished`/`loadingProgressed` are now bound to `mainView_->updateData()` with a disconnect-before-rebind invariant across LRU cache swaps, and truncation clears that file's marks.
- **Color labels in preferences.** New "Color labels ignore case" / "Color labels whole word" checkboxes in Options → search options, sharing the existing `HighlighterSetCollection` single source of truth with the context-menu toggles. Defaults: ignore-case **on**, whole-word **off**; a one-shot marker migration brings the flipped default to existing installs without touching `whole_word` or post-migration explicit choices.
- Also fixed: the pending-open `loadingFinished` connection in `openFileInMainView` now lives only as long as the open it serves — a cached file's background re-index could previously hijack an in-flight open of a different file.

## Background
- Introduced by: folder tabs deliberately never register as a SignalMux document, while Go-to-top/Follow were only mux-routed; color-label defaults were context-menu-only with a compiled case-sensitive default that routine saves persisted forever.
- How to reproduce (actions): open a folder, search, select a result row, scroll the main view down, press T — nothing happens; press F — follow never engages.
- Root cause: (A) both actions dispatched into a null mux document on folder tabs, and the follow data flow (`LogData` re-index → view `updateData()`) was never wired; (B) no preferences surface for the persisted `quick_defaults`, and the old `ignore_case=false` key stuck.
- How to fix: (A) polymorphic `jumpToTop()/followSet(bool)/isFollowEnabled()` hooks on `AbstractCrawlerWidget`, dispatched via `currentDocument()` (the goToLine/textWrapSet channel); single-file behavior is bit-identical since the virtual reaches the same CrawlerWidget slots/signal the mux routed to. (B) OptionsDialog mirrors `HighlighterSetCollection` quick defaults; compiled default flipped to `ignoreCase=true`; one-shot `ignore_case_default_migrated` migration stamped by both retrieve and save.

## Tests
- New itests: folder-tab action/shortcut/focus routing and tab-switch Follow-state sync (`mainwindow_test.cpp`); widget-level dispatch, follow tail-tracking, and pending-open hijack regression (`foldercrawler_test.cpp`).
- New/updated unit tests: product defaults, one-shot migration incl. deliberate-choice survival, save/retrieve round-trip (`colorlabelsmanager_test.cpp`); checkbox mirroring + Apply persistence (`optionsdialog_test.cpp`); OptionsDialog guards now snapshot `HighlighterSetCollection` (`adb_ui_transport_test.cpp`).
- Verified locally (macOS, Qt6): full `ctest` 4/4 green — 510/510 unit, 152/152 integration, smoke; `lint_platform_fragile.py` clean. Not run locally: Qt5.12/Windows/Linux legs — left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Follow mode and “Jump to top” controls for folder views.
  * Folder views now stay synchronized with the Follow action when switching tabs.
  * Live file growth and updates are reflected in the main view.

* **Improvements**
  * Added options for case-sensitive and whole-word color-label matching.
  * Color-label matching now ignores case by default, with existing settings migrated safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->