### PR TITLE
Add Ubuntu 26.04 (Resolute) support: CI leg, .deb artifact, GCC 15 build fixes

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -436,6 +436,25 @@ jobs:
             cmake_opts: -DENABLE_CPPCHECK=ON -DKLOGG_GENERIC_CPU=ON
             package: true
 
+          - os: ubuntu_resolute
+            os_version: 26.04
+            arch: x64
+            label: ubuntu-26.04-deb
+            package_tag: vs-gen
+            check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
+            cpack_gen: DEB
+            artifacts_id: resolute
+            package_suffix: deb
+            # Ubuntu 24.10+ dropped the t64 time_t-transition suffix from the
+            # Qt6 packages (libqt6gui6t64 -> libqt6gui6), so the Noble-built
+            # deb is installable only on 24.04. Resolute carries the current
+            # (unsuffixed) names; building there yields the deb for 26.04 LTS.
+            check_container: ubuntu:26.04
+            container_root: docker/ubuntu26.04
+            container: variar/klogg_ubuntu26.04
+            cmake_opts: -DENABLE_CPPCHECK=ON -DKLOGG_GENERIC_CPU=ON
+            package: true
+
           - os: ubuntu_appimage
             os_version: 20.04
             arch: x64
@@ -1548,6 +1567,7 @@ jobs:
             ### Linux
             - Ubuntu 22.04 (Jammy, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb)
             - Ubuntu 24.04 (Noble, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb)
+            - Ubuntu 26.04 (Resolute, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb)
             - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
 
             ### macOS

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -92,6 +92,11 @@ jobs:
         else
           echo "Warning: ./packages-noble-vs-gen/klogg_noble_vs-gen.debug.xz not found, skipping"
         fi
+        if [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz ]; then
+          xz -d ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz
+        else
+          echo "Warning: ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz not found, skipping"
+        fi
         if [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug.xz ]; then
           xz -d ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug.xz
         else
@@ -129,6 +134,11 @@ jobs:
         else
           echo "Warning: ./packages-noble-vs-gen debug files not found, skipping"
         fi
+        if [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug ] && [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen ]; then
+          sentry-cli upload-dif ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug  ./packages-resolute-vs-gen/klogg_resolute_vs-gen
+        else
+          echo "Warning: ./packages-resolute-vs-gen debug files not found, skipping"
+        fi
         if [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug ] && [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen ]; then
           sentry-cli upload-dif ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug  ./packages-appimage-vs-gen/klogg_appimage_vs-gen
         else
@@ -162,6 +172,7 @@ jobs:
       run: |
         rm -rf ./packages-jammy-vs-gen/klogg_jammy_vs-gen
         rm -rf ./packages-noble-vs-gen/klogg_noble_vs-gen
+        rm -rf ./packages-resolute-vs-gen/klogg_resolute_vs-gen
         rm -rf ./packages-appimage-vs-gen/klogg_appimage_vs-gen
         if [ -d ./packages-macos-intel-qt6-vs-gen/klogg-x64.app ]; then
           rm -rf ./packages-macos-intel-qt6-vs-gen/klogg-x64.app
@@ -175,6 +186,9 @@ jobs:
         fi
         if [ -f ./packages-noble-vs-gen/klogg_noble_vs-gen.debug ]; then
           mv ./packages-noble-vs-gen/klogg_noble_vs-gen.debug ./linux-debug
+        fi
+        if [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug ]; then
+          mv ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug ./linux-debug
         fi
         if [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug ]; then
           mv ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug ./linux-debug
