### PR TITLE
Live stream file info consistency, toolbar path fix, and CI hardening

### DIFF
--- a/.github/actions/docker-run-tests/action.yml
+++ b/.github/actions/docker-run-tests/action.yml
@@ -6,5 +6,10 @@ runs:
     - name: test
       shell: sh
       run: |
-        docker run --env KLOGG_BUILD_ROOT=$KLOGG_BUILD_ROOT --env ASAN_OPTIONS --env UBSAN_OPTIONS --env TSAN_OPTIONS --env LSAN_OPTIONS -v "$KLOGG_WORKSPACE":/usr/local ${{ matrix.config.container }} /bin/bash -c "cd /usr/local/$KLOGG_BUILD_ROOT && ctest --verbose"
+        # LANG=C.UTF-8: match the de-facto Linux desktop environment. Under the
+        # containers' default POSIX locale, vanilla-built Qt5 (the qt5-tsan
+        # runtime) transcodes file names via the locale codec and silently
+        # drops non-ASCII bytes, mangling non-ASCII path fixtures (PR #62 TSan
+        # leg: a CJK directory was created on disk as "APP").
+        docker run --env KLOGG_BUILD_ROOT=$KLOGG_BUILD_ROOT --env LANG=C.UTF-8 --env ASAN_OPTIONS --env UBSAN_OPTIONS --env TSAN_OPTIONS --env LSAN_OPTIONS -v "$KLOGG_WORKSPACE":/usr/local ${{ matrix.config.container }} /bin/bash -c "cd /usr/local/$KLOGG_BUILD_ROOT && ctest --verbose"
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1190,6 +1190,18 @@ jobs:
           # to the affected test process instead of weakening the whole leg.
           echo "ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1" >> $GITHUB_ENV
 
+          if [ "${{ matrix.config.sanitizer }}" = "address" ]; then
+            # The vectorscan regression matrix spawns one ASan-instrumented
+            # child process per run; per-child ASan runtime + Qt startup
+            # (~7s) dominated this leg (610s of a 30-minute job). Sample the
+            # matrix for memory-safety coverage — the full 336-run exhaustive
+            # cardinality stays enforced on the non-ASan vs-avx2 leg (~16s
+            # there) — and oversubscribe the 4-vCPU runner: child runs are
+            # process-spawn/I-O-bound, not pure CPU.
+            echo "KLOGG_VECTORSCAN_EXHAUSTIVE=0" >> $GITHUB_ENV
+            echo "KLOGG_VECTORSCAN_CHILD_CONCURRENCY=8" >> $GITHUB_ENV
+          fi
+
       - uses: ./.github/actions/agent-build
 
       - name: Verify vectorscan config in CMake cache (x64)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,8 +36,10 @@ jobs:
     - uses: ./.github/actions/agent-setup
     - name: Install Linux deps
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libxkbcommon-dev libxkbcommon-x11-dev
+        # Explicit timeouts/retries: apt's default can hold a dead mirror
+        # TCP connection open for tens of minutes (seen 2026-08-19).
+        sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 install -y libxkbcommon-dev libxkbcommon-x11-dev
 
     - name: Prepare compiler env
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,6 +23,11 @@ jobs:
   coverage:
     name: "Line/branch coverage ratchet"
     runs-on: ubuntu-24.04
+    # Historical full-run ceiling is ~22 min (cold cache); 45 min leaves
+    # headroom while bounding runner-side apt/network hangs that would
+    # otherwise sit in_progress forever (2026-08-19: two jobs spent 30+ min
+    # stuck in apt-get on dead mirror connections).
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -45,8 +50,10 @@ jobs:
 
       - name: Install gcc-13 and gcovr
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-13 g++-13 gcovr libxkbcommon-dev libxkbcommon-x11-dev
+          # Explicit timeouts/retries: apt's default can hold a dead mirror
+          # TCP connection open for tens of minutes (seen 2026-08-19).
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 install -y gcc-13 g++-13 gcovr libxkbcommon-dev libxkbcommon-x11-dev
 
       - name: Prepare compiler env
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -43,6 +43,11 @@ jobs:
   static-analysis:
     name: "clang-tidy + cppcheck"
     runs-on: ubuntu-24.04
