### PR TITLE
PR #58 review follow-ups + CI stability hardening

### DIFF
--- a/.github/actions/agent-run-tests/action.yml
+++ b/.github/actions/agent-run-tests/action.yml
@@ -4,6 +4,16 @@ runs:
   using: "composite"
   steps:
 
+    - name: Configure Windows symbol path for crash stacks
+      if: runner.os == 'Windows'
+      shell: sh
+      run: |
+        # backward-cpp (StackWalker/dbghelp) builds its symbol search path from
+        # _NT_SYMBOL_PATH. Point it at the Microsoft public symbol server with
+        # a local downstream store so crash stacks printed on test failure can
+        # resolve OS/CRT frames instead of bare addresses.
+        echo "_NT_SYMBOL_PATH=SRV*C:\symbols*https://msdl.microsoft.com/download/symbols" >> "$GITHUB_ENV"
+
     - name: test
       shell: sh
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1209,17 +1209,27 @@ jobs:
             exit 1
           }
 
-      - name: Configure crash dumps for x86 integration tests
-        if: ${{ matrix.config.arch == 'x86' }}
+      - name: Configure crash dumps for Windows test binaries
         shell: pwsh
         run: |
+          # Every Windows leg (x86 and x64) gets WER LocalDumps so a hard crash
+          # in either test binary leaves an analyzable dump. DumpType=2 (full)
+          # with DumpCount=10 bounds the retained set to the 10 most recent
+          # dumps; the dump directory is only uploaded on test failure below.
           $dumpDir = Join-Path $env:GITHUB_WORKSPACE "build_root\crash_dumps"
           New-Item -ItemType Directory -Force -Path $dumpDir | Out-Null
 
-          $regPath = "HKCU\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\klogg_itests.exe"
-          reg add "$regPath" /v DumpFolder /t REG_EXPAND_SZ /d "$dumpDir" /f
-          reg add "$regPath" /v DumpCount /t REG_DWORD /d 10 /f
-          reg add "$regPath" /v DumpType /t REG_DWORD /d 2 /f
+          foreach ($exe in @("klogg_itests.exe", "klogg_tests.exe")) {
+            $regPath = "HKCU\Software\Microsoft\Windows\Windows Error Reporting\LocalDumps\$exe"
+            reg add "$regPath" /v DumpFolder /t REG_EXPAND_SZ /d "$dumpDir" /f
+            reg add "$regPath" /v DumpCount /t REG_DWORD /d 10 /f
+            reg add "$regPath" /v DumpType /t REG_DWORD /d 2 /f
+          }
+
+          # Pre-create the symbol downstream store used by _NT_SYMBOL_PATH (set
+          # in the agent-run-tests action) so dbghelp can cache OS/CRT symbols
+          # when backward-cpp/StackWalker symbolizes crash stacks.
+          New-Item -ItemType Directory -Force -Path "C:\symbols" | Out-Null
 
       - name: Stage MSVC AddressSanitizer runtime next to test binaries
         if: ${{ matrix.config.sanitizer == 'address' }}
@@ -1257,8 +1267,8 @@ jobs:
         id: run-tests
         continue-on-error: true
 
-      - name: Collect x86 diagnostics on test failure
-        if: ${{ matrix.config.arch == 'x86' && steps.run-tests.outcome == 'failure' }}
+      - name: Collect Windows diagnostics on test failure
+        if: ${{ steps.run-tests.outcome == 'failure' }}
         shell: pwsh
         run: |
           $workspace = $env:GITHUB_WORKSPACE
@@ -1275,9 +1285,11 @@ jobs:
             Copy-Item $dumpDir -Destination (Join-Path $diagRoot "crash_dumps") -Recurse -Force
           }
 