@@ -202,6 +216,9 @@ jobs:
         fi
         if [ -d ./packages-noble-vs-gen ] && [ -n "$(ls -A ./packages-noble-vs-gen/* 2>/dev/null)" ]; then
           sha256sum --binary ./packages-noble-vs-gen/* >> ./packages-bin/klogg-$KLOGG_VERSION-sha256.txt 2>/dev/null || true
+        fi
+        if [ -d ./packages-resolute-vs-gen ] && [ -n "$(ls -A ./packages-resolute-vs-gen/* 2>/dev/null)" ]; then
+          sha256sum --binary ./packages-resolute-vs-gen/* >> ./packages-bin/klogg-$KLOGG_VERSION-sha256.txt 2>/dev/null || true
         fi
         if [ -d ./packages-appimage-vs-gen ] && [ -n "$(ls -A ./packages-appimage-vs-gen/* 2>/dev/null)" ]; then
           sha256sum --binary ./packages-appimage-vs-gen/* >> ./packages-bin/klogg-$KLOGG_VERSION-sha256.txt 2>/dev/null || true
@@ -231,6 +248,7 @@ jobs:
           ### Linux
           - Ubuntu 22.04 (Jammy, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb)
           - Ubuntu 24.04 (Noble, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb)
+          - Ubuntu 26.04 (Resolute, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb)
           - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
 
           ### macOS
@@ -242,6 +260,7 @@ jobs:
           ./packages-windows-x64-qt6-vs-avx2/*
           ./packages-jammy-vs-gen/*
           ./packages-noble-vs-gen/*
+          ./packages-resolute-vs-gen/*
           ./packages-appimage-vs-gen/*
           ./packages-bin/*
           ./linux-debug/*

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -307,6 +307,24 @@ cpmaddpackage(
   EXCLUDE_FROM_ALL
   YES
 )
+
+# GCC 15 (Ubuntu 26.04) removed the transitive <cstdint> include that
+# robin_hood.h relied on for uint64_t/uint32_t; without it the resolute build
+# fails with "'uint32_t' does not name a type" (e.g. booleanevaluator.cpp).
+if(robin_hood_ADDED)
+  execute_process(
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DREPO_DIR=${robin_hood_SOURCE_DIR}
+      -DPATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_robin_hood_cstdint.patch
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/apply_git_patch.cmake
+    RESULT_VARIABLE _robin_hood_patch_result
+  )
+  if(NOT _robin_hood_patch_result EQUAL 0)
+    message(FATAL_ERROR "Failed to apply robin_hood cstdint patch: ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_robin_hood_cstdint.patch")
+  endif()
+endif()
+
 if(NOT TARGET robin_hood)
   message("Adding imported target for robin_hood")
   add_library(robin_hood INTERFACE)
@@ -602,6 +620,24 @@ if(KLOGG_USE_SENTRY)
     EXCLUDE_FROM_ALL
     YES
   )
+
+  # GCC 15 (Ubuntu 26.04) removed a transitive <cstdint> include that
+  # crashpad's util/file/filesystem.h relied on for uint64_t; without it the
+  # resolute build fails with "'uint64_t' does not name a type". crashpad is a
+  # submodule of sentry-native, so the patch targets the submodule root.
+  if(sentry_ADDED)
+    execute_process(
+      COMMAND
+        ${CMAKE_COMMAND}
+        -DREPO_DIR=${sentry_SOURCE_DIR}/external/crashpad
+        -DPATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_sentry_crashpad_cstdint.patch
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/apply_git_patch.cmake
+      RESULT_VARIABLE _sentry_patch_result
+    )
+    if(NOT _sentry_patch_result EQUAL 0)
+      message(FATAL_ERROR "Failed to apply Sentry crashpad cstdint patch: ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_sentry_crashpad_cstdint.patch")
+    endif()
+  endif()
 
   if(WIN32)
     set_target_properties(crashpad_handler PROPERTIES OUTPUT_NAME "klogg_crashpad_handler.exe")

--- a/3rdparty/patches/fix_robin_hood_cstdint.patch
+++ b/3rdparty/patches/fix_robin_hood_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/include/robin_hood.h b/src/include/robin_hood.h
+index 48ae0b6..d6baf80 100644
+--- a/src/include/robin_hood.h
++++ b/src/include/robin_hood.h
+@@ -39,6 +39,7 @@
+ #define ROBIN_HOOD_VERSION_PATCH 2  // for backwards-compatible bug fixes
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>

--- a/3rdparty/patches/fix_sentry_crashpad_cstdint.patch
+++ b/3rdparty/patches/fix_sentry_crashpad_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/util/file/filesystem.h b/util/file/filesystem.h
+index f04ee10d..16d41fdb 100644
+--- a/util/file/filesystem.h
++++ b/util/file/filesystem.h
+@@ -15,6 +15,7 @@
+ #ifndef CRASHPAD_UTIL_FILE_FILESYSTEM_H_
+ #define CRASHPAD_UTIL_FILE_FILESYSTEM_H_
+ 
++#include <cstdint>
+ #include <time.h>
+ 
+ #include "base/files/file_path.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,9 +222,6 @@ endif()
 include(Sanitizers)
 enable_sanitizers(project_options)
 
-# allow for static analysis options
-include(StaticAnalyzers)
-
 ucm_print_flags()
 
 if(APPLE)
@@ -325,6 +322,12 @@ set(BUILD_SHARED_LIBS OFF)
 add_custom_target(ci_build)
 
 add_subdirectory(3rdparty)
+# Static analysis options are scoped to the project's own targets: enabled
+# AFTER third-party is added so vendored subprojects (CPM deps, Vectorscan,
+# Sentry's mini_chromium/crashpad) are not analyzed. Newer cppcheck (2.19+ on
+# Ubuntu 26.04) fails on their Chromium-style macros (BUILDFLAG(...), #error
+# guards), which otherwise fails the build as a compile step.
+include(StaticAnalyzers)
 add_subdirectory(src)
 if(${KLOGG_BUILD_BENCHMARKS})
   add_subdirectory(benchmarks)

--- a/docker/ubuntu26.04/Dockerfile
+++ b/docker/ubuntu26.04/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:26.04
+
+# CCACHE_DIR lives under the workspace mount (/usr/local) so the cache can be
+# persisted across CI runs via actions/cache; keep it bounded and compressed.
+ENV DEBIAN_FRONTEND=noninteractive \
+    CCACHE_DIR=/usr/local/.ccache \
+    CCACHE_MAXSIZE=2G \
+    CCACHE_COMPRESS=1
+
+# Retry apt operations: CI docker builds hit archive.ubuntu.com network
+# flakes; retrying the whole apt invocation makes the base-image build
+# resilient instead of flaky.
+#
+# CMake: the Jammy/Noble images pin the 3.20.2 installer via COPY, but Qt 6.10
+# (Resolute) enforces CMake >= 3.22 (QtPublicCMakeVersionHelpers), so this
+# image uses the distro CMake (4.2 on 26.04) instead.
+RUN set -eux; \
+    apt_retry() { for i in 1 2 3 4 5; do "$@" && return 0; sleep $((i * 15)); done; return 1; }; \
+    apt_install() { for i in 1 2 3 4 5; do \
+      apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update -y \
+        && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install --no-install-recommends "$@" -y \
+        && return 0; \
+      sleep $((i * 15)); \
+    done; return 1; }; \
+    apt_install build-essential python3 python-is-python3 ccache \
+                qt6-base-dev qt6-5compat-dev qt6-svg-dev qt6-translations-l10n \
+                qt6-tools-dev-tools qt6-base-dev-tools qt6-tools-dev \
+                libxkbcommon-dev libxkbcommon-x11-dev \
+                libboost-dev libicu-dev libssl-dev libcurl4-openssl-dev \
+                ragel ninja-build cmake zlib1g-dev git pkg-config cppcheck \
+                wget ca-certificates fuse file && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/packaging/linux/deb
+++ b/packaging/linux/deb
@@ -7,3 +7,4 @@ apt install reprepro
 gpg --import private.pgp
 reprepro --basedir /klogg/website/public/deb/jammy/ includedeb jammy klogg-22.06.0.1289-jammy-vs-gen.deb
 reprepro --basedir /klogg/website/public/deb/noble/ includedeb noble klogg-22.06.0.1289-noble-vs-gen.deb
+reprepro --basedir /klogg/website/public/deb/resolute/ includedeb resolute klogg-22.06.0.1289-resolute-vs-gen.deb

--- a/scripts/verify_ubuntu_deb.sh
+++ b/scripts/verify_ubuntu_deb.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Verify a klogg Ubuntu .deb installs and smoke-runs on a given Ubuntu base image.
+#
+# Usage: scripts/verify_ubuntu_deb.sh <path-to.deb> <ubuntu-base-tag>
+#
+# Runs the exact check_command the ubuntu-*-deb legs of ci-build.yml use:
+#   apt-get update; apt-get install -y /usr/local/<deb>; QT_QPA_PLATFORM=offscreen klogg -v
+#
+# Exit status is the container's exit status, so it can be used as a gate:
+#   scripts/verify_ubuntu_deb.sh klogg-*-noble-vs-gen.deb ubuntu:26.04   # fails (t64 renames)
+#   scripts/verify_ubuntu_deb.sh klogg-*-resolute-vs-gen.deb ubuntu:26.04 # passes
+set -eu
+
+DEB=${1:?usage: verify_ubuntu_deb.sh <path-to.deb> <ubuntu-base-tag>}
+BASE=${2:?usage: verify_ubuntu_deb.sh <path-to.deb> <ubuntu-base-tag>}
+
+DEB_ABS=$(cd "$(dirname "$DEB")" && pwd)/$(basename "$DEB")
+DEB_NAME=$(basename "$DEB_ABS")
+
+test -f "$DEB_ABS" || { echo "error: deb not found: $DEB_ABS" >&2; exit 2; }
+
+echo "==> installing $DEB_NAME on $BASE (apt + offscreen klogg -v)"
+docker run --rm -v "$(dirname "$DEB_ABS")":/usr/local \
+  "$BASE" /bin/bash -c '
+    for attempt in 1 2 3; do
+      apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break
+      if [ "$attempt" = 3 ]; then exit 1; fi
+      sleep $((attempt * 10))
+    done
+    DEBIAN_FRONTEND=noninteractive apt-get install -y "/usr/local/'"$DEB_NAME"'"
+    QT_QPA_PLATFORM=offscreen klogg -v
+  '


### PR DESCRIPTION
## Summary

Adds Ubuntu 26.04 LTS (Resolute) support to the build matrix and releases, fixing the fact that the 24.04 (Noble) `.deb` cannot be installed on any newer release.

- **`ci-build.yml`**: new `ubuntu_resolute` matrix leg (`artifacts_id: resolute`, `check_container: ubuntu:26.04`, container `variar/klogg_ubuntu26.04`) + continuous-release download line.
- **`ci-release.yml`**: resolute handling for debug-symbol decompress, Sentry `upload-dif`, cleanup, checksums, release-notes, and the gh-release files glob.
- **`docker/ubuntu26.04/Dockerfile`**: new build image. Uses the distro CMake (4.2) instead of the pinned 3.20.2 installer — Qt 6.10 enforces CMake ≥ 3.22.
- **`CMakeLists.txt`**: `include(StaticAnalyzers)` moved after `add_subdirectory(3rdparty)` so cppcheck/clang-tidy scope to klogg's own code only (cppcheck 2.19 fails the build on vendored Chromium-style macros).
- **`3rdparty/CMakeLists.txt` + two patches**: add `#include <cstdint>` to sentry-native's crashpad `util/file/filesystem.h` and to `robin_hood.h` (GCC 15 removed the transitive include), applied via the existing `apply_git_patch.cmake` mechanism.
- **`scripts/verify_ubuntu_deb.sh`**: reusable install + offscreen-smoke gate mirroring the CI `check_command`.
- **`packaging/linux/deb`**: reprepro note for the `resolute/` suite.

## Background

- **Introduced by:** Ubuntu 26.04 LTS (Resolute, 2026-04-23). The Qt6 runtime on 24.04 was renamed to `*t64` during the 64-bit `time_t` transition; 24.10+ reverted gui/network/widgets/xml to plain names (only `libqt6core6t64` persists), so the shlibdeps-computed `Depends` of the Noble deb (`libqt6gui6t64` etc.) can never be satisfied on 24.10+.
- **Use case:** A user on the current LTS installs the Noble `.deb` and apt rejects it.
- **How to reproduce:** `apt-get install ./klogg-*-noble-vs-gen.deb` on Ubuntu 26.04 → "Depends: libqt6gui6t64 (>= 6.4.0) but it is not installable".
- **Root cause:** Per-distro `Depends` computed against the 24.04 package names, which only exist on 24.04.
- **How to fix:** Build a per-distro deb on Resolute itself, and make the build work on the 26.04 toolchain (GCC 15, CMake 4.2, Qt 6.10.2, cppcheck 2.19) — see Summary.

## Tests

Ran locally with Docker (`variar/klogg_ubuntu26.04` container), mirroring the CI leg flow:

- Configure + `ci_build` (Qt 6.10.2 / GCC 15 / `-Werror` / `ENABLE_CPPCHECK=ON`) — passes; both vendored patches apply idempotently via the committed mechanism.
- `ctest`: `klogg_smoke`, `klogg_itests`, `klogg_vectorscan_tests` pass. `klogg_tests` passes except two `CaptureStore *aliases*` cases that only run on case-insensitive filesystems (they `SUCCEED`/skip on CI's case-sensitive ext4); they were observed flaky on the case-insensitive macOS bind-mount and are unrelated to this change.
- `cpack -G DEB` → `klogg-*-resolute-vs-gen.deb`; `apt install` + `QT_QPA_PLATFORM=offscreen klogg -v` on `ubuntu:26.04` — passes (`VERIFY_EXIT=0`). Deb `Depends` uses plain names: `libqt6gui6 (>= 6.9.1)`, `libqt6network6`, `libqt6widgets6`, `libqt6xml6`, `libqt6core6t64 (>= 6.10.2)` (core keeps its t64 name on Resolute).
- `python3 scripts/lint_platform_fragile.py` passes; both workflow YAMLs parse (ruby YAML).
- Full cross-platform CI matrix still runs on this PR (jammy/noble/macOS/Windows legs unaffected: the patches only add a standard include; the analyzer scoping only drops cppcheck on vendored code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ubuntu 26.04 support for building, packaging, releases, downloads, and repositories.
  * Added automated verification that Ubuntu packages install and launch successfully.

* **Bug Fixes**
  * Improved compatibility with newer compilers by applying standard-header fixes to bundled components.

* **Build & Quality**
  * Scoped static analysis to project-owned code.
  * Added a dedicated Ubuntu 26.04 build environment with dependency caching and resilient package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->