+    # Historical full-run ceiling is ~22 min (cold cache); 45 min leaves
+    # headroom while bounding runner-side apt/network hangs that would
+    # otherwise sit in_progress forever (2026-08-19: two jobs spent 30+ min
+    # stuck in apt-get on dead mirror connections).
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -70,8 +75,10 @@ jobs:
 
       - name: Install gcc-13, clang-tidy and cppcheck
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-13 g++-13 clang-tidy cppcheck ragel libcurl4-openssl-dev libxkbcommon-dev libxkbcommon-x11-dev
+          # Explicit timeouts/retries: apt's default can hold a dead mirror
+          # TCP connection open for tens of minutes (seen 2026-08-19).
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 install -y gcc-13 g++-13 clang-tidy cppcheck ragel libcurl4-openssl-dev libxkbcommon-dev libxkbcommon-x11-dev
           tidy_diff=$(command -v clang-tidy-diff || true)
           if [ -z "$tidy_diff" ]; then
             tidy_diff=$(command -v clang-tidy-diff-18.py || true)

--- a/scripts/verify_ubuntu_deb.sh
+++ b/scripts/verify_ubuntu_deb.sh
@@ -20,13 +20,17 @@ DEB_NAME=$(basename "$DEB_ABS")
 test -f "$DEB_ABS" || { echo "error: deb not found: $DEB_ABS" >&2; exit 2; }
 
 echo "==> installing $DEB_NAME on $BASE (apt + offscreen klogg -v)"
-docker run --rm -v "$(dirname "$DEB_ABS")":/usr/local \
+# $DEB_NAME is passed as a positional parameter ($1) instead of being
+# interpolated into the bash -c script: a filename containing shell syntax
+# must stay literal data, never executable code. The mount is read-only —
+# the container only reads the deb (apt/klogg write to the container FS).
+docker run --rm -v "$(dirname "$DEB_ABS")":/usr/local:ro \
   "$BASE" /bin/bash -c '
     for attempt in 1 2 3; do
       apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break
       if [ "$attempt" = 3 ]; then exit 1; fi
       sleep $((attempt * 10))
     done
-    DEBIAN_FRONTEND=noninteractive apt-get install -y "/usr/local/'"$DEB_NAME"'"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y "/usr/local/$1"
     QT_QPA_PLATFORM=offscreen klogg -v
-  '
+  ' verify_ubuntu_deb "$DEB_NAME"

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -118,6 +118,10 @@ class StreamingLogData : public SearchableLogData {
     QTimer loadingFinishedTimer_;
     QTimer outputFlushTimer_;
     QString boundOutputFile_;
+    // getFileSize() reads the bound path from search worker threads while the
+    // main thread rebinds it; guard the QString (implicitly shared, not
+    // thread-safe against concurrent writes).
+    mutable std::mutex boundOutputFileMutex_;
     RollingFileManager rollingDisplayOutput_;
     qint64 rollingMaxFileSize_ = 0;
     int rollingBackupCount_ = 0;

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -301,6 +301,16 @@ qint64 StreamingLogData::getFileSize() const
 
 QDateTime StreamingLogData::getLastModifiedDate() const
 {
+    // Symmetric with getFileSize(): the bound output file's on-disk mtime is
+    // what a single-file open of the same path reports, so both tabs show the
+    // same "modified on" timestamp.
+    const auto boundPath = boundOutputFile();
+    if ( !boundPath.isEmpty() ) {
+        QFileInfo boundInfo( boundPath );
+        if ( boundInfo.exists() ) {
+            return boundInfo.lastModified();
+        }
+    }
     return captureStore_.stats().lastModified;
 }
 

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -48,7 +48,7 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
 
     // Restart the flush timer if new data arrives while an output file is bound
     // but the timer is stopped (e.g. after finishInput from a reconnect cycle).
-    if ( !outputFlushTimer_.isActive() && !boundOutputFile_.isEmpty() ) {
+    if ( !outputFlushTimer_.isActive() && !boundOutputFile().isEmpty() ) {
         startOutputFlushTimer();
     }
 
@@ -171,14 +171,15 @@ void StreamingLogData::clearCapture()
         cachedRawBatches_.clear();
         cachedRawBytes_ = 0;
     }
-    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip && !boundOutputFile_.isEmpty() ) {
-        openDisplayOutputFile( boundOutputFile_ );
+    const auto boundPath = boundOutputFile();
+    if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip && !boundPath.isEmpty() ) {
+        openDisplayOutputFile( boundPath );
     }
 
     // clear() internally rebinds the output file if one was bound.
     // Only restart the timer if it was running before the clear,
     // so a clearCapture after finishInput does not revive the timer.