-          $itestsPdb = Join-Path $workspace "build_root\output\klogg_itests.pdb"
-          if ( Test-Path $itestsPdb ) {
-            Copy-Item $itestsPdb -Destination $diagRoot -Force
+          foreach ($name in @("klogg_itests.pdb", "klogg_tests.pdb")) {
+            $pdb = Join-Path $workspace "build_root\output\$name"
+            if ( Test-Path $pdb ) {
+              Copy-Item $pdb -Destination $diagRoot -Force
+            }
           }
 
           $timeRange = (Get-Date).AddHours(-2)
@@ -1288,11 +1300,14 @@ jobs:
             Select-Object TimeCreated, Id, LevelDisplayName, ProviderName, Message |
             Format-List | Out-File -FilePath (Join-Path $diagRoot "eventlog_system.txt") -Width 300
 
-      - name: Upload x86 diagnostics artifact
-        if: ${{ matrix.config.arch == 'x86' && steps.run-tests.outcome == 'failure' }}
+      - name: Upload Windows diagnostics artifact
+        if: ${{ steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
-          name: windows-x86-test-diagnostics
+          # Use label (defined on every config, including the asan leg which
+          # has no artifacts_id) so the diagnostics artifact name is unique per
+          # leg; artifacts_id would render as an empty segment on asan.
+          name: windows-${{ matrix.config.label }}-test-diagnostics
           path: '${{ github.workspace }}\build_root\diagnostics\**\*'
           if-no-files-found: warn
 

--- a/scripts/lint_header_self_contained.py
+++ b/scripts/lint_header_self_contained.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+Verifies that first-party headers are self-contained: each header must
+compile standalone (``-fsyntax-only`` on a TU that includes nothing but the
+header) with the same flags the real build uses.
+
+Background: PR #58's clang-tidy leg failed in CI because
+``src/ui/include/viewinterface.h`` used ``QString`` without including it.
+Every in-tree consumer happened to include ``<QString>`` first, so local
+builds (which never compile a header on its own) stayed green; only the CI
+changed-header clang-tidy sweep, which analyzes the header as its own
+translation unit, saw the error. This script closes that gap locally.
+
+Header set (mirrors the repo convention used by run_changed_clang_tidy.py):
+    * default        -- headers changed vs ``origin/master...HEAD`` under src/
+    * ``--all``      -- every tracked header under src/
+    * explicit paths -- exactly those files (may live anywhere)
+
+For each header a tiny .cpp is synthesized that includes only that header,
+and it is compiled with flags derived from ``build_root/compile_commands.json``:
+a representative translation unit from the same module (longest common path
+prefix with the header) contributes its define/std/warning flags; the source
+file and ``-o`` output are swapped out for the synthesized TU. Include paths
+(-I/-isystem/-iframework) are the UNION across all first-party units, because
+a module's own TUs do not always carry every include path its public headers
+need (``src/utils`` TUs compile without simdutf's -isystem path even though
+``simdutf_wrapper.h`` includes <simdutf.h>; only consuming modules add it).
+This is a lint, not a build: wider include resolution cannot hide the class of
+bug this gate targets (a missing #include of a first-party/Qt type). Because
+the real flags (``-Werror``, ``QT_NO_KEYWORDS``, ...) are reused, a header that
+passes here compiles under the same strictness CI applies.
+
+Requires a configured build: ``build_root/compile_commands.json`` must exist
+(run the cmake configure step from CLAUDE.md first).
+
+Usage:
+    python3 scripts/lint_header_self_contained.py                 # changed headers
+    python3 scripts/lint_header_self_contained.py --all           # all src/ headers
+    python3 scripts/lint_header_self_contained.py src/ui/include/viewinterface.h
+    python3 scripts/lint_header_self_contained.py --base origin/master...HEAD~1
+
+Exit codes:
+    0   All checked headers compiled standalone (or the header set was empty).
+    1   At least one header failed, or the compile database is unusable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+HEADER_EXTENSIONS = {".h", ".hh", ".hpp", ".hxx"}
+SOURCE_EXTENSIONS = {".c", ".cc", ".cpp", ".cxx"}
+
+# How many diagnostic lines of a failing compile to print. The first handful of
+# lines carries the actual "unknown type name" error; the rest is usually note
+# spam from template instantiation backtraces.
+MAX_DIAGNOSTIC_LINES = 12
+
+
+def git_output(root: Path, *arguments: str) -> bytes:
+    return subprocess.check_output(["git", "-C", str(root), *arguments])
+
+
+def changed_headers(root: Path, base: str) -> list[Path]:
+    """Headers changed vs ``base`` under src/ (deleted files excluded -- a
+    deleted header cannot be compiled and would break the gate)."""
+    output = git_output(
+        root,
+        "-c",
+        "core.quotePath=false",
+        "diff",
+        "--name-only",
+        "-z",
+        "--diff-filter=d",
+        base,
+        "--",
+        "src/",
+    )
+    return [
+        root / value.decode()
+        for value in output.split(b"\0")
+        if value and Path(value.decode()).suffix.lower() in HEADER_EXTENSIONS
+    ]
+
+
+def all_headers(root: Path) -> list[Path]:
+    """Every tracked header under src/ (git ls-files, so generated and
+    untracked files are not swept in)."""
+    output = git_output(
+        root, "-c", "core.quotePath=false", "ls-files", "-z", "--", "src/"
+    )
+    return [
+        root / value.decode()
+        for value in output.split(b"\0")
+        if value and Path(value.decode()).suffix.lower() in HEADER_EXTENSIONS
+    ]
+
+
+def entry_file(entry: dict[str, Any]) -> str:
+    if "file" in entry:
+        return str(entry["file"])
+    files = entry.get("files") or []
+    return str(files[0]) if files else ""
+
+
+def entry_arguments(entry: dict[str, Any]) -> list[str]:
+    """Command-line tokens of a compile database entry, whether the entry
+    uses the ``command`` string or the ``arguments`` array form."""
+    if "arguments" in entry:
+        return [str(token) for token in entry["arguments"]]
+    return shlex.split(str(entry.get("command", "")))
+
+
+def load_compile_database(build_dir: Path) -> list[dict[str, Any]]:
+    database_path = build_dir / "compile_commands.json"
+    if not database_path.is_file():
+        raise FileNotFoundError(
+            f"{database_path} not found; configure the build first "
+            f"(see the Build section of CLAUDE.md) so cmake generates "
+            f"compile_commands.json"
+        )
+    database = json.loads(database_path.read_text())
+    if not isinstance(database, list):
+        raise ValueError("compile_commands.json must contain a JSON array")
+    return database
+
+
+def first_party_units(
+    database: list[dict[str, Any]], source_root: Path
+) -> list[tuple[Path, Path, list[str]]]:
+    """(source path, working directory, command tokens) for translation units
+    whose source lives under the repo's src/ tree.
+
+    Autogen units (mocs_compilation.cpp etc.) live under build_root, so they
+    are excluded here; a real module TU is a better flag donor anyway because
+    it carries the module's own include directories.
+    """
+    source_root = source_root.resolve()
+    units: list[tuple[Path, Path, list[str]]] = []
+    for entry in database:
+        filename = entry_file(entry)
+        if not filename:
+            continue
+        path = Path(filename)
+        if not path.is_absolute():
+            path = Path(str(entry.get("directory", "."))) / path
+        path = path.resolve()
+        try:
+            path.relative_to(source_root)
+        except ValueError:
+            continue
+        if path.suffix.lower() not in SOURCE_EXTENSIONS:
+            continue
+        units.append(
+            (path, Path(str(entry.get("directory", "."))), entry_arguments(entry))
+        )
+    return units
+
+
+def representative_unit(
+    header: Path, units: list[tuple[Path, Path, list[str]]]
+) -> tuple[Path, Path, list[str]]:
+    """Pick the TU whose flags best fit ``header``: the one with the longest
+    common directory prefix (i.e. from the same module), so the module's -D/std
+    set is reused. Falls back to the first unit when nothing shares a prefix
+    (e.g. a header outside src/, such as a /tmp probe)."""
+    best: tuple[Path, Path, list[str]] | None = None
+    best_common = -1
+    for unit in units:
+        common = len(os.path.commonpath([unit[0], header]))
+        if common > best_common:
+            best_common = common
+            best = unit
+    if best is None:
+        raise ValueError("compile database contains no first-party translation units")
+    return best
+
+
+# Flags that take their include path as a separate token.
+_INCLUDE_PAIR_FLAGS = ("-I", "-isystem", "-iquote", "-iframework")
+# Joined forms (-I/path, -isystem/path, ...). -iquote/-iframework joined forms
+# are not emitted by cmake, so only -I/-isystem need the prefix match.
+_INCLUDE_JOINED_PREFIXES = ("-I", "-isystem")
+
+
+def include_flag_union(units: list[tuple[Path, Path, list[str]]]) -> list[str]:
+    """Union of every include-path flag across all first-party units.
+
+    A module's TUs do not necessarily carry every include path its public
+    headers rely on: src/utils/src/cpu_info.cpp compiles without simdutf's
+    -isystem path, yet src/utils/include/simdutf_wrapper.h includes
+    <simdutf.h> (only the consuming modules add it). Checking such a header
+    with only its own module's flags would report a spurious 'file not found'.
+    """
+    seen: set[str] = set()
+    union: list[str] = []
+    for _, _, arguments in units:
+        i = 1  # arguments[0] is the compiler
+        while i < len(arguments):
+            token = arguments[i]
+            if token in _INCLUDE_PAIR_FLAGS and i + 1 < len(arguments):
+                pair = token + "\0" + arguments[i + 1]
+                if pair not in seen:
+                    seen.add(pair)
+                    union.extend((token, arguments[i + 1]))
+                i += 2
+                continue
+            if any(
+                token.startswith(prefix) and len(token) > len(prefix)
+                for prefix in _INCLUDE_JOINED_PREFIXES
+            ):
+                if token not in seen:
+                    seen.add(token)
+                    union.append(token)
+            i += 1
+    return union
+
+
+def syntax_only_command(
+    unit: tuple[Path, Path, list[str]], probe: Path, extra_includes: list[str]
+) -> list[str]:
+    """Rewrite a real compile command into a -fsyntax-only check of ``probe``:
+    keep the compiler, all -D/-I/-isystem/-iframework/std/warning flags, and
+    drop the output/dependency-generation/source tokens. ``extra_includes``
+    (the cross-module include-path union) is appended last so headers whose own
+    module lacks a needed path still resolve it.
+
+    Anything not recognised is kept verbatim; only the tokens that would
+    conflict with a swapped-in source are stripped:
+      -o <file>            the real object path
+      -c <source>          the real source file
+      -MD/-MMD + -MF/-MT   depfile generation (meaningless with -fsyntax-only
+                           and -MT's target would dangle)
+    """
+    _, _, arguments = unit
+    if not arguments:
+        raise ValueError("compile database entry has an empty command")
+
+    stripped: list[str] = []
+    skip_next = False
+    for token in arguments[1:]:  # arguments[0] is the compiler
+        if skip_next:
+            skip_next = False
+            continue
+        if token in ("-o", "-c", "-MF", "-MT", "-MQ"):
+            skip_next = True
+            continue
+        if token in ("-MD", "-MMD"):
+            continue
+        stripped.append(token)
+
+    # The source file itself is normally the token right after -c, which the
+    # loop above already consumed; defensive: also drop any bare token that
+    # resolves to the original source path (some generators emit it without -c).
+    source = str(unit[0])
+    stripped = [token for token in stripped if token != source]
+
+    # Deduplicate the union against what the representative already carries.
+    present = set(stripped)
+    additional: list[str] = []
+    i = 0
+    while i < len(extra_includes):
+        token = extra_includes[i]
+        if token in _INCLUDE_PAIR_FLAGS and i + 1 < len(extra_includes):
+            if token not in present or extra_includes[i + 1] not in present:
+                additional.extend((token, extra_includes[i + 1]))
+            i += 2
+            continue
+        if token not in present:
+            additional.append(token)
+        i += 1
+
+    return [
+        arguments[0],
+        *stripped,
+        *additional,
+        "-fsyntax-only",
+        "-x",
+        "c++",
+        str(probe),
+    ]
+
+
+def check_header(
+    header: Path,
+    unit: tuple[Path, Path, list[str]],
+    probe_dir: Path,
+    extra_includes: list[str],
+) -> tuple[Path, bool, str]:
+    """Compile a TU that includes only ``header``; return (header, ok, output)."""
+    # One probe per header: probe files live in a shared tempdir, so the name
+    # must be unique per header.
+    probe = probe_dir / f"probe_{abs(hash(str(header))) & 0xFFFFFFFF:x}.cpp"
+    probe.write_text(f'#include "{header}"\n')
+    command = syntax_only_command(unit, probe, extra_includes)
+    completed = subprocess.run(
+        command,
+        cwd=str(unit[1]),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    return header, completed.returncode == 0, completed.stdout
+
+
+def first_diagnostics(output: str) -> str:
+    """The leading error/warning lines of a compiler invocation, for display."""
+    lines = [
+        line
+        for line in output.splitlines()
+        if " error:" in line or " warning:" in line
+    ]
+    if not lines:
+        # No recognisable diagnostics (e.g. a crash): fall back to the head of
+        # the raw output so the failure is still actionable.
+        lines = output.splitlines()
+    return "\n".join(lines[:MAX_DIAGNOSTIC_LINES])
+
+
+def main(argv: list[str]) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "headers",
+        nargs="*",
+        type=Path,
+        help="explicit header files to check (overrides --all/--base)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="check every tracked header under src/ instead of only changed ones",
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/master...HEAD",
+        help="git revision range to diff for changed headers "
+        "(default: %(default)s)",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=repo_root / "build_root",
+        help="build directory containing compile_commands.json "
+        "(default: %(default)s)",
+    )
+    parser.add_argument("--jobs", type=int, default=os.cpu_count() or 1)
+    args = parser.parse_args(argv)
+
+    if args.headers:
+        headers = [
+            path if path.is_absolute() else (Path.cwd() / path)
+            for path in args.headers
+        ]
+        headers = [path.resolve() for path in headers]
+        missing = [str(path) for path in headers if not path.is_file()]
+        if missing:
+            print(f"error: header not found: {', '.join(missing)}", file=sys.stderr)
+            return 1
+    elif args.all:
+        headers = all_headers(repo_root)
+    else:
+        try:
+            headers = changed_headers(repo_root, args.base)
+        except subprocess.CalledProcessError as error:
+            print(f"error: git diff failed for base {args.base!r}: {error}", file=sys.stderr)
+            return 1
+
+    if not headers:
+        print("header-self-contained: no headers to check")
+        return 0
+
+    try:
+        database = load_compile_database(args.build_dir)
+        units = first_party_units(database, (repo_root / "src").resolve())
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    if not units:
+        print(
+            "error: compile database contains no first-party translation units",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures = 0
+    extra_includes = include_flag_union(units)
+    with tempfile.TemporaryDirectory(prefix="klogg-header-lint-") as temp:
+        probe_dir = Path(temp)
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(1, args.jobs)
+        ) as executor:
+            futures = [
+                executor.submit(
+                    check_header,
+                    header,
+                    representative_unit(header, units),
+                    probe_dir,
+                    extra_includes,
+                )
+                for header in headers
+            ]
+            # Report in input order (not completion order) so output is stable
+            # across runs and diffable in CI logs.
+            for future in futures:
+                header, ok, output = future.result()
+                rel = header
+                try:
+                    rel = header.relative_to(repo_root)
+                except ValueError:
+                    pass
+                if ok:
+                    print(f"PASS {rel}")
+                else:
+                    failures += 1
+                    print(f"FAIL {rel}")
+                    diagnostics = first_diagnostics(output)
+                    if diagnostics:
+                        for line in diagnostics.splitlines():
+                            print(f"    {line}")
+                    print()
+
+    if failures:
+        print(f"header-self-contained: {failures} of {len(headers)} header(s) failed")
+        return 1
+    print(f"header-self-contained: OK ({len(headers)} header(s) compile standalone)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/logdata/include/logdata.h
+++ b/src/logdata/include/logdata.h
@@ -165,6 +165,17 @@ class LogData : public SearchableLogData {
     QMetaObject::Connection workerIndexingFinishedConnection_;
     QMetaObject::Connection workerCheckFileChangesFinishedConnection_;
     bool shuttingDown_{ false };
+
+    // Set when this instance has actually handed its file to the FileWatcher
+    // singleton (only on successful indexing). The destructor consults it to
+    // deregister exactly the files this instance registered: FileWatcher is a
+    // process-wide singleton that outlives every LogData, and in the serial
+    // integration-test binary an unbalanced addFile leaves dead temp paths in
+    // the watch list, so the 1s polling timer keeps generating cross-test
+    // file-changed traffic for files that no longer exist. Calling removeFile
+    // for a file that was never added is equally undesirable because
+    // EfswFileWatcher logs "The file is not watched" for unknown paths.
+    bool fileWatcherRegistered_{ false };
 };
 
 #endif

--- a/src/logdata/src/fileholder.cpp
+++ b/src/logdata/src/fileholder.cpp
@@ -1,7 +1,5 @@
 #include "fileholder.h"
 
-#include <filewatcher.h>
-
 #ifdef Q_OS_WIN
 #include <fcntl.h>
 #include <windows.h>
@@ -78,14 +76,14 @@ FileHolder::~FileHolder()
 {
     LOG_INFO << "destroy file holder "  << reinterpret_cast<void*>(this) << " for " << file_name_;
 
-    try {
-        // Remove the current file from the watch list
-        if ( attached_file_ ) {
-            FileWatcher::getFileWatcher().removeFile( file_name_ );
-        }
-    } catch ( const std::exception& e ) {
-        LOG_ERROR << "Failed to destroy FileHolder: " << e.what();
-    }
+    // FileWatcher deregistration is owned by LogData (~LogData, guarded by its
+    // fileWatcherRegistered_ flag) and must NOT be repeated here: this dtor
+    // used to call removeFile whenever an inner QFile existed, which both
+    // double-removed successfully watched files (the second removeFile hits
+    // EfswFileWatcher's "The file is not watched" warning) and removed files
+    // that were never registered at all (interrupted/failed indexing reaches
+    // here with an open handle but no addFile). LogData is the only owner of
+    // FileHolder and the only component that knows whether addFile happened.
 }
 
 FileId FileHolder::getFileId()

--- a/src/logdata/src/logdata.cpp
+++ b/src/logdata/src/logdata.cpp
@@ -39,6 +39,7 @@
 // This file implements LogData, the content of a log file.
 
 #include <algorithm>
+#include <exception>
 #include <limits>
 #include <numeric>
 #include <qregularexpression.h>
@@ -112,6 +113,32 @@ LogData::~LogData()
     // A queued file-changed or worker callback may already be posted for this
     // object. Purge them before this instance is destroyed.
     QCoreApplication::removePostedEvents( this );
+
+    // Deregister from the FileWatcher singleton. The watcher outlives every
+    // LogData (it is never destroyed), so without this the watch list would
+    // keep every file ever opened for the lifetime of the process; in the
+    // serial integration-test binary that means dead temp paths piling up and
+    // the polling timer emitting cross-test file-changed traffic.
+    //
+    // The removal is keyed on actual registration (fileWatcherRegistered_ is
+    // only set after a successful indexing) because EfswFileWatcher::removeFile
+    // logs a warning for unknown paths. removeFile() itself is safe here: it
+    // only posts a task to the watcher's SerialExecutor, which is alive for
+    // the whole process and serializes this behind the matching addFile.
+    //
+    // Known limitation (pre-existing): if two LogData instances watch the same
+    // file, addFile dedups to a single watch entry, so the first destructor
+    // removes the watch for both. Opening the same file in two tabs therefore
+    // loses change notifications on the surviving tab. That trade-off predates
+    // this guard and is preferable to leaking an entry per closed tab.
+    if ( fileWatcherRegistered_ ) {
+        fileWatcherRegistered_ = false;
+        try {
+            FileWatcher::getFileWatcher().removeFile( indexingFileName_ );
+        } catch ( const std::exception& error ) {
+            LOG_ERROR << "Failed to deregister file from watcher: " << error.what();
+        }
+    }
 }
 
 void LogData::setPrefilter( const QString& prefilterPattern )
@@ -240,6 +267,9 @@ void LogData::indexingFinished( LoadingStatus status )
 
     if ( status == LoadingStatus::Successful ) {
         FileWatcher::getFileWatcher().addFile( indexingFileName_ );
+        // Paired with the guarded removeFile in ~LogData; the flag, not the
+        // FileHolder state, is the source of truth for watcher registration.
+        fileWatcherRegistered_ = true;
 
         // Update the modified date/time if the file exists
         lastModifiedDate_ = QDateTime();

--- a/src/ui/include/foldercrawlerwidget.h
+++ b/src/ui/include/foldercrawlerwidget.h
@@ -421,8 +421,13 @@ class FolderCrawlerWidget : public QWidget,
     // highlight); guards the StyleChange palette re-capture so the error
     // palette is never snapshotted as the "default".
     bool statusErrorActive_ = false;
-    // Encoding override applied via setEncoding (nullopt = auto-detect);
-    // reset when the main-view file changes (the override is per shown file).
+    // Encoding override applied via setEncoding (nullopt = auto-detect). The
+    // override belongs to the DISPLAYED file and resets at the swap point --
+    // when the new file actually replaces the displayed one (cache-hit swap or
+    // async completion in openFileInMainView), not when an open is merely
+    // requested: an async open leaves the previous file on screen for the
+    // whole load window, and canceling that open must find its override still
+    // pinned.
     std::optional<int> encodingMibOverride_;
     // View that had focus when the QuickFind bar opened (enteringQuickFind);
     // restored on exitingQuickFind. Mirrors CrawlerWidget::qfSavedFocus_.

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -260,6 +260,10 @@ class MainWindow : public QMainWindow {
     // Re-registers the folder tab's QuickFind selector with the mux when the
     // folder's searchable set changes (pane create/switch/close).
     void onFolderSearchablesChanged();
+    // Currency-guarded uplink for a folder tab's followModeChanged: only the
+    // CURRENT tab may drive the shared followAction (a hidden folder still
+    // emits when its async main-view open completes in the background).
+    void onFolderFollowModeChanged( bool follow );
     // Disable every file-specific menu action (used for folder / no-tab states).
     void disableFileSpecificActions();
     void showInfoLabels( bool show );

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -37,6 +37,7 @@
 #include <QSplitter>
 #include <QToolButton>
 #include <QTabWidget>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include "qtcompat/qtcompat.h"
@@ -489,6 +490,20 @@ FolderCrawlerWidget::FolderCrawlerWidget( QWidget* parent )
 
 FolderCrawlerWidget::~FolderCrawlerWidget()
 {
+    // Interrupt the folder search engine BEFORE member destruction begins.
+    // engine_ is QObject-owned, so ~FolderSearchEngine (which joins the worker
+    // thread) only runs later, inside ~QObject -- AFTER our members have been
+    // destroyed. Joining alone would let an in-flight scan run to completion
+    // against half-destroyed state: the worker streams fileGroupReady/
+    // searchProgressed signals whose slots read panes_ and the results models.
+    // interrupt() makes the scan wind down between files instead, so the
+    // eventual join returns promptly with the widget's state still intact.
+    // Same discipline as the QuickFind join below: stop the background work
+    // before the members it reads are released.
+    if ( engine_ != nullptr ) {
+        engine_->interrupt();
+    }
+
     // Join every view's in-flight QuickFind worker BEFORE the data-source members
     // are released. A FolderFilteredView's QuickFind worker is a QThreadPool task
     // that holds a `const AbstractLogData&` into the pane's FolderSearchResults
@@ -1287,7 +1302,23 @@ void FolderCrawlerWidget::bindMainViewDataSignals()
     // CrawlerWidget::fileChangedHandler clearing all marks on Truncated).
     mainDataLoadingFinishedConn_
         = connect( currentMainData_.get(), &SearchableLogData::loadingFinished, this,
-                   [ this ]( LoadingStatus ) { mainView_->updateData(); } );
+                   [ this ]( LoadingStatus ) {
+                       mainView_->updateData();
+                       // Single-file parity (CrawlerWidget::loadingFinishedHandler,
+                       // crawlerwidget.cpp:934 refreshes overview_ on every
+                       // loadingFinished): when the followed file grows, the
+                       // Overview's linesInFile_ must track the new total or
+                       // every mapping that divides by it (viewport box,
+                       // click-to-jump, match/mark tick positions) compresses
+                       // into the pre-growth range. Visibility-guarded like
+                       // refreshFileOverview; the finished-only cadence matches
+                       // single-file, and append-only growth does not change
+                       // match/mark ticks, so the heavier refreshFileOverview
+                       // (re-collecting matches + marks) is unnecessary here.
+                       if ( overview_.isVisible() ) {
+                           overview_.updateData( currentMainData_->getNbLine() );
+                       }
+                   } );
     mainDataLoadingProgressedConn_
         = connect( currentMainData_.get(), &SearchableLogData::loadingProgressed, this,
                    [ this ]( int ) { mainView_->updateData(); } );
@@ -1858,12 +1889,6 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
         return;
     }
 
-    // A different file is about to be shown: the encoding override belongs to
-    // the previously displayed file, so it resets to auto-detect (the new
-    // file's detected codec). Mirrors single-file, where the override lives
-    // and dies with the one document in the tab.
-    encodingMibOverride_.reset();
-
     // Cached (recently opened) -> swap instantly. Promote to most-recently-used
     // so the LRU eviction policy keeps it resident.
     const auto it = mainViewCache_.find( filePath );
@@ -1879,6 +1904,16 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
                                     it.value().second );
         currentMainData_ = it.value().first;
         currentMainFilePath_ = filePath;
+        // The encoding override belongs to the DISPLAYED file and dies at the
+        // swap point: now that the cached file has replaced it, reset to
+        // auto-detect (the swapped-in file keeps the codec it was cached
+        // with). Mirrors single-file, where the override lives and dies with
+        // the one document in the tab. This must NOT happen any earlier (e.g.
+        // at open-request time): an async open leaves the previously opened
+        // file on screen for the whole load window, and canceling that open
+        // (re-clicking the displayed file's row) must find its override still
+        // pinned -- an early reset would silently drop it to auto-detect.
+        encodingMibOverride_.reset();
         lastMainViewLine_ = localLine;
         mainView_->setDataSource( currentMainData_.get() );
         // Re-point the follow/refresh data-flow at the swapped-in file (the
@@ -1922,7 +1957,7 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
     // half-indexed state.
     pendingMainDataConn_
         = connect( pendingMainData_.get(), &SearchableLogData::loadingFinished, this,
-                   [ this ]( LoadingStatus ) {
+                   [ this ]( LoadingStatus status ) {
                        if ( pendingMainData_ == nullptr ) {
                            return;
                        }
@@ -1934,6 +1969,34 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
                        // are the long-lived ones bindMainViewDataSignals
                        // installs below.
                        disconnect( pendingMainDataConn_ );
+                       if ( status != LoadingStatus::Successful ) {
+                           // Defensive (no test: there is no deterministic way
+                           // to force an indexer exception). Unreadable or
+                           // deleted files still report Successful with 0 lines
+                           // -- the indexer treats them as empty
+                           // (logdataworker.cpp:616-637) -- so this guard only
+                           // covers the indexer-exception Interrupted path. Do
+                           // NOT promote the failed load: keep the previous
+                           // file displayed (a failed FIRST open leaves the
+                           // placeholder, a supported state), drop the pending
+                           // state, and skip caching/jumping/emitting.
+                           LOG_WARNING << "FolderCrawlerWidget: open of "
+                                       << pendingMainFilePath_ << " finished with status "
+                                       << static_cast<int>( status ) << "; keeping the "
+                                          "previously displayed file";
+                           // Defer the LogData destruction past the current
+                           // emission: this lambda runs inside
+                           // LogData::indexingFinished's Q_EMIT, and resetting
+                           // the last shared_ptr ref here would free the object
+                           // whose indexingFinished epilogue
+                           // (finishOperationAndStartNext, logdata.cpp:286) is
+                           // still on the stack.
+                           auto abandonedData = std::move( pendingMainData_ );
+                           pendingMainFilePath_.clear();
+                           QTimer::singleShot( 0, this,
+                                               [ abandonedData ]() mutable { abandonedData.reset(); } );
+                           return;
+                       }
                        currentMainData_ = pendingMainData_;
                        currentMainFilePath_ = pendingMainFilePath_;
                        lastMainViewLine_ = pendingJumpLine_;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -2324,9 +2324,16 @@ void MainWindow::currentTabChanged( int index )
                 // Follow-state uplink (single-file parity with the mux-routed
                 // CrawlerWidget::followModeChanged): the folder main view's
                 // follow changes (elastic-hook disengage on scroll-up, ...) keep
-                // the Follow action's checked state in sync.
+                // the Follow action's checked state in sync. Routed through the
+                // currency-guarded onFolderFollowModeChanged (same precedent as
+                // onFolderSearchablesChanged): the folder widget stays alive in
+                // the tab widget while hidden, and an async main-view open
+                // completing in the background emits followModeChanged via
+                // selectInMainView -> disableFollow -- an unguarded connection
+                // would uncheck the shared followAction, whose toggled dispatch
+                // then kills the CURRENT tab's follow mode.
                 connect( folder_widget, &FolderCrawlerWidget::followModeChanged, this,
-                         &MainWindow::changeFollowMode, Qt::UniqueConnection );
+                         &MainWindow::onFolderFollowModeChanged, Qt::UniqueConnection );
             }
 
             // Routes to the folder via the connection above.
@@ -3234,6 +3241,21 @@ void MainWindow::onFolderSearchablesChanged()
     }
     // Rebuild the mux's searchable registry from the folder's live panes.
     quickFindMux_.registerSelector( folderWidget );
+}
+
+void MainWindow::onFolderFollowModeChanged( bool follow )
+{
+    auto* folderWidget = qobject_cast<FolderCrawlerWidget*>( sender() );
+    // Only the CURRENT tab owns the shared followAction: a background
+    // folder's follow transition (async open completing -> selectInMainView
+    // -> disableFollow) must not uncheck the action, whose toggled dispatch
+    // would otherwise kill the current document's follow mode. Same guard
+    // shape as onFolderSearchablesChanged.
+    if ( folderWidget == nullptr
+         || dynamic_cast<AbstractCrawlerWidget*>( folderWidget ) != currentDocument() ) {
+        return;
+    }
+    changeFollowMode( follow );
 }
 
 // Update the top info line from the session

--- a/tests/scripts/test_lint_header_self_contained.py
+++ b/tests/scripts/test_lint_header_self_contained.py
@@ -1,0 +1,182 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+SCRIPT = ROOT / "scripts" / "lint_header_self_contained.py"
+SPEC = importlib.util.spec_from_file_location("lint_header_self_contained", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def make_unit(source: str, directory: str, arguments: list[str]):
+    return (
+        pathlib.Path(source),
+        pathlib.Path(directory),
+        ["/usr/bin/c++", *arguments],
+    )
+
+
+class EntryParsingTest(unittest.TestCase):
+    def test_entry_file_supports_command_and_files_forms(self):
+        self.assertEqual(MODULE.entry_file({"file": "/a/b.cpp"}), "/a/b.cpp")
+        self.assertEqual(MODULE.entry_file({"files": ["/a/b.cpp"]}), "/a/b.cpp")
+        self.assertEqual(MODULE.entry_file({}), "")
+
+    def test_entry_arguments_splits_command_strings(self):
+        entry = {"command": '/usr/bin/c++ -DFOO="a b" -Isrc -c foo.cpp'}
+        self.assertEqual(
+            MODULE.entry_arguments(entry),
+            ["/usr/bin/c++", '-DFOO=a b', "-Isrc", "-c", "foo.cpp"],
+        )
+        entry = {"arguments": ["c++", "-DFOO", "foo.cpp"]}
+        self.assertEqual(MODULE.entry_arguments(entry), ["c++", "-DFOO", "foo.cpp"])
+
+
+class FirstPartyUnitsTest(unittest.TestCase):
+    def test_keeps_only_src_tree_sources(self):
+        database = [
+            {
+                "directory": "/ws/build",
+                "file": "/ws/src/ui/src/mainwindow.cpp",
+                "command": "c++ -c mainwindow.cpp",
+            },
+            {
+                "directory": "/ws/build",
+                "file": "/ws/build/generated/mocs_compilation.cpp",
+                "command": "c++ -c mocs_compilation.cpp",
+            },
+            {
+                "directory": "/ws/build",
+                "file": "/ws/src/ui/src/relative.cpp",
+                "command": "c++ -c relative.cpp",
+            },
+        ]
+        units = MODULE.first_party_units(database, pathlib.Path("/ws/src"))
+        sources = [str(unit[0]) for unit in units]
+        self.assertEqual(len(units), 2)
+        self.assertNotIn("mocs_compilation.cpp", " ".join(sources))
+
+    def test_relative_paths_resolve_against_entry_directory(self):
+        database = [
+            {
+                "directory": "/ws/build",
+                "file": "../src/logdata/src/logdata.cpp",
+                "command": "c++ -c logdata.cpp",
+            }
+        ]
+        units = MODULE.first_party_units(database, pathlib.Path("/ws/src"))
+        self.assertEqual(str(units[0][0]), "/ws/src/logdata/src/logdata.cpp")
+
+
+class RepresentativeUnitTest(unittest.TestCase):
+    def test_picks_same_module_unit(self):
+        units = [
+            make_unit("/ws/src/ui/src/mainwindow.cpp", "/ws/build", ["-DUI"]),
+            make_unit("/ws/src/logdata/src/logdata.cpp", "/ws/build", ["-DLOGDATA"]),
+        ]
+        _, _, arguments = MODULE.representative_unit(
+            pathlib.Path("/ws/src/logdata/include/logdata.h"), units
+        )
+        self.assertEqual(arguments, ["/usr/bin/c++", "-DLOGDATA"])
+
+    def test_empty_units_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "no first-party"):
+            MODULE.representative_unit(pathlib.Path("/ws/src/x.h"), [])
+
+
+class IncludeFlagUnionTest(unittest.TestCase):
+    def test_unions_pair_and_joined_forms_without_duplicates(self):
+        units = [
+            make_unit(
+                "/ws/src/a/a.cpp",
+                "/ws/build",
+                ["-I", "/qt/include", "-I/local", "-isystem", "/boost", "-DNDEBUG"],
+            ),
+            make_unit(
+                "/ws/src/b/b.cpp",
+                "/ws/build",
+                ["-I", "/qt/include", "-I/other", "-isystem/boost"],
+            ),
+        ]
+        union = MODULE.include_flag_union(units)
+        # Pair forms keep their value token; joined forms stay one token.
+        self.assertEqual(
+            union,
+            ["-I", "/qt/include", "-I/local", "-isystem", "/boost", "-I/other", "-isystem/boost"],
+        )
+        # -D flags are not include paths and must not leak into the union.
+        self.assertNotIn("-DNDEBUG", union)
+
+
+class SyntaxOnlyCommandTest(unittest.TestCase):
+    def test_strips_output_depfile_and_source_tokens(self):
+        unit = make_unit(
+            "/ws/src/ui/src/mainwindow.cpp",
+            "/ws/build",
+            [
+                "-DQT_NO_KEYWORDS",
+                "-std=c++17",
+                "-MD",
+                "-MT",
+                "target",
+                "-MF",
+                "dep.d",
+                "-o",
+                "mainwindow.cpp.o",
+                "-c",
+                "/ws/src/ui/src/mainwindow.cpp",
+            ],
+        )
+        command = MODULE.syntax_only_command(
+            unit, pathlib.Path("/tmp/probe.cpp"), ["-I", "/extra"]
+        )
+        self.assertEqual(command[0], "/usr/bin/c++")
+        for banned in ("-MD", "-MT", "-MF", "-o", "-c", "dep.d", "mainwindow.cpp.o"):
+            self.assertNotIn(banned, command)
+        self.assertNotIn("/ws/src/ui/src/mainwindow.cpp", command)
+        self.assertIn("-DQT_NO_KEYWORDS", command)
+        self.assertIn("-std=c++17", command)
+        self.assertEqual(command[-4:], ["-fsyntax-only", "-x", "c++", "/tmp/probe.cpp"])
+
+    def test_dedupes_union_against_carried_flags(self):
+        unit = make_unit(
+            "/ws/src/a/a.cpp", "/ws/build", ["-I", "/qt/include", "-I/local"]
+        )
+        command = MODULE.syntax_only_command(
+            unit,
+            pathlib.Path("/tmp/probe.cpp"),
+            ["-I", "/qt/include", "-I", "/new", "-I/local2"],
+        )
+        self.assertEqual(command.count("-I"), len([t for t in command if t == "-I"]))
+        joined = " ".join(command)
+        self.assertEqual(joined.count("/qt/include"), 1)
+        self.assertIn("/new", command)
+        self.assertIn("-I/local2", command)
+
+    def test_empty_command_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "empty command"):
+            MODULE.syntax_only_command(
+                (pathlib.Path("/x.cpp"), pathlib.Path("/ws"), []),
+                pathlib.Path("/tmp/probe.cpp"),
+                [],
+            )
+
+
+class FirstDiagnosticsTest(unittest.TestCase):
+    def test_extracts_error_and_warning_lines(self):
+        output = "noise\n/x.h:1:2: error: unknown type name 'QString'\nmore\n/y.h:2:3: warning: unused\n"
+        diagnostics = MODULE.first_diagnostics(output)
+        self.assertIn("error:", diagnostics)
+        self.assertIn("warning:", diagnostics)
+        self.assertNotIn("noise", diagnostics)
+
+    def test_falls_back_to_raw_output_head(self):
+        output = "line1\nline2\n"
+        self.assertEqual(MODULE.first_diagnostics(output), "line1\nline2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -402,6 +402,10 @@ TEST_CASE( "FolderCrawlerWidget selecting a result opens the source file", "[fol
 
     REQUIRE( waitFor( [ & ]() { return !widget.currentMainFilePath().isEmpty(); } ) );
     REQUIRE( widget.currentMainFilePath() == a );
+    // Settle after the load completes before teardown (CLAUDE.md
+    // close-after-load pattern): the indexer worker may still be unwinding
+    // after the main-thread completion signal fires.
+    QTest::qWait( 200 );
 }
 
 TEST_CASE( "FolderCrawlerWidget main view mark-navigation is safe without filtered data",
@@ -3811,4 +3815,179 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
     }
     REQUIRE( waitFor( [ & ]() { return widget.mainView()->getTopLine() > topBefore; },
                       15000 ) );
+}
+
+TEST_CASE( "FolderCrawlerWidget canceling a pending open keeps the displayed file's encoding override",
+           "[folder]" )
+{
+    // Regression for the reset PLACEMENT in openFileInMainView: the encoding
+    // override is wiped at the START of an async open (the
+    // `encodingMibOverride_.reset()` ahead of the cache/pending branches),
+    // while the previously opened file is still the one displayed. Sequence:
+    // A is displayed with an explicit override; the user clicks uncached B
+    // (async open starts, the override is wiped while A is still on screen);
+    // the user re-clicks A's row before B finishes (the same-file fast path
+    // abandons B's pending open and keeps A). A never stopped being the
+    // displayed file, yet encodingMib() reports nullopt, so the Encoding menu
+    // falls back to "Auto-detect" for a file the user explicitly pinned. The
+    // override belongs to the DISPLAYED file and must die at the swap point
+    // (when the new file actually replaces it), not when an open is merely
+    // requested.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "a.log", 200, { 0 } );
+    const QString b = makeFile( dir, "b.log", 200, { 0 } );
+
+    FolderCrawlerWidget widget;
+    widget.resize( 800, 600 );
+    widget.show();
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    // Resolve each file's match row dynamically (group headers shift row
+    // indices); the same lookup the other multi-file tests use.
+    const auto matchRowForFile = [ & ]( const QString& path ) -> LineNumber {
+        const auto total = widget.folderResults()->getNbLine().get();
+        for ( uint64_t i = 0; i < total; ++i ) {
+            const LineNumber row{ i };
+            if ( widget.folderResults()->lineKind( row ) == LineKind::Data
+                 && widget.folderResults()->sourceForLine( row ).filePath == path ) {
+                return row;
+            }
+        }
+        FAIL( "matchRowForFile: no matching result row found for the requested file" );
+        return 0_lnum; // unreachable; FAIL aborts the test case
+    };
+
+    // Open A (uncached -> async) and pin an explicit encoding override on it.
+    // ISO 8859-1 (Latin-1): the ASCII fixture decodes fine under it, and it
+    // differs from the detected UTF-8 so the override is a real state change.
+    constexpr int latin1Mib = 4;
+    widget.selectResultRow( matchRowForFile( a ) );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 ); // settle per CLAUDE.md
+    widget.setEncoding( latin1Mib );
+    REQUIRE( widget.encodingMib().has_value() );
+    REQUIRE( *widget.encodingMib() == latin1Mib );
+
+    // Click B (uncached -> async open starts) and IMMEDIATELY re-click A, with
+    // NO event-loop turn in between: B's loadingFinished is a queued signal,
+    // so B's open is still pending when A's row is clicked, and the same-file
+    // fast path cancels it (A is still currentMainFilePath_). This is the
+    // cancel-a-pending-open sequence from the bug report, made deterministic.
+    widget.selectResultRow( matchRowForFile( b ) );
+    widget.selectResultRow( matchRowForFile( a ) );
+    REQUIRE( widget.currentMainFilePath() == a );
+
+    // The displayed file never changed, so its override must still be pinned.
+    // RED: the reset at the start of B's open already wiped it (nullopt).
+    REQUIRE( widget.encodingMib().has_value() );
+    REQUIRE( *widget.encodingMib() == latin1Mib );
+
+    // Settle so any late/queued side effects of the canceled open land, then
+    // re-assert: the override must survive the full unwind of the cancel, not
+    // just the synchronous fast path.
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+    REQUIRE( widget.encodingMib().has_value() );
+    REQUIRE( *widget.encodingMib() == latin1Mib );
+}
+
+TEST_CASE( "FolderCrawlerWidget follow growth refreshes the overview line count", "[folder]" )
+{
+    // Regression for the follow data-flow in bindMainViewDataSignals: its
+    // loadingFinished lambda calls only mainView_->updateData(), so when the
+    // followed file grows, the Overview model keeps the OPEN-TIME total in
+    // linesInFile_ (set once by refreshFileOverview). Single-file refreshes it
+    // on every loadingFinished (CrawlerWidget::loadingFinishedHandler,
+    // crawlerwidget.cpp:934: overview_.updateData( logData_->getNbLine() )).
+    // A stale total skews every Overview mapping that divides by linesInFile_:
+    // the viewport box (getViewLines), click-to-jump (fileLineFromY), and the
+    // match/mark tick positions (yFromFileLine) all compress into the
+    // pre-growth range, so the grown tail has no minimap presence.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "a.log", 200, { 0, 100 } );
+
+    FolderCrawlerWidget widget;
+    widget.resize( 800, 600 );
+    widget.show();
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    REQUIRE( waitFor(
+        [ & ]() { return widget.mainView()->verticalScrollBar()->maximum() > 0; } ) );
+    QTest::qWait( 200 ); // settle per CLAUDE.md
+
+    // The overview follows Configuration (default visible); refreshFileOverview
+    // no-ops when hidden, which would make the baseline below meaningless.
+    REQUIRE( widget.overview()->isVisible() );
+
+    // Overview exposes no getter for its total line count (linesInFile_ is
+    // private), but the total is recoverable EXACTLY through the public
+    // coordinate mapping: fileLineFromY(y) = y * linesInFile_ / height_
+    // (overview.cpp, unclamped), so after updateView(H) the readout
+    // fileLineFromY(H) == linesInFile_ for any H > 0 (the *H and /H cancel in
+    // exact integer math). updateView also lifts the model out of its initial
+    // zero height so the division is always defined.
+    const auto overviewLinesInFile = []( FolderCrawlerWidget& w ) -> uint64_t {
+        Overview* const ov = w.overview();
+        REQUIRE( ov != nullptr );
+        ov->updateView( 1000 );
+        return ov->fileLineFromY( 1000 ).get();
+    };
+
+    // Baseline: the open-time total (refreshFileOverview ->
+    // overview_.updateData( currentMainData_->getNbLine() )).
+    REQUIRE( overviewLinesInFile( widget ) == uint64_t{ 200 } );
+
+    // Enable follow through the same dispatch MainWindow uses (same as the
+    // follow-tail test): the view jumps to the bottom of the 200-line file.
+    static_cast<AbstractCrawlerWidget*>( &widget )->followSet( true );
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->isFollowEnabled(); } ) );
+    LineNumber topBefore = 0_lnum;
+    REQUIRE( waitFor( [ & ]() {
+        topBefore = widget.mainView()->getTopLine();
+        return topBefore.get() > 0;
+    } ) );
+
+    // Grow the file by 100 lines, then deliver the change notification through
+    // the same entry point the FileWatcher uses (queued FileWatcher::fileChanged
+    // -> LogData::fileChangedOnDisk). Invoking the slot directly keeps the test
+    // deterministic -- watcher timing (1s polling on Windows/macOS, efsw on
+    // Linux) is too slow on loaded CI runners; what this test pins is that the
+    // follow completion refreshes the OVERVIEW, not only the view.
+    {
+        QFile f( a );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
+        QByteArray payload;
+        for ( int i = 0; i < 100; ++i ) {
+            payload.append( "appended line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+        f.flush();
+    }
+
+    auto* mainData = const_cast<AbstractLogData*>(
+        AbstractLogView::access_by<FolderViewTestAccess>::logData( widget.mainView() ) );
+    REQUIRE( mainData != nullptr );
+    QMetaObject::invokeMethod( mainData, "fileChangedOnDisk", Qt::QueuedConnection,
+                               Q_ARG( QString, widget.currentMainFilePath() ) );
+
+    // Wait for the re-index + view refresh to land (follow tracking the new
+    // tail proves the re-index's loadingFinished fired through
+    // bindMainViewDataSignals), then settle so every queued side effect of
+    // that completion has run before reading the overview.
+    REQUIRE( waitFor( [ & ]() { return widget.mainView()->getTopLine() > topBefore; },
+                      15000 ) );
+    QTest::qWait( 200 );
+
+    // The overview total must track the grown file (300 lines), like
+    // single-file. RED: linesInFile_ stays at the open-time 200 -- nothing in
+    // the folder follow data-flow calls Overview::updateData on growth.
+    REQUIRE( overviewLinesInFile( widget ) == uint64_t{ 300 } );
 }

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1258,6 +1258,10 @@ SCENARIO( "Folder tab go-to-top and follow actions apply to the main view file",
     QTimer::singleShot( 0, [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
 
     QTest::qWait( 100 );
+    // The singleShot above is queued on the UI event loop; if it has not run
+    // by now (starved loop on a loaded CI runner) every subsequent deref is
+    // UB, so fail loudly instead of crashing through resize().
+    REQUIRE( mainWindow != nullptr );
     mainWindow->resize( 1600, 900 );
     mainWindow->show();
     QTest::qWait( 100 );
@@ -1416,6 +1420,162 @@ SCENARIO( "Folder tab go-to-top and follow actions apply to the main view file",
                 // (filtered) view's selection must not be moved by it.
                 REQUIRE( folderWidget->filteredView()->getSelectedLinesText()
                          == selectedRowsBefore );
+            }
+        }
+    }
+}
+
+// Codex P1 (background-follow leak): the direct connection
+// FolderCrawlerWidget::followModeChanged -> MainWindow::changeFollowMode
+// (mainwindow.cpp:2328) has no currency guard. A HIDDEN folder tab can still
+// emit followModeChanged: its main view's selectAndDisplayLine unconditionally
+// calls disableFollow() -> followModeChanged(false) (abstractlogview.cpp:1970
+// -> 3563, relayed by foldercrawlerwidget.cpp:478). changeFollowMode unchecks
+// the shared followAction, and followAction::toggled dispatches followSet to
+// the CURRENT document (mainwindow.cpp:802) -- so a background folder event
+// silently kills the follow mode of a following file tab. This test pins the
+// expected behavior: only the current tab's follow transitions may touch the
+// shared action / other tabs' state.
+TEST_CASE( "Background folder tab must not change the current tab's follow state",
+           "[ui][folder]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    // Deterministic followAction enabled state (must precede MainWindow
+    // construction: the action reads anyFileWatchEnabled() at creation).
+    FileWatchConfigGuard fileWatchConfigGuard;
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "folder-bg-follow-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+    mainWindow->resize( 1600, 900 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+    auto* followAction = mainWindow->findChild<QAction*>( QStringLiteral( "followAction" ) );
+    REQUIRE( followAction != nullptr );
+
+    // 200 all-ERROR lines so every line matches the folder search below and
+    // the folder main view is comfortably scrollable once a.log is opened
+    // from a result row.
+    const auto tempDirPath = makeTestDir( "folderbgfollow" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto logFilePath = QDir( tempDirPath ).absoluteFilePath( "a.log" );
+    {
+        QFile f( logFilePath );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        QByteArray payload;
+        for ( int i = 0; i < 200; ++i ) {
+            payload.append( "ERROR line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+    }
+    // A standalone file to open as the second (file) tab.
+    const auto standaloneFile = QDir( tempDirPath ).absoluteFilePath( "standalone.log" );
+    {
+        QFile f( standaloneFile );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        QByteArray payload;
+        for ( int i = 0; i < 200; ++i ) {
+            payload.append( "standalone line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+    }
+
+    GIVEN( "a folder tab with follow armed, hidden behind a following file tab" )
+    {
+        runInUiThread( [ &mainWindow, tempDirPath ] {
+            mainWindow->openFolderByPath( tempDirPath );
+        } );
+        REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+        QTest::qWait( 200 );
+        auto* folderWidget = qobject_cast<FolderCrawlerWidget*>( tabArea->widget( 0 ) );
+        REQUIRE( folderWidget != nullptr );
+
+        // Open a.log in the folder main view from a result row. Results rows:
+        // group header at 0, then one data row per match -- row 1 is the
+        // first data row.
+        runInUiThread( [ folderWidget ] {
+            folderWidget->searchFor( QStringLiteral( "ERROR" ) );
+        } );
+        REQUIRE( waitUiState( [ & ] { return !folderWidget->isSearchActive(); } ) );
+        runInUiThread( [ folderWidget ] {
+            folderWidget->selectResultRow( 1_lnum );
+        } );
+        REQUIRE( waitUiState(
+            [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        // The on-demand index + layout of the main-view file are async; wait
+        // until it is scrollable, then settle so the worker thread unwinds.
+        REQUIRE( waitUiState( [ & ] {
+            return folderWidget->mainView()->verticalScrollBar()->maximum() > 0;
+        } ) );
+        QTest::qWait( 200 );
+
+        // Arm the folder main view's follow FIRST so the later emission is a
+        // genuine "follow turned off" transition from the folder tab, and so
+        // the folder->MainWindow uplink (connected when the folder tab was
+        // current) has carried a real state before going background.
+        runInUiThread( [ folderWidget ] {
+            folderWidget->followSet( true );
+        } );
+        REQUIRE( waitUiState(
+            [ & ] { return folderWidget->mainView()->isFollowEnabled(); } ) );
+
+        // Open the standalone file as the SECOND tab; it becomes current.
+        runInUiThread( [ &mainWindow, standaloneFile ] {
+            mainWindow->loadInitialFile( standaloneFile, false );
+        } );
+        REQUIRE( waitUiState( [&] { return tabArea->count() == 2; } ) );
+        auto* crawler = qobject_cast<CrawlerWidget*>( tabArea->widget( 1 ) );
+        REQUIRE( crawler != nullptr );
+        // Let the file tab's background load finish (and its worker thread
+        // unwind) before driving follow / switching context.
+        REQUIRE( waitUiState( [ & ] { return crawler->isFirstLoadDone(); } ) );
+        QTest::qWait( 200 );
+
+        // Enable follow on the now-current file tab via the shared action.
+        runInUiThread( [ followAction ] {
+            followAction->trigger();
+        } );
+        REQUIRE( waitUiState( [ & ] { return crawler->isFollowEnabled(); } ) );
+        REQUIRE( followAction->isChecked() );
+
+        WHEN( "the hidden folder tab emits followModeChanged(false)" )
+        {
+            // selectAndDisplayLine -> disableFollow -> followModeChanged(false)
+            // on the folder main view, relayed to MainWindow over the
+            // unguarded direct connection -- all while the file tab is
+            // current.
+            runInUiThread( [ folderWidget ] {
+                folderWidget->mainView()->selectAndDisplayLine( 0_lnum );
+            } );
+            // Pump events so every queued leg of the emission has landed
+            // before the state is sampled.
+            QTest::qWait( 200 );
+
+            THEN( "the current file tab's follow state is untouched" )
+            {
+                // Without the currency guard in onFolderFollowModeChanged the
+                // hidden folder tab's emission would uncheck the shared
+                // followAction and toggled would dispatch followSet(false) to
+                // the CURRENT document -- both of these assertions flipped
+                // false before the guard existed.
+                REQUIRE( waitUiState( [ & ] { return crawler->isFollowEnabled(); } ) );
+                REQUIRE( followAction->isChecked() );
             }
         }
     }

--- a/tests/ui/qtests_main.cpp
+++ b/tests/ui/qtests_main.cpp
@@ -23,7 +23,10 @@
 #include <QApplication>
 #include <QDir>
 #include <QMetaType>
+#include <QThreadPool>
 #include <QtConcurrent>
+
+#include <cstdio>
 
 #if defined( Q_OS_UNIX )
 #include <sys/resource.h>
@@ -79,6 +82,55 @@ void configureTestFdLimit()
     }
 #endif
 }
+} // namespace
+
+namespace {
+
+// Catch2 v2 listener that drains the global QThreadPool after every test
+// case. The integration tests run serially in one process, so a forgotten
+// QtConcurrent task that outlives its test would otherwise keep running
+// (and touching dead temp files / destroyed models) while the NEXT test
+// executes — a classic source of flaky cross-test failures on slower
+// Windows/x86 CI legs. Joining between test cases converts such leaks into
+// a deterministic, attributable stall at the end of the offending test.
+//
+// Why this cannot deadlock: the wait runs on the main thread, and no global
+// -pool task in this codebase blocks on the main thread — there is no
+// Qt::BlockingQueuedConnection anywhere in src/, QuickFind search futures are
+// interrupted and joined by widget destructors (stopSearchAndWait, which runs
+// before this listener fires), and decompressor/device-list futures only
+// deliver their finished signal through the queued event loop. A task that
+// never finishes on its own would hang the wait forever, so the wait is
+// bounded: on timeout the test case is named and the run continues.
+//
+// The wait is cheap when idle (waitForDone returns immediately with an empty
+// pool), so per-test-case granularity costs nothing in the common case.
+//
+// CaptureStore is deliberately NOT drained here: its cleanup runs on its own
+// std::thread set whose shutdown flag has no re-arm path, so it can only be
+// stopped once, at process exit (see shutdownBackgroundWorkers below).
+class ThreadDrainListener : public Catch::TestEventListenerBase {
+  public:
+    using Catch::TestEventListenerBase::TestEventListenerBase;
+
+    void testCaseEnded( Catch::TestCaseStats const& testCaseStats ) override
+    {
+        // Generous bound: normal pool tasks (search on small temp files)
+        // finish in milliseconds; this only trips for genuinely leaked work.
+        constexpr int DrainTimeoutMs = 30000;
+
+        if ( !QThreadPool::globalInstance()->waitForDone( DrainTimeoutMs ) ) {
+            fprintf( stderr,
+                     "ThreadDrainListener: global QThreadPool still busy %d ms after "
+                     "test case \"%s\" -- leaked QtConcurrent task?\n",
+                     DrainTimeoutMs,
+                     testCaseStats.testInfo.name.c_str() );
+        }
+    }
+};
+
+CATCH_REGISTER_LISTENER( ThreadDrainListener )
+
 } // namespace
 
 class TestRunner : public QObject {


### PR DESCRIPTION
## Summary
Follow-up to #58 (merged): review-verified fixes plus CI-stability hardening.

**Review follow-ups** (each verified against code before applying):
- **P1 — background folder tab could kill the current tab's follow mode.** The unguarded `FolderCrawlerWidget::followModeChanged → changeFollowMode` connection let a hidden folder's async-open completion flip the shared Follow action, dispatching `followSet(false)` to the current file tab. Now routed through a currency-guarded slot (`onFolderFollowModeChanged`, the `onFolderSearchablesChanged` precedent).
- **P2 — folder follow left the overview stale on growth.** The growth callbacks now also refresh `Overview::linesInFile_` on `loadingFinished` (visibility-guarded), mirroring single-file (`crawlerwidget.cpp:934`).
- **P2 — canceling a pending open dropped the displayed file's encoding override.** The reset moved from open-request time to the two actual swap points (cache-hit + async completion).
- **LoadingStatus guard** in the pending-open completion: failed indexes are no longer promoted into the main view / LRU cache; the failed LogData is destroyed via a posted lambda to avoid freeing it mid-emission.
- Test robustness: `REQUIRE(mainWindow != nullptr)` after the singleShot construction wait.

**CI stability hardening** (motive: the #58 Windows x64-qt6 flaky worker-thread SIGSEGV and the clang-tidy leg failure):
- `~LogData` deregisters from the FileWatcher singleton (registration was add-only → dead temp paths accumulated → 1s Windows polling generated cross-test traffic in serial itests). `FileHolder` no longer double-removes; LogData owns the pair.
- `~FolderCrawlerWidget` interrupts the search engine before joining view workers; per-test `QThreadPool` drain in `qtests_main`; missing `qWait(200)` settle added to one test.
- **Crash diagnosability**: WER LocalDumps + diagnostics artifact upload extended from x86-only to all Windows legs (both test binaries, DumpCount-bounded, failure-only); `_NT_SYMBOL_PATH` set so backward-cpp resolves OS/CRT frames in logs.
- **New local guard** `scripts/lint_header_self_contained.py`: compiles each changed header as a standalone TU with real build flags — closes the gap that let `viewinterface.h`'s missing include reach CI (local builds never compile headers standalone; CI's changed-header clang-tidy sweep does). Companion unittests included.

## Tests
- Three new failing-first tests: encoding-cancel and overview-growth (widget level), background-follow leak (MainWindow level, deterministic — driven via `selectAndDisplayLine`, no watcher timing).
- Full `ctest` 4/4 green (510 unit + 156 integration + vectorscan + smoke); 234 scripts unittests pass; `lint_platform_fragile.py` + `lint_header_self_contained.py` clean; workflow YAML re-validated.
- Not verifiable locally: Windows runner behavior (WER dumps, polling-watcher timing) — CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous file loading so failed or canceled opens preserve the currently displayed file and its encoding settings.
  * Fixed folder follow mode so background tabs no longer change the active tab’s follow state.
  * Updated line counts reliably when files grow while follow mode is enabled.
  * Improved cleanup during folder searches and file monitoring to prevent shutdown-related issues.

* **Documentation**
  * Clarified when file encoding overrides are reset during file replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->