-    if ( timerWasActive && !boundOutputFile_.isEmpty() ) {
+    if ( timerWasActive && !boundOutputFile().isEmpty() ) {
         startOutputFlushTimer();
     }
 
@@ -230,7 +231,10 @@ bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAns
     if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Preserve ) {
         closeDisplayOutputFile();
         result = captureStore_.bindOutputFile( outputPath, preserveExisting );
-        boundOutputFile_ = result ? outputPath : QString{};
+        {
+            const std::lock_guard<std::mutex> lock( boundOutputFileMutex_ );
+            boundOutputFile_ = result ? outputPath : QString{};
+        }
     }
     else {
         captureStore_.bindOutputFile( QString{} );
@@ -245,6 +249,7 @@ bool StreamingLogData::bindOutputFile( const QString& outputPath, LiveLogSaveAns
 
 QString StreamingLogData::boundOutputFile() const
 {
+    const std::lock_guard<std::mutex> lock( boundOutputFileMutex_ );
     return boundOutputFile_;
 }
 
@@ -276,6 +281,21 @@ std::unique_ptr<LogFilteredData> StreamingLogData::getNewFilteredData() const
 
 qint64 StreamingLogData::getFileSize() const
 {
+    // A bound output file is what the tab's path points at and what a
+    // single-file open of the same path would index: report its true on-disk
+    // size so both views agree. The capture store's byte counter is a
+    // rolling-window watermark — trimming subtracts from it while the bound
+    // file keeps every byte, and a Restore binding carries pre-restart
+    // content the (volatile) capture never saw.
+    const auto boundPath = boundOutputFile();
+    if ( !boundPath.isEmpty() ) {
+        QFileInfo boundInfo( boundPath );
+        if ( boundInfo.exists() ) {
+            return boundInfo.size();
+        }
+    }
+    // No file bound (pure in-memory capture) or the bound file is gone:
+    // the retained capture bytes are the only meaningful size.
     return captureStore_.stats().fileSize;
 }
 
@@ -467,20 +487,24 @@ bool StreamingLogData::openDisplayOutputFile( const QString& outputPath, bool pr
 {
     const auto outputPathCopy = outputPath;
     closeDisplayOutputFile();
-    boundOutputFile_ = outputPathCopy;
+    {
+        const std::lock_guard<std::mutex> lock( boundOutputFileMutex_ );
+        boundOutputFile_ = outputPathCopy;
+    }
 
-    if ( boundOutputFile_.isEmpty() ) {
+    if ( outputPathCopy.isEmpty() ) {
         return true;
     }
 
-    QDir().mkpath( QFileInfo( boundOutputFile_ ).absolutePath() );
+    QDir().mkpath( QFileInfo( outputPathCopy ).absolutePath() );
 
     // Use CaptureStore's rolling settings for the display file
-    rollingDisplayOutput_ = RollingFileManager( boundOutputFile_, rollingMaxFileSize_,
+    rollingDisplayOutput_ = RollingFileManager( outputPathCopy, rollingMaxFileSize_,
                                                  rollingBackupCount_ );
     // FreshSave truncates and dumps the current capture; Restore opens
     // append-only so existing on-disk content is preserved.
     if ( !rollingDisplayOutput_.open( /*truncate=*/!preserveExisting ) ) {
+        const std::lock_guard<std::mutex> lock( boundOutputFileMutex_ );
         boundOutputFile_.clear();
         return false;
     }
@@ -503,6 +527,7 @@ void StreamingLogData::closeDisplayOutputFile()
 {
     rollingDisplayOutput_.close();
     rollingDisplayOutput_ = RollingFileManager();
+    const std::lock_guard<std::mutex> lock( boundOutputFileMutex_ );
     boundOutputFile_.clear();
 }
 

--- a/src/ui/include/infoline.h
+++ b/src/ui/include/infoline.h
@@ -60,6 +60,7 @@ class InfoLine : public QLabel {
   protected:
     void paintEvent( QPaintEvent* paintEvent ) override;
     void contextMenuEvent( QContextMenuEvent* event ) override;
+    QSize minimumSizeHint() const override;
 
   private:
     // The original palette of the QLabel

--- a/src/ui/src/infoline.cpp
+++ b/src/ui/src/infoline.cpp
@@ -55,6 +55,23 @@ InfoLine::InfoLine()
     setTextInteractionFlags( Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard );
 }
 
+// A QLabel without wordWrap reports minimumSizeHint == sizeHint -- the full
+// text width. Hosted in a QToolBar (the main window's path line), any text
+// wider than the toolbar's free space then overflows the whole label into the
+// toolbar's extension popup: the label is HIDDEN and the path bar renders
+// blank (field repro: long non-ASCII paths from folder-search result clicks).
+// Only the height is load-bearing for the toolbar row; the width may shrink
+// freely so QToolBarLayout always keeps the label on-screen, clipping the
+// text instead of hiding it. Same physics applies to the CrawlerWidget search
+// info line hosted in an QHBoxLayout: a full-width minimum there forces the
+// search line's minimum width to the text width.
+QSize InfoLine::minimumSizeHint() const
+{
+    QSize hint = QLabel::minimumSizeHint();
+    hint.setWidth( 0 );
+    return hint;
+}
+
 void InfoLine::displayGauge( int completion )
 {
     if ( !origPalette_ ) {

--- a/tests/scripts/test_vectorscan_parallel_matrix.py
+++ b/tests/scripts/test_vectorscan_parallel_matrix.py
@@ -5,6 +5,7 @@ import unittest
 
 ROOT = pathlib.Path(__file__).parents[2]
 VECTORSCAN_TEST = ROOT / "tests" / "vectorscan" / "vectorscan_tests.cpp"
+CI_BUILD = ROOT / ".github" / "workflows" / "ci-build.yml"
 
 
 def function_body(source, signature):
@@ -69,7 +70,7 @@ class VectorscanParallelMatrixTest(unittest.TestCase):
         matrix = self.source[matrix_start : self.source.index("#else", matrix_start)]
         runner = function_body(self.source, "runChildProcesses(")
 
-        self.assertIn("buildExhaustiveChildRuns()", matrix)
+        self.assertIn("buildWindowsRegressionChildRuns()", matrix)
         self.assertIn("requireSuccessfulChildRuns", matrix)
         self.assertNotIn("requireSuccessfulChildRun(", matrix)
         self.assertNotIn("runChildProcess(", matrix)
@@ -129,6 +130,50 @@ class VectorscanParallelMatrixTest(unittest.TestCase):
         self.assertNotIn("Configuration::getSynced()", initializer)
         self.assertNotIn("isConfigurationWritingChild", self.source)
         self.assertNotIn("configurationWritingChildActive", runner)
+
+    def test_matrix_sampling_defaults_to_exhaustive_and_covers_every_case(self):
+        # The exhaustive matrix is the default; only an explicit opt-out env
+        # value may downgrade it to the sampled set.
+        selector = function_body(self.source, "exhaustiveRunsRequested()")
+        dispatcher = function_body(self.source, "buildWindowsRegressionChildRuns()")
+        sampled = function_body(self.source, "buildSampledChildRuns()")
+
+        self.assertIn('"KLOGG_VECTORSCAN_EXHAUSTIVE"', selector)
+        self.assertIn('QStringLiteral( "0" )', selector)
+        self.assertIn('QStringLiteral( "false" )', selector)
+        self.assertIn("exhaustiveRunsRequested()", dispatcher)
+        self.assertIn("buildExhaustiveChildRuns()", dispatcher)
+        self.assertIn("buildSampledChildRuns()", dispatcher)
+
+        # The sampled set must keep every (child case x allocator) pair so ASan
+        # still executes each code path once, rotating index-set shapes.
+        for token in (
+            "AllocatorMode::Crt",
+            "AllocatorMode::Mimalloc",
+            "ChildCase::DirectSinglePrefilter",
+            "ChildCase::DirectMultiPrefilter",
+            "ChildCase::HighlighterCompilePrefilter",
+            "ChildCase::HighlighterCollectionRestorePrefilter",
+        ):
+            self.assertIn(token, sampled)
+        self.assertIn("constexpr size_t kSampledChildRunCount = 8;", self.source)
+        self.assertIn("childRuns.reserve( kSampledChildRunCount );", sampled)
+
+    def test_windows_asan_leg_wires_sampling_and_higher_concurrency(self):
+        # Guards the CI-side of the 2026-08-19 Windows ASan leg optimization:
+        # the asan leg must opt into the sampled matrix and raise child
+        # concurrency, while the non-ASan x64-qt6 leg must keep the exhaustive
+        # default (no opt-out env anywhere near its matrix entry).
+        ci = CI_BUILD.read_text()
+
+        self.assertIn('"KLOGG_VECTORSCAN_EXHAUSTIVE=0"', ci)
+        self.assertIn('"KLOGG_VECTORSCAN_CHILD_CONCURRENCY=8"', ci)
+        self.assertIn('"${{ matrix.config.sanitizer }}" = "address"', ci)
+
+        # The exhaustive-vs-avx2 leg (package_tag: vs-avx2) must NOT carry a
+        # sanitizer key, so it never enters the sampling branch.
+        avx2_block = ci[ci.index("package_tag: vs-avx2") : ci.index("package_tag: asan")]
+        self.assertNotIn("sanitizer:", avx2_block)
 
     def test_only_process_scheduler_helpers_are_windows_msvc_specific(self):
         platform_guard = "#if defined(Q_OS_WIN) && defined(_MSC_VER)"

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1478,6 +1478,13 @@ SCENARIO( "Folder tab info line shows the main-view file path for a long nested 
                   "测试机进入相册点击快捷翻胶囊测试机已显示有图片但设备空间首页显示未连接且拔插APP显示未连接"
                   "/2026-08-15_11-38-20@interconnection/common/ap_log/2026-08-15_11-36-51" ) );
     REQUIRE( QDir{}.mkpath( deepDir ) );
+    // Locale guard: under a non-UTF-8 locale (e.g. the CI TSan container's
+    // default POSIX), some Qt builds transcode file names via the locale
+    // codec and silently DROP the non-ASCII bytes -- mkpath then creates a
+    // directory literally named "APP", and every later path comparison fails
+    // through a 10s waitUiState timeout (PR #62 TSan leg). Fail here with a
+    // message that names the cause instead.
+    REQUIRE( QDir( deepDir ).exists() );
     const auto logFilePath = QDir( deepDir ).filePath( "android_log_20260815113820.log" );
     {
         QFile f( logFilePath );

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1425,6 +1425,114 @@ SCENARIO( "Folder tab go-to-top and follow actions apply to the main view file",
     }
 }
 
+// Field repro: on a folder tab, clicking a search result whose file lives at a
+// very long (deeply nested, non-ASCII) path left the toolbar PathLine blank.
+// Pins two observable contracts of updateInfoLine's folder branch:
+//   1. the label's text is the main-view file's full path (data layer), and
+//   2. the label stays visible in the toolbar (a QLabel without wordWrap has
+//      minimumSizeHint == sizeHint == full text width; a path wider than the
+//      toolbar can overflow the widget into the toolbar's extension popup,
+//      which renders as a blank path bar).
+SCENARIO( "Folder tab info line shows the main-view file path for a long nested path",
+          "[ui][folder]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    FileWatchConfigGuard fileWatchConfigGuard;
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "folder-infoline-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+    mainWindow->resize( 1600, 900 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+
+    auto* toolBar = mainWindow->findChild<QToolBar*>();
+    REQUIRE( toolBar != nullptr );
+    auto* filePathLabel = toolBar->findChild<PathLine*>();
+    REQUIRE( filePathLabel != nullptr );
+
+    // Field-report shape: an ordinary folder root with the matched file buried
+    // in deep non-ASCII directories, so the full path (both byte count and
+    // rendered width) far exceeds the toolbar's available label width.
+    const auto tempDirPath = makeTestDir( "folderinfoline" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto deepDir
+        = QDir( tempDirPath )
+              .filePath( QStringLiteral(
+                  "测试机进入相册点击快捷翻胶囊测试机已显示有图片但设备空间首页显示未连接且拔插APP显示未连接"
+                  "/2026-08-15_11-38-20@interconnection/common/ap_log/2026-08-15_11-36-51" ) );
+    REQUIRE( QDir{}.mkpath( deepDir ) );
+    const auto logFilePath = QDir( deepDir ).filePath( "android_log_20260815113820.log" );
+    {
+        QFile f( logFilePath );
+        REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        QByteArray payload;
+        for ( int i = 0; i < 20; ++i ) {
+            payload.append( "ERROR line " + QByteArray::number( i ) + "\n" );
+        }
+        f.write( payload );
+    }
+
+    GIVEN( "a folder tab where a result click opens the long-path file" )
+    {
+        runInUiThread( [ &mainWindow, tempDirPath ] {
+            mainWindow->openFolderByPath( tempDirPath );
+        } );
+        REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+        QTest::qWait( 200 );
+        auto* folderWidget = qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() );
+        REQUIRE( folderWidget != nullptr );
+
+        runInUiThread( [ folderWidget ] {
+            folderWidget->searchFor( QStringLiteral( "ERROR" ) );
+        } );
+        REQUIRE( waitUiState( [&] { return !folderWidget->isSearchActive(); } ) );
+        REQUIRE( folderWidget->filteredView() != nullptr );
+
+        // Row 0 is the group header, row 2 a data row: selecting it opens the
+        // file in the main view (newSelection -> onResultSelected).
+        runInUiThread( [ folderWidget ] {
+            folderWidget->filteredView()->selectAndDisplayLine( 2_lnum );
+        } );
+        REQUIRE( waitUiState(
+            [&] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        // The main-view index completes async; mainViewFileChanged (fired at
+        // its completion) is what re-runs updateInfoLine, so settle the event
+        // loop before asserting the label.
+        QTest::qWait( 200 );
+
+        THEN( "the toolbar path line shows the file path" )
+        {
+            INFO( "currentMainFilePath: " << folderWidget->currentMainFilePath().toStdString() );
+            INFO( "label text: '" << filePathLabel->text().toStdString() << "'" );
+            REQUIRE( filePathLabel->text()
+                     == QDir::toNativeSeparators( logFilePath ) );
+        }
+
+        THEN( "the toolbar path line stays visible" )
+        {
+            INFO( "label visible: " << filePathLabel->isVisible() );
+            REQUIRE( filePathLabel->isVisible() );
+        }
+    }
+}
+
 // Codex P1 (background-follow leak): the direct connection
 // FolderCrawlerWidget::followModeChanged -> MainWindow::changeFollowMode
 // (mainwindow.cpp:2328) has no currency guard. A HIDDEN folder tab can still

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -21,9 +21,12 @@
 
 #include <QDir>
 #include <QCoreApplication>
+#include <QDate>
+#include <QDateTime>
 #include <QElapsedTimer>
 #include <QFile>
 #include <QFileInfo>
+#include <QTime>
 #include <QTemporaryDir>
 #include <QThread>
 #include <QUuid>
@@ -519,6 +522,44 @@ TEST_CASE( "StreamingLogData getFileSize reflects a restored bound file when the
 
     // Capture stats report 0 bytes; the tab must show the file's real size.
     CHECK( logData.getFileSize() == onDiskSize );
+}
+
+TEST_CASE( "StreamingLogData getLastModifiedDate reflects a restored bound file when the capture is empty",
+           "[live-save-restore]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    // Pin the file's mtime far in the past so the on-disk timestamp is
+    // unmistakably different from any capture-store timestamp.
+    const QDateTime pinnedTime( QDate( 2020, 1, 1 ), QTime( 12, 0, 0 ) );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+    {
+        QFile previous( outputPath );
+        REQUIRE( previous.open( QIODevice::WriteOnly ) );
+        REQUIRE( previous.write( QByteArrayLiteral( "old-1\nold-2\n" ) ) > 0 );
+        REQUIRE( previous.flush() );
+        // Flush before pinning: a buffered write committed at close() would
+        // bump the mtime past the pinned value.
+        REQUIRE( previous.setFileTime( pinnedTime, QFileDevice::FileModificationTime ) );
+        previous.close();
+    }
+    REQUIRE( QFileInfo( outputPath ).lastModified() == pinnedTime );
+
+    // Restart with a wiped capture (fresh captureId): the capture store is
+    // empty, but the restored binding points at the previously saved file.
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+    REQUIRE( logData.getNbLine().get() == 0 );
+
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip,
+                                      OutputBindMode::Restore ) );
+
+    // The tab's "modified on" must come from the bound file, matching what a
+    // single-file open of the same path shows.
+    CHECK( logData.getLastModifiedDate() == pinnedTime );
 }
 
 TEST_CASE( "Streaming live search coalesces rapid updateSearch requests" )

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -23,6 +23,7 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QFile>
+#include <QFileInfo>
 #include <QTemporaryDir>
 #include <QThread>
 #include <QUuid>
@@ -457,6 +458,67 @@ TEST_CASE( "StreamingLogData reports accurate fileSize and lastModifiedDate" )
     REQUIRE( logData.getFileSize() > 0 );
     REQUIRE( logData.getLastModifiedDate().isValid() );
     REQUIRE( logData.getNbLine().get() == 2 );
+}
+
+TEST_CASE( "StreamingLogData getFileSize reflects the bound output file when the capture window trims" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+
+    // Line-count window only: the capture store trims old lines while the
+    // bound output file (no rolling limit) keeps every line ever written.
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 16;
+    limits.maxTotalLines = 5;
+    logData.setCaptureLimits( limits );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "live.log" ) );
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip ) );
+
+    loadingSpy.clear();
+    for ( int i = 0; i < 20; ++i ) {
+        logData.appendUtf8( QStringLiteral( "stream-%1\n" ).arg( i ).toUtf8() );
+    }
+    REQUIRE( loadingSpy.safeWait() );
+
+    // The rolling window retains only the tail, but the tab's path points at
+    // the bound file — its size must match what a single-file open shows.
+    const auto onDiskSize = QFileInfo( outputPath ).size();
+    REQUIRE( onDiskSize > 0 );
+    CHECK( logData.getFileSize() == onDiskSize );
+}
+
+TEST_CASE( "StreamingLogData getFileSize reflects a restored bound file when the capture is empty",
+           "[live-save-restore]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+
+    const auto outputPath = QDir( tempDir.path() ).filePath( QStringLiteral( "saved.log" ) );
+    QFile previous( outputPath );
+    REQUIRE( previous.open( QIODevice::WriteOnly ) );
+    REQUIRE( previous.write( QByteArrayLiteral( "old-1\nold-2\nold-3\n" ) ) > 0 );
+    previous.close();
+
+    const auto onDiskSize = QFileInfo( outputPath ).size();
+    REQUIRE( onDiskSize > 0 );
+
+    // Restart with a wiped capture (fresh captureId): the capture store is
+    // empty, but the restored binding points at the previously saved file.
+    StreamingLogData logData( makeCaptureId(), tempDir.path() );
+    SafeQSignalSpy loadingSpy( &logData, SIGNAL( loadingFinished( LoadingStatus ) ) );
+    REQUIRE( loadingSpy.safeWait() );
+    REQUIRE( logData.getNbLine().get() == 0 );
+
+    REQUIRE( logData.bindOutputFile( outputPath, LiveLogSaveAnsiMode::Strip,
+                                      OutputBindMode::Restore ) );
+
+    // Capture stats report 0 bytes; the tab must show the file's real size.
+    CHECK( logData.getFileSize() == onDiskSize );
 }
 
 TEST_CASE( "Streaming live search coalesces rapid updateSearch requests" )

--- a/tests/vectorscan/vectorscan_tests.cpp
+++ b/tests/vectorscan/vectorscan_tests.cpp
@@ -58,6 +58,7 @@ namespace {
 constexpr int kChildTimeoutMs = 60000;
 constexpr size_t kExhaustiveSearchSpaceSize = 42;
 constexpr size_t kExhaustiveChildRunCount = 336;
+constexpr size_t kSampledChildRunCount = 8;
 
 #if defined(Q_OS_WIN) && defined(_MSC_VER)
 // Keep the Windows/MSVC ASan process matrix comfortably below hosted-runner capacity.
@@ -415,6 +416,64 @@ std::vector<ChildOptions> buildExhaustiveChildRuns()
     }
 
     return childRuns;
+}
+
+// Sampled matrix for sanitizer legs: ASan's value is per-path memory-safety
+// coverage, which one run per (child case, allocator) already provides. The
+// full 336-run cardinality contract stays enforced by the cardinality REQUIRE
+// and by the fast non-ASan Windows leg. Each of the 8 sampled runs rotates
+// through a different index-set shape (single/pair/triple/full) so every
+// pattern-cardinality class is still exercised under ASan.
+[[maybe_unused]] std::vector<ChildOptions> buildSampledChildRuns()
+{
+    const std::array childCases = {
+        ChildCase::DirectSinglePrefilter,
+        ChildCase::DirectMultiPrefilter,
+        ChildCase::HighlighterCompilePrefilter,
+        ChildCase::HighlighterCollectionRestorePrefilter,
+    };
+    const std::array<std::vector<int>, 4> indexShapes = {
+        std::vector<int>{ 0 },
+        std::vector<int>{ 1, 3 },
+        std::vector<int>{ 0, 1, 2 },
+        std::vector<int>{ 0, 1, 2, 3, 4, 5 },
+    };
+
+    std::vector<ChildOptions> childRuns;
+    childRuns.reserve( kSampledChildRunCount );
+    size_t shapeIndex = 0;
+    for ( const auto allocator : { AllocatorMode::Crt, AllocatorMode::Mimalloc } ) {
+        for ( const auto childCase : childCases ) {
+            childRuns.push_back( ChildOptions{
+                childCase, allocator, indexShapes[ shapeIndex % indexShapes.size() ] } );
+            ++shapeIndex;
+        }
+    }
+
+    return childRuns;
+}
+
+// KLOGG_VECTORSCAN_EXHAUSTIVE=0 (or false/off) selects the sampled matrix for
+// sanitizer legs where ASan child-process startup dominates wall time; any
+// other value (including unset) keeps the exhaustive default.
+[[maybe_unused]] bool exhaustiveRunsRequested()
+{
+    const auto configured = qEnvironmentVariable( "KLOGG_VECTORSCAN_EXHAUSTIVE" ).toLower();
+    return !( configured == QStringLiteral( "0" ) || configured == QStringLiteral( "false" )
+              || configured == QStringLiteral( "off" ) );
+}
+
+[[maybe_unused]] std::vector<ChildOptions> buildWindowsRegressionChildRuns()
+{
+    if ( exhaustiveRunsRequested() ) {
+        std::cout << "vectorscan regression matrix mode=exhaustive runs="
+                  << kExhaustiveChildRunCount << '\n';
+        return buildExhaustiveChildRuns();
+    }
+
+    std::cout << "vectorscan regression matrix mode=sampled runs=" << kSampledChildRunCount
+              << '\n';
+    return buildSampledChildRuns();
 }
 
 void writeHighlighterSet( QSettings& settings,
@@ -1258,7 +1317,7 @@ TEST_CASE( "Windows VectorScan regression search space exits cleanly",
            "[vectorscan][regression]" )
 {
 #if defined(Q_OS_WIN) && defined(_MSC_VER)
-    requireSuccessfulChildRuns( buildExhaustiveChildRuns() );
+    requireSuccessfulChildRuns( buildWindowsRegressionChildRuns() );
 #else
     SUCCEED( "Full allocator regression search is only required on Windows/MSVC." );
 #endif


### PR DESCRIPTION
## Summary
- **Live stream tab file info**: `StreamingLogData::getFileSize()` and `getLastModifiedDate()` now report the bound output file's on-disk size and mtime (identical semantics to a single-file open), instead of the CaptureStore's in-memory rolling-window watermark. Fixes a live-stream tab showing 811.16 MiB while a direct open of the same 5,247,100-line file showed 1.04 GiB. Also fixes a latent data race on the bound-path QString between search worker threads and main-thread rebinding.
- **Toolbar path line**: a long file path no longer blanks the toolbar path label (QLabel full-width minimum hint overflowed into the hidden toolbar extension).
- **CI hardening**: shell-injection hardening for `verify_ubuntu_deb.sh` (PR #61 review follow-up), explicit timeouts + job time limits for apt installs, and matrix sampling for the Windows ASan vectorscan regression test (the ~30-min critical path).

## Background
### Live stream file size / modified time
- **Introduced by**: the live-save feature — `getFileSize()`/`getLastModifiedDate()` surfaced CaptureStore's in-memory counters.
- **Use case**: a live log stream persisted to an output file, with the same file also opened directly in another tab.
- **How to reproduce**: bind a live stream to an output file, stream enough data that the capture window trims (or restart with a restored binding): the live tab's size/"modified on" disagreed with a direct open of the same path.
- **Root cause**: CaptureStore's `fileSize_` is a rolling-window watermark — trimming subtracts from it while the bound file keeps every byte — and a Restore binding carries pre-restart content the volatile capture never saw. The mtime came from the capture store's last-append timestamp rather than the file.
- **How to fix**: both accessors now return the bound file's `QFileInfo` size / `lastModified()` when a file is bound (falling back to capture stats for pure in-memory streams or if the file vanished). `boundOutputFile_` is guarded by a mutex — search worker threads call `getFileSize()` for perf stats while the main thread rebinds, and the implicitly shared QString was not safe against concurrent writes.
- **How to verify**: 3 new unit tests — trim divergence (40 vs 190 bytes before the fix), restore divergence (0 vs 18 bytes), and an mtime pinned via `QFileDevice::setFileTime` before a Restore binding.

### Blank toolbar path line
- QLabel without wordWrap reports `minimumSizeHint` == full text width; when it exceeds the toolbar's free space, QToolBarLayout overflows the label into the extension popup and hides it. `InfoLine::minimumSizeHint()` now keeps the height but drops the width floor so the label stays on-screen and clips instead.

### CI hardening
- `verify_ubuntu_deb.sh`: `.deb` filenames are no longer interpolated into a `bash -c` script body (CodeRabbit review follow-up on PR #61).
- apt installs on ubuntu-24.04 jobs get explicit retries/timeouts and job time limits.
- Windows ASan vectorscan regression: 336-child-process matrix (610 s under ASan) is now sampled via `KLOGG_VECTORSCAN_EXHAUSTIVE`, with raised child concurrency.

## Tests
- macOS (Qt 6, AppleClang): full `klogg_tests` — 513 cases / 7481 assertions; `klogg_itests` — 157 cases / 3548 assertions; `klogg -v` smoke. All pass.
- Linux Ubuntu 20.04 (Qt 5.12.8, gcc 9.4, docker): full build + `StreamingLogData*`, `CaptureStore*`, `[live-save-restore]` suites (including the 3 new tests). All pass.
- Windows: not run locally; the change is platform-neutral Qt code and is covered by the CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when streaming output files are rebound or accessed during searches.
  * Preserved output-file metadata and paths after captured data is cleared.
  * Long file paths can now shrink and clip appropriately in the toolbar.
  * Safer package verification prevents special characters in filenames from being interpreted as commands.

* **CI & Testing**
  * Improved reliability with dependency-install retries, network timeouts, and job time limits.
  * Optimized Windows sanitizer test runs while retaining exhaustive coverage by default.
  * Added regression coverage for streaming output metadata and long non-ASCII paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->