### PR TITLE
Unify filter favorites, shortcuts, and menu behavior

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -87,7 +87,7 @@ view mode to show either only the lines matching search pattern or only marked l
 
 Marks also appear as blue lines in the match overview.
 
-It is possible to quickly jump to a specific line using `Ctrl+L` shortcut.
+It is possible to quickly jump to a specific line using the `Ctrl+G` shortcut.
 
 *klogg* uses Vectorscan library to perform regular expressions search. Vectorscan is very
 fast, but it doesn't support some patterns, most notably any lookahead is not supported
@@ -129,10 +129,10 @@ download the file to a temporary directory and open it from there.
 *klogg* saves a history of recent opened files. Up to 5 recent files are
 available from the `File` menu.
 
-#### Favorites
+#### Favorite Files
 
-Opened files can be added to the `Favorites` menu either from
-`Favorites->Add to Favorites` or from the toolbar.
+Opened files can be added to the `Favorite Files` menu using
+`Favorite Files -> Add Current File` or the toolbar.
 
 This menu is used to provide fast access to files that are opened less
 often and don't end up in the recent files section.
@@ -146,7 +146,7 @@ exploring.
 #### Switching between opened files
 
 Switching from one opened file to another can be done from the
-`View->Opened files` menu or by using the `Ctrl+Shift+O` shortcut 
+`View -> Opened Files` menu or by using the `Ctrl+Shift+O` shortcut
 which displays special dialogue to choose between opened files.
 
 ### Encodings

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -38,6 +38,149 @@ from typing import Iterable
 ALLOW_MARKER = "lint-allow: platform-fragile"
 
 
+def _strip_cpp_comments(text: str) -> str:
+    """Blank C++ line and block comments while preserving literals and lines."""
+    output: list[str] = []
+    state = "code"
+    escaped = False
+    raw_terminator = ""
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        next_ch = text[i + 1] if i + 1 < len(text) else ""
+
+        if state == "line-comment":
+            if ch == "\n":
+                output.append(ch)
+                state = "code"
+            else:
+                output.append(" ")
+        elif state == "block-comment":
+            if ch == "*" and next_ch == "/":
+                output.extend((" ", " "))
+                state = "code"
+                i += 1
+            else:
+                output.append(ch if ch == "\n" else " ")
+        elif state == "raw-string":
+            if text.startswith(raw_terminator, i):
+                output.extend(raw_terminator)
+                i += len(raw_terminator) - 1
+                state = "code"
+            else:
+                output.append(ch)
+        elif state in ("string", "character"):
+            output.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif (state == "string" and ch == '"') or (
+                state == "character" and ch == "'"
+            ):
+                state = "code"
+        elif ch == "/" and next_ch == "/":
+            output.extend((" ", " "))
+            state = "line-comment"
+            i += 1
+        elif ch == "/" and next_ch == "*":
+            output.extend((" ", " "))
+            state = "block-comment"
+            i += 1
+        else:
+            raw_open = -1
+            if ch == "R" and next_ch == '"':
+                candidate_open = text.find("(", i + 2, min(len(text), i + 19))
+                if candidate_open >= 0:
+                    delimiter = text[i + 2 : candidate_open]
+                    if not any(char.isspace() or char in "()\\" for char in delimiter):
+                        raw_open = candidate_open
+
+            if raw_open >= 0:
+                output.extend(text[i : raw_open + 1])
+                raw_terminator = ")" + text[i + 2 : raw_open] + '"'
+                state = "raw-string"
+                i = raw_open
+            else:
+                output.append(ch)
+                if ch == '"':
+                    state = "string"
+                    escaped = False
+                elif ch == "'" and not (
+                    i > 0
+                    and i + 1 < len(text)
+                    and text[i - 1].isalnum()
+                    and text[i + 1].isalnum()
+                ):
+                    state = "character"
+                    escaped = False
+        i += 1
+
+    return "".join(output)
+
+
+def _strip_cpp_literals(text: str) -> str:
+    """Blank C++ string/character literals while preserving code and lines."""
+    output: list[str] = []
+    state = "code"
+    escaped = False
+    raw_terminator = ""
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        next_ch = text[i + 1] if i + 1 < len(text) else ""
+
+        if state == "raw-string":
+            if text.startswith(raw_terminator, i):
+                output.extend(" " * len(raw_terminator))
+                i += len(raw_terminator) - 1
+                state = "code"
+            else:
+                output.append("\n" if ch == "\n" else " ")
+        elif state in ("string", "character"):
+            output.append("\n" if ch == "\n" else " ")
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif (state == "string" and ch == '"') or (
+                state == "character" and ch == "'"
+            ):
+                state = "code"
+        else:
+            raw_open = -1
+            if ch == "R" and next_ch == '"':
+                candidate_open = text.find("(", i + 2, min(len(text), i + 19))
+                if candidate_open >= 0:
+                    delimiter = text[i + 2 : candidate_open]
+                    if not any(char.isspace() or char in "()\\" for char in delimiter):
+                        raw_open = candidate_open
+
+            if raw_open >= 0:
+                output.extend(" " * (raw_open - i + 1))
+                raw_terminator = ")" + text[i + 2 : raw_open] + '"'
+                state = "raw-string"
+                i = raw_open
+            elif ch == '"':
+                output.append(" ")
+                state = "string"
+                escaped = False
+            elif ch == "'" and not (
+                i > 0
+                and i + 1 < len(text)
+                and text[i - 1].isalnum()
+                and text[i + 1].isalnum()
+            ):
+                output.append(" ")
+                state = "character"
+                escaped = False
+            else:
+                output.append(ch)
+        i += 1
+
+    return "".join(output)
+
+
 def _strip_line_comment(line: str) -> str:
     """Return the code portion of a C++ line: everything before an
     unquoted ``//`` comment.
@@ -232,10 +375,11 @@ def _extract_call_args(code: str, open_paren_pos: int) -> str:
     is recognised as passing ``start`` (the nested QLatin1Char call would defeat
     a naive ``[^)]*`` capture).
     """
+    masked = _strip_cpp_literals(_strip_cpp_comments(code))
     depth = 0
     start = open_paren_pos + 1
-    for i in range(start, len(code)):
-        ch = code[i]
+    for i in range(start, len(masked)):
+        ch = masked[i]
         if ch == "(":
             depth += 1
         elif ch == ")":
@@ -376,6 +520,114 @@ def _strip_literals(s: str) -> str:
             out.append(ch)
             i += 1
     return "".join(out)
+
+
+def _check_qmessagebox_in_tests(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag executable QMessageBox references under tests/.
+
+    Modal message boxes block headless/offscreen test runs. Includes and text in
+    comments or string literals are harmless and intentionally ignored.
+    """
+    if "tests" not in path.parts:
+        return []
+
+    findings: list[tuple[int, str]] = []
+    source_lines = text.splitlines()
+    code = _strip_cpp_literals(_strip_cpp_comments(text))
+    for line_num, line in enumerate(code.splitlines(), start=1):
+        if line_num <= len(source_lines) and ALLOW_MARKER in source_lines[line_num - 1]:
+            continue
+        if re.match(r"^\s*#\s*include\b", line):
+            continue
+        if re.search(r"\bQMessageBox\b", line):
+            findings.append(
+                (
+                    line_num,
+                    "Do not execute QMessageBox code in tests/: modal dialogs can "
+                    "block indefinitely on headless/offscreen CI runners. Exercise "
+                    "the underlying action or inject a non-modal test seam instead.",
+                )
+            )
+    return findings
+
+
+_WATCHDOG_LITERAL_RE = re.compile(
+    r'"(?:\\.|[^"\\])*watchdog expired(?:\\.|[^"\\])*"'
+)
+_ZERO_DELAY_RE = re.compile(
+    r"(?:0(?:[uUlL]*|ns|us|ms|s|min|h)"
+    r"|std::chrono::(?:nano|micro|milli)?seconds[({]0[)}])"
+)
+
+
+def _first_call_argument(arguments: str) -> str:
+    """Return the first top-level argument from a balanced call body."""
+    masked = _strip_cpp_literals(_strip_cpp_comments(arguments))
+    depth = 0
+    angle_depth = 0
+    previous_significant = ""
+    for index, ch in enumerate(masked):
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}" and depth > 0:
+            depth -= 1
+        elif ch == "<" and depth == 0 and (
+            previous_significant.isalnum() or previous_significant in "_:>"
+        ):
+            angle_depth += 1
+        elif ch == ">" and angle_depth > 0:
+            angle_depth -= 1
+        elif ch == "," and depth == 0 and angle_depth == 0:
+            return arguments[:index]
+
+        if not ch.isspace():
+            previous_significant = ch
+    return arguments
+
+
+def _is_zero_timer_delay(expression: str) -> bool:
+    compact = re.sub(r"[\s']", "", expression)
+    if re.fullmatch(r"std::chrono::duration<[^>]+>[({]0[)}]", compact):
+        return True
+    return bool(_ZERO_DELAY_RE.fullmatch(compact))
+
+
+def _check_nonzero_watchdog_timer(text: str, path: Path) -> list[tuple[int, str]]:
+    """Flag nonzero singleShot callbacks that implement wall-clock failures.
+
+    Requiring the ``watchdog expired`` marker inside the timer call binds the
+    diagnostic to one execution scope without guessing Catch macro boundaries.
+    Zero-delay dispatch and unrelated timers remain allowed.
+    """
+    if "tests" not in path.parts:
+        return []
+
+    source_lines = text.splitlines()
+    code = _strip_cpp_comments(text)
+    findings: list[tuple[int, str]] = []
+    timer_re = re.compile(r"\bQTimer\s*::\s*singleShot\s*\(")
+
+    for timer_match in timer_re.finditer(code):
+        arguments = _extract_call_args(code, timer_match.end() - 1)
+        if not arguments or not _WATCHDOG_LITERAL_RE.search(arguments):
+            continue
+        delay = _first_call_argument(arguments)
+        if _is_zero_timer_delay(delay):
+            continue
+        line_num = code[: timer_match.start()].count("\n") + 1
+        if line_num <= len(source_lines) and ALLOW_MARKER in source_lines[line_num - 1]:
+            continue
+        findings.append(
+            (
+                line_num,
+                "A nonzero QTimer::singleShot callback reports 'watchdog expired'. "
+                "Wall-clock watchdogs make test success depend on CI runner speed; "
+                "wait on a deterministic state/signal or invoke the dispatch path "
+                "directly instead.",
+            )
+        )
+
+    return findings
 
 
 def _check_qsizetype_to_int_conversion(text: str, path: Path) -> list[tuple[int, str]]:
@@ -974,6 +1226,14 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "qt-version-macro-in-tests",
         "check": _check_qt_version_macro_in_tests,
+    },
+    {
+        "name": "qmessagebox-in-tests",
+        "check": _check_qmessagebox_in_tests,
+    },
+    {
+        "name": "nonzero-watchdog-timer",
+        "check": _check_nonzero_watchdog_timer,
     },
 ]
 

--- a/scripts/run_changed_clang_tidy.py
+++ b/scripts/run_changed_clang_tidy.py
@@ -274,7 +274,50 @@ def run_direct_header_pass(
     return status, "".join(outputs)
 
 
-def main() -> int:
+def run_changed_header_passes(
+    clang_tidy: Path,
+    build_dir: Path,
+    units: list[Path],
+    headers: list[Path],
+    line_filter: str,
+    jobs: int,
+    extra_arguments: list[str],
+    environment: dict[str, str],
+    *,
+    fast: bool,
+) -> tuple[int, str]:
+    """Analyze changed header lines, optionally skipping all-TU fan-out."""
+    status = 0
+    outputs: list[str] = []
+
+    if not fast:
+        fan_out_status, fan_out_output = run_header_pass(
+            clang_tidy,
+            build_dir,
+            units,
+            line_filter,
+            jobs,
+            extra_arguments,
+            environment,
+        )
+        status = status or fan_out_status
+        outputs.append(fan_out_output)
+
+    direct_status, direct_output = run_direct_header_pass(
+        clang_tidy,
+        build_dir,
+        headers,
+        line_filter,
+        jobs,
+        extra_arguments,
+        environment,
+    )
+    status = status or direct_status
+    outputs.append(direct_output)
+    return status, "".join(outputs)
+
+
+def parse_arguments(arguments: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", required=True, help="base commit to diff against")
     parser.add_argument("--build-dir", type=Path, required=True)
@@ -288,7 +331,19 @@ def main() -> int:
         help="additional compiler argument forwarded to clang-tidy; repeat as needed",
     )
     parser.add_argument("--jobs", type=int, default=os.cpu_count() or 1)
-    args = parser.parse_args()
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help=(
+            "analyze changed sources and headers directly, skipping the "
+            "changed-header fan-out through every translation unit"
+        ),
+    )
+    return parser.parse_args(arguments)
+
+
+def main() -> int:
+    args = parse_arguments()
 
     root = Path(__file__).resolve().parents[1]
     build_dir = args.build_dir.resolve()
@@ -361,29 +416,19 @@ def main() -> int:
         return 1
     if header_filter:
         line_filter = json.dumps(header_filter, separators=(",", ":"))
-        header_status, header_output = run_header_pass(
+        header_status, header_output = run_changed_header_passes(
             clang_tidy,
             build_dir,
             units,
-            line_filter,
-            args.jobs,
-            args.extra_arg,
-            environment,
-        )
-        status = status or header_status
-        output_parts.append(header_output)
-
-        direct_status, direct_output = run_direct_header_pass(
-            clang_tidy,
-            build_dir,
             [(root / path).resolve() for path in live_header_paths],
             line_filter,
             args.jobs,
             args.extra_arg,
             environment,
+            fast=args.fast,
         )
-        status = status or direct_status
-        output_parts.append(direct_output)
+        status = status or header_status
+        output_parts.append(header_output)
 
     output = "".join(output_parts)
     if output:

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -696,6 +696,16 @@
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>Unable to export filter favorites to the selected file.</translation>
     </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1854"/>
+        <source>Filter favorites changed while the import was being applied. Try again.</source>
+        <translation>Filter favorites changed while the import was being applied. Try again.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1860"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>Unable to save filter favorites. Try again.</translation>
+    </message>
 </context>
 <context>
     <name>OptionsDialog</name>
@@ -1225,6 +1235,11 @@
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>Unable to export filter favorites to the selected file.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="204"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>Unable to save filter favorites. Try again.</translation>
     </message>
 </context>
 <context>
@@ -2213,8 +2228,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
-        <source>Open Recent</source>
-        <translation>Open Recent</translation>
+        <source>Open &amp;Recent</source>
+        <translation>Open &amp;Recent</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
@@ -2289,14 +2304,19 @@
         <translation>Favorite &quot;%1&quot; changed while the save dialog was open. Try again.</translation>
     </message>
     <message>
-        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
-        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
-        <translation>Favorite &quot;%1&quot; already exists with the same content.</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
         <source>Favorite &quot;%1&quot; already has the same content.</source>
         <translation>Favorite &quot;%1&quot; already has the same content.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="530"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>Unable to save filter favorites. Try again.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="548"/>
+        <source>A favorite named &quot;%1&quot; already exists. Choose a different name.</source>
+        <translation>A favorite named &quot;%1&quot; already exists. Choose a different name.</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -16,19 +16,19 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="572"/>
-        <source>&amp;Copy this line</source>
-        <translation>&amp;Copy this line</translation>
+        <source>&amp;Copy This Line</source>
+        <translation>&amp;Copy This Line</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="573"/>
-        <source>Copy this line with line number</source>
-        <translation type="unfinished"></translation>
+        <source>Copy This Line with Line Number</source>
+        <translation>Copy This Line with Line Number</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="585"/>
         <location filename="../../ui/src/abstractlogview.cpp" line="2020"/>
-        <source>Copy with line numbers</source>
-        <translation type="unfinished"></translation>
+        <source>Copy with Line Numbers</source>
+        <translation>Copy with Line Numbers</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="629"/>
@@ -52,18 +52,18 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2028"/>
-        <source>Save to file</source>
-        <translation>Save to file</translation>
+        <source>Save to File...</source>
+        <translation>Save to File...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2032"/>
-        <source>Save selected to file</source>
-        <translation>Save selected to file</translation>
+        <source>Save Selected to File...</source>
+        <translation>Save Selected to File...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2039"/>
-        <source>Find &amp;next</source>
-        <translation>Find &amp;next</translation>
+        <source>Find &amp;Next</source>
+        <translation>Find &amp;Next</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2041"/>
@@ -72,8 +72,8 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2045"/>
-        <source>Find &amp;previous</source>
-        <translation>Find &amp;previous</translation>
+        <source>Find &amp;Previous</source>
+        <translation>Find &amp;Previous</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2046"/>
@@ -87,8 +87,8 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2051"/>
-        <source>&amp;Replace search</source>
-        <translation>&amp;Replace search</translation>
+        <source>&amp;Replace Search</source>
+        <translation>&amp;Replace Search</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2052"/>
@@ -97,8 +97,8 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2056"/>
-        <source>&amp;Add to search</source>
-        <translation>&amp;Add to search</translation>
+        <source>&amp;Add to Search</source>
+        <translation>&amp;Add to Search</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2057"/>
@@ -107,8 +107,8 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2061"/>
-        <source>&amp;Exclude from search</source>
-        <translation>&amp;Exclude from search</translation>
+        <source>&amp;Exclude from Search</source>
+        <translation>&amp;Exclude from Search</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2062"/>
@@ -117,43 +117,43 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2066"/>
-        <source>Set search start</source>
-        <translation>Set search start</translation>
+        <source>Set Search Start</source>
+        <translation>Set Search Start</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2070"/>
-        <source>Set search end</source>
-        <translation>Set search end</translation>
+        <source>Set Search End</source>
+        <translation>Set Search End</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2074"/>
-        <source>Clear search limits</source>
-        <translation>Clear search limits</translation>
+        <source>Clear Search Limits</source>
+        <translation>Clear Search Limits</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2078"/>
-        <source>Set selection start</source>
-        <translation>Set selection start</translation>
+        <source>Set Selection Start</source>
+        <translation>Set Selection Start</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2082"/>
-        <source>Set selection end</source>
-        <translation>Set selection end</translation>
+        <source>Set Selection End</source>
+        <translation>Set Selection End</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2086"/>
-        <source>Save splitter position</source>
-        <translation>Save splitter position</translation>
+        <source>Save Splitter Position</source>
+        <translation>Save Splitter Position</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2090"/>
-        <source>Send to scratchpad</source>
-        <translation>Send to scratchpad</translation>
+        <source>Send to Scratchpad</source>
+        <translation>Send to Scratchpad</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2094"/>
-        <source>Replace scratchpad</source>
-        <translation>Replace scratchpad</translation>
+        <source>Replace Scratchpad</source>
+        <translation>Replace Scratchpad</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2099"/>
@@ -162,8 +162,28 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2100"/>
-        <source>Color labels</source>
-        <translation>Color labels</translation>
+        <source>Color Labels</source>
+        <translation>Color Labels</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="658"/>
+        <source>Ignore Case</source>
+        <translation>Ignore Case</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="662"/>
+        <source>Whole Word</source>
+        <translation>Whole Word</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2596"/>
+        <source>Add Line Mark</source>
+        <translation>Add Line Mark</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2599"/>
+        <source>Delete Line Mark</source>
+        <translation>Delete Line Mark</translation>
     </message>
 </context>
 <context>
@@ -467,24 +487,9 @@
         <translation>Open URL as log file</translation>
     </message>
     <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="871"/>
-        <source>Open window</source>
-        <translation>Open window</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/mainwindow.cpp" line="196"/>
         <source>klogg - scratchpad</source>
         <translation>klogg - scratchpad</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="740"/>
-        <source>Open Recent</source>
-        <translation>Open Recent</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="872"/>
-        <source>Quit</source>
-        <translation>Quit</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="924"/>
@@ -680,6 +685,16 @@
         <location filename="../../ui/src/mainwindow.cpp" line="2270"/>
         <source>This will shutdown klogg and generate diagnostic crash dump. Continue?</source>
         <translation>This will shutdown klogg and generate diagnostic crash dump. Continue?</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1813"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>Unable to import filter favorites from the selected file.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1842"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>Unable to export filter favorites to the selected file.</translation>
     </message>
 </context>
 <context>
@@ -1074,18 +1089,18 @@
     <name>PathLine</name>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="39"/>
-        <source>Copy full path</source>
-        <translation>Copy full path</translation>
+        <source>Copy Full Path</source>
+        <translation>Copy Full Path</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="40"/>
-        <source>Copy file name</source>
-        <translation>Copy file name</translation>
+        <source>Copy File Name</source>
+        <translation>Copy File Name</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="41"/>
-        <source>Open containing folder</source>
-        <translation>Open containing folder</translation>
+        <source>Open Containing Folder</source>
+        <translation>Open Containing Folder</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="43"/>
@@ -1094,8 +1109,21 @@
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="45"/>
-        <source>Select all</source>
-        <translation>Select all</translation>
+        <source>Select All</source>
+        <translation>Select All</translation>
+    </message>
+</context>
+<context>
+    <name>InfoLine</name>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="120"/>
+        <source>Copy</source>
+        <translation>Copy</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="122"/>
+        <source>Select All</source>
+        <translation>Select All</translation>
     </message>
 </context>
 <context>
@@ -1165,18 +1193,38 @@
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="289"/>
-        <source>Predefined filters (*.conf);;All files (*)</source>
-        <translation>Predefined filters (*.conf);;All files (*)</translation>
+        <source>Filter favorites (*.conf);;All files (*)</source>
+        <translation>Filter favorites (*.conf);;All files (*)</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="305"/>
-        <source>Export predefined filters</source>
-        <translation>Export predefined filters</translation>
+        <source>Export filter favorites</source>
+        <translation>Export filter favorites</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="306"/>
-        <source>Predefined filters (*.conf)</source>
-        <translation>Predefined filters (*.conf)</translation>
+        <source>Filter favorites (*.conf)</source>
+        <translation>Filter favorites (*.conf)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="190"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="191"/>
+        <source>Filter favorites changed outside this dialog. Reopen the dialog and try again.</source>
+        <translation>Filter favorites changed outside this dialog. Reopen the dialog and try again.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="322"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>Unable to import filter favorites from the selected file.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>Unable to export filter favorites to the selected file.</translation>
     </message>
 </context>
 <context>
@@ -1604,56 +1652,146 @@
     <name>TabbedCrawlerWidget</name>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="180"/>
-        <source>Close this</source>
-        <translation>Close this</translation>
+        <source>Close This</source>
+        <translation>Close This</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="181"/>
-        <source>Close others</source>
-        <translation>Close others</translation>
+        <source>Close Others</source>
+        <translation>Close Others</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="182"/>
-        <source>Close to the left</source>
-        <translation>Close to the left</translation>
+        <source>Close to the Left</source>
+        <translation>Close to the Left</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="183"/>
-        <source>Close to the right</source>
-        <translation>Close to the right</translation>
+        <source>Close to the Right</source>
+        <translation>Close to the Right</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="184"/>
-        <source>Close all</source>
-        <translation>Close all</translation>
+        <source>Close All</source>
+        <translation>Close All</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="186"/>
-        <source>Copy full path</source>
-        <translation>Copy full path</translation>
+        <source>Copy Full Path</source>
+        <translation>Copy Full Path</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="187"/>
-        <source>Open containing folder</source>
-        <translation>Open containing folder</translation>
+        <source>Open Containing Folder</source>
+        <translation>Open Containing Folder</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="189"/>
-        <source>Rename tab</source>
-        <translation>Rename tab</translation>
+        <source>Rename Tab...</source>
+        <translation>Rename Tab...</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="190"/>
-        <source>Reset tab name</source>
-        <translation>Reset tab name</translation>
+        <source>Reset Tab Name</source>
+        <translation>Reset Tab Name</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="835"/>
+        <source>Add to Group</source>
+        <translation>Add to Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="842"/>
+        <source>Remove from Group</source>
+        <translation>Remove from Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="848"/>
+        <source>Group</source>
+        <translation>Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1061"/>
+        <source>New Group...</source>
+        <translation>New Group...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>New Tab Group</source>
+        <translation>New Tab Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>Group name:</source>
+        <translation>Group name:</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1071"/>
+        <source>New Group</source>
+        <translation>New Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1078"/>
+        <source>Choose Group Color</source>
+        <translation>Choose Group Color</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1195"/>
+        <source>Group: %1 (click to collapse/expand)</source>
+        <translation>Group: %1 (click to collapse/expand)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1318"/>
+        <source>%1&#xa;Group: %2</source>
+        <translation>%1&#xa;Group: %2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1335"/>
+        <source>[%1] %2</source>
+        <translation>[%1] %2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Expand Group</source>
+        <translation>Expand Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Collapse Group</source>
+        <translation>Collapse Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1371"/>
+        <source>Rename Group...</source>
+        <translation>Rename Group...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1374"/>
+        <source>Rename Group</source>
+        <translation>Rename Group</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1382"/>
+        <source>Change Color...</source>
+        <translation>Change Color...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1393"/>
+        <source>Ungroup All</source>
+        <translation>Ungroup All</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1399"/>
+        <source>Close All in Group</source>
+        <translation>Close All in Group</translation>
     </message>
 </context>
 <context>
     <name>klogg::mainwindow::action</name>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="29"/>
-        <source>&amp;New window</source>
-        <translation>&amp;New window</translation>
+        <source>&amp;New Window</source>
+        <translation>&amp;New Window</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="30"/>
@@ -1727,8 +1865,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
-        <source>Go to line...</source>
-        <translation>Go to line...</translation>
+        <source>Go to Line...</source>
+        <translation>Go to Line...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="46"/>
@@ -1747,8 +1885,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="49"/>
-        <source>Clear file...</source>
-        <translation>Clear file...</translation>
+        <source>Clear File...</source>
+        <translation>Clear File...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="50"/>
@@ -1757,8 +1895,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="51"/>
-        <source>Open containing folder</source>
-        <translation>Open containing folder</translation>
+        <source>Open Containing Folder</source>
+        <translation>Open Containing Folder</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="53"/>
@@ -1767,8 +1905,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="54"/>
-        <source>Open in editor</source>
-        <translation>Open in editor</translation>
+        <source>Open in Editor</source>
+        <translation>Open in Editor</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="55"/>
@@ -1777,8 +1915,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="56"/>
-        <source>Copy full path</source>
-        <translation>Copy full path</translation>
+        <source>Copy Full Path</source>
+        <translation>Copy Full Path</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="58"/>
@@ -1787,8 +1925,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="59"/>
-        <source>Open from clipboard</source>
-        <translation>Open from clipboard</translation>
+        <source>Open from Clipboard</source>
+        <translation>Open from Clipboard</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="60"/>
@@ -1807,18 +1945,18 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="63"/>
-        <source>Matches &amp;overview</source>
-        <translation>Matches &amp;overview</translation>
+        <source>Matches &amp;Overview</source>
+        <translation>Matches &amp;Overview</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="64"/>
-        <source>Line &amp;numbers in main view</source>
-        <translation>Line &amp;numbers in main view</translation>
+        <source>Line &amp;Numbers in Main View</source>
+        <translation>Line &amp;Numbers in Main View</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="66"/>
-        <source>Line &amp;numbers in filtered view</source>
-        <translation>Line &amp;numbers in filtered view</translation>
+        <source>Line &amp;Numbers in Filtered View</source>
+        <translation>Line &amp;Numbers in Filtered View</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="67"/>
@@ -1827,8 +1965,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="68"/>
-        <source>&amp;Wrap text</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Wrap Text</source>
+        <translation>&amp;Wrap Text</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="69"/>
@@ -1852,8 +1990,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="73"/>
-        <source>Configure &amp;highlighters...</source>
-        <translation>Configure &amp;highlighters...</translation>
+        <source>Configure &amp;Highlighters...</source>
+        <translation>Configure &amp;Highlighters...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="74"/>
@@ -1862,8 +2000,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="75"/>
-        <source>&amp;Documentation...</source>
-        <translation>&amp;Documentation...</translation>
+        <source>&amp;Documentation</source>
+        <translation>&amp;Documentation</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="76"/>
@@ -1892,8 +2030,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="81"/>
-        <source>Report issue...</source>
-        <translation>Report issue...</translation>
+        <source>Report Issue</source>
+        <translation>Report Issue</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="82"/>
@@ -1902,8 +2040,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="89"/>
-        <source>Generate crash dump</source>
-        <translation>Generate crash dump</translation>
+        <source>Generate Crash Dump</source>
+        <translation>Generate Crash Dump</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="90"/>
@@ -1922,23 +2060,23 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="93"/>
-        <source>Add to favorites</source>
-        <translation>Add to favorites</translation>
+        <source>Add Current File to Favorites</source>
+        <translation>Add Current File to Favorites</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="94"/>
-        <source>Remove from favorites...</source>
-        <translation>Remove from favorites...</translation>
+        <source>Remove Current File from Favorites</source>
+        <translation>Remove Current File from Favorites</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="95"/>
-        <source>Switch to opened file...</source>
-        <translation>Switch to opened file...</translation>
+        <source>Switch to Opened File...</source>
+        <translation>Switch to Opened File...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
-        <source>Predefined filters...</source>
-        <translation>Predefined filters...</translation>
+        <source>Filter Favorites...</source>
+        <translation>Filter Favorites...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="98"/>
@@ -1954,6 +2092,76 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="101"/>
         <source>Automatically detect the file&apos;s encoding</source>
         <translation>Automatically detect the file&apos;s encoding</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="38"/>
+        <source>Open Folder...</source>
+        <translation>Open Folder...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="41"/>
+        <source>Open ADB Logcat...</source>
+        <translation>Open ADB Logcat...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
+        <source>Open iOS Log Stream...</source>
+        <translation>Open iOS Log Stream...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="67"/>
+        <source>Without ANSI Sequences...</source>
+        <translation>Without ANSI Sequences...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="71"/>
+        <source>With ANSI Sequences...</source>
+        <translation>With ANSI Sequences...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="74"/>
+        <source>Disconnect Source</source>
+        <translation>Disconnect Source</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="77"/>
+        <source>Reconnect Source</source>
+        <translation>Reconnect Source</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
+        <source>Go to &amp;Top</source>
+        <translation>Go to &amp;Top</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="114"/>
+        <source>Check for New Version</source>
+        <translation>Check for New Version</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="121"/>
+        <source>Add Current File</source>
+        <translation>Add Current File</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="122"/>
+        <source>Remove Favorite File...</source>
+        <translation>Remove Favorite File...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="127"/>
+        <source>Import Filter Favorites...</source>
+        <translation>Import Filter Favorites...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="130"/>
+        <source>Export Filter Favorites...</source>
+        <translation>Export Filter Favorites...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="133"/>
+        <source>Merge Tabs...</source>
+        <translation>Merge Tabs...</translation>
     </message>
 </context>
 <context>
@@ -1975,8 +2183,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="15"/>
-        <source>Opened files</source>
-        <translation>Opened files</translation>
+        <source>Opened Files</source>
+        <translation>Opened Files</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="16"/>
@@ -1990,8 +2198,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="18"/>
-        <source>F&amp;avorites</source>
-        <translation>F&amp;avorites</translation>
+        <source>F&amp;avorite Files</source>
+        <translation>F&amp;avorite Files</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="19"/>
@@ -2002,6 +2210,21 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="20"/>
         <source>E&amp;ncoding</source>
         <translation>E&amp;ncoding</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
+        <source>Open Recent</source>
+        <translation>Open Recent</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
+        <source>Open Recent Fol&amp;der</source>
+        <translation>Open Recent Fol&amp;der</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="16"/>
+        <source>Save Live Log As</source>
+        <translation>Save Live Log As</translation>
     </message>
 </context>
 <context>
@@ -2018,6 +2241,62 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="26"/>
         <source>klogg log viewer</source>
         <translation>klogg log viewer</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="30"/>
+        <source>Open Window</source>
+        <translation>Open Window</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="31"/>
+        <source>Quit</source>
+        <translation>Quit</translation>
+    </message>
+</context>
+<context>
+    <name>HighlightersMenu</name>
+    <message>
+        <location filename="../../ui/src/highlightersmenu.cpp" line="49"/>
+        <source>None</source>
+        <translation>None</translation>
+    </message>
+</context>
+<context>
+    <name>SearchToolbar</name>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="113"/>
+        <source>Clear Search History</source>
+        <translation>Clear Search History</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="115"/>
+        <source>Edit Search History...</source>
+        <translation>Edit Search History...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="118"/>
+        <source>Add to Filter Favorites...</source>
+        <translation>Add to Filter Favorites...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="511"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="512"/>
+        <source>Favorite &quot;%1&quot; changed while the save dialog was open. Try again.</source>
+        <translation>Favorite &quot;%1&quot; changed while the save dialog was open. Try again.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
+        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
+        <translation>Favorite &quot;%1&quot; already exists with the same content.</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
+        <source>Favorite &quot;%1&quot; already has the same content.</source>
+        <translation>Favorite &quot;%1&quot; already has the same content.</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_CN.ts
+++ b/src/app/i18n/zh_CN.ts
@@ -16,18 +16,18 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="572"/>
-        <source>&amp;Copy this line</source>
+        <source>&amp;Copy This Line</source>
         <translation>拷贝当前行(&amp;C)</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="573"/>
-        <source>Copy this line with line number</source>
+        <source>Copy This Line with Line Number</source>
         <translation type="unfinished">拷贝当前行并附加行号</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="585"/>
         <location filename="../../ui/src/abstractlogview.cpp" line="2020"/>
-        <source>Copy with line numbers</source>
+        <source>Copy with Line Numbers</source>
         <translation type="unfinished">拷贝并附加行号</translation>
     </message>
     <message>
@@ -52,17 +52,17 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2028"/>
-        <source>Save to file</source>
-        <translation>保存到文件</translation>
+        <source>Save to File...</source>
+        <translation>保存到文件...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2032"/>
-        <source>Save selected to file</source>
-        <translation>保存选中内容到文件</translation>
+        <source>Save Selected to File...</source>
+        <translation>保存选中内容到文件...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2039"/>
-        <source>Find &amp;next</source>
+        <source>Find &amp;Next</source>
         <translation>查找下一个(&amp;n)</translation>
     </message>
     <message>
@@ -72,7 +72,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2045"/>
-        <source>Find &amp;previous</source>
+        <source>Find &amp;Previous</source>
         <translation>查找上一个(&amp;p)</translation>
     </message>
     <message>
@@ -87,7 +87,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2051"/>
-        <source>&amp;Replace search</source>
+        <source>&amp;Replace Search</source>
         <translation type="unfinished">替换(&amp;R)</translation>
     </message>
     <message>
@@ -97,7 +97,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2056"/>
-        <source>&amp;Add to search</source>
+        <source>&amp;Add to Search</source>
         <translation type="unfinished">添加到搜索(&amp;A)</translation>
     </message>
     <message>
@@ -107,7 +107,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2061"/>
-        <source>&amp;Exclude from search</source>
+        <source>&amp;Exclude from Search</source>
         <translation>从搜索中排除所选内容(&amp;E)</translation>
     </message>
     <message>
@@ -117,42 +117,42 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2066"/>
-        <source>Set search start</source>
+        <source>Set Search Start</source>
         <translation>设置搜索起点</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2070"/>
-        <source>Set search end</source>
+        <source>Set Search End</source>
         <translation>设置搜索终点</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2074"/>
-        <source>Clear search limits</source>
+        <source>Clear Search Limits</source>
         <translation type="unfinished">清除搜索限制</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2078"/>
-        <source>Set selection start</source>
+        <source>Set Selection Start</source>
         <translation>设置选择起点</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2082"/>
-        <source>Set selection end</source>
+        <source>Set Selection End</source>
         <translation>设置选择终点</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2086"/>
-        <source>Save splitter position</source>
+        <source>Save Splitter Position</source>
         <translation type="unfinished">设置为默认窗口分割线位置</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2090"/>
-        <source>Send to scratchpad</source>
+        <source>Send to Scratchpad</source>
         <translation>追加到暂存器</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2094"/>
-        <source>Replace scratchpad</source>
+        <source>Replace Scratchpad</source>
         <translation>替换暂存器</translation>
     </message>
     <message>
@@ -162,8 +162,28 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2100"/>
-        <source>Color labels</source>
+        <source>Color Labels</source>
         <translation type="unfinished">颜色标签</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="658"/>
+        <source>Ignore Case</source>
+        <translation>忽略大小写</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="662"/>
+        <source>Whole Word</source>
+        <translation>全词匹配</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2596"/>
+        <source>Add Line Mark</source>
+        <translation>标记当前行</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2599"/>
+        <source>Delete Line Mark</source>
+        <translation>删除行标记</translation>
     </message>
 </context>
 <context>
@@ -487,24 +507,9 @@
         <translation>关闭klogg并产生诊断性的崩溃信息。是否继续？</translation>
     </message>
     <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="871"/>
-        <source>Open window</source>
-        <translation>打开窗口</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/mainwindow.cpp" line="196"/>
         <source>klogg - scratchpad</source>
         <translation type="unfinished">klogg - 暂存器</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="740"/>
-        <source>Open Recent</source>
-        <translation type="unfinished">最近打开文件</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="872"/>
-        <source>Quit</source>
-        <translation>退出</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="924"/>
@@ -680,6 +685,16 @@
         <location filename="../../ui/src/mainwindow.cpp" line="2071"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1813"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>无法从所选文件导入筛选器收藏。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1842"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>无法将筛选器收藏导出到所选文件。</translation>
     </message>
 </context>
 <context>
@@ -1074,17 +1089,17 @@
     <name>PathLine</name>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="39"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation type="unfinished">拷贝完整路径</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="40"/>
-        <source>Copy file name</source>
+        <source>Copy File Name</source>
         <translation type="unfinished">拷贝文件名</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="41"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation type="unfinished">打开包含此文件的文件夹</translation>
     </message>
     <message>
@@ -1094,8 +1109,21 @@
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="45"/>
-        <source>Select all</source>
+        <source>Select All</source>
         <translation type="unfinished">选择全部</translation>
+    </message>
+</context>
+<context>
+    <name>InfoLine</name>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="120"/>
+        <source>Copy</source>
+        <translation>复制</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="122"/>
+        <source>Select All</source>
+        <translation>全选</translation>
     </message>
 </context>
 <context>
@@ -1165,18 +1193,38 @@
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="289"/>
-        <source>Predefined filters (*.conf);;All files (*)</source>
-        <translation type="unfinished">预定义过滤器 (*.conf);;全部文件 (*)</translation>
+        <source>Filter favorites (*.conf);;All files (*)</source>
+        <translation>筛选器收藏 (*.conf);;所有文件 (*)</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="305"/>
-        <source>Export predefined filters</source>
-        <translation type="unfinished">导出预定义的过滤器</translation>
+        <source>Export filter favorites</source>
+        <translation>导出筛选器收藏</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="306"/>
-        <source>Predefined filters (*.conf)</source>
-        <translation type="unfinished">预定义过滤器 (*.conf)</translation>
+        <source>Filter favorites (*.conf)</source>
+        <translation>筛选器收藏 (*.conf)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="190"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="191"/>
+        <source>Filter favorites changed outside this dialog. Reopen the dialog and try again.</source>
+        <translation>筛选器收藏已在此对话框外发生更改。请重新打开对话框后重试。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="322"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>无法从所选文件导入筛选器收藏。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>无法将筛选器收藏导出到所选文件。</translation>
     </message>
 </context>
 <context>
@@ -1604,55 +1652,145 @@
     <name>TabbedCrawlerWidget</name>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="180"/>
-        <source>Close this</source>
+        <source>Close This</source>
         <translation>关闭</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="181"/>
-        <source>Close others</source>
+        <source>Close Others</source>
         <translation>关闭其他标签页</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="182"/>
-        <source>Close to the left</source>
+        <source>Close to the Left</source>
         <translation>关闭左侧标签页</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="183"/>
-        <source>Close to the right</source>
+        <source>Close to the Right</source>
         <translation>关闭右侧标签页</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="184"/>
-        <source>Close all</source>
+        <source>Close All</source>
         <translation>关闭所有标签页</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="186"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation>拷贝完整路径</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="187"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation>打开包含此文件的文件夹</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="189"/>
-        <source>Rename tab</source>
-        <translation>重命名标签页</translation>
+        <source>Rename Tab...</source>
+        <translation>重命名标签页...</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="190"/>
-        <source>Reset tab name</source>
+        <source>Reset Tab Name</source>
         <translation>恢复标签页名称</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="835"/>
+        <source>Add to Group</source>
+        <translation>添加到分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="842"/>
+        <source>Remove from Group</source>
+        <translation>从分组中移除</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="848"/>
+        <source>Group</source>
+        <translation>分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1061"/>
+        <source>New Group...</source>
+        <translation>新建分组...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>New Tab Group</source>
+        <translation>新建标签页分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>Group name:</source>
+        <translation>分组名称：</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1071"/>
+        <source>New Group</source>
+        <translation>新分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1078"/>
+        <source>Choose Group Color</source>
+        <translation>选择分组颜色</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1195"/>
+        <source>Group: %1 (click to collapse/expand)</source>
+        <translation>分组：%1（单击以折叠/展开）</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1318"/>
+        <source>%1&#xa;Group: %2</source>
+        <translation>%1&#xa;分组：%2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1335"/>
+        <source>[%1] %2</source>
+        <translation>[%1] %2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Expand Group</source>
+        <translation>展开分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Collapse Group</source>
+        <translation>折叠分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1371"/>
+        <source>Rename Group...</source>
+        <translation>重命名分组...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1374"/>
+        <source>Rename Group</source>
+        <translation>重命名分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1382"/>
+        <source>Change Color...</source>
+        <translation>更改颜色...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1393"/>
+        <source>Ungroup All</source>
+        <translation>取消全部分组</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1399"/>
+        <source>Close All in Group</source>
+        <translation>关闭分组内所有标签页</translation>
     </message>
 </context>
 <context>
     <name>klogg::mainwindow::action</name>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="29"/>
-        <source>&amp;New window</source>
+        <source>&amp;New Window</source>
         <translation>新建窗口(&amp;N)</translation>
     </message>
     <message>
@@ -1727,7 +1865,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
-        <source>Go to line...</source>
+        <source>Go to Line...</source>
         <translation>跳转到行...</translation>
     </message>
     <message>
@@ -1747,7 +1885,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="49"/>
-        <source>Clear file...</source>
+        <source>Clear File...</source>
         <translation>清除文件内容...</translation>
     </message>
     <message>
@@ -1757,7 +1895,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="51"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation type="unfinished">打开包含此文件的文件夹</translation>
     </message>
     <message>
@@ -1767,7 +1905,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="54"/>
-        <source>Open in editor</source>
+        <source>Open in Editor</source>
         <translation>在编辑器中打开</translation>
     </message>
     <message>
@@ -1777,7 +1915,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="56"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation>拷贝完整路径</translation>
     </message>
     <message>
@@ -1787,7 +1925,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="59"/>
-        <source>Open from clipboard</source>
+        <source>Open from Clipboard</source>
         <translation>从剪贴板打开</translation>
     </message>
     <message>
@@ -1807,17 +1945,17 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="63"/>
-        <source>Matches &amp;overview</source>
+        <source>Matches &amp;Overview</source>
         <translation type="unfinished">匹配预览(&amp;o)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="64"/>
-        <source>Line &amp;numbers in main view</source>
+        <source>Line &amp;Numbers in Main View</source>
         <translation type="unfinished">主视图中的行号(&amp;n)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="66"/>
-        <source>Line &amp;numbers in filtered view</source>
+        <source>Line &amp;Numbers in Filtered View</source>
         <translation type="unfinished">过滤视图中的行号(&amp;n)</translation>
     </message>
     <message>
@@ -1827,7 +1965,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="68"/>
-        <source>&amp;Wrap text</source>
+        <source>&amp;Wrap Text</source>
         <translation type="unfinished">文本换行(&amp;W)</translation>
     </message>
     <message>
@@ -1852,7 +1990,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="73"/>
-        <source>Configure &amp;highlighters...</source>
+        <source>Configure &amp;Highlighters...</source>
         <translation type="unfinished">配置高亮显示(&amp;h)...</translation>
     </message>
     <message>
@@ -1862,8 +2000,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="75"/>
-        <source>&amp;Documentation...</source>
-        <translation>文档(&amp;D)...</translation>
+        <source>&amp;Documentation</source>
+        <translation>文档(&amp;D)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="76"/>
@@ -1892,8 +2030,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="81"/>
-        <source>Report issue...</source>
-        <translation>报告问题...</translation>
+        <source>Report Issue</source>
+        <translation>报告问题</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="82"/>
@@ -1902,7 +2040,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="89"/>
-        <source>Generate crash dump</source>
+        <source>Generate Crash Dump</source>
         <translation>生成崩溃报告</translation>
     </message>
     <message>
@@ -1922,23 +2060,23 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="93"/>
-        <source>Add to favorites</source>
-        <translation>加入收藏</translation>
+        <source>Add Current File to Favorites</source>
+        <translation>将当前文件加入收藏</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="94"/>
-        <source>Remove from favorites...</source>
-        <translation>从收藏中移除...</translation>
+        <source>Remove Current File from Favorites</source>
+        <translation>从收藏中移除当前文件</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="95"/>
-        <source>Switch to opened file...</source>
+        <source>Switch to Opened File...</source>
         <translation>切换到已打开文件...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
-        <source>Predefined filters...</source>
-        <translation type="unfinished">预定义的过滤器...</translation>
+        <source>Filter Favorites...</source>
+        <translation>筛选器收藏...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="98"/>
@@ -1954,6 +2092,76 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="101"/>
         <source>Automatically detect the file&apos;s encoding</source>
         <translation>自动检测文件的编码</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="38"/>
+        <source>Open Folder...</source>
+        <translation>打开文件夹...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="41"/>
+        <source>Open ADB Logcat...</source>
+        <translation>打开 ADB Logcat...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
+        <source>Open iOS Log Stream...</source>
+        <translation>打开 iOS 日志流...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="67"/>
+        <source>Without ANSI Sequences...</source>
+        <translation>不含 ANSI 序列...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="71"/>
+        <source>With ANSI Sequences...</source>
+        <translation>包含 ANSI 序列...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="74"/>
+        <source>Disconnect Source</source>
+        <translation>断开源连接</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="77"/>
+        <source>Reconnect Source</source>
+        <translation>重新连接源</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
+        <source>Go to &amp;Top</source>
+        <translation>转到顶部(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="114"/>
+        <source>Check for New Version</source>
+        <translation>检查新版本</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="121"/>
+        <source>Add Current File</source>
+        <translation>添加当前文件</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="122"/>
+        <source>Remove Favorite File...</source>
+        <translation>移除收藏文件...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="127"/>
+        <source>Import Filter Favorites...</source>
+        <translation>导入筛选器收藏...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="130"/>
+        <source>Export Filter Favorites...</source>
+        <translation>导出筛选器收藏...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="133"/>
+        <source>Merge Tabs...</source>
+        <translation>合并标签页...</translation>
     </message>
 </context>
 <context>
@@ -1975,7 +2183,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="15"/>
-        <source>Opened files</source>
+        <source>Opened Files</source>
         <translation>已打开文件</translation>
     </message>
     <message>
@@ -1990,8 +2198,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="18"/>
-        <source>F&amp;avorites</source>
-        <translation>收藏(&amp;F)</translation>
+        <source>F&amp;avorite Files</source>
+        <translation>收藏文件(&amp;F)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="19"/>
@@ -2002,6 +2210,21 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="20"/>
         <source>E&amp;ncoding</source>
         <translation>编码(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
+        <source>Open Recent</source>
+        <translation type="unfinished">最近打开文件</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
+        <source>Open Recent Fol&amp;der</source>
+        <translation>最近打开文件夹(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="16"/>
+        <source>Save Live Log As</source>
+        <translation>实时日志另存为</translation>
     </message>
 </context>
 <context>
@@ -2018,6 +2241,62 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="26"/>
         <source>klogg log viewer</source>
         <translation>Klogg 日志阅读器</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="30"/>
+        <source>Open Window</source>
+        <translation>打开窗口</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="31"/>
+        <source>Quit</source>
+        <translation>退出</translation>
+    </message>
+</context>
+<context>
+    <name>HighlightersMenu</name>
+    <message>
+        <location filename="../../ui/src/highlightersmenu.cpp" line="49"/>
+        <source>None</source>
+        <translation>无</translation>
+    </message>
+</context>
+<context>
+    <name>SearchToolbar</name>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="113"/>
+        <source>Clear Search History</source>
+        <translation>清空搜索历史</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="115"/>
+        <source>Edit Search History...</source>
+        <translation>编辑搜索历史...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="118"/>
+        <source>Add to Filter Favorites...</source>
+        <translation>添加到筛选器收藏...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="511"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="512"/>
+        <source>Favorite &quot;%1&quot; changed while the save dialog was open. Try again.</source>
+        <translation>筛选器收藏“%1”在保存对话框打开期间发生了更改。请重试。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
+        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
+        <translation>筛选器收藏“%1”已存在，且内容相同。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
+        <source>Favorite &quot;%1&quot; already has the same content.</source>
+        <translation>筛选器收藏“%1”的内容已相同。</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_CN.ts
+++ b/src/app/i18n/zh_CN.ts
@@ -696,6 +696,16 @@
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>无法将筛选器收藏导出到所选文件。</translation>
     </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1854"/>
+        <source>Filter favorites changed while the import was being applied. Try again.</source>
+        <translation>应用导入时筛选收藏已发生更改。请重试。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1860"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>无法保存筛选收藏。请重试。</translation>
+    </message>
 </context>
 <context>
     <name>OptionsDialog</name>
@@ -1225,6 +1235,11 @@
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>无法将筛选器收藏导出到所选文件。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="204"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>无法保存筛选收藏。请重试。</translation>
     </message>
 </context>
 <context>
@@ -2213,8 +2228,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
-        <source>Open Recent</source>
-        <translation type="unfinished">最近打开文件</translation>
+        <source>Open &amp;Recent</source>
+        <translation>最近打开文件(&amp;R)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
@@ -2289,14 +2304,19 @@
         <translation>筛选器收藏“%1”在保存对话框打开期间发生了更改。请重试。</translation>
     </message>
     <message>
-        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
-        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
-        <translation>筛选器收藏“%1”已存在，且内容相同。</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
         <source>Favorite &quot;%1&quot; already has the same content.</source>
         <translation>筛选器收藏“%1”的内容已相同。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="530"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>无法保存筛选收藏。请重试。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="548"/>
+        <source>A favorite named &quot;%1&quot; already exists. Choose a different name.</source>
+        <translation>名为“%1”的收藏已存在。请选择其他名称。</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_CN.ts
+++ b/src/app/i18n/zh_CN.ts
@@ -699,12 +699,12 @@
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="1854"/>
         <source>Filter favorites changed while the import was being applied. Try again.</source>
-        <translation>应用导入时筛选收藏已发生更改。请重试。</translation>
+        <translation>应用导入时筛选器收藏已发生更改。请重试。</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="1860"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>无法保存筛选收藏。请重试。</translation>
+        <translation>无法保存筛选器收藏。请重试。</translation>
     </message>
 </context>
 <context>
@@ -1239,7 +1239,7 @@
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="204"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>无法保存筛选收藏。请重试。</translation>
+        <translation>无法保存筛选器收藏。请重试。</translation>
     </message>
 </context>
 <context>
@@ -2311,12 +2311,12 @@
     <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="530"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>无法保存筛选收藏。请重试。</translation>
+        <translation>无法保存筛选器收藏。请重试。</translation>
     </message>
     <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="548"/>
         <source>A favorite named &quot;%1&quot; already exists. Choose a different name.</source>
-        <translation>名为“%1”的收藏已存在。请选择其他名称。</translation>
+        <translation>名为“%1”的筛选器收藏已存在。请选择其他名称。</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_TW.ts
+++ b/src/app/i18n/zh_TW.ts
@@ -699,12 +699,12 @@
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="1854"/>
         <source>Filter favorites changed while the import was being applied. Try again.</source>
-        <translation>套用匯入時篩選收藏已發生變更。請重試。</translation>
+        <translation>套用匯入時篩選器書籤已發生變更。請重試。</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="1860"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>無法儲存篩選收藏。請重試。</translation>
+        <translation>無法儲存篩選器書籤。請重試。</translation>
     </message>
 </context>
 <context>
@@ -1239,7 +1239,7 @@
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="204"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>無法儲存篩選收藏。請重試。</translation>
+        <translation>無法儲存篩選器書籤。請重試。</translation>
     </message>
 </context>
 <context>
@@ -2311,12 +2311,12 @@
     <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="530"/>
         <source>Unable to save filter favorites. Try again.</source>
-        <translation>無法儲存篩選收藏。請重試。</translation>
+        <translation>無法儲存篩選器書籤。請重試。</translation>
     </message>
     <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="548"/>
         <source>A favorite named &quot;%1&quot; already exists. Choose a different name.</source>
-        <translation>名為「%1」的收藏已存在。請選擇其他名稱。</translation>
+        <translation>名為「%1」的篩選器書籤已存在。請選擇其他名稱。</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_TW.ts
+++ b/src/app/i18n/zh_TW.ts
@@ -16,18 +16,18 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="572"/>
-        <source>&amp;Copy this line</source>
+        <source>&amp;Copy This Line</source>
         <translation>複製此行(&amp;C)</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="573"/>
-        <source>Copy this line with line number</source>
+        <source>Copy This Line with Line Number</source>
         <translation>複製此行並附加行號</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="585"/>
         <location filename="../../ui/src/abstractlogview.cpp" line="2020"/>
-        <source>Copy with line numbers</source>
+        <source>Copy with Line Numbers</source>
         <translation>複製並附加行號</translation>
     </message>
     <message>
@@ -52,17 +52,17 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2028"/>
-        <source>Save to file</source>
-        <translation>儲存到檔案</translation>
+        <source>Save to File...</source>
+        <translation>儲存到檔案...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2032"/>
-        <source>Save selected to file</source>
-        <translation>儲存選取內容到檔案</translation>
+        <source>Save Selected to File...</source>
+        <translation>儲存選取內容到檔案...</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2039"/>
-        <source>Find &amp;next</source>
+        <source>Find &amp;Next</source>
         <translation>尋找下一個(&amp;n)</translation>
     </message>
     <message>
@@ -72,7 +72,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2045"/>
-        <source>Find &amp;previous</source>
+        <source>Find &amp;Previous</source>
         <translation>尋找上一個(&amp;p)</translation>
     </message>
     <message>
@@ -87,7 +87,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2051"/>
-        <source>&amp;Replace search</source>
+        <source>&amp;Replace Search</source>
         <translation>取代(&amp;R)</translation>
     </message>
     <message>
@@ -97,7 +97,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2056"/>
-        <source>&amp;Add to search</source>
+        <source>&amp;Add to Search</source>
         <translation>新增到搜尋(&amp;A)</translation>
     </message>
     <message>
@@ -107,7 +107,7 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2061"/>
-        <source>&amp;Exclude from search</source>
+        <source>&amp;Exclude from Search</source>
         <translation>從搜尋中排除所選內容(&amp;E)</translation>
     </message>
     <message>
@@ -117,42 +117,42 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2066"/>
-        <source>Set search start</source>
+        <source>Set Search Start</source>
         <translation>設定搜尋起點</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2070"/>
-        <source>Set search end</source>
+        <source>Set Search End</source>
         <translation>設定搜尋終點</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2074"/>
-        <source>Clear search limits</source>
+        <source>Clear Search Limits</source>
         <translation>清除搜尋限制</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2078"/>
-        <source>Set selection start</source>
+        <source>Set Selection Start</source>
         <translation>設定選取起點</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2082"/>
-        <source>Set selection end</source>
+        <source>Set Selection End</source>
         <translation>設定選取終點</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2086"/>
-        <source>Save splitter position</source>
+        <source>Save Splitter Position</source>
         <translation>儲存分隔線位置</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2090"/>
-        <source>Send to scratchpad</source>
+        <source>Send to Scratchpad</source>
         <translation>傳送到便條</translation>
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2094"/>
-        <source>Replace scratchpad</source>
+        <source>Replace Scratchpad</source>
         <translation>取代便條</translation>
     </message>
     <message>
@@ -162,8 +162,28 @@
     </message>
     <message>
         <location filename="../../ui/src/abstractlogview.cpp" line="2100"/>
-        <source>Color labels</source>
+        <source>Color Labels</source>
         <translation>顏色標籤</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="658"/>
+        <source>Ignore Case</source>
+        <translation>忽略大小寫</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="662"/>
+        <source>Whole Word</source>
+        <translation>全字匹配</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2596"/>
+        <source>Add Line Mark</source>
+        <translation>新增行標記</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/abstractlogview.cpp" line="2599"/>
+        <source>Delete Line Mark</source>
+        <translation>刪除行標記</translation>
     </message>
 </context>
 <context>
@@ -487,24 +507,9 @@
         <translation>關閉 klogg 並產生診斷性的當機記錄。是否繼續？</translation>
     </message>
     <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="871"/>
-        <source>Open window</source>
-        <translation>開啟視窗</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/mainwindow.cpp" line="196"/>
         <source>klogg - scratchpad</source>
         <translation>klogg - 便條</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="740"/>
-        <source>Open Recent</source>
-        <translation>最近開啟檔案</translation>
-    </message>
-    <message>
-        <location filename="../../ui/src/mainwindow.cpp" line="872"/>
-        <source>Quit</source>
-        <translation>退出</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindow.cpp" line="924"/>
@@ -680,6 +685,16 @@
         <location filename="../../ui/src/mainwindow.cpp" line="2071"/>
         <source>Remove from favorites</source>
         <translation>從書籤中移除</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1813"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>無法從所選檔案匯入篩選器書籤。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1842"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>無法將篩選器書籤匯出到所選檔案。</translation>
     </message>
 </context>
 <context>
@@ -1074,17 +1089,17 @@
     <name>PathLine</name>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="39"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation>複製完整路徑</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="40"/>
-        <source>Copy file name</source>
+        <source>Copy File Name</source>
         <translation>複製檔案名稱</translation>
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="41"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation>開啟包含此檔案的資料夾</translation>
     </message>
     <message>
@@ -1094,7 +1109,20 @@
     </message>
     <message>
         <location filename="../../ui/src/pathline.cpp" line="45"/>
-        <source>Select all</source>
+        <source>Select All</source>
+        <translation>全選</translation>
+    </message>
+</context>
+<context>
+    <name>InfoLine</name>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="120"/>
+        <source>Copy</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/infoline.cpp" line="122"/>
+        <source>Select All</source>
         <translation>全選</translation>
     </message>
 </context>
@@ -1165,18 +1193,38 @@
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="289"/>
-        <source>Predefined filters (*.conf);;All files (*)</source>
-        <translation>預設篩選器 (*.conf);;所有檔案 (*)</translation>
+        <source>Filter favorites (*.conf);;All files (*)</source>
+        <translation>篩選器書籤 (*.conf);;所有檔案 (*)</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="305"/>
-        <source>Export predefined filters</source>
-        <translation>匯出預設篩選器</translation>
+        <source>Export filter favorites</source>
+        <translation>匯出篩選器書籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="306"/>
-        <source>Predefined filters (*.conf)</source>
-        <translation>預設篩選器 (*.conf)</translation>
+        <source>Filter favorites (*.conf)</source>
+        <translation>篩選器書籤 (*.conf)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="190"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="191"/>
+        <source>Filter favorites changed outside this dialog. Reopen the dialog and try again.</source>
+        <translation>篩選器書籤已在此對話框外變更。請重新開啟對話框後再試一次。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="322"/>
+        <source>Unable to import filter favorites from the selected file.</source>
+        <translation>無法從所選檔案匯入篩選器書籤。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
+        <source>Unable to export filter favorites to the selected file.</source>
+        <translation>無法將篩選器書籤匯出到所選檔案。</translation>
     </message>
 </context>
 <context>
@@ -1604,55 +1652,145 @@
     <name>TabbedCrawlerWidget</name>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="180"/>
-        <source>Close this</source>
+        <source>Close This</source>
         <translation>關閉此標籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="181"/>
-        <source>Close others</source>
+        <source>Close Others</source>
         <translation>關閉其他標籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="182"/>
-        <source>Close to the left</source>
+        <source>Close to the Left</source>
         <translation>關閉左側標籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="183"/>
-        <source>Close to the right</source>
+        <source>Close to the Right</source>
         <translation>關閉右側標籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="184"/>
-        <source>Close all</source>
+        <source>Close All</source>
         <translation>全部關閉</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="186"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation>複製完整路徑</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="187"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation>開啟所在資料夾</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="189"/>
-        <source>Rename tab</source>
-        <translation>重新命名標籤</translation>
+        <source>Rename Tab...</source>
+        <translation>重新命名標籤...</translation>
     </message>
     <message>
         <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="190"/>
-        <source>Reset tab name</source>
+        <source>Reset Tab Name</source>
         <translation>重設標籤名稱</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="835"/>
+        <source>Add to Group</source>
+        <translation>加入群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="842"/>
+        <source>Remove from Group</source>
+        <translation>從群組中移除</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="848"/>
+        <source>Group</source>
+        <translation>群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1061"/>
+        <source>New Group...</source>
+        <translation>新增群組...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>New Tab Group</source>
+        <translation>新增標籤頁群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1070"/>
+        <source>Group name:</source>
+        <translation>群組名稱：</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1071"/>
+        <source>New Group</source>
+        <translation>新群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1078"/>
+        <source>Choose Group Color</source>
+        <translation>選擇群組顏色</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1195"/>
+        <source>Group: %1 (click to collapse/expand)</source>
+        <translation>群組：%1（按一下以收合/展開）</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1318"/>
+        <source>%1&#xa;Group: %2</source>
+        <translation>%1&#xa;群組：%2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1335"/>
+        <source>[%1] %2</source>
+        <translation>[%1] %2</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Expand Group</source>
+        <translation>展開群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1363"/>
+        <source>Collapse Group</source>
+        <translation>收合群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1371"/>
+        <source>Rename Group...</source>
+        <translation>重新命名群組...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1374"/>
+        <source>Rename Group</source>
+        <translation>重新命名群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1382"/>
+        <source>Change Color...</source>
+        <translation>變更顏色...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1393"/>
+        <source>Ungroup All</source>
+        <translation>取消所有群組</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/tabbedcrawlerwidget.cpp" line="1399"/>
+        <source>Close All in Group</source>
+        <translation>關閉群組中的所有標籤頁</translation>
     </message>
 </context>
 <context>
     <name>klogg::mainwindow::action</name>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="29"/>
-        <source>&amp;New window</source>
+        <source>&amp;New Window</source>
         <translation>開新視窗(&amp;N)</translation>
     </message>
     <message>
@@ -1727,7 +1865,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
-        <source>Go to line...</source>
+        <source>Go to Line...</source>
         <translation>跳至行數...</translation>
     </message>
     <message>
@@ -1747,7 +1885,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="49"/>
-        <source>Clear file...</source>
+        <source>Clear File...</source>
         <translation>清除檔案內容...</translation>
     </message>
     <message>
@@ -1757,7 +1895,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="51"/>
-        <source>Open containing folder</source>
+        <source>Open Containing Folder</source>
         <translation>開啟所在資料夾</translation>
     </message>
     <message>
@@ -1767,7 +1905,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="54"/>
-        <source>Open in editor</source>
+        <source>Open in Editor</source>
         <translation>在編輯器中開啟</translation>
     </message>
     <message>
@@ -1777,7 +1915,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="56"/>
-        <source>Copy full path</source>
+        <source>Copy Full Path</source>
         <translation>複製完整路徑</translation>
     </message>
     <message>
@@ -1787,7 +1925,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="59"/>
-        <source>Open from clipboard</source>
+        <source>Open from Clipboard</source>
         <translation>從剪貼簿開啟</translation>
     </message>
     <message>
@@ -1807,17 +1945,17 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="63"/>
-        <source>Matches &amp;overview</source>
+        <source>Matches &amp;Overview</source>
         <translation>符合項目概覽(&amp;o)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="64"/>
-        <source>Line &amp;numbers in main view</source>
+        <source>Line &amp;Numbers in Main View</source>
         <translation>主檢視中的行號(&amp;n)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="66"/>
-        <source>Line &amp;numbers in filtered view</source>
+        <source>Line &amp;Numbers in Filtered View</source>
         <translation>篩選檢視中的行號(&amp;n)</translation>
     </message>
     <message>
@@ -1827,7 +1965,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="68"/>
-        <source>&amp;Wrap text</source>
+        <source>&amp;Wrap Text</source>
         <translation>文字換行(&amp;W)</translation>
     </message>
     <message>
@@ -1852,7 +1990,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="73"/>
-        <source>Configure &amp;highlighters...</source>
+        <source>Configure &amp;Highlighters...</source>
         <translation>設定醒目提示(&amp;h)...</translation>
     </message>
     <message>
@@ -1862,8 +2000,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="75"/>
-        <source>&amp;Documentation...</source>
-        <translation>文件(&amp;D)...</translation>
+        <source>&amp;Documentation</source>
+        <translation>文件(&amp;D)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="76"/>
@@ -1892,8 +2030,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="81"/>
-        <source>Report issue...</source>
-        <translation>回報問題...</translation>
+        <source>Report Issue</source>
+        <translation>回報問題</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="82"/>
@@ -1902,7 +2040,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="89"/>
-        <source>Generate crash dump</source>
+        <source>Generate Crash Dump</source>
         <translation>產生當機報告</translation>
     </message>
     <message>
@@ -1922,23 +2060,23 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="93"/>
-        <source>Add to favorites</source>
-        <translation>加入書籤</translation>
+        <source>Add Current File to Favorites</source>
+        <translation>將目前檔案加入書籤</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="94"/>
-        <source>Remove from favorites...</source>
-        <translation>從書籤中移除...</translation>
+        <source>Remove Current File from Favorites</source>
+        <translation>從書籤中移除目前檔案</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="95"/>
-        <source>Switch to opened file...</source>
+        <source>Switch to Opened File...</source>
         <translation>切換到已開啟檔案...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
-        <source>Predefined filters...</source>
-        <translation>預設篩選器...</translation>
+        <source>Filter Favorites...</source>
+        <translation>篩選器書籤...</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="98"/>
@@ -1954,6 +2092,76 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="101"/>
         <source>Automatically detect the file&apos;s encoding</source>
         <translation>自動偵測檔案的編碼</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="38"/>
+        <source>Open Folder...</source>
+        <translation>開啟資料夾...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="41"/>
+        <source>Open ADB Logcat...</source>
+        <translation>開啟 ADB Logcat...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="44"/>
+        <source>Open iOS Log Stream...</source>
+        <translation>開啟 iOS 日誌串流...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="67"/>
+        <source>Without ANSI Sequences...</source>
+        <translation>不含 ANSI 序列...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="71"/>
+        <source>With ANSI Sequences...</source>
+        <translation>包含 ANSI 序列...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="74"/>
+        <source>Disconnect Source</source>
+        <translation>中斷來源連線</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="77"/>
+        <source>Reconnect Source</source>
+        <translation>重新連線來源</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="96"/>
+        <source>Go to &amp;Top</source>
+        <translation>移至頂端(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="114"/>
+        <source>Check for New Version</source>
+        <translation>檢查新版本</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="121"/>
+        <source>Add Current File</source>
+        <translation>加入目前檔案</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="122"/>
+        <source>Remove Favorite File...</source>
+        <translation>移除書籤檔案...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="127"/>
+        <source>Import Filter Favorites...</source>
+        <translation>匯入篩選器書籤...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="130"/>
+        <source>Export Filter Favorites...</source>
+        <translation>匯出篩選器書籤...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="133"/>
+        <source>Merge Tabs...</source>
+        <translation>合併標籤頁...</translation>
     </message>
 </context>
 <context>
@@ -1975,7 +2183,7 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="15"/>
-        <source>Opened files</source>
+        <source>Opened Files</source>
         <translation>已開啟檔案</translation>
     </message>
     <message>
@@ -1990,8 +2198,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="18"/>
-        <source>F&amp;avorites</source>
-        <translation>書籤(&amp;F)</translation>
+        <source>F&amp;avorite Files</source>
+        <translation>書籤檔案(&amp;F)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="19"/>
@@ -2002,6 +2210,21 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="20"/>
         <source>E&amp;ncoding</source>
         <translation>編碼(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
+        <source>Open Recent</source>
+        <translation>最近開啟檔案</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
+        <source>Open Recent Fol&amp;der</source>
+        <translation>最近開啟資料夾(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="16"/>
+        <source>Save Live Log As</source>
+        <translation>即時日誌另存為</translation>
     </message>
 </context>
 <context>
@@ -2018,6 +2241,62 @@
         <location filename="../../ui/src/mainwindowtext.cpp" line="26"/>
         <source>klogg log viewer</source>
         <translation>Klogg 日誌檢視器</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="30"/>
+        <source>Open Window</source>
+        <translation>開啟視窗</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindowtext.cpp" line="31"/>
+        <source>Quit</source>
+        <translation>退出</translation>
+    </message>
+</context>
+<context>
+    <name>HighlightersMenu</name>
+    <message>
+        <location filename="../../ui/src/highlightersmenu.cpp" line="49"/>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+</context>
+<context>
+    <name>SearchToolbar</name>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="113"/>
+        <source>Clear Search History</source>
+        <translation>清除搜尋歷史</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="115"/>
+        <source>Edit Search History...</source>
+        <translation>編輯搜尋歷史...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="118"/>
+        <source>Add to Filter Favorites...</source>
+        <translation>加入篩選器書籤...</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="511"/>
+        <source>klogg</source>
+        <translation>klogg</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="512"/>
+        <source>Favorite &quot;%1&quot; changed while the save dialog was open. Try again.</source>
+        <translation>篩選器書籤「%1」在儲存對話框開啟期間已變更。請再試一次。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
+        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
+        <translation>篩選器書籤「%1」已存在，且內容相同。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
+        <source>Favorite &quot;%1&quot; already has the same content.</source>
+        <translation>篩選器書籤「%1」已有相同內容。</translation>
     </message>
 </context>
 </TS>

--- a/src/app/i18n/zh_TW.ts
+++ b/src/app/i18n/zh_TW.ts
@@ -696,6 +696,16 @@
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>無法將篩選器書籤匯出到所選檔案。</translation>
     </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1854"/>
+        <source>Filter favorites changed while the import was being applied. Try again.</source>
+        <translation>套用匯入時篩選收藏已發生變更。請重試。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/mainwindow.cpp" line="1860"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>無法儲存篩選收藏。請重試。</translation>
+    </message>
 </context>
 <context>
     <name>OptionsDialog</name>
@@ -1225,6 +1235,11 @@
         <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="349"/>
         <source>Unable to export filter favorites to the selected file.</source>
         <translation>無法將篩選器書籤匯出到所選檔案。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/predefinedfiltersdialog.cpp" line="204"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>無法儲存篩選收藏。請重試。</translation>
     </message>
 </context>
 <context>
@@ -2213,8 +2228,8 @@
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="13"/>
-        <source>Open Recent</source>
-        <translation>最近開啟檔案</translation>
+        <source>Open &amp;Recent</source>
+        <translation>最近開啟檔案(&amp;R)</translation>
     </message>
     <message>
         <location filename="../../ui/src/mainwindowtext.cpp" line="14"/>
@@ -2289,14 +2304,19 @@
         <translation>篩選器書籤「%1」在儲存對話框開啟期間已變更。請再試一次。</translation>
     </message>
     <message>
-        <location filename="../../ui/src/searchtoolbar.cpp" line="539"/>
-        <source>Favorite &quot;%1&quot; already exists with the same content.</source>
-        <translation>篩選器書籤「%1」已存在，且內容相同。</translation>
-    </message>
-    <message>
         <location filename="../../ui/src/searchtoolbar.cpp" line="540"/>
         <source>Favorite &quot;%1&quot; already has the same content.</source>
         <translation>篩選器書籤「%1」已有相同內容。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="530"/>
+        <source>Unable to save filter favorites. Try again.</source>
+        <translation>無法儲存篩選收藏。請重試。</translation>
+    </message>
+    <message>
+        <location filename="../../ui/src/searchtoolbar.cpp" line="548"/>
+        <source>A favorite named &quot;%1&quot; already exists. Choose a different name.</source>
+        <translation>名為「%1」的收藏已存在。請選擇其他名稱。</translation>
     </message>
 </context>
 </TS>

--- a/src/settings/include/shortcuts.h
+++ b/src/settings/include/shortcuts.h
@@ -168,4 +168,9 @@ private:
 // actions that should use the platform's primary modifier key.
 QString commandShortcutModifier();
 
+// Returns the platform Find Next bindings after runtime normalization, excluding
+// the literal Ctrl+G binding reserved for Go to Line. Duplicate bindings are
+// removed and F3 is always present as a fallback.
+QStringList findNextShortcutBindings();
+
 #endif

--- a/src/settings/src/configuration.cpp
+++ b/src/settings/src/configuration.cpp
@@ -38,8 +38,10 @@
 
 #include <algorithm>
 #include <mutex>
+#include <utility>
 
 #include <QFontInfo>
+#include <QList>
 #include <QKeySequence>
 #include <qcolor.h>
 #include <qglobal.h>
@@ -55,10 +57,104 @@ namespace {
 std::once_flag fontInitFlag;
 static const Configuration DefaultConfiguration = {};
 
+constexpr auto CtrlGDefaultsMigrationMarker = "shortcuts.ctrlGDefaultsMigrated";
+
 int clampLineSpacingPercent( int percent )
 {
     return std::clamp( percent, Configuration::MinLineSpacingPercent,
                        Configuration::MaxLineSpacingPercent );
+}
+
+QStringList normalizedShortcutBindings( QStringList bindings )
+{
+    for ( auto& binding : bindings ) {
+        binding = QKeySequence( binding, QKeySequence::PortableText )
+                      .toString( QKeySequence::PortableText );
+    }
+    while ( !bindings.isEmpty() && bindings.back().isEmpty() ) {
+        bindings.removeLast();
+    }
+    return bindings;
+}
+
+QStringList legacyFindNextBindings( const QString& commandModifier )
+{
+    QStringList bindings;
+    for ( const auto& key : QKeySequence::keyBindings( QKeySequence::FindNext ) ) {
+        const auto portable = key.toString( QKeySequence::PortableText );
+        if ( !portable.isEmpty() && !bindings.contains( portable ) ) {
+            bindings.push_back( portable );
+        }
+    }
+
+    const auto commandG = QKeySequence( commandModifier + QStringLiteral( "+G" ),
+                                        QKeySequence::PortableText )
+                              .toString( QKeySequence::PortableText );
+    if ( !commandG.isEmpty() && !bindings.contains( commandG ) ) {
+        bindings.push_back( commandG );
+    }
+    return bindings;
+}
+
+bool matchesLegacyJumpToLineDefault( const QStringList& bindings )
+{
+    const auto normalized = normalizedShortcutBindings( bindings );
+    return normalized
+               == normalizedShortcutBindings(
+                   { commandShortcutModifier() + QStringLiteral( "+L" ) } )
+           || normalized == normalizedShortcutBindings( { QStringLiteral( "Ctrl+L" ) } );
+}
+
+bool matchesLegacyFindNextDefault( const QStringList& bindings )
+{
+    const auto normalized = normalizedShortcutBindings( bindings );
+    const auto platformBindings = legacyFindNextBindings( commandShortcutModifier() );
+    const auto literalCtrlBindings = legacyFindNextBindings( QStringLiteral( "Ctrl" ) );
+    const QList<QStringList> candidates{
+        platformBindings,
+        platformBindings.mid( 0, 2 ),
+        literalCtrlBindings,
+        literalCtrlBindings.mid( 0, 2 ),
+        { commandShortcutModifier() + QStringLiteral( "+G" ) },
+        { QStringLiteral( "Ctrl+G" ) },
+    };
+
+    return std::any_of( candidates.cbegin(), candidates.cend(), [ &normalized ]( auto candidate ) {
+        return normalized == normalizedShortcutBindings( std::move( candidate ) );
+    } );
+}
+
+bool migrateLegacyCtrlGDefaults( ShortcutAction::ConfiguredShortcuts& shortcuts )
+{
+    bool changed = false;
+    const auto eraseIfLegacy = [ &shortcuts, &changed ]( const std::string& action,
+                                                        const auto& isLegacy ) {
+        const auto found = shortcuts.find( action );
+        if ( found != shortcuts.end() && isLegacy( found->second ) ) {
+            shortcuts.erase( found );
+            changed = true;
+        }
+    };
+
+    eraseIfLegacy( ShortcutAction::LogViewJumpToLine, matchesLegacyJumpToLineDefault );
+    eraseIfLegacy( ShortcutAction::LogViewQfForward, matchesLegacyFindNextDefault );
+    return changed;
+}
+
+void writeShortcutArray( QSettings& settings,
+                         const ShortcutAction::ConfiguredShortcuts& shortcuts )
+{
+    settings.remove( QStringLiteral( "shortcuts" ) );
+    settings.beginWriteArray( QStringLiteral( "shortcuts" ) );
+    int shortcutIndex = 0;
+    for ( const auto& mapping : shortcuts ) {
+        settings.setArrayIndex( shortcutIndex );
+        settings.setValue( QStringLiteral( "action" ),
+                           QString::fromStdString( mapping.first ) );
+        settings.setValue( QStringLiteral( "keys" ), mapping.second );
+        ++shortcutIndex;
+    }
+    settings.endArray();
 }
 
 } // namespace
@@ -399,8 +495,10 @@ void Configuration::retrieveFromStorage( QSettings& settings )
                         []( auto v ) { return v.toInt(); } );
     }
 
+    bool loadedLegacyShortcutMapping = false;
     if ( settings.contains( "shortcuts.mapping" ) ) {
         shortcuts_.clear();
+        loadedLegacyShortcutMapping = true;
 
         const auto mapping = settings.value( "shortcuts.mapping" ).toMap();
         for ( auto keys = mapping.begin(); keys != mapping.end(); ++keys ) {
@@ -427,6 +525,24 @@ void Configuration::retrieveFromStorage( QSettings& settings )
         }
     }
     settings.endArray();
+
+    // Preferences used to materialize the old defaults as explicit overrides.
+    // Drop only exact legacy values so Ctrl+G reaches the new compiled default;
+    // rewrite before stamping the marker so stale array entries cannot return.
+    const bool ctrlGDefaultsAlreadyMigrated
+        = settings.value( CtrlGDefaultsMigrationMarker, false ).toBool();
+    const bool migratedCtrlGDefaults
+        = !ctrlGDefaultsAlreadyMigrated && migrateLegacyCtrlGDefaults( shortcuts_ );
+    if ( loadedLegacyShortcutMapping || migratedCtrlGDefaults ) {
+        writeShortcutArray( settings, shortcuts_ );
+    }
+    if ( !ctrlGDefaultsAlreadyMigrated ) {
+        settings.setValue( CtrlGDefaultsMigrationMarker, true );
+    }
+    if ( loadedLegacyShortcutMapping || migratedCtrlGDefaults
+         || !ctrlGDefaultsAlreadyMigrated ) {
+        settings.sync();
+    }
 
     settings.beginGroup( "dark" );
     for ( auto& color : darkPalette_ ) {
@@ -533,15 +649,8 @@ void Configuration::saveToStorage( QSettings& settings ) const
 
     settings.setValue( "defaultView.splitterSizes", serializedSplitterSizes );
 
-    settings.beginWriteArray( "shortcuts" );
-    auto shortcutIndex = 0;
-    for ( const auto& mapping : shortcuts_ ) {
-        settings.setArrayIndex( shortcutIndex );
-        settings.setValue( "action", QString::fromStdString( mapping.first ) );
-        settings.setValue( "keys", mapping.second );
-        shortcutIndex++;
-    }
-    settings.endArray();
+    writeShortcutArray( settings, shortcuts_ );
+    settings.setValue( CtrlGDefaultsMigrationMarker, true );
 
     settings.beginGroup( "dark" );
     for ( const auto& color : darkPalette_ ) {

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -167,7 +167,7 @@ QList<QKeySequence> ShortcutAction::shortcutKeys( const std::string& action,
 
 const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
 {
-    static ShortcutList defaultShortcutKeys = {
+    static ShortcutList shortcuts = {
         {
             MainWindowNewWindow,
             {
@@ -777,5 +777,5 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             },
         },
     };
-    return defaultShortcutKeys;
+    return shortcuts;
 }

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -60,7 +60,7 @@ QStringList uniqueKeyBindings( const QStringList& bindings )
 namespace {
 QKeySequence normalizedRuntimeSequence( const QKeySequence& sequence )
 {
-    return QKeySequence( sequence.toString( QKeySequence::NativeText ), QKeySequence::NativeText );
+    return { sequence.toString( QKeySequence::NativeText ), QKeySequence::NativeText };
 }
 
 bool isExactRuntimeMatch( const QKeySequence& left, const QKeySequence& right )
@@ -98,9 +98,9 @@ QStringList findNextShortcutBindings()
         }
     }
 
-    const auto f3 = QKeySequence( Qt::Key_F3 );
-    if ( !containsExactRuntimeMatch( safeBindings, f3 ) ) {
-        safeBindings.push_back( f3.toString( QKeySequence::PortableText ) );
+    const auto f3Sequence = QKeySequence( Qt::Key_F3 );
+    if ( !containsExactRuntimeMatch( safeBindings, f3Sequence ) ) {
+        safeBindings.push_back( f3Sequence.toString( QKeySequence::PortableText ) );
     }
 
     return safeBindings;

--- a/src/settings/src/shortcuts.cpp
+++ b/src/settings/src/shortcuts.cpp
@@ -17,6 +17,7 @@
  * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <algorithm>
 #include <functional>
 
 #include <QApplication>
@@ -54,6 +55,55 @@ QStringList uniqueKeyBindings( const QStringList& bindings )
         }
     }
     return uniqueBindings;
+}
+
+namespace {
+QKeySequence normalizedRuntimeSequence( const QKeySequence& sequence )
+{
+    return QKeySequence( sequence.toString( QKeySequence::NativeText ), QKeySequence::NativeText );
+}
+
+bool isExactRuntimeMatch( const QKeySequence& left, const QKeySequence& right )
+{
+    const auto normalizedLeft = normalizedRuntimeSequence( left );
+    const auto normalizedRight = normalizedRuntimeSequence( right );
+    return normalizedLeft.matches( normalizedRight ) == QKeySequence::ExactMatch
+           && normalizedRight.matches( normalizedLeft ) == QKeySequence::ExactMatch;
+}
+
+bool containsExactRuntimeMatch( const QStringList& bindings, const QKeySequence& expected )
+{
+    return std::any_of( bindings.cbegin(), bindings.cend(), [ &expected ]( const auto& binding ) {
+        return isExactRuntimeMatch(
+            QKeySequence( binding, QKeySequence::PortableText ), expected );
+    } );
+}
+} // namespace
+
+QStringList findNextShortcutBindings()
+{
+    const auto reservedCtrlG
+        = QKeySequence( QStringLiteral( "Ctrl+G" ), QKeySequence::PortableText );
+    QStringList safeBindings;
+
+    for ( const auto& binding : QKeySequence::keyBindings( QKeySequence::FindNext ) ) {
+        if ( binding.isEmpty() || isExactRuntimeMatch( binding, reservedCtrlG )
+             || containsExactRuntimeMatch( safeBindings, binding ) ) {
+            continue;
+        }
+
+        const auto portableBinding = binding.toString( QKeySequence::PortableText );
+        if ( !portableBinding.isEmpty() ) {
+            safeBindings.push_back( portableBinding );
+        }
+    }
+
+    const auto f3 = QKeySequence( Qt::Key_F3 );
+    if ( !containsExactRuntimeMatch( safeBindings, f3 ) ) {
+        safeBindings.push_back( f3.toString( QKeySequence::PortableText ) );
+    }
+
+    return safeBindings;
 }
 
 QStringList ShortcutAction::defaultShortcutKeys( const std::string& action )
@@ -556,14 +606,14 @@ const ShortcutAction::ShortcutList& ShortcutAction::defaultShortcutList()
             LogViewJumpToLine,
             {
                 QApplication::tr( "Jump to line" ),
-                QStringList{ commandShortcutModifier() + "+L" },
+                QStringList{ QStringLiteral( "Ctrl+G" ) },
             },
         },
         {
             LogViewQfForward,
             {
                 QApplication::tr( "Main view: find next" ),
-                uniqueKeyBindings( getKeyBindings( QKeySequence::FindNext ) << commandShortcutModifier() + "+G" ),
+                findNextShortcutBindings(),
             },
         },
         {

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tabbedcrawlerwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tabgroup.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/tabgroupdropresolver.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/uimessage.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/viewinterface.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/viewtools.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/scratchpad.h
@@ -135,6 +136,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tabbedcrawlerwidget.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tabgroup.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/tabgroupdropresolver.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/uimessage.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/viewtools.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/scratchpad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/searchtoolbar.cpp

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/crawlerwidget.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/devicelistprovider.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/filteredview.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/filterfavoritesmodel.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/folderenumeration.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/folderfilteredview.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/foldercrawlerwidget.h
@@ -90,6 +91,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/adblogcatsource.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/crawlerwidget.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/filteredview.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/filterfavoritesmodel.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/folderenumeration.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/folderfilteredview.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/foldercrawlerwidget.cpp

--- a/src/ui/include/crawlerwidget.h
+++ b/src/ui/include/crawlerwidget.h
@@ -249,8 +249,6 @@ class CrawlerWidget : public QSplitter,
     void clearSearchHistory();
     void editSearchHistory();
 
-    // Save current search as a favorite filter
-    void saveAsFavorite();
     void setSearchPatternFromPredefinedFilters( const QList<PredefinedFilter>& filters );
 
     // Called when there was activity in the views
@@ -334,9 +332,6 @@ class CrawlerWidget : public QSplitter,
     void changeTopViewSize( int32_t delta );
     void updatePredefinedFiltersWidget();
     void applyEmptyFilterBehavior();
-
-    // Reload predefined filters after changing settings
-    void reloadPredefinedFilters() const;
 
     void resetStateOnSearchPatternChanges();
 

--- a/src/ui/include/filterfavoritesmodel.h
+++ b/src/ui/include/filterfavoritesmodel.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef FILTERFAVORITESMODEL_H
+#define FILTERFAVORITESMODEL_H
+
+#include <QAbstractListModel>
+#include <QByteArray>
+#include <QHash>
+#include <QVariant>
+
+#include "predefinedfilters.h"
+
+class FilterFavoritesModel final : public QAbstractListModel {
+    Q_OBJECT
+
+  public:
+    using Collection = PredefinedFiltersCollection::Collection;
+
+    enum Roles {
+        NameRole = Qt::UserRole + 1,
+        PatternRole,
+        RegexRole,
+    };
+
+    static FilterFavoritesModel& instance();
+
+    Collection favorites() const;
+    void replaceFavorites( const Collection& favorites );
+    void synchronizeFromStorage();
+
+    int rowCount( const QModelIndex& parent = QModelIndex{} ) const override;
+    QVariant data( const QModelIndex& index, int role = Qt::DisplayRole ) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+  private:
+    explicit FilterFavoritesModel( QObject* parent = nullptr );
+
+    Collection favorites_;
+};
+
+#endif // FILTERFAVORITESMODEL_H

--- a/src/ui/include/filterfavoritesmodel.h
+++ b/src/ui/include/filterfavoritesmodel.h
@@ -20,6 +20,8 @@
 #ifndef FILTERFAVORITESMODEL_H
 #define FILTERFAVORITESMODEL_H
 
+#include <cstdint>
+
 #include <QAbstractListModel>
 #include <QByteArray>
 #include <QHash>
@@ -33,7 +35,9 @@ class FilterFavoritesModel final : public QAbstractListModel {
   public:
     using Collection = PredefinedFiltersCollection::Collection;
 
-    enum Roles {
+    // Qt model roles are consumed by int-based APIs and switch statements.
+    // NOLINTNEXTLINE(cppcoreguidelines-use-enum-class)
+    enum Roles : std::uint16_t {
         NameRole = Qt::UserRole + 1,
         PatternRole,
         RegexRole,
@@ -41,8 +45,11 @@ class FilterFavoritesModel final : public QAbstractListModel {
 
     static FilterFavoritesModel& instance();
 
+    using CommitResult = PredefinedFiltersCollection::CommitResult;
+
     Collection favorites() const;
-    void replaceFavorites( const Collection& favorites );
+    CommitResult replaceFavorites( const Collection& favorites );
+    CommitResult replaceFavorites( const Collection& expected, const Collection& favorites );
     void synchronizeFromStorage();
 
     int rowCount( const QModelIndex& parent = QModelIndex{} ) const override;
@@ -51,6 +58,7 @@ class FilterFavoritesModel final : public QAbstractListModel {
 
   private:
     explicit FilterFavoritesModel( QObject* parent = nullptr );
+    void publishFavorites( const Collection& favorites );
 
     Collection favorites_;
 };

--- a/src/ui/include/foldercrawlerwidget.h
+++ b/src/ui/include/foldercrawlerwidget.h
@@ -308,11 +308,7 @@ class FolderCrawlerWidget : public QWidget,
     // loaded into currentMainData_. Folder mode uses an explicit match-line list
     // (no LogFilteredData), so this is a pure else-branch on the Overview.
     void refreshFileOverview( const QString& filePath );
-    // Filter favorites + predefined filters (mirror CrawlerWidget; the host owns
-    // the dialogs + the shared PredefinedFiltersCollection persistence).
-    void saveAsFavorite();
     void updatePredefinedFiltersWidget();
-    void reloadPredefinedFilters() const;
     // Search-history context-menu actions (parity with CrawlerWidget): the
     // toolbar emits clearHistoryRequested / editHistoryRequested; the host owns
     // the shared SavedSearches + dialogs.

--- a/src/ui/include/mainwindow.h
+++ b/src/ui/include/mainwindow.h
@@ -139,7 +139,9 @@ class MainWindow : public QMainWindow {
     void editHighlighters();
     void editPredefinedFilters( const QString& newFilter = {} );
     void importFilterFavorites();
+    void importFilterFavoritesFromFile( const QString& file );
     void exportFilterFavorites();
+    void exportFilterFavoritesToFile( QString file );
     void mergeTabs();
     std::vector<QString> showMergeFilesDialog( const QStringList& filePaths );
     bool executeMerge( const std::vector<QString>& filesToMerge );
@@ -380,6 +382,8 @@ class MainWindow : public QMainWindow {
     std::map<QString, QShortcut*> shortcuts_;
 
     QSystemTrayIcon* trayIcon_;
+    QAction* trayOpenWindowAction_;
+    QAction* trayQuitAction_;
 
     QIcon mainIcon_;
 

--- a/src/ui/include/mainwindowtext.h
+++ b/src/ui/include/mainwindowtext.h
@@ -7,7 +7,10 @@ namespace klogg {
 namespace mainwindow {
 namespace menu {
 extern const char* fileTitle;
+extern const char* recentFilesTitle;
+extern const char* recentFoldersTitle;
 extern const char* editTitle;
+extern const char* saveCurrentLiveLogTitle;
 extern const char* viewTitle;
 // openedFilesTitle is the submenu of view menu
 extern const char* openedFilesTitle;
@@ -24,6 +27,8 @@ extern const char* toolbarTitle;
 
 namespace trayicon {
 extern const char* trayiconTip;
+extern const char* openWindowText;
+extern const char* quitText;
 }
 
 namespace action {
@@ -31,6 +36,12 @@ extern const char* newWindowText;
 extern const char* newWindowStatusTip;
 extern const char* openText;
 extern const char* openStatusTip;
+extern const char* openFolderText;
+extern const char* openFolderStatusTip;
+extern const char* openAdbLogcatText;
+extern const char* openAdbLogcatStatusTip;
+extern const char* openIosLogStreamText;
+extern const char* openIosLogStreamStatusTip;
 extern const char* recentFilesCleanupText;
 extern const char* recentFoldersCleanupText;
 extern const char* closeText;
@@ -49,6 +60,14 @@ extern const char* findText;
 extern const char* findStatusTip;
 extern const char* clearLogText;
 extern const char* clearLogStatusTip;
+extern const char* saveCurrentLiveLogStripAnsiText;
+extern const char* saveCurrentLiveLogStripAnsiStatusTip;
+extern const char* saveCurrentLiveLogPreserveAnsiText;
+extern const char* saveCurrentLiveLogPreserveAnsiStatusTip;
+extern const char* disconnectSourceText;
+extern const char* disconnectSourceStatusTip;
+extern const char* reconnectSourceText;
+extern const char* reconnectSourceStatusTip;
 extern const char* openContainingFolderText;
 extern const char* openContainingFolderStatusTip;
 extern const char* openInEditorText;
@@ -87,6 +106,8 @@ extern const char* showScratchPadText;
 extern const char* showScratchPadStatusTip;
 extern const char* addToFavoritesText;
 extern const char* removeFromFavoritesText;
+extern const char* addCurrentFileText;
+extern const char* removeFavoriteFileText;
 extern const char* selectOpenFileText;
 extern const char* predefinedFiltersDialogText;
 extern const char* predefinedFiltersDialogStatusTip;
@@ -94,6 +115,8 @@ extern const char* importFilterFavoritesText;
 extern const char* importFilterFavoritesStatusTip;
 extern const char* exportFilterFavoritesText;
 extern const char* exportFilterFavoritesStatusTip;
+extern const char* mergeTabsText;
+extern const char* mergeTabsStatusTip;
 extern const char* autoEncodingText;
 extern const char* autoEncodingStatusTip;
 } // namespace action

--- a/src/ui/include/predefinedfilters.h
+++ b/src/ui/include/predefinedfilters.h
@@ -40,6 +40,8 @@
 #ifndef PREDEFINEDFILTERS_H_
 #define PREDEFINEDFILTERS_H_
 
+#include <cstdint>
+
 #include <QList>
 #include <QString>
 
@@ -67,7 +69,10 @@ class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCo
   public:
     using Collection = QList<PredefinedFilter>;
 
-    enum class LoadStatus {
+    // The editor materializes each favorite as table items plus a checkbox widget.
+    static constexpr int MaximumFilterCount = 1000;
+
+    enum class LoadStatus : std::uint8_t {
         Success,
         MissingFile,
         MalformedFile,
@@ -77,6 +82,21 @@ class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCo
     struct LoadResult {
         LoadStatus status;
         Collection filters;
+    };
+
+    enum class CommitStatus : std::uint8_t {
+        Success,
+        Unchanged,
+        Conflict,
+        InvalidReplacement,
+        LockError,
+        StorageError,
+        WriteError,
+    };
+
+    struct CommitResult {
+        CommitStatus status;
+        Collection storedFilters;
     };
 
     static const char* persistableName()
@@ -90,6 +110,7 @@ class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCo
     static LoadResult tryLoadFromFile( const QString& file );
     static Collection loadFromFile( const QString& file );
     static bool saveToFile( const QString& file, const Collection& filters );
+    static CommitResult commit( const Collection& expected, const Collection& replacement );
 
     void retrieveFromStorage( QSettings& settings );
     void saveToStorage( QSettings& settings ) const;
@@ -97,6 +118,14 @@ class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCo
 
   private:
     static constexpr int PredefinedFiltersCollection_VERSION = 2;
+
+    static LoadResult readFromSettings( QSettings& settings, bool missingIsSuccess );
+    static CommitResult commitToSettings( QSettings& settings, const QString& lockFile,
+                                          const Collection& expected,
+                                          const Collection& replacement );
+    static QString storageLockFilePath( const QSettings& settings );
+
+    friend struct PredefinedFiltersCollectionTestAccess;
 
     Collection filters_;
 };

--- a/src/ui/include/predefinedfilters.h
+++ b/src/ui/include/predefinedfilters.h
@@ -51,10 +51,33 @@ struct PredefinedFilter {
     bool useRegex;
 };
 
+inline bool operator==( const PredefinedFilter& left, const PredefinedFilter& right )
+{
+    return left.name == right.name && left.pattern == right.pattern
+           && left.useRegex == right.useRegex;
+}
+
+inline bool operator!=( const PredefinedFilter& left, const PredefinedFilter& right )
+{
+    return !( left == right );
+}
+
 // Represents collection of filters read from settings file.
 class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCollection> {
   public:
     using Collection = QList<PredefinedFilter>;
+
+    enum class LoadStatus {
+        Success,
+        MissingFile,
+        MalformedFile,
+        UnsupportedVersion,
+    };
+
+    struct LoadResult {
+        LoadStatus status;
+        Collection filters;
+    };
 
     static const char* persistableName()
     {
@@ -64,6 +87,7 @@ class PredefinedFiltersCollection final : public Persistable<PredefinedFiltersCo
     Collection getSyncedFilters();
     Collection getFilters() const;
     void setFilters( const Collection& filters );
+    static LoadResult tryLoadFromFile( const QString& file );
     static Collection loadFromFile( const QString& file );
     static bool saveToFile( const QString& file, const Collection& filters );
 

--- a/src/ui/include/predefinedfilterscombobox.h
+++ b/src/ui/include/predefinedfilterscombobox.h
@@ -44,8 +44,6 @@
 
 #include "predefinedfilters.h"
 
-class QStandardItemModel;
-
 class PredefinedFiltersComboBox final : public QComboBox {
     Q_OBJECT
 
@@ -58,21 +56,19 @@ class PredefinedFiltersComboBox final : public QComboBox {
     PredefinedFiltersComboBox& operator=( const PredefinedFiltersComboBox& other ) = delete;
     PredefinedFiltersComboBox& operator=( PredefinedFiltersComboBox&& other ) = delete;
 
-    void populatePredefinedFilters();
     void updateSearchPattern( const QString newSearchPattern, bool useLogicalCombining );
 
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override;
+    void showPopup() override;
+
   Q_SIGNALS:
-    void filterChanged( const QList<PredefinedFilter>& selectedFilters);
+    void filterChanged( const QList<PredefinedFilter>& selectedFilters );
 
   private:
-    void insertFilters( const PredefinedFiltersCollection::Collection& filters );
-    void collectFilters();
-
-  private:
-    PredefinedFiltersCollection filtersCollection_;
-
-    QStandardItemModel* model_;
-    bool ignoreCollecting_{false};
+    QSize closedSizeHint() const;
+    void collectFilter( int index );
+    void resetSelection();
 };
 
 #endif

--- a/src/ui/include/predefinedfiltersdialog.h
+++ b/src/ui/include/predefinedfiltersdialog.h
@@ -43,7 +43,6 @@
 #include <QDialog>
 
 #include "predefinedfilters.h"
-#include "predefinedfiltersdialog.h"
 #include "ui_predefinedfiltersdialog.h"
 
 class PredefinedFiltersDialog : public QDialog, public Ui::PredefinedFiltersDialog {
@@ -62,14 +61,13 @@ class PredefinedFiltersDialog : public QDialog, public Ui::PredefinedFiltersDial
 
     void exportFilters();
     void importFilters();
+    void exportFiltersToFile( const QString& file );
+    void importFiltersFromFile( const QString& file );
 
     void resolveStandardButton( QAbstractButton* button );
 
     void onCurrentCellChanged( int currentRow, int currentColumn, int previousRow,
                                int previousColumn );
-
-  Q_SIGNALS:
-    void optionsChanged();
 
   private:
     void addFilterRow( const QString& newFilter );
@@ -77,11 +75,13 @@ class PredefinedFiltersDialog : public QDialog, public Ui::PredefinedFiltersDial
 
     void swapFilters( int currentRow, int newRow, int column );
 
-    void saveSettings() const;
+    bool saveSettings();
     PredefinedFiltersCollection::Collection readFiltersTable() const;
 
     void updateButtons();
     void updateUpDownButtons( int currentRow );
+
+    PredefinedFiltersCollection::Collection baseFavorites_;
 };
 
 #endif

--- a/src/ui/include/searchtoolbar.h
+++ b/src/ui/include/searchtoolbar.h
@@ -160,13 +160,15 @@ class SearchToolbar : public QWidget {
     void matchCaseChanged( bool matchCase );
     // "auto-refresh" toggle changed (forwarded to the host).
     void autoRefreshChanged( bool isRefreshing );
-    // Context-menu / favorite actions (host owns the dialogs / persistence).
+    // Search-history actions remain host-specific; favorite saving is owned here.
     void clearHistoryRequested();
     void editHistoryRequested();
-    void saveFavoriteRequested();
 
   protected:
     bool eventFilter( QObject* watched, QEvent* event ) override;
+
+  private Q_SLOTS:
+    void saveCurrentSearchAsFavorite();
 
   private:
     void setupWidgets();

--- a/src/ui/include/uimessage.h
+++ b/src/ui/include/uimessage.h
@@ -17,6 +17,7 @@
 
 #include <QString>
 
+class QDialog;
 class QWidget;
 
 namespace klogg::ui {
@@ -32,6 +33,9 @@ using MessageHandler
 void warning( QWidget* parent, const QString& title, const QString& text );
 void information( QWidget* parent, const QString& title, const QString& text );
 
+using DialogHandler = std::function<int( QDialog& )>;
+int execDialog( QDialog& dialog );
+
 class ScopedMessageHandler final {
   public:
     explicit ScopedMessageHandler( MessageHandler handler );
@@ -41,6 +45,20 @@ class ScopedMessageHandler final {
     ScopedMessageHandler& operator=( const ScopedMessageHandler& ) = delete;
     ScopedMessageHandler( ScopedMessageHandler&& ) = delete;
     ScopedMessageHandler& operator=( ScopedMessageHandler&& ) = delete;
+
+  private:
+    std::uint64_t token_;
+};
+
+class ScopedDialogHandler final {
+  public:
+    explicit ScopedDialogHandler( DialogHandler handler );
+    ~ScopedDialogHandler();
+
+    ScopedDialogHandler( const ScopedDialogHandler& ) = delete;
+    ScopedDialogHandler& operator=( const ScopedDialogHandler& ) = delete;
+    ScopedDialogHandler( ScopedDialogHandler&& ) = delete;
+    ScopedDialogHandler& operator=( ScopedDialogHandler&& ) = delete;
 
   private:
     std::uint64_t token_;

--- a/src/ui/include/uimessage.h
+++ b/src/ui/include/uimessage.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef KLOGG_UIMESSAGE_H
+#define KLOGG_UIMESSAGE_H
+
+#include <cstdint>
+#include <functional>
+
+#include <QString>
+
+class QWidget;
+
+namespace klogg::ui {
+
+enum class MessageKind : std::uint8_t {
+    Warning,
+    Information,
+};
+
+using MessageHandler
+    = std::function<void( MessageKind, QWidget*, const QString&, const QString& )>;
+
+void warning( QWidget* parent, const QString& title, const QString& text );
+void information( QWidget* parent, const QString& title, const QString& text );
+
+class ScopedMessageHandler final {
+  public:
+    explicit ScopedMessageHandler( MessageHandler handler );
+    ~ScopedMessageHandler();
+
+    ScopedMessageHandler( const ScopedMessageHandler& ) = delete;
+    ScopedMessageHandler& operator=( const ScopedMessageHandler& ) = delete;
+    ScopedMessageHandler( ScopedMessageHandler&& ) = delete;
+    ScopedMessageHandler& operator=( ScopedMessageHandler&& ) = delete;
+
+  private:
+    std::uint64_t token_;
+};
+
+} // namespace klogg::ui
+
+#endif // KLOGG_UIMESSAGE_H

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -533,8 +533,8 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
         }
 
         if ( selection_.isSingleLine() ) {
-            copyAction_->setText( tr( "&Copy this line" ) );
-            copyWithLineNumbersAction_->setText( tr( "Copy this line with line number" ) );
+            copyAction_->setText( tr( "&Copy This Line" ) );
+            copyWithLineNumbersAction_->setText( tr( "Copy This Line with Line Number" ) );
 
             setSearchStartAction_->setEnabled( true );
             setSearchEndAction_->setEnabled( true );
@@ -546,7 +546,7 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
             copyAction_->setText( tr( "&Copy" ) );
             copyAction_->setStatusTip( tr( "Copy the selection" ) );
 
-            copyWithLineNumbersAction_->setText( tr( "Copy with line numbers" ) );
+            copyWithLineNumbersAction_->setText( tr( "Copy with Line Numbers" ) );
 
             setSearchStartAction_->setEnabled( false );
             setSearchEndAction_->setEnabled( false );
@@ -655,11 +655,11 @@ void AbstractLogView::mousePressEvent( QMouseEvent* mouseEvent )
 
             colorLabelsMenu_->addSeparator();
 
-            auto ignoreCaseAction = colorLabelsMenu_->addAction( tr( "Ignore case" ) );
+            auto ignoreCaseAction = colorLabelsMenu_->addAction( tr( "Ignore Case" ) );
             ignoreCaseAction->setCheckable( true );
             ignoreCaseAction->setChecked( quickHighlighterDefaults.ignoreCase );
 
-            auto wholeWordAction = colorLabelsMenu_->addAction( tr( "Whole word" ) );
+            auto wholeWordAction = colorLabelsMenu_->addAction( tr( "Whole Word" ) );
             wholeWordAction->setCheckable( true );
             wholeWordAction->setChecked( quickHighlighterDefaults.wholeWord );
 
@@ -2588,85 +2588,88 @@ void AbstractLogView::createMenu()
     // No text as this action title depends on the type of selection
     connect( copyAction_, &QAction::triggered, this, [ this ]( auto ) { this->copy(); } );
 
-    copyWithLineNumbersAction_ = new QAction( tr( "Copy with line numbers" ), this );
+    copyWithLineNumbersAction_ = new QAction( tr( "Copy with Line Numbers" ), this );
     // No text as this action title depends on the type of selection
     connect( copyWithLineNumbersAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->copyWithLineNumbers(); } );
 
-    markAction_ = new QAction( tr( "Add line mark" ), this );
+    markAction_ = new QAction( tr( "Add Line Mark" ), this );
     connect( markAction_, &QAction::triggered, this, [ this ]( auto ) { this->markSelected(); } );
 
-    deleteMarkAction_ = new QAction( tr( "Delete line mark" ), this );
+    deleteMarkAction_ = new QAction( tr( "Delete Line Mark" ), this );
     connect( deleteMarkAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->deleteMarksSelected(); } );
 
-    saveToFileAction_ = new QAction( tr( "Save to file" ), this );
+    saveToFileAction_ = new QAction( tr( "Save to File..." ), this );
     connect( saveToFileAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->saveToFile(); } );
 
-    saveSelectedToFileAction_ = new QAction( tr( "Save selected to file" ), this );
+    saveSelectedToFileAction_ = new QAction( tr( "Save Selected to File..." ), this );
     connect( saveSelectedToFileAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->saveSelectedToFile(); } );
 
     // For '#' and '*', shortcuts doesn't seem to work but
     // at least it displays them in the menu, we manually handle those keys
     // as keys event anyway (in keyPressEvent).
-    findNextAction_ = new QAction( tr( "Find &next" ), this );
+    findNextAction_ = new QAction( tr( "Find &Next" ), this );
     findNextAction_->setShortcut( Qt::Key_Asterisk );
     findNextAction_->setStatusTip( tr( "Find the next occurrence" ) );
     connect( findNextAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->findNextSelected(); } );
 
-    findPreviousAction_ = new QAction( tr( "Find &previous" ), this );
+    findPreviousAction_ = new QAction( tr( "Find &Previous" ), this );
     findPreviousAction_->setShortcut( tr( "/" ) );
     findPreviousAction_->setStatusTip( tr( "Find the previous occurrence" ) );
     connect( findPreviousAction_, &QAction::triggered,
              [ this ]( auto ) { this->findPreviousSelected(); } );
 
-    replaceSearchAction_ = new QAction( tr( "&Replace search" ), this );
+    replaceSearchAction_ = new QAction( tr( "&Replace Search" ), this );
     replaceSearchAction_->setStatusTip( tr( "Replace the search expression with the selection" ) );
     connect( replaceSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->replaceSearch(); } );
 
-    addToSearchAction_ = new QAction( tr( "&Add to search" ), this );
+    addToSearchAction_ = new QAction( tr( "&Add to Search" ), this );
     addToSearchAction_->setStatusTip( tr( "Add the selection to the current search" ) );
     connect( addToSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->addToSearch(); } );
 
-    excludeFromSearchAction_ = new QAction( tr( "&Exclude from search" ), this );
+    excludeFromSearchAction_ = new QAction( tr( "&Exclude from Search" ), this );
     excludeFromSearchAction_->setStatusTip( tr( "Excludes the selection from search" ) );
     connect( excludeFromSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->excludeFromSearch(); } );
 
-    setSearchStartAction_ = new QAction( tr( "Set search start" ), this );
+    setSearchStartAction_ = new QAction( tr( "Set Search Start" ), this );
+    setSearchStartAction_->setObjectName( QStringLiteral( "setSearchStartAction" ) );
     connect( setSearchStartAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSearchStart(); } );
 
-    setSearchEndAction_ = new QAction( tr( "Set search end" ), this );
+    setSearchEndAction_ = new QAction( tr( "Set Search End" ), this );
+    setSearchEndAction_->setObjectName( QStringLiteral( "setSearchEndAction" ) );
     connect( setSearchEndAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSearchEnd(); } );
 
-    clearSearchLimitAction_ = new QAction( tr( "Clear search limits" ), this );
+    clearSearchLimitAction_ = new QAction( tr( "Clear Search Limits" ), this );
+    clearSearchLimitAction_->setObjectName( QStringLiteral( "clearSearchLimitAction" ) );
     connect( clearSearchLimitAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->clearSearchLimits(); } );
 
-    setSelectionStartAction_ = new QAction( tr( "Set selection start" ), this );
+    setSelectionStartAction_ = new QAction( tr( "Set Selection Start" ), this );
     connect( setSelectionStartAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSelectionStart(); } );
 
-    setSelectionEndAction_ = new QAction( tr( "Set selection end" ), this );
+    setSelectionEndAction_ = new QAction( tr( "Set Selection End" ), this );
     connect( setSelectionEndAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSelectionEnd(); } );
 
-    saveDefaultSplitterSizesAction_ = new QAction( tr( "Save splitter position" ), this );
+    saveDefaultSplitterSizesAction_ = new QAction( tr( "Save Splitter Position" ), this );
     connect( saveDefaultSplitterSizesAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT saveDefaultSplitterSizes(); } );
 
-    sendToScratchpadAction_ = new QAction( tr( "Send to scratchpad" ), this );
+    sendToScratchpadAction_ = new QAction( tr( "Send to Scratchpad" ), this );
     connect( sendToScratchpadAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT sendSelectionToScratchpad(); } );
 
-    replaceInScratchpadAction_ = new QAction( tr( "Replace scratchpad" ), this );
+    replaceInScratchpadAction_ = new QAction( tr( "Replace Scratchpad" ), this );
     connect( replaceInScratchpadAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT replaceScratchpadWithSelection(); } );
 
@@ -2675,7 +2678,7 @@ void AbstractLogView::createMenu()
     // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     highlightersMenu_ = new HighlightersMenu( tr( "Highlighters" ), popupMenu_ );
     popupMenu_->addMenu( highlightersMenu_ );
-    colorLabelsMenu_ = popupMenu_->addMenu( tr( "Color labels" ) );
+    colorLabelsMenu_ = popupMenu_->addMenu( tr( "Color Labels" ) );
 
     popupMenu_->addSeparator();
     popupMenu_->addAction( markAction_ );

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -2588,22 +2588,32 @@ void AbstractLogView::createMenu()
     // No text as this action title depends on the type of selection
     connect( copyAction_, &QAction::triggered, this, [ this ]( auto ) { this->copy(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     copyWithLineNumbersAction_ = new QAction( tr( "Copy with Line Numbers" ), this );
     // No text as this action title depends on the type of selection
     connect( copyWithLineNumbersAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->copyWithLineNumbers(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     markAction_ = new QAction( tr( "Add Line Mark" ), this );
     connect( markAction_, &QAction::triggered, this, [ this ]( auto ) { this->markSelected(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     deleteMarkAction_ = new QAction( tr( "Delete Line Mark" ), this );
     connect( deleteMarkAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->deleteMarksSelected(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveToFileAction_ = new QAction( tr( "Save to File..." ), this );
     connect( saveToFileAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->saveToFile(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveSelectedToFileAction_ = new QAction( tr( "Save Selected to File..." ), this );
     connect( saveSelectedToFileAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->saveSelectedToFile(); } );
@@ -2611,64 +2621,90 @@ void AbstractLogView::createMenu()
     // For '#' and '*', shortcuts doesn't seem to work but
     // at least it displays them in the menu, we manually handle those keys
     // as keys event anyway (in keyPressEvent).
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     findNextAction_ = new QAction( tr( "Find &Next" ), this );
     findNextAction_->setShortcut( Qt::Key_Asterisk );
     findNextAction_->setStatusTip( tr( "Find the next occurrence" ) );
     connect( findNextAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->findNextSelected(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     findPreviousAction_ = new QAction( tr( "Find &Previous" ), this );
     findPreviousAction_->setShortcut( tr( "/" ) );
     findPreviousAction_->setStatusTip( tr( "Find the previous occurrence" ) );
     connect( findPreviousAction_, &QAction::triggered,
              [ this ]( auto ) { this->findPreviousSelected(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     replaceSearchAction_ = new QAction( tr( "&Replace Search" ), this );
     replaceSearchAction_->setStatusTip( tr( "Replace the search expression with the selection" ) );
     connect( replaceSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->replaceSearch(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     addToSearchAction_ = new QAction( tr( "&Add to Search" ), this );
     addToSearchAction_->setStatusTip( tr( "Add the selection to the current search" ) );
     connect( addToSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->addToSearch(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     excludeFromSearchAction_ = new QAction( tr( "&Exclude from Search" ), this );
     excludeFromSearchAction_->setStatusTip( tr( "Excludes the selection from search" ) );
     connect( excludeFromSearchAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->excludeFromSearch(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     setSearchStartAction_ = new QAction( tr( "Set Search Start" ), this );
     setSearchStartAction_->setObjectName( QStringLiteral( "setSearchStartAction" ) );
     connect( setSearchStartAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSearchStart(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     setSearchEndAction_ = new QAction( tr( "Set Search End" ), this );
     setSearchEndAction_->setObjectName( QStringLiteral( "setSearchEndAction" ) );
     connect( setSearchEndAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSearchEnd(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     clearSearchLimitAction_ = new QAction( tr( "Clear Search Limits" ), this );
     clearSearchLimitAction_->setObjectName( QStringLiteral( "clearSearchLimitAction" ) );
     connect( clearSearchLimitAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->clearSearchLimits(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     setSelectionStartAction_ = new QAction( tr( "Set Selection Start" ), this );
     connect( setSelectionStartAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSelectionStart(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     setSelectionEndAction_ = new QAction( tr( "Set Selection End" ), this );
     connect( setSelectionEndAction_, &QAction::triggered, this,
              [ this ]( auto ) { this->setSelectionEnd(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveDefaultSplitterSizesAction_ = new QAction( tr( "Save Splitter Position" ), this );
     connect( saveDefaultSplitterSizesAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT saveDefaultSplitterSizes(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     sendToScratchpadAction_ = new QAction( tr( "Send to Scratchpad" ), this );
     connect( sendToScratchpadAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT sendSelectionToScratchpad(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     replaceInScratchpadAction_ = new QAction( tr( "Replace Scratchpad" ), this );
     connect( replaceInScratchpadAction_, &QAction::triggered, this,
              [ this ]( auto ) { Q_EMIT replaceScratchpadWithSelection(); } );

--- a/src/ui/src/crawlerwidget.cpp
+++ b/src/ui/src/crawlerwidget.cpp
@@ -63,7 +63,6 @@
 #include <QKeySequence>
 #include <QLineEdit>
 #include <QListView>
-#include <QMessageBox>
 #include <QShortcut>
 #include <QStandardItemModel>
 #include <QStringListModel>
@@ -79,12 +78,10 @@
 #include "crawlershortcuts.h"
 #include "dispatch_to.h"
 #include "filewatcher.h"
-#include "filterdiffdialog.h"
 #include "fontutils.h"
 #include "infoline.h"
 #include "predefinedfilters.h"
 #include "quickfindpattern.h"
-#include "savefavoritedialog.h"
 #include "savedsearches.h"
 #include "shortcuts.h"
 
@@ -250,11 +247,6 @@ bool CrawlerWidget::isFirstLoadDone() const
 bool CrawlerWidget::isTextWrapEnabled() const
 {
     return logMainView_->isTextWrapEnabled();
-}
-
-void CrawlerWidget::reloadPredefinedFilters() const
-{
-    searchToolbar_->predefinedFilters()->populatePredefinedFilters();
 }
 
 QString CrawlerWidget::encodingText() const
@@ -538,89 +530,6 @@ void CrawlerWidget::editSearchHistory()
     updateSearchCombo();
 }
 
-void CrawlerWidget::saveAsFavorite()
-{
-    const auto currentText = searchToolbar_->currentSearchText().trimmed();
-    if ( currentText.isEmpty() ) {
-        return;
-    }
-
-    auto filters = PredefinedFiltersCollection::getSynced().getFilters();
-    const auto useRegex = searchToolbar_->isUseRegexp();
-
-    SaveFavoriteDialog dialog( currentText, filters, this );
-    if ( dialog.exec() != QDialog::Accepted ) {
-        return;
-    }
-
-    const auto trimmedName = dialog.favoriteName();
-    if ( trimmedName.isEmpty() ) {
-        return;
-    }
-
-    if ( dialog.isCreateNew() ) {
-        // Check if a filter with this name already exists
-        auto existing = std::find_if(
-            filters.begin(), filters.end(), [ &trimmedName ]( const auto& filter ) {
-                return filter.name.compare( trimmedName, Qt::CaseInsensitive ) == 0;
-            } );
-
-        if ( existing != filters.end() ) {
-            const auto isSamePattern = ( existing->pattern == currentText );
-            const auto isSameRegex = ( existing->useRegex == useRegex );
-            if ( isSamePattern && isSameRegex ) {
-                QMessageBox::information(
-                    this, tr( "klogg" ),
-                    tr( "Favorite \"%1\" already exists with the same content." )
-                        .arg( trimmedName ) );
-                return;
-            }
-
-            // Show diff dialog for confirmation
-            FilterDiffDialog diffDialog( trimmedName, *existing, currentText, useRegex, this );
-            if ( diffDialog.exec() != QDialog::Accepted ) {
-                return;
-            }
-
-            existing->pattern = currentText;
-            existing->useRegex = useRegex;
-        }
-        else {
-            filters.push_back( { trimmedName, currentText, useRegex } );
-        }
-    }
-    else {
-        // Overwriting an existing filter
-        const int index = dialog.selectedExistingIndex();
-        if ( index < 0 || index >= filters.size() ) {
-            return;
-        }
-
-        auto& existing = filters[ index ];
-
-        const auto isSamePattern = ( existing.pattern == currentText );
-        const auto isSameRegex = ( existing.useRegex == useRegex );
-        if ( isSamePattern && isSameRegex ) {
-            QMessageBox::information(
-                this, tr( "klogg" ),
-                tr( "Favorite \"%1\" already has the same content." ).arg( existing.name ) );
-            return;
-        }
-
-        // Show diff dialog for confirmation
-        FilterDiffDialog diffDialog( existing.name, existing, currentText, useRegex, this );
-        if ( diffDialog.exec() != QDialog::Accepted ) {
-            return;
-        }
-
-        existing.pattern = currentText;
-        existing.useRegex = useRegex;
-    }
-
-    PredefinedFiltersCollection::getSynced().saveToStorage( filters );
-    reloadPredefinedFilters();
-}
-
 // When receiving the 'newDataAvailable' signal from LogFilteredData
 void CrawlerWidget::updateFilteredView( LinesCount nbMatches, int progress,
                                         LineNumber initialPosition,
@@ -885,7 +794,6 @@ void CrawlerWidget::applyConfiguration()
         changeDataStatus( DataStatus::OLD_DATA );
     }
 
-    reloadPredefinedFilters();
     applyEmptyFilterBehavior();
 }
 
@@ -1367,13 +1275,11 @@ void CrawlerWidget::setup()
     connect( searchToolbar_, &SearchToolbar::autoRefreshChanged, this,
              &CrawlerWidget::searchRefreshChanged );
 
-    // Context-menu / favorite actions (host owns the dialogs / persistence).
+    // Search-history dialogs remain host-specific.
     connect( searchToolbar_, &SearchToolbar::clearHistoryRequested, this,
              &CrawlerWidget::clearSearchHistory );
     connect( searchToolbar_, &SearchToolbar::editHistoryRequested, this,
              &CrawlerWidget::editSearchHistory );
-    connect( searchToolbar_, &SearchToolbar::saveFavoriteRequested, this,
-             &CrawlerWidget::saveAsFavorite );
 
     // Predefined filters combo is owned by the toolbar; connect its filterChanged.
     connect( searchToolbar_->predefinedFilters(), &PredefinedFiltersComboBox::filterChanged, this,

--- a/src/ui/src/favoritefiles.cpp
+++ b/src/ui/src/favoritefiles.cpp
@@ -44,8 +44,11 @@ void FavoriteFiles::add( const QString& path )
 
 void FavoriteFiles::remove( const QString& path )
 {
-    auto existingFile = std::find_if( files_.begin(), files_.end(), FullPathComparator( path ) );
-    files_.erase( existingFile );
+    const auto existingFile
+        = std::find_if( files_.begin(), files_.end(), FullPathComparator( path ) );
+    if ( existingFile != files_.end() ) {
+        files_.erase( existingFile );
+    }
 }
 
 std::vector<DisplayFilePath> FavoriteFiles::favorites() const

--- a/src/ui/src/filterfavoritesmodel.cpp
+++ b/src/ui/src/filterfavoritesmodel.cpp
@@ -38,32 +38,44 @@ FilterFavoritesModel::Collection FilterFavoritesModel::favorites() const
     return favorites_;
 }
 
-void FilterFavoritesModel::replaceFavorites( const Collection& favorites )
+FilterFavoritesModel::CommitResult FilterFavoritesModel::replaceFavorites(
+    const Collection& favorites )
 {
-    if ( favorites_ != favorites ) {
-        beginResetModel();
-        favorites_ = favorites;
-        endResetModel();
-    }
+    return replaceFavorites( favorites_, favorites );
+}
 
-    // The caller's collection is authoritative. Do not synchronize the model
-    // away from it when another process changed storage; only inspect storage
-    // and repair it when needed. An identical model+store remains a no-op.
-    const auto storedFavorites = PredefinedFiltersCollection::getSynced().getFilters();
-    if ( storedFavorites != favorites ) {
-        PredefinedFiltersCollection::get().saveToStorage( favorites );
+FilterFavoritesModel::CommitResult FilterFavoritesModel::replaceFavorites(
+    const Collection& expected, const Collection& favorites )
+{
+    const auto result = PredefinedFiltersCollection::commit( expected, favorites );
+    switch ( result.status ) {
+    case PredefinedFiltersCollection::CommitStatus::Success:
+    case PredefinedFiltersCollection::CommitStatus::Unchanged:
+    case PredefinedFiltersCollection::CommitStatus::Conflict:
+    case PredefinedFiltersCollection::CommitStatus::WriteError:
+        publishFavorites( result.storedFilters );
+        break;
+    case PredefinedFiltersCollection::CommitStatus::InvalidReplacement:
+    case PredefinedFiltersCollection::CommitStatus::LockError:
+    case PredefinedFiltersCollection::CommitStatus::StorageError:
+        break;
     }
+    return result;
 }
 
 void FilterFavoritesModel::synchronizeFromStorage()
 {
-    const auto storedFavorites = PredefinedFiltersCollection::getSynced().getFilters();
-    if ( favorites_ == storedFavorites ) {
+    publishFavorites( PredefinedFiltersCollection::getSynced().getFilters() );
+}
+
+void FilterFavoritesModel::publishFavorites( const Collection& favorites )
+{
+    if ( favorites_ == favorites ) {
         return;
     }
 
     beginResetModel();
-    favorites_ = storedFavorites;
+    favorites_ = favorites;
     endResetModel();
 }
 

--- a/src/ui/src/filterfavoritesmodel.cpp
+++ b/src/ui/src/filterfavoritesmodel.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "filterfavoritesmodel.h"
+
+#include "containers.h"
+
+FilterFavoritesModel& FilterFavoritesModel::instance()
+{
+    static FilterFavoritesModel model;
+    return model;
+}
+
+FilterFavoritesModel::FilterFavoritesModel( QObject* parent )
+    : QAbstractListModel( parent )
+    , favorites_( PredefinedFiltersCollection::getSynced().getFilters() )
+{
+}
+
+FilterFavoritesModel::Collection FilterFavoritesModel::favorites() const
+{
+    return favorites_;
+}
+
+void FilterFavoritesModel::replaceFavorites( const Collection& favorites )
+{
+    if ( favorites_ != favorites ) {
+        beginResetModel();
+        favorites_ = favorites;
+        endResetModel();
+    }
+
+    // The caller's collection is authoritative. Do not synchronize the model
+    // away from it when another process changed storage; only inspect storage
+    // and repair it when needed. An identical model+store remains a no-op.
+    const auto storedFavorites = PredefinedFiltersCollection::getSynced().getFilters();
+    if ( storedFavorites != favorites ) {
+        PredefinedFiltersCollection::get().saveToStorage( favorites );
+    }
+}
+
+void FilterFavoritesModel::synchronizeFromStorage()
+{
+    const auto storedFavorites = PredefinedFiltersCollection::getSynced().getFilters();
+    if ( favorites_ == storedFavorites ) {
+        return;
+    }
+
+    beginResetModel();
+    favorites_ = storedFavorites;
+    endResetModel();
+}
+
+int FilterFavoritesModel::rowCount( const QModelIndex& parent ) const
+{
+    return parent.isValid() ? 0 : klogg::isize( favorites_ );
+}
+
+QVariant FilterFavoritesModel::data( const QModelIndex& index, int role ) const
+{
+    if ( !index.isValid() || index.column() != 0 || index.row() < 0
+         || index.row() >= klogg::isize( favorites_ ) ) {
+        return {};
+    }
+
+    const auto& favorite = favorites_.at( index.row() );
+    switch ( role ) {
+    case Qt::DisplayRole:
+    case Qt::ToolTipRole:
+    case NameRole:
+        return favorite.name;
+    case PatternRole:
+        return favorite.pattern;
+    case RegexRole:
+        return favorite.useRegex;
+    default:
+        return {};
+    }
+}
+
+QHash<int, QByteArray> FilterFavoritesModel::roleNames() const
+{
+    auto roles = QAbstractListModel::roleNames();
+    roles.insert( NameRole, QByteArrayLiteral( "name" ) );
+    roles.insert( PatternRole, QByteArrayLiteral( "pattern" ) );
+    roles.insert( RegexRole, QByteArrayLiteral( "regex" ) );
+    return roles;
+}

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -25,7 +25,6 @@
 #include <QDir>
 #include <QFontMetrics>
 #include <QInputDialog>
-#include <QMessageBox>
 #include <QSpinBox>
 #include <QStringListModel>
 #include <QTextCodec>
@@ -47,7 +46,6 @@
 #include "abstractlogview.h"
 #include "configuration.h"
 #include "crawlershortcuts.h"
-#include "filterdiffdialog.h"
 #include "folderfilteredview.h"
 #include "foldersearchengine.h"
 #include "foldersearchresults.h"
@@ -58,7 +56,6 @@
 #include "overviewwidget.h"
 #include "predefinedfilters.h"
 #include "predefinedfilterscombobox.h"
-#include "savefavoritedialog.h"
 #include "quickfindpattern.h"
 #include "regularexpression.h"
 #include "regularexpressionpattern.h"
@@ -398,11 +395,8 @@ FolderCrawlerWidget::FolderCrawlerWidget( QWidget* parent )
             }
         }
     } );
-    // Filter favorites + predefined filters mirror CrawlerWidget: the host owns
-    // the dialogs/persistence; selecting a predefined filter applies its pattern
-    // (+regex) to the toolbar so the next search uses it.
-    connect( searchToolbar_, &SearchToolbar::saveFavoriteRequested, this,
-             &FolderCrawlerWidget::saveAsFavorite );
+    // Selecting a predefined filter applies its pattern (+regex) to the toolbar
+    // so the next search uses it.
     // Predefined-filter dropdown selection: update the predefined-filters state
     // only (must NOT toggle auto-refresh tracking). Mirrors
     // crawlerwidget.cpp:1348-1349; without this the combo's currentIndex is not
@@ -484,8 +478,6 @@ FolderCrawlerWidget::FolderCrawlerWidget( QWidget* parent )
     // MainWindow::optionsChanged (the folder's applyConfiguration is connected
     // to optionsChanged by MainWindow::currentTabChanged).
     applyConfiguration();
-    // Populate the predefined-filters combo from the shared collection.
-    reloadPredefinedFilters();
 }
 
 FolderCrawlerWidget::~FolderCrawlerWidget()
@@ -931,97 +923,10 @@ void FolderCrawlerWidget::unmarkMainViewLine( LineNumber line )
     refreshAllPanesForMarks();
 }
 
-void FolderCrawlerWidget::saveAsFavorite()
-{
-    // Mirrors CrawlerWidget::saveAsFavorite: folder search uses the same shared
-    // PredefinedFiltersCollection + dialogs as single-file, so saved favorites
-    // are available across tab kinds. (The duplication is a candidate for
-    // extraction into SearchToolbar.)
-    const auto currentText = searchToolbar_->currentSearchText().trimmed();
-    if ( currentText.isEmpty() ) {
-        return;
-    }
-
-    auto filters = PredefinedFiltersCollection::getSynced().getFilters();
-    const auto useRegex = searchToolbar_->isUseRegexp();
-
-    SaveFavoriteDialog dialog( currentText, filters, this );
-    if ( dialog.exec() != QDialog::Accepted ) {
-        return;
-    }
-
-    const auto trimmedName = dialog.favoriteName();
-    if ( trimmedName.isEmpty() ) {
-        return;
-    }
-
-    if ( dialog.isCreateNew() ) {
-        auto existing = std::find_if(
-            filters.begin(), filters.end(), [ &trimmedName ]( const auto& filter ) {
-                return filter.name.compare( trimmedName, Qt::CaseInsensitive ) == 0;
-            } );
-
-        if ( existing != filters.end() ) {
-            const auto isSamePattern = ( existing->pattern == currentText );
-            const auto isSameRegex = ( existing->useRegex == useRegex );
-            if ( isSamePattern && isSameRegex ) {
-                QMessageBox::information(
-                    this, tr( "klogg" ),
-                    tr( "Favorite \"%1\" already exists with the same content." ).arg( trimmedName ) );
-                return;
-            }
-
-            FilterDiffDialog diffDialog( trimmedName, *existing, currentText, useRegex, this );
-            if ( diffDialog.exec() != QDialog::Accepted ) {
-                return;
-            }
-
-            existing->pattern = currentText;
-            existing->useRegex = useRegex;
-        }
-        else {
-            filters.push_back( { trimmedName, currentText, useRegex } );
-        }
-    }
-    else {
-        const int index = dialog.selectedExistingIndex();
-        if ( index < 0 || index >= filters.size() ) {
-            return;
-        }
-
-        auto& existing = filters[ index ];
-
-        const auto isSamePattern = ( existing.pattern == currentText );
-        const auto isSameRegex = ( existing.useRegex == useRegex );
-        if ( isSamePattern && isSameRegex ) {
-            QMessageBox::information(
-                this, tr( "klogg" ),
-                tr( "Favorite \"%1\" already has the same content." ).arg( existing.name ) );
-            return;
-        }
-
-        FilterDiffDialog diffDialog( existing.name, existing, currentText, useRegex, this );
-        if ( diffDialog.exec() != QDialog::Accepted ) {
-            return;
-        }
-
-        existing.pattern = currentText;
-        existing.useRegex = useRegex;
-    }
-
-    PredefinedFiltersCollection::getSynced().saveToStorage( filters );
-    reloadPredefinedFilters();
-}
-
 void FolderCrawlerWidget::updatePredefinedFiltersWidget()
 {
     searchToolbar_->predefinedFilters()->updateSearchPattern( searchToolbar_->currentSearchText(),
                                                               searchToolbar_->isBoolean() );
-}
-
-void FolderCrawlerWidget::reloadPredefinedFilters() const
-{
-    searchToolbar_->predefinedFilters()->populatePredefinedFilters();
 }
 
 void FolderCrawlerWidget::applyConfiguration()
@@ -1062,12 +967,6 @@ void FolderCrawlerWidget::applyConfiguration()
             pane->view->updateFont( font );
         }
     }
-
-    // Re-sync the predefined-filters combo from the shared collection, mirroring
-    // CrawlerWidget::applyConfiguration (crawlerwidget.cpp:866). A filter saved
-    // via another tab (or the options dialog) must appear here on the next
-    // optionsChanged broadcast without restarting klogg.
-    reloadPredefinedFilters();
 
     registerShortcuts();
 }

--- a/src/ui/src/infoline.cpp
+++ b/src/ui/src/infoline.cpp
@@ -117,9 +117,9 @@ void InfoLine::contextMenuEvent( QContextMenuEvent* event )
 {
     QMenu menu( this );
 
-    auto copySelection = menu.addAction( "Copy" );
+    auto copySelection = menu.addAction( tr( "Copy" ) );
     menu.addSeparator();
-    auto selectAll = menu.addAction( "Select all" );
+    auto selectAll = menu.addAction( tr( "Select All" ) );
 
     copySelection->setEnabled( this->hasSelectedText() );
     connect( copySelection, &QAction::triggered, this,

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -125,6 +125,7 @@
 #include "styles.h"
 #include "tabgroup.h"
 #include "tabbedcrawlerwidget.h"
+#include "uimessage.h"
 
 namespace {
 
@@ -181,7 +182,7 @@ class ScopedMainWindowShortcutSuspender {
 
   private:
     struct ActionShortcuts {
-        QAction* action;
+        QAction* action = nullptr;
         QList<QKeySequence> shortcuts;
     };
 
@@ -639,17 +640,23 @@ void MainWindow::createActions()
     openAction->setStatusTip( tr( action::openStatusTip ) );
     connect( openAction, &QAction::triggered, [ this ]( auto ) { this->open(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     openFolderAction = new QAction( tr( action::openFolderText ), this );
     openFolderAction->setObjectName( QStringLiteral( "openFolderAction" ) );
     openFolderAction->setStatusTip( tr( action::openFolderStatusTip ) );
     connect( openFolderAction, &QAction::triggered, [ this ]( auto ) { this->openFolder(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     openAdbLogcatAction = new QAction( tr( action::openAdbLogcatText ), this );
     openAdbLogcatAction->setObjectName( QStringLiteral( "openAdbLogcatAction" ) );
     openAdbLogcatAction->setStatusTip( tr( action::openAdbLogcatStatusTip ) );
     connect( openAdbLogcatAction, &QAction::triggered, this,
              [ this ]( auto ) { this->openAdbLogcat(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     openIosLogStreamAction = new QAction( tr( action::openIosLogStreamText ), this );
     openIosLogStreamAction->setObjectName( QStringLiteral( "openIosLogStreamAction" ) );
     openIosLogStreamAction->setStatusTip( tr( action::openIosLogStreamStatusTip ) );
@@ -732,8 +739,12 @@ void MainWindow::createActions()
     clearLogAction->setStatusTip( tr( action::clearLogStatusTip ) );
     connect( clearLogAction, &QAction::triggered, this, [ this ]( auto ) { this->clearLog(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveCurrentLiveLogMenu = new QMenu( tr( menu::saveCurrentLiveLogTitle ), this );
     saveCurrentLiveLogMenu->setObjectName( QStringLiteral( "saveCurrentLiveLogMenu" ) );
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveCurrentLiveLogStripAnsiAction
         = new QAction( tr( action::saveCurrentLiveLogStripAnsiText ), this );
     saveCurrentLiveLogStripAnsiAction->setObjectName(
@@ -743,6 +754,8 @@ void MainWindow::createActions()
     connect( saveCurrentLiveLogStripAnsiAction, &QAction::triggered, this,
              [ this ]( auto ) { this->saveCurrentLiveLog( LiveLogSaveAnsiMode::Strip ); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     saveCurrentLiveLogPreserveAnsiAction
         = new QAction( tr( action::saveCurrentLiveLogPreserveAnsiText ), this );
     saveCurrentLiveLogPreserveAnsiAction->setObjectName(
@@ -755,12 +768,16 @@ void MainWindow::createActions()
     saveCurrentLiveLogMenu->addAction( saveCurrentLiveLogPreserveAnsiAction );
     saveCurrentLiveLogMenu->setEnabled( false );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     disconnectSourceAction = new QAction( tr( action::disconnectSourceText ), this );
     disconnectSourceAction->setObjectName( QStringLiteral( "disconnectSourceAction" ) );
     disconnectSourceAction->setStatusTip( tr( action::disconnectSourceStatusTip ) );
     connect( disconnectSourceAction, &QAction::triggered, this,
              [ this ]( auto ) { this->disconnectCurrentSource(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     reconnectSourceAction = new QAction( tr( action::reconnectSourceText ), this );
     reconnectSourceAction->setObjectName( QStringLiteral( "reconnectSourceAction" ) );
     reconnectSourceAction->setStatusTip( tr( action::reconnectSourceStatusTip ) );
@@ -912,6 +929,8 @@ void MainWindow::createActions()
     connect( showScratchPadAction, &QAction::triggered, this,
              [ this ]( auto ) { this->showScratchPad(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     mergeTabsAction = new QAction( tr( action::mergeTabsText ), this );
     mergeTabsAction->setObjectName( QStringLiteral( "mergeTabsAction" ) );
     mergeTabsAction->setStatusTip( tr( action::mergeTabsStatusTip ) );
@@ -933,11 +952,15 @@ void MainWindow::createActions()
     connect( addToFavoritesAction, &QAction::triggered, this,
              [ this ]( auto ) { this->addToFavorites(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     addToFavoritesMenuAction = new QAction( tr( action::addCurrentFileText ), this );
     addToFavoritesMenuAction->setObjectName( QStringLiteral( "addToFavoritesMenuAction" ) );
     connect( addToFavoritesMenuAction, &QAction::triggered, this,
              [ this ]( auto ) { this->addToFavorites(); } );
 
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     removeFromFavoritesAction = new QAction( tr( action::removeFavoriteFileText ), this );
     removeFromFavoritesAction->setObjectName( QStringLiteral( "removeFromFavoritesAction" ) );
     connect( removeFromFavoritesAction, &QAction::triggered, this,
@@ -1228,10 +1251,16 @@ void MainWindow::createTrayIcon()
 {
     trayIcon_ = new QSystemTrayIcon( this );
 
+    // QObject parentage owns this menu.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     auto* trayMenu = new QMenu( this );
     trayMenu->setObjectName( QStringLiteral( "trayMenu" ) );
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     trayOpenWindowAction_ = new QAction( tr( klogg::mainwindow::trayicon::openWindowText ), this );
     trayOpenWindowAction_->setObjectName( QStringLiteral( "trayOpenWindowAction" ) );
+    // QObject parentage owns this action.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     trayQuitAction_ = new QAction( tr( klogg::mainwindow::trayicon::quitText ), this );
     trayQuitAction_->setObjectName( QStringLiteral( "trayQuitAction" ) );
 
@@ -1810,14 +1839,32 @@ void MainWindow::importFilterFavoritesFromFile( const QString& file )
 {
     const auto result = PredefinedFiltersCollection::tryLoadFromFile( file );
     if ( result.status != PredefinedFiltersCollection::LoadStatus::Success ) {
-        QMessageBox::warning( this, tr( "klogg" ),
-                              tr( "Unable to import filter favorites from the selected file." ) );
+        klogg::ui::warning( this, tr( "klogg" ),
+                            tr( "Unable to import filter favorites from the selected file." ) );
         return;
     }
 
     auto& favoritesModel = FilterFavoritesModel::instance();
     favoritesModel.synchronizeFromStorage();
-    favoritesModel.replaceFavorites( result.filters );
+    const auto expected = favoritesModel.favorites();
+    const auto commitResult = favoritesModel.replaceFavorites( expected, result.filters );
+    switch ( commitResult.status ) {
+    case PredefinedFiltersCollection::CommitStatus::Success:
+    case PredefinedFiltersCollection::CommitStatus::Unchanged:
+        return;
+    case PredefinedFiltersCollection::CommitStatus::Conflict:
+        klogg::ui::warning(
+            this, tr( "klogg" ),
+            tr( "Filter favorites changed while the import was being applied. Try again." ) );
+        return;
+    case PredefinedFiltersCollection::CommitStatus::InvalidReplacement:
+    case PredefinedFiltersCollection::CommitStatus::LockError:
+    case PredefinedFiltersCollection::CommitStatus::StorageError:
+    case PredefinedFiltersCollection::CommitStatus::WriteError:
+        klogg::ui::warning( this, tr( "klogg" ),
+                            tr( "Unable to save filter favorites. Try again." ) );
+        return;
+    }
 }
 
 void MainWindow::exportFilterFavorites()
@@ -1839,8 +1886,8 @@ void MainWindow::exportFilterFavoritesToFile( QString file )
     auto& favoritesModel = FilterFavoritesModel::instance();
     favoritesModel.synchronizeFromStorage();
     if ( !PredefinedFiltersCollection::saveToFile( file, favoritesModel.favorites() ) ) {
-        QMessageBox::warning( this, tr( "klogg" ),
-                              tr( "Unable to export filter favorites to the selected file." ) );
+        klogg::ui::warning( this, tr( "klogg" ),
+                            tr( "Unable to export filter favorites to the selected file." ) );
     }
 }
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -99,6 +99,7 @@
 #include "folderenumeration.h"
 #include "dispatch_to.h"
 #include "downloader.h"
+#include "filterfavoritesmodel.h"
 #include "encodings.h"
 #include "favoritefiles.h"
 #include "highlightersdialog.h"
@@ -430,7 +431,10 @@ void MainWindow::reTranslateUI()
         return QApplication::translate( "klogg::mainwindow::menu", text );
     };
     fileMenu->setTitle( transMenu( menu::fileTitle ) );
+    recentFilesMenu->setTitle( transMenu( menu::recentFilesTitle ) );
+    recentFoldersMenu->setTitle( transMenu( menu::recentFoldersTitle ) );
     editMenu->setTitle( transMenu( menu::editTitle ) );
+    saveCurrentLiveLogMenu->setTitle( transMenu( menu::saveCurrentLiveLogTitle ) );
     viewMenu->setTitle( transMenu( menu::viewTitle ) );
     openedFilesMenu->setTitle( transMenu( menu::openedFilesTitle ) );
     toolsMenu->setTitle( transMenu( menu::toolsTitle ) );
@@ -451,10 +455,12 @@ void MainWindow::reTranslateUI()
 
     openAction->setText( transAction( action::openText ) );
     openAction->setStatusTip( transAction( action::openStatusTip ) );
-    openAdbLogcatAction->setText( tr( "Open ADB Logcat..." ) );
-    openAdbLogcatAction->setStatusTip( tr( "Open Android logcat as a live source" ) );
-    openIosLogStreamAction->setText( tr( "Open iOS Log Stream..." ) );
-    openIosLogStreamAction->setStatusTip( tr( "Open iOS device logs as a live source" ) );
+    openFolderAction->setText( transAction( action::openFolderText ) );
+    openFolderAction->setStatusTip( transAction( action::openFolderStatusTip ) );
+    openAdbLogcatAction->setText( transAction( action::openAdbLogcatText ) );
+    openAdbLogcatAction->setStatusTip( transAction( action::openAdbLogcatStatusTip ) );
+    openIosLogStreamAction->setText( transAction( action::openIosLogStreamText ) );
+    openIosLogStreamAction->setStatusTip( transAction( action::openIosLogStreamStatusTip ) );
 
     recentFilesCleanup->setText( transAction( action::recentFilesCleanupText ) );
     recentFoldersCleanup->setText( transAction( action::recentFoldersCleanupText ) );
@@ -482,17 +488,18 @@ void MainWindow::reTranslateUI()
 
     clearLogAction->setText( transAction( action::clearLogText ) );
     clearLogAction->setStatusTip( transAction( action::clearLogStatusTip ) );
-    saveCurrentLiveLogMenu->setTitle( tr( "Save Live Log As" ) );
-    saveCurrentLiveLogStripAnsiAction->setText( tr( "Without ANSI Sequences..." ) );
+    saveCurrentLiveLogStripAnsiAction->setText(
+        transAction( action::saveCurrentLiveLogStripAnsiText ) );
     saveCurrentLiveLogStripAnsiAction->setStatusTip(
-        tr( "Persist the current live capture to a file after removing ANSI sequences" ) );
-    saveCurrentLiveLogPreserveAnsiAction->setText( tr( "With ANSI Sequences..." ) );
+        transAction( action::saveCurrentLiveLogStripAnsiStatusTip ) );
+    saveCurrentLiveLogPreserveAnsiAction->setText(
+        transAction( action::saveCurrentLiveLogPreserveAnsiText ) );
     saveCurrentLiveLogPreserveAnsiAction->setStatusTip(
-        tr( "Persist the current live capture to a file without modifying ANSI sequences" ) );
-    disconnectSourceAction->setText( tr( "Disconnect Source" ) );
-    disconnectSourceAction->setStatusTip( tr( "Stop streaming from the current live source" ) );
-    reconnectSourceAction->setText( tr( "Reconnect Source" ) );
-    reconnectSourceAction->setStatusTip( tr( "Reconnect the current live source" ) );
+        transAction( action::saveCurrentLiveLogPreserveAnsiStatusTip ) );
+    disconnectSourceAction->setText( transAction( action::disconnectSourceText ) );
+    disconnectSourceAction->setStatusTip( transAction( action::disconnectSourceStatusTip ) );
+    reconnectSourceAction->setText( transAction( action::reconnectSourceText ) );
+    reconnectSourceAction->setStatusTip( transAction( action::reconnectSourceStatusTip ) );
 
     openContainingFolderAction->setText( transAction( action::openContainingFolderText ) );
     openContainingFolderAction->setStatusTip(
@@ -517,6 +524,7 @@ void MainWindow::reTranslateUI()
         transAction( action::lineNumbersVisibleInFilteredText ) );
 
     followAction->setText( transAction( action::followText ) );
+    goToTopAction->setText( transAction( action::goToTopText ) );
     textWrapAction->setText( transAction( action::wrapText ) );
     reloadAction->setText( transAction( action::reloadText ) );
     stopAction->setText( transAction( action::stopText ) );
@@ -549,13 +557,12 @@ void MainWindow::reTranslateUI()
     showScratchPadAction->setText( transAction( action::showScratchPadText ) );
     showScratchPadAction->setStatusTip( transAction( action::showScratchPadStatusTip ) );
 
-    auto curFavoritesIconText = addToFavoritesAction->data().toBool()
-                                    ? transAction( action::addToFavoritesText )
-                                    : transAction( action::removeFromFavoritesText );
-    addToFavoritesAction->setText( curFavoritesIconText );
-    addToFavoritesMenuAction->setText( transAction( action::addToFavoritesText ) );
-
-    removeFromFavoritesAction->setText( transAction( action::removeFromFavoritesText ) );
+    const auto currentFileFavoriteText = addToFavoritesAction->data().toBool()
+                                             ? transAction( action::addToFavoritesText )
+                                             : transAction( action::removeFromFavoritesText );
+    addToFavoritesAction->setText( currentFileFavoriteText );
+    addToFavoritesMenuAction->setText( transAction( action::addCurrentFileText ) );
+    removeFromFavoritesAction->setText( transAction( action::removeFavoriteFileText ) );
 
     selectOpenFileAction->setText( transAction( action::selectOpenFileText ) );
 
@@ -568,10 +575,16 @@ void MainWindow::reTranslateUI()
     exportFilterFavoritesAction->setText( transAction( action::exportFilterFavoritesText ) );
     exportFilterFavoritesAction->setStatusTip(
         transAction( action::exportFilterFavoritesStatusTip ) );
+    mergeTabsAction->setText( transAction( action::mergeTabsText ) );
+    mergeTabsAction->setStatusTip( transAction( action::mergeTabsStatusTip ) );
 
     // trayIcon
-    trayIcon_->setToolTip( QApplication::translate( "klogg::mainwindow::trayicon",
-                                                    klogg::mainwindow::trayicon::trayiconTip ) );
+    const auto transTrayIcon = []( const char* text ) -> auto {
+        return QApplication::translate( "klogg::mainwindow::trayicon", text );
+    };
+    trayIcon_->setToolTip( transTrayIcon( trayicon::trayiconTip ) );
+    trayOpenWindowAction_->setText( transTrayIcon( trayicon::openWindowText ) );
+    trayQuitAction_->setText( transTrayIcon( trayicon::quitText ) );
 }
 
 int MainWindow::installLanguage( QString lang )
@@ -622,20 +635,24 @@ void MainWindow::createActions()
     newWindowAction->setVisible( config.allowMultipleWindows() );
 
     openAction = new QAction( tr( action::openText ), this );
+    openAction->setObjectName( QStringLiteral( "openAction" ) );
     openAction->setStatusTip( tr( action::openStatusTip ) );
     connect( openAction, &QAction::triggered, [ this ]( auto ) { this->open(); } );
 
-    openFolderAction = new QAction( tr( "Open Folder..." ), this );
-    openFolderAction->setStatusTip( tr( "Search every file in a folder (like grep -EIrn)" ) );
+    openFolderAction = new QAction( tr( action::openFolderText ), this );
+    openFolderAction->setObjectName( QStringLiteral( "openFolderAction" ) );
+    openFolderAction->setStatusTip( tr( action::openFolderStatusTip ) );
     connect( openFolderAction, &QAction::triggered, [ this ]( auto ) { this->openFolder(); } );
 
-    openAdbLogcatAction = new QAction( tr( "Open ADB Logcat..." ), this );
-    openAdbLogcatAction->setStatusTip( tr( "Open Android logcat as a live source" ) );
+    openAdbLogcatAction = new QAction( tr( action::openAdbLogcatText ), this );
+    openAdbLogcatAction->setObjectName( QStringLiteral( "openAdbLogcatAction" ) );
+    openAdbLogcatAction->setStatusTip( tr( action::openAdbLogcatStatusTip ) );
     connect( openAdbLogcatAction, &QAction::triggered, this,
              [ this ]( auto ) { this->openAdbLogcat(); } );
 
-    openIosLogStreamAction = new QAction( tr( "Open iOS Log Stream..." ), this );
-    openIosLogStreamAction->setStatusTip( tr( "Open iOS device logs as a live source" ) );
+    openIosLogStreamAction = new QAction( tr( action::openIosLogStreamText ), this );
+    openIosLogStreamAction->setObjectName( QStringLiteral( "openIosLogStreamAction" ) );
+    openIosLogStreamAction->setStatusTip( tr( action::openIosLogStreamStatusTip ) );
 #ifndef Q_OS_MAC
     openIosLogStreamAction->setVisible( false );
 #endif
@@ -715,35 +732,38 @@ void MainWindow::createActions()
     clearLogAction->setStatusTip( tr( action::clearLogStatusTip ) );
     connect( clearLogAction, &QAction::triggered, this, [ this ]( auto ) { this->clearLog(); } );
 
-    saveCurrentLiveLogMenu = new QMenu( tr( "Save Live Log As" ), this );
+    saveCurrentLiveLogMenu = new QMenu( tr( menu::saveCurrentLiveLogTitle ), this );
     saveCurrentLiveLogMenu->setObjectName( QStringLiteral( "saveCurrentLiveLogMenu" ) );
-    saveCurrentLiveLogStripAnsiAction = new QAction( tr( "Without ANSI Sequences..." ), this );
+    saveCurrentLiveLogStripAnsiAction
+        = new QAction( tr( action::saveCurrentLiveLogStripAnsiText ), this );
     saveCurrentLiveLogStripAnsiAction->setObjectName(
         QStringLiteral( "saveCurrentLiveLogStripAnsiAction" ) );
     saveCurrentLiveLogStripAnsiAction->setStatusTip(
-        tr( "Persist the current live capture to a file after removing ANSI sequences" ) );
+        tr( action::saveCurrentLiveLogStripAnsiStatusTip ) );
     connect( saveCurrentLiveLogStripAnsiAction, &QAction::triggered, this,
              [ this ]( auto ) { this->saveCurrentLiveLog( LiveLogSaveAnsiMode::Strip ); } );
 
-    saveCurrentLiveLogPreserveAnsiAction = new QAction( tr( "With ANSI Sequences..." ), this );
+    saveCurrentLiveLogPreserveAnsiAction
+        = new QAction( tr( action::saveCurrentLiveLogPreserveAnsiText ), this );
     saveCurrentLiveLogPreserveAnsiAction->setObjectName(
         QStringLiteral( "saveCurrentLiveLogPreserveAnsiAction" ) );
     saveCurrentLiveLogPreserveAnsiAction->setStatusTip(
-        tr( "Persist the current live capture to a file without modifying ANSI sequences" ) );
+        tr( action::saveCurrentLiveLogPreserveAnsiStatusTip ) );
     connect( saveCurrentLiveLogPreserveAnsiAction, &QAction::triggered, this,
              [ this ]( auto ) { this->saveCurrentLiveLog( LiveLogSaveAnsiMode::Preserve ); } );
     saveCurrentLiveLogMenu->addAction( saveCurrentLiveLogStripAnsiAction );
     saveCurrentLiveLogMenu->addAction( saveCurrentLiveLogPreserveAnsiAction );
     saveCurrentLiveLogMenu->setEnabled( false );
 
-    disconnectSourceAction = new QAction( tr( "Disconnect Source" ), this );
-    disconnectSourceAction->setStatusTip(
-        tr( "Stop streaming from the current live source" ) );
+    disconnectSourceAction = new QAction( tr( action::disconnectSourceText ), this );
+    disconnectSourceAction->setObjectName( QStringLiteral( "disconnectSourceAction" ) );
+    disconnectSourceAction->setStatusTip( tr( action::disconnectSourceStatusTip ) );
     connect( disconnectSourceAction, &QAction::triggered, this,
              [ this ]( auto ) { this->disconnectCurrentSource(); } );
 
-    reconnectSourceAction = new QAction( tr( "Reconnect Source" ), this );
-    reconnectSourceAction->setStatusTip( tr( "Reconnect the current live source" ) );
+    reconnectSourceAction = new QAction( tr( action::reconnectSourceText ), this );
+    reconnectSourceAction->setObjectName( QStringLiteral( "reconnectSourceAction" ) );
+    reconnectSourceAction->setStatusTip( tr( action::reconnectSourceStatusTip ) );
     connect( reconnectSourceAction, &QAction::triggered, this,
              [ this ]( auto ) { this->reconnectCurrentSource(); } );
 
@@ -764,11 +784,13 @@ void MainWindow::createActions()
              [ this ]( auto ) { this->copyFullPath(); } );
 
     openClipboardAction = new QAction( tr( action::openClipboardText ), this );
+    openClipboardAction->setObjectName( QStringLiteral( "openClipboardAction" ) );
     openClipboardAction->setStatusTip( tr( action::openClipboardStatusTip ) );
     connect( openClipboardAction, &QAction::triggered, this,
              [ this ]( auto ) { this->openClipboard(); } );
 
     openUrlAction = new QAction( tr( action::openUrlText ), this );
+    openUrlAction->setObjectName( QStringLiteral( "openUrlAction" ) );
     openUrlAction->setStatusTip( tr( action::openUrlStatusTip ) );
     connect( openUrlAction, &QAction::triggered, this, [ this ]( auto ) { this->openUrl(); } );
 
@@ -856,6 +878,7 @@ void MainWindow::createActions()
              [ this ]( auto ) { this->editHighlighters(); } );
 
     showDocumentationAction = new QAction( tr( action::showDocumentationText ), this );
+    showDocumentationAction->setObjectName( QStringLiteral( "showDocumentationAction" ) );
     showDocumentationAction->setStatusTip( tr( action::showDocumentationStatusTip ) );
     connect( showDocumentationAction, &QAction::triggered, this,
              [ this ]( auto ) { this->documentation(); } );
@@ -869,6 +892,7 @@ void MainWindow::createActions()
     connect( aboutQtAction, &QAction::triggered, this, [ this ]( auto ) { this->aboutQt(); } );
 
     reportIssueAction = new QAction( tr( action::reportIssueText ), this );
+    reportIssueAction->setObjectName( QStringLiteral( "reportIssueAction" ) );
     reportIssueAction->setStatusTip( tr( action::reportIssueStatusTip ) );
     connect( reportIssueAction, &QAction::triggered, this,
              []( auto ) { IssueReporter::reportIssue( IssueTemplate::Bug ); } );
@@ -888,8 +912,9 @@ void MainWindow::createActions()
     connect( showScratchPadAction, &QAction::triggered, this,
              [ this ]( auto ) { this->showScratchPad(); } );
 
-    mergeTabsAction = new QAction( tr( "Merge Tabs..." ), this );
-    mergeTabsAction->setStatusTip( tr( "Merge selected tabs into a single view" ) );
+    mergeTabsAction = new QAction( tr( action::mergeTabsText ), this );
+    mergeTabsAction->setObjectName( QStringLiteral( "mergeTabsAction" ) );
+    mergeTabsAction->setStatusTip( tr( action::mergeTabsStatusTip ) );
     connect( mergeTabsAction, &QAction::triggered, this,
              [ this ]( auto ) { this->mergeTabs(); } );
 
@@ -903,15 +928,18 @@ void MainWindow::createActions()
     connect( openedFilesGroup, &QActionGroup::triggered, this, &MainWindow::switchToOpenedFile );
 
     addToFavoritesAction = new QAction( tr( action::addToFavoritesText ), this );
+    addToFavoritesAction->setObjectName( QStringLiteral( "addToFavoritesAction" ) );
     addToFavoritesAction->setData( true );
     connect( addToFavoritesAction, &QAction::triggered, this,
              [ this ]( auto ) { this->addToFavorites(); } );
 
-    addToFavoritesMenuAction = new QAction( tr( action::addToFavoritesText ), this );
+    addToFavoritesMenuAction = new QAction( tr( action::addCurrentFileText ), this );
+    addToFavoritesMenuAction->setObjectName( QStringLiteral( "addToFavoritesMenuAction" ) );
     connect( addToFavoritesMenuAction, &QAction::triggered, this,
              [ this ]( auto ) { this->addToFavorites(); } );
 
-    removeFromFavoritesAction = new QAction( tr( action::removeFromFavoritesText ), this );
+    removeFromFavoritesAction = new QAction( tr( action::removeFavoriteFileText ), this );
+    removeFromFavoritesAction->setObjectName( QStringLiteral( "removeFromFavoritesAction" ) );
     connect( removeFromFavoritesAction, &QAction::triggered, this,
              [ this ]( auto ) { this->removeFromFavorites(); } );
 
@@ -920,16 +948,20 @@ void MainWindow::createActions()
              [ this ]( auto ) { this->selectOpenedFile(); } );
 
     predefinedFiltersDialogAction = new QAction( tr( action::predefinedFiltersDialogText ), this );
+    predefinedFiltersDialogAction->setObjectName(
+        QStringLiteral( "predefinedFiltersDialogAction" ) );
     predefinedFiltersDialogAction->setStatusTip( tr( action::predefinedFiltersDialogStatusTip ) );
     connect( predefinedFiltersDialogAction, &QAction::triggered, this,
              [ this ]( auto ) { this->editPredefinedFilters(); } );
 
     importFilterFavoritesAction = new QAction( tr( action::importFilterFavoritesText ), this );
+    importFilterFavoritesAction->setObjectName( QStringLiteral( "importFilterFavoritesAction" ) );
     importFilterFavoritesAction->setStatusTip( tr( action::importFilterFavoritesStatusTip ) );
     connect( importFilterFavoritesAction, &QAction::triggered, this,
              [ this ]( auto ) { this->importFilterFavorites(); } );
 
     exportFilterFavoritesAction = new QAction( tr( action::exportFilterFavoritesText ), this );
+    exportFilterFavoritesAction->setObjectName( QStringLiteral( "exportFilterFavoritesAction" ) );
     exportFilterFavoritesAction->setStatusTip( tr( action::exportFilterFavoritesStatusTip ) );
     connect( exportFilterFavoritesAction, &QAction::triggered, this,
              [ this ]( auto ) { this->exportFilterFavorites(); } );
@@ -1025,6 +1057,7 @@ void MainWindow::createMenus()
     using namespace klogg::mainwindow;
 
     fileMenu = menuBar()->addMenu( tr( menu::fileTitle ) );
+    fileMenu->setObjectName( QStringLiteral( "fileMenu" ) );
     fileMenu->setToolTipsVisible( true );
     fileMenu->addAction( newWindowAction );
     fileMenu->addAction( openAction );
@@ -1033,7 +1066,8 @@ void MainWindow::createMenus()
     fileMenu->addAction( openIosLogStreamAction );
     fileMenu->addAction( openClipboardAction );
     fileMenu->addAction( openUrlAction );
-    recentFilesMenu = fileMenu->addMenu( tr( "Open Recent" ) );
+    recentFilesMenu = fileMenu->addMenu( tr( menu::recentFilesTitle ) );
+    recentFilesMenu->setObjectName( QStringLiteral( "recentFilesMenu" ) );
     for ( auto i = 0u; i < recentFileActions.size(); ++i ) {
         recentFilesMenu->addAction( recentFileActions[ i ] );
     }
@@ -1041,7 +1075,8 @@ void MainWindow::createMenus()
     recentFilesMenu->addAction( recentFilesCleanup );
     recentFilesMenu->setEnabled( false );
 
-    recentFoldersMenu = fileMenu->addMenu( tr( "Open Recent Fol&der" ) );
+    recentFoldersMenu = fileMenu->addMenu( tr( menu::recentFoldersTitle ) );
+    recentFoldersMenu->setObjectName( QStringLiteral( "recentFoldersMenu" ) );
     for ( auto i = 0u; i < recentFolderActions.size(); ++i ) {
         recentFoldersMenu->addAction( recentFolderActions[ i ] );
     }
@@ -1060,6 +1095,7 @@ void MainWindow::createMenus()
     fileMenu->addAction( exitAction );
 
     editMenu = menuBar()->addMenu( tr( menu::editTitle ) );
+    editMenu->setObjectName( QStringLiteral( "editMenu" ) );
     editMenu->addAction( copyAction );
     editMenu->addAction( selectAllAction );
     editMenu->addSeparator();
@@ -1078,7 +1114,9 @@ void MainWindow::createMenus()
     editMenu->setEnabled( false );
 
     viewMenu = menuBar()->addMenu( tr( menu::viewTitle ) );
+    viewMenu->setObjectName( QStringLiteral( "viewMenu" ) );
     openedFilesMenu = viewMenu->addMenu( tr( menu::openedFilesTitle ) );
+    openedFilesMenu->setObjectName( QStringLiteral( "openedFilesMenu" ) );
     viewMenu->addSeparator();
     viewMenu->addAction( overviewVisibleAction );
     viewMenu->addSeparator();
@@ -1093,8 +1131,10 @@ void MainWindow::createMenus()
     viewMenu->addAction( reloadAction );
 
     toolsMenu = menuBar()->addMenu( tr( menu::toolsTitle ) );
+    toolsMenu->setObjectName( QStringLiteral( "toolsMenu" ) );
 
     highlightersMenu = new HighlightersMenu( tr( menu::highlightersTitle ), menuBar() );
+    highlightersMenu->setObjectName( QStringLiteral( "highlightersMenu" ) );
     menuBar()->addMenu( highlightersMenu );
     highlightersMenu->setApplyChange( [ this ]() {
         auto crawler = currentCrawlerWidget();
@@ -1116,9 +1156,12 @@ void MainWindow::createMenus()
     menuBar()->addSeparator();
 
     favoritesMenu = menuBar()->addMenu( tr( menu::favoritesTitle ) );
+    favoritesMenu->setObjectName( QStringLiteral( "favoritesMenu" ) );
     favoritesMenu->setToolTipsVisible( true );
+    connect( favoritesMenu, &QMenu::aboutToShow, this, &MainWindow::updateFavoritesMenu );
 
     helpMenu = menuBar()->addMenu( tr( menu::helpTitle ) );
+    helpMenu->setObjectName( QStringLiteral( "helpMenu" ) );
     helpMenu->addAction( showDocumentationAction );
     helpMenu->addSeparator();
     helpMenu->addAction( checkForNewVersionAction );
@@ -1185,15 +1228,18 @@ void MainWindow::createTrayIcon()
 {
     trayIcon_ = new QSystemTrayIcon( this );
 
-    QMenu* trayMenu = new QMenu( this );
-    QAction* openWindowAction = new QAction( tr( "Open window" ), this );
-    QAction* quitAction = new QAction( tr( "Quit" ), this );
+    auto* trayMenu = new QMenu( this );
+    trayMenu->setObjectName( QStringLiteral( "trayMenu" ) );
+    trayOpenWindowAction_ = new QAction( tr( klogg::mainwindow::trayicon::openWindowText ), this );
+    trayOpenWindowAction_->setObjectName( QStringLiteral( "trayOpenWindowAction" ) );
+    trayQuitAction_ = new QAction( tr( klogg::mainwindow::trayicon::quitText ), this );
+    trayQuitAction_->setObjectName( QStringLiteral( "trayQuitAction" ) );
 
-    trayMenu->addAction( openWindowAction );
-    trayMenu->addAction( quitAction );
+    trayMenu->addAction( trayOpenWindowAction_ );
+    trayMenu->addAction( trayQuitAction_ );
 
-    connect( openWindowAction, &QAction::triggered, this, &QMainWindow::show );
-    connect( quitAction, &QAction::triggered, [ this ] {
+    connect( trayOpenWindowAction_, &QAction::triggered, this, &QMainWindow::show );
+    connect( trayQuitAction_, &QAction::triggered, [ this ] {
         this->isCloseFromTray_ = true;
         this->close();
     } );
@@ -1746,11 +1792,7 @@ void MainWindow::editHighlighters()
 void MainWindow::editPredefinedFilters( const QString& newFilter )
 {
     PredefinedFiltersDialog dialog( newFilter, this );
-
-    signalMux_.connect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
-
     dialog.exec();
-    signalMux_.disconnect( &dialog, SIGNAL( optionsChanged() ), SLOT( applyConfiguration() ) );
 }
 
 void MainWindow::importFilterFavorites()
@@ -1759,30 +1801,47 @@ void MainWindow::importFilterFavorites()
         = QFileDialog::getOpenFileName( this, tr( "Select file to import" ), "",
                                         tr( "Filter favorites (*.conf);;All files (*)" ) );
 
-    if ( file.isEmpty() ) {
+    if ( !file.isEmpty() ) {
+        importFilterFavoritesFromFile( file );
+    }
+}
+
+void MainWindow::importFilterFavoritesFromFile( const QString& file )
+{
+    const auto result = PredefinedFiltersCollection::tryLoadFromFile( file );
+    if ( result.status != PredefinedFiltersCollection::LoadStatus::Success ) {
+        QMessageBox::warning( this, tr( "klogg" ),
+                              tr( "Unable to import filter favorites from the selected file." ) );
         return;
     }
 
-    const auto filters = PredefinedFiltersCollection::loadFromFile( file );
-    PredefinedFiltersCollection::getSynced().saveToStorage( filters );
-    Q_EMIT optionsChanged();
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    favoritesModel.synchronizeFromStorage();
+    favoritesModel.replaceFavorites( result.filters );
 }
 
 void MainWindow::exportFilterFavorites()
 {
-    auto file = QFileDialog::getSaveFileName( this, tr( "Export filter favorites" ), "",
-                                              tr( "Filter favorites (*.conf)" ) );
+    const auto file = QFileDialog::getSaveFileName( this, tr( "Export filter favorites" ), "",
+                                                    tr( "Filter favorites (*.conf)" ) );
 
-    if ( file.isEmpty() ) {
-        return;
+    if ( !file.isEmpty() ) {
+        exportFilterFavoritesToFile( file );
     }
+}
 
+void MainWindow::exportFilterFavoritesToFile( QString file )
+{
     if ( !file.endsWith( ".conf" ) ) {
         file += ".conf";
     }
 
-    PredefinedFiltersCollection::saveToFile( file,
-                                             PredefinedFiltersCollection::getSynced().getFilters() );
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    favoritesModel.synchronizeFromStorage();
+    if ( !PredefinedFiltersCollection::saveToFile( file, favoritesModel.favorites() ) ) {
+        QMessageBox::warning( this, tr( "klogg" ),
+                              tr( "Unable to export filter favorites to the selected file." ) );
+    }
 }
 
 // Opens the 'Options' modal dialog box
@@ -3404,6 +3463,8 @@ void MainWindow::updateFavoritesMenu()
 
     for ( const auto& file : favorites ) {
         auto action = favoritesMenu->addAction( file.displayName() );
+        action->setObjectName( QStringLiteral( "favoriteFileAction" ) );
+        action->setMenuRole( QAction::NoRole );
 
         action->setActionGroup( favoritesGroup );
         action->setToolTip( file.nativeFullPath() );
@@ -3415,18 +3476,20 @@ void MainWindow::addToFavorites()
 {
     if ( const auto crawler = currentCrawlerWidget();
          crawler != nullptr && session_.getDocumentKind( crawler ) == DocumentKind::File ) {
-        auto& favorites = FavoriteFiles::get();
+        auto& favorites = FavoriteFiles::getSynced();
         const auto path = session_.getAssociatedPath( crawler );
+        const auto currentFavorites = favorites.favorites();
+        const auto isFavorite = std::any_of( currentFavorites.cbegin(), currentFavorites.cend(),
+                                             FullPathComparator( path ) );
 
-        if ( addToFavoritesAction->data().toBool() ) {
-            favorites.add( path );
+        if ( isFavorite ) {
+            favorites.remove( path );
         }
         else {
-            favorites.remove( path );
+            favorites.add( path );
         }
 
         favorites.save();
-
         updateFavoritesMenu();
     }
 }

--- a/src/ui/src/mainwindowtext.cpp
+++ b/src/ui/src/mainwindowtext.cpp
@@ -10,12 +10,15 @@ using namespace klogg::mainwindow;
 
 // menu
 const char* menu::fileTitle = QT_TR_NOOP( "&File" );
+const char* menu::recentFilesTitle = QT_TR_NOOP( "Open Recent" );
+const char* menu::recentFoldersTitle = QT_TR_NOOP( "Open Recent Fol&der" );
 const char* menu::editTitle = QT_TR_NOOP( "&Edit" );
+const char* menu::saveCurrentLiveLogTitle = QT_TR_NOOP( "Save Live Log As" );
 const char* menu::viewTitle = QT_TR_NOOP( "&View" );
-const char* menu::openedFilesTitle = QT_TR_NOOP( "Opened files" );
+const char* menu::openedFilesTitle = QT_TR_NOOP( "Opened Files" );
 const char* menu::toolsTitle = QT_TR_NOOP( "&Tools" );
 const char* menu::highlightersTitle = QT_TR_NOOP( "Highlighters" );
-const char* menu::favoritesTitle = QT_TR_NOOP( "F&avorites" );
+const char* menu::favoritesTitle = QT_TR_NOOP( "F&avorite Files" );
 const char* menu::helpTitle = QT_TR_NOOP( "&Help" );
 const char* menu::encodingTitle = QT_TR_NOOP( "E&ncoding" );
 
@@ -24,14 +27,25 @@ const char* toolbar::toolbarTitle = QT_TR_NOOP( "&Toolbar" );
 
 // trayicon
 const char* trayicon::trayiconTip = QT_TR_NOOP( "klogg log viewer" );
+const char* trayicon::openWindowText = QT_TR_NOOP( "Open Window" );
+const char* trayicon::quitText = QT_TR_NOOP( "Quit" );
 
 // action
-const char* action::newWindowText = QT_TR_NOOP( "&New window" );
+const char* action::newWindowText = QT_TR_NOOP( "&New Window" );
 const char* action::newWindowStatusTip = QT_TR_NOOP( "Create new klogg window" );
 const char* action::openText = QT_TR_NOOP( "&Open..." );
 const char* action::openStatusTip = QT_TR_NOOP( "Open a file" );
-const char* action::recentFilesCleanupText = QT_TR_NOOP("Clear list");
-const char* action::recentFoldersCleanupText = QT_TR_NOOP("Clear list");
+const char* action::openFolderText = QT_TR_NOOP( "Open Folder..." );
+const char* action::openFolderStatusTip
+    = QT_TR_NOOP( "Search every file in a folder (like grep -EIrn)" );
+const char* action::openAdbLogcatText = QT_TR_NOOP( "Open ADB Logcat..." );
+const char* action::openAdbLogcatStatusTip
+    = QT_TR_NOOP( "Open Android logcat as a live source" );
+const char* action::openIosLogStreamText = QT_TR_NOOP( "Open iOS Log Stream..." );
+const char* action::openIosLogStreamStatusTip
+    = QT_TR_NOOP( "Open iOS device logs as a live source" );
+const char* action::recentFilesCleanupText = QT_TR_NOOP( "Clear List" );
+const char* action::recentFoldersCleanupText = QT_TR_NOOP( "Clear List" );
 const char* action::closeText = QT_TR_NOOP( "&Close" );
 const char* action::closeStatusTip = QT_TR_NOOP( "Close document" );
 const char* action::closeAllText = QT_TR_NOOP( "Close &All" );
@@ -42,64 +56,82 @@ const char* action::copyText = QT_TR_NOOP( "&Copy" );
 const char* action::copyStatusTip = QT_TR_NOOP( "Copy the selection" );
 const char* action::selectAllText = QT_TR_NOOP( "Select &All" );
 const char* action::selectAllStatusTip = QT_TR_NOOP( "Select all the text" );
-const char* action::goToLineText = QT_TR_NOOP( "Go to line..." );
+const char* action::goToLineText = QT_TR_NOOP( "Go to Line..." );
 const char* action::goToLineStatusTip
     = QT_TR_NOOP( "Scrolls selected main view to specified line" );
 const char* action::findText = QT_TR_NOOP( "&Find..." );
 const char* action::findStatusTip = QT_TR_NOOP( "Find the text" );
-const char* action::clearLogText = QT_TR_NOOP( "Clear file..." );
+const char* action::clearLogText = QT_TR_NOOP( "Clear File..." );
 const char* action::clearLogStatusTip = QT_TR_NOOP( "Clear current file" );
-const char* action::openContainingFolderText = QT_TR_NOOP( "Open containing folder" );
+const char* action::saveCurrentLiveLogStripAnsiText
+    = QT_TR_NOOP( "Without ANSI Sequences..." );
+const char* action::saveCurrentLiveLogStripAnsiStatusTip
+    = QT_TR_NOOP( "Persist the current live capture to a file after removing ANSI sequences" );
+const char* action::saveCurrentLiveLogPreserveAnsiText
+    = QT_TR_NOOP( "With ANSI Sequences..." );
+const char* action::saveCurrentLiveLogPreserveAnsiStatusTip
+    = QT_TR_NOOP( "Persist the current live capture to a file without modifying ANSI sequences" );
+const char* action::disconnectSourceText = QT_TR_NOOP( "Disconnect Source" );
+const char* action::disconnectSourceStatusTip
+    = QT_TR_NOOP( "Stop streaming from the current live source" );
+const char* action::reconnectSourceText = QT_TR_NOOP( "Reconnect Source" );
+const char* action::reconnectSourceStatusTip = QT_TR_NOOP( "Reconnect the current live source" );
+const char* action::openContainingFolderText = QT_TR_NOOP( "Open Containing Folder" );
 const char* action::openContainingFolderStatusTip
     = QT_TR_NOOP( "Open folder containing current file" );
-const char* action::openInEditorText = QT_TR_NOOP( "Open in editor" );
+const char* action::openInEditorText = QT_TR_NOOP( "Open in Editor" );
 const char* action::openInEditorStatusTip = QT_TR_NOOP( "Open current file in default editor" );
-const char* action::copyPathToClipboardText = QT_TR_NOOP( "Copy full path" );
+const char* action::copyPathToClipboardText = QT_TR_NOOP( "Copy Full Path" );
 const char* action::copyPathToClipboardStatusTip
     = QT_TR_NOOP( "Copy full path for file to clipboard" );
-const char* action::openClipboardText = QT_TR_NOOP( "Open from clipboard" );
+const char* action::openClipboardText = QT_TR_NOOP( "Open from Clipboard" );
 const char* action::openClipboardStatusTip = QT_TR_NOOP( "Open clipboard as log file" );
 const char* action::openUrlText = QT_TR_NOOP( "Open from URL..." );
 const char* action::openUrlStatusTip = QT_TR_NOOP( "Open URL as log file" );
-const char* action::overviewVisibleText = QT_TR_NOOP( "Matches &overview" );
-const char* action::lineNumbersVisibleInMainText = QT_TR_NOOP( "Line &numbers in main view" );
+const char* action::overviewVisibleText = QT_TR_NOOP( "Matches &Overview" );
+const char* action::lineNumbersVisibleInMainText = QT_TR_NOOP( "Line &Numbers in Main View" );
 const char* action::lineNumbersVisibleInFilteredText
-    = QT_TR_NOOP( "Line &numbers in filtered view" );
-const char* action::followText = QT_TR_NOOP( "&Follow file" );
-const char* action::goToTopText = QT_TR_NOOP( "Go to &top" );
-const char* action::wrapText = QT_TR_NOOP( "&Wrap text" );
+    = QT_TR_NOOP( "Line &Numbers in Filtered View" );
+const char* action::followText = QT_TR_NOOP( "&Follow File" );
+const char* action::goToTopText = QT_TR_NOOP( "Go to &Top" );
+const char* action::wrapText = QT_TR_NOOP( "&Wrap Text" );
 const char* action::reloadText = QT_TR_NOOP( "&Reload" );
 const char* action::stopText = QT_TR_NOOP( "&Stop" );
 const char* action::optionsText = QT_TR_NOOP( "&Preferences..." );
 const char* action::optionsStatusTip = QT_TR_NOOP( "Show application settings dialog" );
-const char* action::editHighlightersText = QT_TR_NOOP( "Configure &highlighters..." );
+const char* action::editHighlightersText = QT_TR_NOOP( "Configure &Highlighters..." );
 const char* action::editHighlightersStatusTip = QT_TR_NOOP( "Show highlighters configuration" );
-const char* action::showDocumentationText = QT_TR_NOOP( "&Documentation..." );
+const char* action::showDocumentationText = QT_TR_NOOP( "&Documentation" );
 const char* action::showDocumentationStatusTip = QT_TR_NOOP( "Show documentation" );
 const char* action::aboutText = QT_TR_NOOP( "&About" );
 const char* action::aboutStatusTip = QT_TR_NOOP( "Show the About box" );
 const char* action::aboutQtText = QT_TR_NOOP( "About &Qt" );
 const char* action::aboutQtStatusTip = QT_TR_NOOP( "Show the Qt library's About box" );
-const char* action::reportIssueText = QT_TR_NOOP( "Report issue..." );
+const char* action::reportIssueText = QT_TR_NOOP( "Report Issue" );
 const char* action::reportIssueStatusTip = QT_TR_NOOP( "Report an issue on GitHub" );
-const char* action::generateDumpText = QT_TR_NOOP( "Generate crash dump" );
+const char* action::generateDumpText = QT_TR_NOOP( "Generate Crash Dump" );
 const char* action::generateDumpStatusTip = QT_TR_NOOP( "Generate diagnostic crash dump" );
-const char* action::checkForNewVersionText = QT_TR_NOOP( "Check for new version" );
+const char* action::checkForNewVersionText = QT_TR_NOOP( "Check for New Version" );
 const char* action::checkForNewVersionStatusTip = QT_TR_NOOP( "Check for new version of klogg" );
 const char* action::showScratchPadText = QT_TR_NOOP( "Scratchpad" );
 const char* action::showScratchPadStatusTip = QT_TR_NOOP( "Show the scratchpad" );
-const char* action::addToFavoritesText = QT_TR_NOOP( "Add to favorites" );
-const char* action::removeFromFavoritesText = QT_TR_NOOP( "Remove from favorites..." );
-const char* action::selectOpenFileText = QT_TR_NOOP( "Switch to opened file..." );
-const char* action::predefinedFiltersDialogText = QT_TR_NOOP( "Filter favorites..." );
+const char* action::addToFavoritesText = QT_TR_NOOP( "Add Current File to Favorites" );
+const char* action::removeFromFavoritesText
+    = QT_TR_NOOP( "Remove Current File from Favorites" );
+const char* action::addCurrentFileText = QT_TR_NOOP( "Add Current File" );
+const char* action::removeFavoriteFileText = QT_TR_NOOP( "Remove Favorite File..." );
+const char* action::selectOpenFileText = QT_TR_NOOP( "Switch to Opened File..." );
+const char* action::predefinedFiltersDialogText = QT_TR_NOOP( "Filter Favorites..." );
 const char* action::predefinedFiltersDialogStatusTip
     = QT_TR_NOOP( "Show dialog to manage filter favorites" );
-const char* action::importFilterFavoritesText = QT_TR_NOOP( "Import filter favorites..." );
+const char* action::importFilterFavoritesText = QT_TR_NOOP( "Import Filter Favorites..." );
 const char* action::importFilterFavoritesStatusTip
     = QT_TR_NOOP( "Import filter favorites from a file" );
-const char* action::exportFilterFavoritesText = QT_TR_NOOP( "Export filter favorites..." );
+const char* action::exportFilterFavoritesText = QT_TR_NOOP( "Export Filter Favorites..." );
 const char* action::exportFilterFavoritesStatusTip
     = QT_TR_NOOP( "Export filter favorites to a file" );
+const char* action::mergeTabsText = QT_TR_NOOP( "Merge Tabs..." );
+const char* action::mergeTabsStatusTip = QT_TR_NOOP( "Merge selected tabs into a single view" );
 const char* action::autoEncodingText = QT_TR_NOOP( "Auto" );
 const char* action::autoEncodingStatusTip
     = QT_TR_NOOP( "Automatically detect the file's encoding" );

--- a/src/ui/src/mainwindowtext.cpp
+++ b/src/ui/src/mainwindowtext.cpp
@@ -10,7 +10,7 @@ using namespace klogg::mainwindow;
 
 // menu
 const char* menu::fileTitle = QT_TR_NOOP( "&File" );
-const char* menu::recentFilesTitle = QT_TR_NOOP( "Open Recent" );
+const char* menu::recentFilesTitle = QT_TR_NOOP( "Open &Recent" );
 const char* menu::recentFoldersTitle = QT_TR_NOOP( "Open Recent Fol&der" );
 const char* menu::editTitle = QT_TR_NOOP( "&Edit" );
 const char* menu::saveCurrentLiveLogTitle = QT_TR_NOOP( "Save Live Log As" );

--- a/src/ui/src/pathline.cpp
+++ b/src/ui/src/pathline.cpp
@@ -39,13 +39,13 @@ void PathLine::contextMenuEvent( QContextMenuEvent* event )
 {
     QMenu menu( this );
 
-    auto copyFullPath = menu.addAction( tr( "Copy full path" ) );
-    auto copyFileName = menu.addAction( tr( "Copy file name" ) );
-    auto openContainingFolder = menu.addAction( tr( "Open containing folder" ) );
+    auto copyFullPath = menu.addAction( tr( "Copy Full Path" ) );
+    auto copyFileName = menu.addAction( tr( "Copy File Name" ) );
+    auto openContainingFolder = menu.addAction( tr( "Open Containing Folder" ) );
     menu.addSeparator();
     auto copySelection = menu.addAction( tr( "Copy" ) );
     menu.addSeparator();
-    auto selectAll = menu.addAction( tr( "Select all" ) );
+    auto selectAll = menu.addAction( tr( "Select All" ) );
 
     connect( copyFullPath, &QAction::triggered, this,
              [ this ]( auto ) { sendTextToClipboard( this->path_ ); } );

--- a/src/ui/src/predefinedfilters.cpp
+++ b/src/ui/src/predefinedfilters.cpp
@@ -38,65 +38,120 @@
 
 #include "predefinedfilters.h"
 
+#include <QCryptographicHash>
+#include <QDir>
 #include <QFileInfo>
+#include <QLockFile>
 #include <QSettings>
+#include <QStandardPaths>
 
 #include "log.h"
+#include "persistentinfo.h"
+
+namespace {
+constexpr auto SettingsGroup = "PredefinedFiltersCollection";
+constexpr auto FiltersArray = "filters";
+constexpr auto VersionKey = "version";
+constexpr int LockTimeoutMs = 100;
+} // namespace
+
+PredefinedFiltersCollection::LoadResult PredefinedFiltersCollection::readFromSettings(
+    QSettings& settings, bool missingIsSuccess )
+{
+    if ( settings.status() != QSettings::NoError ) {
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    settings.beginGroup( QLatin1String( SettingsGroup ) );
+    if ( !settings.contains( QLatin1String( VersionKey ) ) ) {
+        settings.endGroup();
+        return { missingIsSuccess ? LoadStatus::Success : LoadStatus::MalformedFile, {} };
+    }
+
+    bool versionIsValid = false;
+    const int version = settings.value( QLatin1String( VersionKey ) ).toInt( &versionIsValid );
+    if ( !versionIsValid || version < 1 ) {
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+    if ( version > PredefinedFiltersCollection_VERSION ) {
+        settings.endGroup();
+        return { LoadStatus::UnsupportedVersion, {} };
+    }
+
+    bool sizeIsValid = false;
+    const auto sizeKey = QStringLiteral( "filters/size" );
+    const int declaredSize = settings.value( sizeKey ).toInt( &sizeIsValid );
+    if ( !settings.contains( sizeKey ) || !sizeIsValid || declaredSize < 0
+         || declaredSize > MaximumFilterCount ) {
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    const int size = settings.beginReadArray( QLatin1String( FiltersArray ) );
+    if ( size != declaredSize || size > MaximumFilterCount ) {
+        settings.endArray();
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    Collection filters;
+    filters.reserve( size );
+    for ( int index = 0; index < size; ++index ) {
+        settings.setArrayIndex( index );
+        if ( !settings.contains( QStringLiteral( "name" ) )
+             || !settings.contains( QStringLiteral( "filter" ) ) ) {
+            settings.endArray();
+            settings.endGroup();
+            return { LoadStatus::MalformedFile, {} };
+        }
+
+        filters.push_back( { settings.value( QStringLiteral( "name" ) ).toString(),
+                             settings.value( QStringLiteral( "filter" ) ).toString(),
+                             settings.value( QStringLiteral( "regex" ), true ).toBool() } );
+    }
+    settings.endArray();
+    settings.endGroup();
+
+    if ( settings.status() != QSettings::NoError ) {
+        return { LoadStatus::MalformedFile, {} };
+    }
+    return { LoadStatus::Success, filters };
+}
 
 void PredefinedFiltersCollection::retrieveFromStorage( QSettings& settings )
 {
     LOG_DEBUG << "PredefinedFiltersCollection::retrieveFromStorage";
 
-    filters_.clear();
-    if ( !settings.contains( "PredefinedFiltersCollection/version" ) ) {
+    const auto result = readFromSettings( settings, true );
+    if ( result.status != LoadStatus::Success ) {
+        LOG_ERROR << "Invalid PredefinedFiltersCollection settings, keeping the last valid state";
         return;
     }
-
-    settings.beginGroup( "PredefinedFiltersCollection" );
-    bool versionIsValid = false;
-    const int version = settings.value( "version" ).toInt( &versionIsValid );
-    if ( !versionIsValid || version < 1 ) {
-        LOG_ERROR << "Invalid version of PredefinedFiltersCollection, ignoring it...";
-        settings.endGroup();
-        return;
-    }
-    if ( version > PredefinedFiltersCollection_VERSION ) {
-        LOG_ERROR << "Unknown version of PredefinedFiltersCollection, ignoring it...";
-        settings.endGroup();
-        return;
-    }
-
-    const int size = settings.beginReadArray( "filters" );
-    filters_.reserve( size );
-    for ( int i = 0; i < size; ++i ) {
-        settings.setArrayIndex( i );
-
-        filters_.push_back( { settings.value( "name" ).toString(),
-                              settings.value( "filter" ).toString(),
-                              settings.value( "regex", true ).toBool() } );
-    }
-    settings.endArray();
-    settings.endGroup();
+    filters_ = result.filters;
 }
 
 void PredefinedFiltersCollection::saveToStorage( QSettings& settings ) const
 {
     LOG_DEBUG << "PredefinedFiltersCollection::saveToStorage";
 
-    settings.beginGroup( "PredefinedFiltersCollection" );
-    settings.setValue( "version", PredefinedFiltersCollection_VERSION );
+    if ( filters_.size() > MaximumFilterCount ) {
+        LOG_ERROR << "Too many filter favorites to persist";
+        return;
+    }
 
-    settings.remove( "filters" );
+    settings.beginGroup( QLatin1String( SettingsGroup ) );
+    settings.setValue( QLatin1String( VersionKey ), PredefinedFiltersCollection_VERSION );
+    settings.remove( QLatin1String( FiltersArray ) );
 
-    settings.beginWriteArray( "filters" );
+    settings.beginWriteArray( QLatin1String( FiltersArray ) );
     int arrayIndex = 0;
     for ( const auto& filter : filters_ ) {
         settings.setArrayIndex( arrayIndex );
-        settings.setValue( "name", filter.name );
-        settings.setValue( "filter", filter.pattern );
-        settings.setValue( "regex", filter.useRegex );
-
-        arrayIndex++;
+        settings.setValue( QStringLiteral( "name" ), filter.name );
+        settings.setValue( QStringLiteral( "filter" ), filter.pattern );
+        settings.setValue( QStringLiteral( "regex" ), filter.useRegex );
+        ++arrayIndex;
     }
     settings.endArray();
     settings.endGroup();
@@ -105,6 +160,11 @@ void PredefinedFiltersCollection::saveToStorage( QSettings& settings ) const
 void PredefinedFiltersCollection::saveToStorage(
     const PredefinedFiltersCollection::Collection& filters )
 {
+    if ( filters.size() > MaximumFilterCount ) {
+        LOG_ERROR << "Too many filter favorites to persist";
+        return;
+    }
+
     filters_ = filters;
     this->save();
 }
@@ -138,62 +198,7 @@ PredefinedFiltersCollection::LoadResult PredefinedFiltersCollection::tryLoadFrom
     if ( settings.status() != QSettings::NoError ) {
         return { LoadStatus::MalformedFile, {} };
     }
-
-    settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
-    if ( !settings.contains( QStringLiteral( "version" ) ) ) {
-        settings.endGroup();
-        return { LoadStatus::MalformedFile, {} };
-    }
-
-    bool versionValid = false;
-    const int version = settings.value( QStringLiteral( "version" ) ).toInt( &versionValid );
-    if ( !versionValid || version <= 0 ) {
-        settings.endGroup();
-        return { LoadStatus::MalformedFile, {} };
-    }
-    if ( version > PredefinedFiltersCollection_VERSION ) {
-        settings.endGroup();
-        return { LoadStatus::UnsupportedVersion, {} };
-    }
-
-    bool sizeValid = false;
-    const int declaredSize
-        = settings.value( QStringLiteral( "filters/size" ) ).toInt( &sizeValid );
-    if ( !settings.contains( QStringLiteral( "filters/size" ) ) || !sizeValid
-         || declaredSize < 0 ) {
-        settings.endGroup();
-        return { LoadStatus::MalformedFile, {} };
-    }
-
-    Collection filters;
-    const int size = settings.beginReadArray( QStringLiteral( "filters" ) );
-    if ( size != declaredSize ) {
-        settings.endArray();
-        settings.endGroup();
-        return { LoadStatus::MalformedFile, {} };
-    }
-
-    filters.reserve( size );
-    for ( int index = 0; index < size; ++index ) {
-        settings.setArrayIndex( index );
-        if ( !settings.contains( QStringLiteral( "name" ) )
-             || !settings.contains( QStringLiteral( "filter" ) ) ) {
-            settings.endArray();
-            settings.endGroup();
-            return { LoadStatus::MalformedFile, {} };
-        }
-
-        filters.push_back( { settings.value( QStringLiteral( "name" ) ).toString(),
-                             settings.value( QStringLiteral( "filter" ) ).toString(),
-                             settings.value( QStringLiteral( "regex" ), true ).toBool() } );
-    }
-    settings.endArray();
-    settings.endGroup();
-
-    if ( settings.status() != QSettings::NoError ) {
-        return { LoadStatus::MalformedFile, {} };
-    }
-    return { LoadStatus::Success, filters };
+    return readFromSettings( settings, false );
 }
 
 PredefinedFiltersCollection::Collection PredefinedFiltersCollection::loadFromFile(
@@ -206,10 +211,103 @@ PredefinedFiltersCollection::Collection PredefinedFiltersCollection::loadFromFil
 bool PredefinedFiltersCollection::saveToFile(
     const QString& file, const PredefinedFiltersCollection::Collection& filters )
 {
+    if ( filters.size() > MaximumFilterCount ) {
+        return false;
+    }
+
     QSettings settings{ file, QSettings::IniFormat };
     PredefinedFiltersCollection collection;
     collection.setFilters( filters );
     collection.saveToStorage( settings );
     settings.sync();
     return settings.status() == QSettings::NoError;
+}
+
+QString PredefinedFiltersCollection::storageLockFilePath( const QSettings& settings )
+{
+    if ( settings.format() == QSettings::IniFormat && !settings.fileName().isEmpty() ) {
+        return settings.fileName() + QStringLiteral( ".filter-favorites.lock" );
+    }
+
+    const auto identity = QCryptographicHash::hash( settings.fileName().toUtf8(),
+                                                    QCryptographicHash::Sha256 )
+                              .toHex();
+    auto coordinationRoot
+        = QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation );
+    if ( coordinationRoot.isEmpty() ) {
+        coordinationRoot = QStandardPaths::writableLocation( QStandardPaths::TempLocation );
+    }
+    const QDir configDirectory{ coordinationRoot };
+    return configDirectory.filePath(
+        QStringLiteral( "locks/filter-favorites-%1.lock" ).arg( QString::fromLatin1( identity ) ) );
+}
+
+PredefinedFiltersCollection::CommitResult PredefinedFiltersCollection::commitToSettings(
+    QSettings& settings, const QString& lockFile, const Collection& expected,
+    const Collection& replacement )
+{
+    if ( replacement.size() > MaximumFilterCount ) {
+        return { CommitStatus::InvalidReplacement, {} };
+    }
+
+    const QFileInfo lockInfo{ lockFile };
+    if ( !QDir{}.mkpath( lockInfo.absolutePath() ) ) {
+        return { CommitStatus::LockError, {} };
+    }
+
+    QLockFile lock{ lockFile };
+    if ( !lock.tryLock( LockTimeoutMs ) ) {
+        return { CommitStatus::LockError, {} };
+    }
+
+    settings.sync();
+    if ( settings.status() != QSettings::NoError ) {
+        return { CommitStatus::StorageError, {} };
+    }
+
+    const auto current = readFromSettings( settings, true );
+    const bool repairingMalformedStorage = current.status == LoadStatus::MalformedFile;
+    if ( current.status == LoadStatus::UnsupportedVersion ) {
+        return { CommitStatus::StorageError, {} };
+    }
+    if ( !repairingMalformedStorage && current.status != LoadStatus::Success ) {
+        return { CommitStatus::StorageError, {} };
+    }
+    if ( !repairingMalformedStorage && current.filters != expected ) {
+        return { CommitStatus::Conflict, current.filters };
+    }
+    if ( !repairingMalformedStorage && current.filters == replacement ) {
+        return { CommitStatus::Unchanged, current.filters };
+    }
+
+    PredefinedFiltersCollection replacementCollection;
+    replacementCollection.setFilters( replacement );
+    replacementCollection.saveToStorage( settings );
+    settings.sync();
+    if ( settings.status() != QSettings::NoError ) {
+        QSettings verificationSettings{ settings.fileName(), settings.format() };
+        verificationSettings.sync();
+        const auto durable = readFromSettings( verificationSettings, true );
+        if ( durable.status == LoadStatus::Success ) {
+            return { CommitStatus::WriteError, durable.filters };
+        }
+        return { CommitStatus::StorageError, {} };
+    }
+
+    return { CommitStatus::Success, replacement };
+}
+
+PredefinedFiltersCollection::CommitResult PredefinedFiltersCollection::commit(
+    const Collection& expected, const Collection& replacement )
+{
+    auto& sharedSettings = PersistentInfo::getSettings( app_settings{} );
+    QSettings transactionSettings{ sharedSettings.fileName(), sharedSettings.format() };
+    auto result = commitToSettings( transactionSettings, storageLockFilePath( sharedSettings ),
+                                    expected, replacement );
+    if ( result.status == CommitStatus::Success || result.status == CommitStatus::Unchanged
+         || result.status == CommitStatus::Conflict || result.status == CommitStatus::WriteError ) {
+        PredefinedFiltersCollection::get().setFilters( result.storedFilters );
+    }
+    sharedSettings.sync();
+    return result;
 }

--- a/src/ui/src/predefinedfilters.cpp
+++ b/src/ui/src/predefinedfilters.cpp
@@ -38,63 +38,51 @@
 
 #include "predefinedfilters.h"
 
-#include <algorithm>
-
-#include <QCollator>
+#include <QFileInfo>
 #include <QSettings>
 
 #include "log.h"
-
-namespace {
-void sortFilters( PredefinedFiltersCollection::Collection& filters )
-{
-    QCollator collator;
-    collator.setCaseSensitivity( Qt::CaseInsensitive );
-    collator.setNumericMode( true );
-
-    std::stable_sort( filters.begin(), filters.end(),
-                      [ &collator ]( const PredefinedFilter& left,
-                                     const PredefinedFilter& right ) {
-                          return collator.compare( left.name, right.name ) < 0;
-                      } );
-}
-} // namespace
 
 void PredefinedFiltersCollection::retrieveFromStorage( QSettings& settings )
 {
     LOG_DEBUG << "PredefinedFiltersCollection::retrieveFromStorage";
 
-    if ( settings.contains( "PredefinedFiltersCollection/version" ) ) {
-        settings.beginGroup( "PredefinedFiltersCollection" );
-        if ( settings.value( "version" ).toInt() <= PredefinedFiltersCollection_VERSION ) {
-            filters_.clear();
-
-            int size = settings.beginReadArray( "filters" );
-
-            filters_.reserve( size );
-            for ( int i = 0; i < size; ++i ) {
-                settings.setArrayIndex( i );
-
-                filters_.push_back( { settings.value( "name" ).toString(),
-                                      settings.value( "filter" ).toString(),
-                                      settings.value( "regex", true ).toBool() } );
-            }
-            settings.endArray();
-            sortFilters( filters_ );
-        }
-        else {
-            LOG_ERROR << "Unknown version of PredefinedFiltersCollection, ignoring it...";
-        }
-        settings.endGroup();
+    filters_.clear();
+    if ( !settings.contains( "PredefinedFiltersCollection/version" ) ) {
+        return;
     }
+
+    settings.beginGroup( "PredefinedFiltersCollection" );
+    bool versionIsValid = false;
+    const int version = settings.value( "version" ).toInt( &versionIsValid );
+    if ( !versionIsValid || version < 1 ) {
+        LOG_ERROR << "Invalid version of PredefinedFiltersCollection, ignoring it...";
+        settings.endGroup();
+        return;
+    }
+    if ( version > PredefinedFiltersCollection_VERSION ) {
+        LOG_ERROR << "Unknown version of PredefinedFiltersCollection, ignoring it...";
+        settings.endGroup();
+        return;
+    }
+
+    const int size = settings.beginReadArray( "filters" );
+    filters_.reserve( size );
+    for ( int i = 0; i < size; ++i ) {
+        settings.setArrayIndex( i );
+
+        filters_.push_back( { settings.value( "name" ).toString(),
+                              settings.value( "filter" ).toString(),
+                              settings.value( "regex", true ).toBool() } );
+    }
+    settings.endArray();
+    settings.endGroup();
 }
 
 void PredefinedFiltersCollection::saveToStorage( QSettings& settings ) const
 {
     LOG_DEBUG << "PredefinedFiltersCollection::saveToStorage";
 
-    auto sortedFilters = filters_;
-    sortFilters( sortedFilters );
     settings.beginGroup( "PredefinedFiltersCollection" );
     settings.setValue( "version", PredefinedFiltersCollection_VERSION );
 
@@ -102,7 +90,7 @@ void PredefinedFiltersCollection::saveToStorage( QSettings& settings ) const
 
     settings.beginWriteArray( "filters" );
     int arrayIndex = 0;
-    for ( const auto& filter : sortedFilters ) {
+    for ( const auto& filter : filters_ ) {
         settings.setArrayIndex( arrayIndex );
         settings.setValue( "name", filter.name );
         settings.setValue( "filter", filter.pattern );
@@ -118,7 +106,6 @@ void PredefinedFiltersCollection::saveToStorage(
     const PredefinedFiltersCollection::Collection& filters )
 {
     filters_ = filters;
-    sortFilters( filters_ );
     this->save();
 }
 
@@ -136,16 +123,84 @@ PredefinedFiltersCollection::Collection PredefinedFiltersCollection::getSyncedFi
 void PredefinedFiltersCollection::setFilters( const Collection& filters )
 {
     filters_ = filters;
-    sortFilters( filters_ );
+}
+
+PredefinedFiltersCollection::LoadResult PredefinedFiltersCollection::tryLoadFromFile(
+    const QString& file )
+{
+    const QFileInfo fileInfo( file );
+    if ( !fileInfo.exists() || !fileInfo.isFile() ) {
+        return { LoadStatus::MissingFile, {} };
+    }
+
+    QSettings settings{ file, QSettings::IniFormat };
+    settings.sync();
+    if ( settings.status() != QSettings::NoError ) {
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+    if ( !settings.contains( QStringLiteral( "version" ) ) ) {
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    bool versionValid = false;
+    const int version = settings.value( QStringLiteral( "version" ) ).toInt( &versionValid );
+    if ( !versionValid || version <= 0 ) {
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+    if ( version > PredefinedFiltersCollection_VERSION ) {
+        settings.endGroup();
+        return { LoadStatus::UnsupportedVersion, {} };
+    }
+
+    bool sizeValid = false;
+    const int declaredSize
+        = settings.value( QStringLiteral( "filters/size" ) ).toInt( &sizeValid );
+    if ( !settings.contains( QStringLiteral( "filters/size" ) ) || !sizeValid
+         || declaredSize < 0 ) {
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    Collection filters;
+    const int size = settings.beginReadArray( QStringLiteral( "filters" ) );
+    if ( size != declaredSize ) {
+        settings.endArray();
+        settings.endGroup();
+        return { LoadStatus::MalformedFile, {} };
+    }
+
+    filters.reserve( size );
+    for ( int index = 0; index < size; ++index ) {
+        settings.setArrayIndex( index );
+        if ( !settings.contains( QStringLiteral( "name" ) )
+             || !settings.contains( QStringLiteral( "filter" ) ) ) {
+            settings.endArray();
+            settings.endGroup();
+            return { LoadStatus::MalformedFile, {} };
+        }
+
+        filters.push_back( { settings.value( QStringLiteral( "name" ) ).toString(),
+                             settings.value( QStringLiteral( "filter" ) ).toString(),
+                             settings.value( QStringLiteral( "regex" ), true ).toBool() } );
+    }
+    settings.endArray();
+    settings.endGroup();
+
+    if ( settings.status() != QSettings::NoError ) {
+        return { LoadStatus::MalformedFile, {} };
+    }
+    return { LoadStatus::Success, filters };
 }
 
 PredefinedFiltersCollection::Collection PredefinedFiltersCollection::loadFromFile(
     const QString& file )
 {
-    QSettings settings{ file, QSettings::IniFormat };
-    PredefinedFiltersCollection collection;
-    collection.retrieveFromStorage( settings );
-    return collection.getFilters();
+    const auto result = tryLoadFromFile( file );
+    return result.status == LoadStatus::Success ? result.filters : Collection{};
 }
 
 bool PredefinedFiltersCollection::saveToFile(
@@ -155,5 +210,6 @@ bool PredefinedFiltersCollection::saveToFile(
     PredefinedFiltersCollection collection;
     collection.setFilters( filters );
     collection.saveToStorage( settings );
-    return true;
+    settings.sync();
+    return settings.status() == QSettings::NoError;
 }

--- a/src/ui/src/predefinedfilters.cpp
+++ b/src/ui/src/predefinedfilters.cpp
@@ -89,7 +89,7 @@ PredefinedFiltersCollection::LoadResult PredefinedFiltersCollection::readFromSet
     }
 
     const int size = settings.beginReadArray( QLatin1String( FiltersArray ) );
-    if ( size != declaredSize || size > MaximumFilterCount ) {
+    if ( size != declaredSize ) {
         settings.endArray();
         settings.endGroup();
         return { LoadStatus::MalformedFile, {} };

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -38,84 +38,199 @@
 
 #include "predefinedfilterscombobox.h"
 
-#include <QStandardItemModel>
-#include <qabstractitemview.h>
+#include <QAbstractItemView>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QScrollBar>
+#include <QSignalBlocker>
+#include <QStyle>
+#include <QStyledItemDelegate>
+#include <QStyleOptionComboBox>
+#include <QStyleOptionViewItem>
 
-#include "log.h"
+#include <algorithm>
+
+#include "filterfavoritesmodel.h"
 #include "qtcompat/qtcompat.h"
 
-constexpr int PatternRole = Qt::UserRole + 1;
-constexpr int RegexRole = PatternRole + 1;
+namespace {
+constexpr int MaximumClosedWidthInEms = 24;
+constexpr int PopupTextHorizontalPadding = 12;
+
+class FullTextItemDelegate final : public QStyledItemDelegate {
+  public:
+    explicit FullTextItemDelegate( QObject* parent )
+        : QStyledItemDelegate( parent )
+    {
+    }
+
+    QSize sizeHint( const QStyleOptionViewItem& option,
+                    const QModelIndex& index ) const override
+    {
+        QStyleOptionViewItem textOption( option );
+        initStyleOption( &textOption, index );
+
+        auto hint = QStyledItemDelegate::sizeHint( option, index );
+        const int fullTextWidth
+            = QFontMetrics( textOption.font ).horizontalAdvance( textOption.text );
+        hint.setWidth( std::max( hint.width(), fullTextWidth + PopupTextHorizontalPadding ) );
+        return hint;
+    }
+};
+}
 
 PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     : QComboBox( parent )
-    , model_( new QStandardItemModel(this) )
 {
     setFocusPolicy( Qt::ClickFocus );
-    populatePredefinedFilters();
+    setSizeAdjustPolicy( QComboBox::AdjustToMinimumContentsLengthWithIcon );
+    setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Minimum );
+
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    favoritesModel.synchronizeFromStorage();
+    setModel( &favoritesModel );
+    view()->setItemDelegate( new FullTextItemDelegate( view() ) );
 
     connect( this, QOverload<int>::of( &QComboBox::activated ), this,
-             [ this ]( int ) { collectFilters(); } );
+             &PredefinedFiltersComboBox::collectFilter );
+    connect( model(), &QAbstractItemModel::modelReset, this,
+             &PredefinedFiltersComboBox::resetSelection );
 
-    QPalette palette = this->palette();
-    palette.setColor( QPalette::Base, palette.color( QPalette::Window ) );
-    view()->setPalette( palette );
-
+    QPalette popupPalette = palette();
+    popupPalette.setColor( QPalette::Base, popupPalette.color( QPalette::Window ) );
+    view()->setPalette( popupPalette );
     view()->setTextElideMode( Qt::ElideNone );
-    setSizeAdjustPolicy( QComboBox::AdjustToContents );
+    view()->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+    view()->setHorizontalScrollMode( QAbstractItemView::ScrollPerPixel );
 
-klogg::qtcompat::setPlaceholderText( this, tr( "Filter favorites" ) );
+    klogg::qtcompat::setPlaceholderText( this, tr( "Filter favorites" ) );
+    resetSelection();
 }
 
-void PredefinedFiltersComboBox::populatePredefinedFilters()
-{
-    model_->clear();
-    const auto filters = filtersCollection_.getSyncedFilters();
-
-    insertFilters( filters );
-
-    this->setModel( model_ );
-    setCurrentIndex( -1 );
-}
-
-void PredefinedFiltersComboBox::updateSearchPattern( const QString newSearchPattern, bool useLogicalCombining )
+void PredefinedFiltersComboBox::updateSearchPattern( const QString newSearchPattern,
+                                                     bool useLogicalCombining )
 {
     Q_UNUSED( newSearchPattern );
     Q_UNUSED( useLogicalCombining );
-    QSignalBlocker blocker( this );
-    setCurrentIndex( -1 );
+    resetSelection();
 }
 
-void PredefinedFiltersComboBox::insertFilters(
-    const PredefinedFiltersCollection::Collection& filters )
+QSize PredefinedFiltersComboBox::sizeHint() const
 {
-    for ( const auto& filter : filters ) {
-        auto* item = new QStandardItem( filter.name );
+    return closedSizeHint();
+}
 
-        item->setData( filter.pattern, PatternRole );
-        item->setData( filter.useRegex, RegexRole );
+QSize PredefinedFiltersComboBox::minimumSizeHint() const
+{
+    return closedSizeHint();
+}
 
-        model_->insertRow( model_->rowCount(), item );
+void PredefinedFiltersComboBox::showPopup()
+{
+    FilterFavoritesModel::instance().synchronizeFromStorage();
+
+    view()->setTextElideMode( Qt::ElideNone );
+    view()->setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+    view()->setHorizontalScrollMode( QAbstractItemView::ScrollPerPixel );
+
+    QStyleOptionViewItem itemOption;
+    itemOption.initFrom( view() );
+    itemOption.font = view()->font();
+
+    int contentWidth = 0;
+    for ( int row = 0; row < model()->rowCount( rootModelIndex() ); ++row ) {
+        const auto index = model()->index( row, modelColumn(), rootModelIndex() );
+        if ( index.isValid() ) {
+            contentWidth
+                = std::max( contentWidth,
+                            view()->itemDelegate()->sizeHint( itemOption, index ).width() );
+        }
     }
-}
 
-void PredefinedFiltersComboBox::collectFilters()
-{
-    if ( ignoreCollecting_ ) {
+    const int frameWidth = style()->pixelMetric( QStyle::PM_DefaultFrameWidth, nullptr, this );
+    const int scrollbarWidth
+        = count() > maxVisibleItems()
+            ? style()->pixelMetric( QStyle::PM_ScrollBarExtent, nullptr, view() )
+            : 0;
+    const int desiredWidth
+        = std::max( width(), contentWidth + scrollbarWidth + 2 * frameWidth );
+
+    const QPoint popupAnchor = mapToGlobal( rect().center() );
+    QScreen* screen = QGuiApplication::screenAt( popupAnchor );
+    if ( screen == nullptr ) {
+        screen = QGuiApplication::primaryScreen();
+    }
+
+    QComboBox::showPopup();
+
+    QWidget* const popup = view()->window();
+    if ( popup == nullptr ) {
         return;
     }
 
-    QList<PredefinedFilter> selectedPatterns;
-    const auto item = model_->item( currentIndex() );
-    if ( !item || currentIndex() < 0 ) {
+    const auto updateHorizontalScrollRange = [ this, contentWidth ] {
+        view()->doItemsLayout();
+        auto* const scrollBar = view()->horizontalScrollBar();
+        const int viewportWidth = view()->viewport()->width();
+        scrollBar->setPageStep( viewportWidth );
+        scrollBar->setRange( 0, std::max( 0, contentWidth - viewportWidth ) );
+    };
+
+    if ( screen == nullptr ) {
+        popup->resize( desiredWidth, popup->height() );
+        updateHorizontalScrollRange();
         return;
     }
 
-    selectedPatterns.append(
-        { item->text(), item->data( PatternRole ).toString(), item->data( RegexRole ).toBool() } );
+    const QRect available = screen->availableGeometry();
+    const int popupWidth = std::min( desiredWidth, available.width() );
+    const int popupHeight = std::min( popup->height(), available.height() );
+    QRect popupGeometry = popup->geometry();
+    popupGeometry.setSize( QSize( popupWidth, popupHeight ) );
+    popupGeometry.moveLeft( std::max(
+        available.left(),
+        std::min( popupGeometry.left(), available.right() - popupWidth + 1 ) ) );
+    popupGeometry.moveTop( std::max(
+        available.top(),
+        std::min( popupGeometry.top(), available.bottom() - popupHeight + 1 ) ) );
+    popup->setGeometry( popupGeometry );
+    updateHorizontalScrollRange();
+}
 
-    Q_EMIT filterChanged( selectedPatterns );
+QSize PredefinedFiltersComboBox::closedSizeHint() const
+{
+    const QString placeholder = tr( "Filter favorites" );
+    const QFontMetrics metrics( font() );
+    const int maximumTextWidth
+        = metrics.horizontalAdvance( QString( MaximumClosedWidthInEms, QLatin1Char( 'M' ) ) );
+    const QSize textSize( std::min( metrics.horizontalAdvance( placeholder ), maximumTextWidth ),
+                          metrics.height() );
 
+    QStyleOptionComboBox option;
+    initStyleOption( &option );
+    option.currentText = placeholder;
+    option.currentIcon = {};
+    return style()->sizeFromContents( QStyle::CT_ComboBox, &option, textSize, this );
+}
+
+void PredefinedFiltersComboBox::collectFilter( int index )
+{
+    const QModelIndex modelIndex = model()->index( index, modelColumn(), rootModelIndex() );
+    if ( modelIndex.isValid() ) {
+        QList<PredefinedFilter> selectedFilters;
+        selectedFilters.append(
+            { model()->data( modelIndex, FilterFavoritesModel::NameRole ).toString(),
+              model()->data( modelIndex, FilterFavoritesModel::PatternRole ).toString(),
+              model()->data( modelIndex, FilterFavoritesModel::RegexRole ).toBool() } );
+        Q_EMIT filterChanged( selectedFilters );
+    }
+
+    resetSelection();
+}
+
+void PredefinedFiltersComboBox::resetSelection()
+{
     QSignalBlocker blocker( this );
     setCurrentIndex( -1 );
 }

--- a/src/ui/src/predefinedfilterscombobox.cpp
+++ b/src/ui/src/predefinedfilterscombobox.cpp
@@ -90,6 +90,8 @@ PredefinedFiltersComboBox::PredefinedFiltersComboBox( QWidget* parent )
     auto& favoritesModel = FilterFavoritesModel::instance();
     favoritesModel.synchronizeFromStorage();
     setModel( &favoritesModel );
+    // QAbstractItemView takes ownership of the delegate.
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     view()->setItemDelegate( new FullTextItemDelegate( view() ) );
 
     connect( this, QOverload<int>::of( &QComboBox::activated ), this,

--- a/src/ui/src/predefinedfiltersdialog.cpp
+++ b/src/ui/src/predefinedfiltersdialog.cpp
@@ -40,6 +40,7 @@
 
 #include <QDialogButtonBox>
 #include <QFileDialog>
+#include <QMessageBox>
 #include <QTimer>
 #include <QToolButton>
 #include <qboxlayout.h>
@@ -47,7 +48,7 @@
 #include <qglobal.h>
 #include <qwidget.h>
 
-#include "dispatch_to.h"
+#include "filterfavoritesmodel.h"
 #include "iconloader.h"
 #include "log.h"
 #include "predefinedfilters.h"
@@ -87,7 +88,10 @@ PredefinedFiltersDialog::PredefinedFiltersDialog( QWidget* parent )
 {
     setupUi( this );
 
-    populateFiltersTable( PredefinedFiltersCollection::getSynced().getFilters() );
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    favoritesModel.synchronizeFromStorage();
+    baseFavorites_ = favoritesModel.favorites();
+    populateFiltersTable( baseFavorites_ );
 
     connect( addFilterButton, &QToolButton::clicked, this, &PredefinedFiltersDialog::addFilter );
     connect( removeFilterButton, &QToolButton::clicked, this,
@@ -105,7 +109,7 @@ PredefinedFiltersDialog::PredefinedFiltersDialog( QWidget* parent )
     connect( filtersTableWidget, &QTableWidget::currentCellChanged, this,
              &PredefinedFiltersDialog::onCurrentCellChanged );
 
-    dispatchToMainThread( [ this ] {
+    QTimer::singleShot( 0, this, [ this ] {
         IconLoader iconLoader( this );
 
         addFilterButton->setIcon( iconLoader.load( "icons8-plus" ) );
@@ -177,9 +181,21 @@ void PredefinedFiltersDialog::populateFiltersTable(
     updateButtons();
 }
 
-void PredefinedFiltersDialog::saveSettings() const
+bool PredefinedFiltersDialog::saveSettings()
 {
-    PredefinedFiltersCollection::getSynced().saveToStorage( readFiltersTable() );
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    favoritesModel.synchronizeFromStorage();
+    if ( favoritesModel.favorites() != baseFavorites_ ) {
+        QMessageBox::warning(
+            this, tr( "klogg" ),
+            tr( "Filter favorites changed outside this dialog. Reopen the dialog and try again." ) );
+        return false;
+    }
+
+    const auto updatedFavorites = readFiltersTable();
+    favoritesModel.replaceFavorites( updatedFavorites );
+    baseFavorites_ = updatedFavorites;
+    return true;
 }
 
 PredefinedFiltersCollection::Collection PredefinedFiltersDialog::readFiltersTable() const
@@ -259,7 +275,7 @@ void PredefinedFiltersDialog::moveFilterDown()
 
 void PredefinedFiltersDialog::swapFilters( int currentRow, int newRow, int selectedColumn )
 {
-    dispatchToMainThread( [ this, currentRow, newRow, selectedColumn ] {
+    QTimer::singleShot( 0, this, [ this, currentRow, newRow, selectedColumn ] {
         for ( int column = 0; column < filtersTableWidget->columnCount(); ++column ) {
             auto currentUseRegex = static_cast<CenteredCheckbox*>(
                 filtersTableWidget->cellWidget( currentRow, column ) );
@@ -294,8 +310,20 @@ void PredefinedFiltersDialog::importFilters()
         return;
     }
 
+    importFiltersFromFile( file );
+}
+
+void PredefinedFiltersDialog::importFiltersFromFile( const QString& file )
+{
     LOG_DEBUG << "Loading predefined filters from " << file;
-    populateFiltersTable( PredefinedFiltersCollection::loadFromFile( file ) );
+    const auto result = PredefinedFiltersCollection::tryLoadFromFile( file );
+    if ( result.status != PredefinedFiltersCollection::LoadStatus::Success ) {
+        QMessageBox::warning( this, tr( "klogg" ),
+                              tr( "Unable to import filter favorites from the selected file." ) );
+        return;
+    }
+
+    populateFiltersTable( result.filters );
 }
 
 void PredefinedFiltersDialog::exportFilters()
@@ -311,7 +339,15 @@ void PredefinedFiltersDialog::exportFilters()
         file += ".conf";
     }
 
-    PredefinedFiltersCollection::saveToFile( file, readFiltersTable() );
+    exportFiltersToFile( file );
+}
+
+void PredefinedFiltersDialog::exportFiltersToFile( const QString& file )
+{
+    if ( !PredefinedFiltersCollection::saveToFile( file, readFiltersTable() ) ) {
+        QMessageBox::warning( this, tr( "klogg" ),
+                              tr( "Unable to export filter favorites to the selected file." ) );
+    }
 }
 
 void PredefinedFiltersDialog::resolveStandardButton( QAbstractButton* button )
@@ -330,13 +366,12 @@ void PredefinedFiltersDialog::resolveStandardButton( QAbstractButton* button )
         break;
 
     case QDialogButtonBox::AcceptRole:
-        saveSettings();
-        accept();
+        if ( saveSettings() ) {
+            accept();
+        }
         break;
     default:
         LOG_ERROR << "PredefinedFiltersDialog::resolveStandardButton unhandled role: " << role;
         return;
     }
-
-    Q_EMIT optionsChanged();
 }

--- a/src/ui/src/predefinedfiltersdialog.cpp
+++ b/src/ui/src/predefinedfiltersdialog.cpp
@@ -40,7 +40,6 @@
 
 #include <QDialogButtonBox>
 #include <QFileDialog>
-#include <QMessageBox>
 #include <QTimer>
 #include <QToolButton>
 #include <qboxlayout.h>
@@ -52,6 +51,7 @@
 #include "iconloader.h"
 #include "log.h"
 #include "predefinedfilters.h"
+#include "uimessage.h"
 
 class CenteredCheckbox : public QWidget {
   public:
@@ -184,18 +184,28 @@ void PredefinedFiltersDialog::populateFiltersTable(
 bool PredefinedFiltersDialog::saveSettings()
 {
     auto& favoritesModel = FilterFavoritesModel::instance();
-    favoritesModel.synchronizeFromStorage();
-    if ( favoritesModel.favorites() != baseFavorites_ ) {
-        QMessageBox::warning(
+    const auto updatedFavorites = readFiltersTable();
+    const auto result = favoritesModel.replaceFavorites( baseFavorites_, updatedFavorites );
+
+    switch ( result.status ) {
+    case PredefinedFiltersCollection::CommitStatus::Success:
+    case PredefinedFiltersCollection::CommitStatus::Unchanged:
+        baseFavorites_ = result.storedFilters;
+        return true;
+    case PredefinedFiltersCollection::CommitStatus::Conflict:
+        klogg::ui::warning(
             this, tr( "klogg" ),
             tr( "Filter favorites changed outside this dialog. Reopen the dialog and try again." ) );
         return false;
+    case PredefinedFiltersCollection::CommitStatus::InvalidReplacement:
+    case PredefinedFiltersCollection::CommitStatus::LockError:
+    case PredefinedFiltersCollection::CommitStatus::StorageError:
+    case PredefinedFiltersCollection::CommitStatus::WriteError:
+        klogg::ui::warning( this, tr( "klogg" ),
+                            tr( "Unable to save filter favorites. Try again." ) );
+        return false;
     }
-
-    const auto updatedFavorites = readFiltersTable();
-    favoritesModel.replaceFavorites( updatedFavorites );
-    baseFavorites_ = updatedFavorites;
-    return true;
+    return false;
 }
 
 PredefinedFiltersCollection::Collection PredefinedFiltersDialog::readFiltersTable() const
@@ -214,7 +224,7 @@ PredefinedFiltersCollection::Collection PredefinedFiltersDialog::readFiltersTabl
         const auto value = filtersTableWidget->item( i, 1 )->text();
 
         const auto useRegexCheckbox
-            = static_cast<CenteredCheckbox*>( filtersTableWidget->cellWidget( i, 2 ) );
+            = dynamic_cast<CenteredCheckbox*>( filtersTableWidget->cellWidget( i, 2 ) );
         const auto useRegex = useRegexCheckbox ? useRegexCheckbox->isChecked() : false;
 
         if ( !name.isEmpty() && !value.isEmpty() ) {
@@ -275,29 +285,32 @@ void PredefinedFiltersDialog::moveFilterDown()
 
 void PredefinedFiltersDialog::swapFilters( int currentRow, int newRow, int selectedColumn )
 {
-    QTimer::singleShot( 0, this, [ this, currentRow, newRow, selectedColumn ] {
-        for ( int column = 0; column < filtersTableWidget->columnCount(); ++column ) {
-            auto currentUseRegex = static_cast<CenteredCheckbox*>(
-                filtersTableWidget->cellWidget( currentRow, column ) );
-            auto newUseRegex = static_cast<CenteredCheckbox*>(
-                filtersTableWidget->cellWidget( newRow, column ) );
+    if ( currentRow < 0 || currentRow >= filtersTableWidget->rowCount() || newRow < 0
+         || newRow >= filtersTableWidget->rowCount() ) {
+        return;
+    }
 
-            if ( currentUseRegex && newUseRegex ) {
-                const auto currentCheckState = currentUseRegex->isChecked();
-                const auto newCheckState = newUseRegex->isChecked();
-                currentUseRegex->setChecked( newCheckState );
-                newUseRegex->setChecked( currentCheckState );
-            }
-            else {
-                auto currentItem = filtersTableWidget->takeItem( currentRow, column );
-                auto newItem = filtersTableWidget->takeItem( newRow, column );
+    for ( int column = 0; column < filtersTableWidget->columnCount(); ++column ) {
+        auto currentUseRegex
+            = dynamic_cast<CenteredCheckbox*>( filtersTableWidget->cellWidget( currentRow, column ) );
+        auto newUseRegex
+            = dynamic_cast<CenteredCheckbox*>( filtersTableWidget->cellWidget( newRow, column ) );
 
-                filtersTableWidget->setItem( newRow, column, currentItem );
-                filtersTableWidget->setItem( currentRow, column, newItem );
-            }
+        if ( currentUseRegex && newUseRegex ) {
+            const auto currentCheckState = currentUseRegex->isChecked();
+            const auto newCheckState = newUseRegex->isChecked();
+            currentUseRegex->setChecked( newCheckState );
+            newUseRegex->setChecked( currentCheckState );
         }
-        filtersTableWidget->setCurrentCell( newRow, selectedColumn );
-    } );
+        else {
+            auto currentItem = filtersTableWidget->takeItem( currentRow, column );
+            auto newItem = filtersTableWidget->takeItem( newRow, column );
+
+            filtersTableWidget->setItem( newRow, column, currentItem );
+            filtersTableWidget->setItem( currentRow, column, newItem );
+        }
+    }
+    filtersTableWidget->setCurrentCell( newRow, selectedColumn );
 }
 
 void PredefinedFiltersDialog::importFilters()
@@ -318,7 +331,7 @@ void PredefinedFiltersDialog::importFiltersFromFile( const QString& file )
     LOG_DEBUG << "Loading predefined filters from " << file;
     const auto result = PredefinedFiltersCollection::tryLoadFromFile( file );
     if ( result.status != PredefinedFiltersCollection::LoadStatus::Success ) {
-        QMessageBox::warning( this, tr( "klogg" ),
+        klogg::ui::warning( this, tr( "klogg" ),
                               tr( "Unable to import filter favorites from the selected file." ) );
         return;
     }
@@ -345,7 +358,7 @@ void PredefinedFiltersDialog::exportFilters()
 void PredefinedFiltersDialog::exportFiltersToFile( const QString& file )
 {
     if ( !PredefinedFiltersCollection::saveToFile( file, readFiltersTable() ) ) {
-        QMessageBox::warning( this, tr( "klogg" ),
+        klogg::ui::warning( this, tr( "klogg" ),
                               tr( "Unable to export filter favorites to the selected file." ) );
     }
 }

--- a/src/ui/src/quickfindwidget.cpp
+++ b/src/ui/src/quickfindwidget.cpp
@@ -55,6 +55,7 @@
 #include "iconloader.h"
 #include "qfnotifications.h"
 #include "savedsearches.h"
+#include "shortcuts.h"
 
 #include "quickfindwidget.h"
 
@@ -109,7 +110,9 @@ QuickFindWidget::QuickFindWidget( QWidget* parent )
 
     nextButton_
         = setupToolButton( QLatin1String( "Next" ), QLatin1String( "arrowdown" ) );
-    nextButton_->setShortcut( QKeySequence::FindNext );
+    const auto findNextBindings = findNextShortcutBindings();
+    nextButton_->setShortcut(
+        QKeySequence( findNextBindings.front(), QKeySequence::PortableText ) );
     layout->addWidget( nextButton_ );
 
     notificationText_ = new QLabel( "" );

--- a/src/ui/src/savefavoritedialog.cpp
+++ b/src/ui/src/savefavoritedialog.cpp
@@ -31,6 +31,7 @@ SaveFavoriteDialog::SaveFavoriteDialog(
     : QDialog( parent )
     , existingFilters_( existingFilters )
 {
+    setObjectName( QStringLiteral( "SaveFavoriteDialog" ) );
     setWindowTitle( tr( "Save Favorite" ) );
     setMinimumWidth( 400 );
 
@@ -42,15 +43,19 @@ SaveFavoriteDialog::SaveFavoriteDialog(
     // Create new section
     auto* createNewLayout = new QHBoxLayout();
     createNewRadio_ = new QRadioButton( tr( "Create new:" ), this );
+    createNewRadio_->setObjectName( QStringLiteral( "createNewFavoriteRadioButton" ) );
     createNewRadio_->setChecked( true );
     newNameEdit_ = new QLineEdit( defaultName, this );
+    newNameEdit_->setObjectName( QStringLiteral( "favoriteNameLineEdit" ) );
     createNewLayout->addWidget( createNewRadio_ );
     createNewLayout->addWidget( newNameEdit_, 1 );
 
     // Overwrite existing section
     auto* overwriteLayout = new QHBoxLayout();
     overwriteRadio_ = new QRadioButton( tr( "Overwrite existing:" ), this );
+    overwriteRadio_->setObjectName( QStringLiteral( "overwriteFavoriteRadioButton" ) );
     existingCombo_ = new QComboBox( this );
+    existingCombo_->setObjectName( QStringLiteral( "existingFavoriteComboBox" ) );
     existingCombo_->setEnabled( false );
 
     for ( const auto& filter : existingFilters_ ) {
@@ -76,6 +81,7 @@ SaveFavoriteDialog::SaveFavoriteDialog(
     // Button box
     auto* buttonBox
         = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this );
+    buttonBox->setObjectName( QStringLiteral( "saveFavoriteButtonBox" ) );
     layout->addWidget( buttonBox );
 
     connect( buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );

--- a/src/ui/src/searchtoolbar.cpp
+++ b/src/ui/src/searchtoolbar.cpp
@@ -568,7 +568,7 @@ void SearchToolbar::saveCurrentSearchAsFavorite()
 
     const auto displayedFavorite = *existing;
     FilterDiffDialog diffDialog( existing->name, displayedFavorite, currentText, useRegex, this );
-    if ( diffDialog.exec() != QDialog::Accepted ) {
+    if ( klogg::ui::execDialog( diffDialog ) != QDialog::Accepted ) {
         return;
     }
 

--- a/src/ui/src/searchtoolbar.cpp
+++ b/src/ui/src/searchtoolbar.cpp
@@ -28,12 +28,14 @@
 #include <QCompleter>
 #include <QContextMenuEvent>
 #include <QCursor>
+#include <QDialog>
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QListView>
 #include <QMenu>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QStringListModel>
 #include <QToolButton>
@@ -42,7 +44,10 @@
 
 #include "configuration.h"
 #include "dispatch_to.h"
+#include "filterdiffdialog.h"
+#include "filterfavoritesmodel.h"
 #include "predefinedfilterscombobox.h"
+#include "savefavoritedialog.h"
 #include "savedsearches.h"
 
 SearchToolbar::SearchToolbar( QWidget* parent, SavedSearches* savedSearches )
@@ -105,9 +110,13 @@ void SearchToolbar::setupWidgets()
     searchLineEdit_->installEventFilter( this );
     searchLineEdit_->lineEdit()->installEventFilter( this );
 
-    QAction* clearSearchHistoryAction = new QAction( tr( "Clear search history" ), this );
-    QAction* editSearchHistoryAction = new QAction( tr( "Edit search history" ), this );
-    QAction* addFavoriteFilterAction = new QAction( tr( "Add to favorites" ), this );
+    QAction* clearSearchHistoryAction = new QAction( tr( "Clear Search History" ), this );
+    clearSearchHistoryAction->setObjectName( QStringLiteral( "clearSearchHistoryAction" ) );
+    QAction* editSearchHistoryAction = new QAction( tr( "Edit Search History..." ), this );
+    editSearchHistoryAction->setObjectName( QStringLiteral( "editSearchHistoryAction" ) );
+    QAction* addFavoriteFilterAction
+        = new QAction( tr( "Add to Filter Favorites..." ), this );
+    addFavoriteFilterAction->setObjectName( QStringLiteral( "addFavoriteFilterAction" ) );
 
     searchLineContextMenu_ = searchLineEdit_->lineEdit()->createStandardContextMenu();
     searchLineContextMenu_->addSeparator();
@@ -170,15 +179,15 @@ void SearchToolbar::setupWidgets()
 
     setLayout( layout );
 
-    // Wire the context-menu / favorite actions to our signals.
+    // Favorite persistence is common to every host; history remains host-specific.
     connect( addFavoriteFilterAction, &QAction::triggered, this,
-             [ this ]() { Q_EMIT saveFavoriteRequested(); } );
+             &SearchToolbar::saveCurrentSearchAsFavorite );
     connect( clearSearchHistoryAction, &QAction::triggered, this,
              [ this ]() { Q_EMIT clearHistoryRequested(); } );
     connect( editSearchHistoryAction, &QAction::triggered, this,
              [ this ]() { Q_EMIT editHistoryRequested(); } );
     connect( favoriteFilterButton_, &QToolButton::clicked, this,
-             [ this ]() { Q_EMIT saveFavoriteRequested(); } );
+             &SearchToolbar::saveCurrentSearchAsFavorite );
     connect( searchLineEdit_, &QWidget::customContextMenuRequested, this,
              [ this ]() { searchLineContextMenu_->exec( QCursor::pos() ); } );
 }
@@ -421,6 +430,139 @@ void SearchToolbar::recordSearch()
     savedSearches_->addRecent( pattern );
     searches.save();
     setItems( savedSearches_->recentSearches() );
+}
+
+void SearchToolbar::saveCurrentSearchAsFavorite()
+{
+    const auto currentText = currentSearchText().trimmed();
+    if ( currentText.isEmpty() ) {
+        return;
+    }
+
+    auto& model = FilterFavoritesModel::instance();
+    model.synchronizeFromStorage();
+    const auto dialogFavorites = model.favorites();
+    const auto useRegex = isUseRegexp();
+
+    SaveFavoriteDialog dialog( currentText, dialogFavorites, this );
+    if ( dialog.exec() != QDialog::Accepted ) {
+        return;
+    }
+
+    const auto favoriteName = dialog.favoriteName();
+    if ( favoriteName.isEmpty() ) {
+        return;
+    }
+
+    const bool isCreateNew = dialog.isCreateNew();
+    QString targetName = favoriteName;
+    PredefinedFilter selectedFavorite{};
+    const PredefinedFilter* selectedIdentity = nullptr;
+    if ( !isCreateNew ) {
+        const int selectedIndex = dialog.selectedExistingIndex();
+        if ( selectedIndex < 0 || selectedIndex >= dialogFavorites.size() ) {
+            return;
+        }
+        selectedFavorite = dialogFavorites.at( selectedIndex );
+        selectedIdentity = &selectedFavorite;
+        targetName = selectedFavorite.name;
+    }
+
+    const auto countByName = []( const auto& favorites, const QString& name ) {
+        int count = 0;
+        for ( const auto& favorite : favorites ) {
+            if ( favorite.name.compare( name, Qt::CaseInsensitive ) == 0 ) {
+                ++count;
+            }
+        }
+        return count;
+    };
+    const auto findStableTarget = []( auto& favorites, const QString& name,
+                                      const PredefinedFilter* identity ) {
+        auto onlyNameMatch = favorites.end();
+        auto exactIdentityMatch = favorites.end();
+        int nameMatchCount = 0;
+        int identityMatchCount = 0;
+
+        for ( auto candidate = favorites.begin(); candidate != favorites.end(); ++candidate ) {
+            if ( candidate->name.compare( name, Qt::CaseInsensitive ) != 0 ) {
+                continue;
+            }
+
+            ++nameMatchCount;
+            onlyNameMatch = candidate;
+            if ( identity != nullptr && candidate->pattern == identity->pattern
+                 && candidate->useRegex == identity->useRegex ) {
+                ++identityMatchCount;
+                exactIdentityMatch = candidate;
+            }
+        }
+
+        if ( nameMatchCount == 1 ) {
+            return onlyNameMatch;
+        }
+        if ( identityMatchCount == 1 ) {
+            return exactIdentityMatch;
+        }
+        return favorites.end();
+    };
+    const auto warnConflict = [ this, &targetName ] {
+        QMessageBox::warning(
+            this, tr( "klogg" ),
+            tr( "Favorite \"%1\" changed while the save dialog was open. Try again." )
+                .arg( targetName ) );
+    };
+
+    // The modal can remain open while another window or process changes the
+    // collection. Merge the requested target against the latest snapshot so
+    // unrelated concurrent favorites are retained.
+    model.synchronizeFromStorage();
+    auto favorites = model.favorites();
+    const int nameMatchCount = countByName( favorites, targetName );
+    auto existing = findStableTarget( favorites, targetName, selectedIdentity );
+
+    if ( isCreateNew && nameMatchCount == 0 ) {
+        favorites.push_back( { favoriteName, currentText, useRegex } );
+        model.replaceFavorites( favorites );
+        return;
+    }
+
+    if ( existing == favorites.end() ) {
+        warnConflict();
+        return;
+    }
+
+    if ( existing->pattern == currentText && existing->useRegex == useRegex ) {
+        QMessageBox::information(
+            this, tr( "klogg" ),
+            isCreateNew
+                ? tr( "Favorite \"%1\" already exists with the same content." ).arg( existing->name )
+                : tr( "Favorite \"%1\" already has the same content." ).arg( existing->name ) );
+        return;
+    }
+
+    const auto displayedFavorite = *existing;
+    FilterDiffDialog diffDialog( existing->name, displayedFavorite, currentText, useRegex, this );
+    if ( diffDialog.exec() != QDialog::Accepted ) {
+        return;
+    }
+
+    // A second modal was open. Re-read once more and only overwrite the exact
+    // target the user reviewed; retain concurrent changes to other favorites.
+    model.synchronizeFromStorage();
+    favorites = model.favorites();
+    existing = findStableTarget( favorites, targetName, &displayedFavorite );
+    if ( existing == favorites.end()
+         || existing->name.compare( displayedFavorite.name, Qt::CaseInsensitive ) != 0
+         || existing->pattern != displayedFavorite.pattern
+         || existing->useRegex != displayedFavorite.useRegex ) {
+        warnConflict();
+        return;
+    }
+
+    existing->pattern = currentText;
+    existing->useRegex = useRegex;
+    model.replaceFavorites( favorites );
 }
 
 void SearchToolbar::loadIcons()

--- a/src/ui/src/searchtoolbar.cpp
+++ b/src/ui/src/searchtoolbar.cpp
@@ -35,11 +35,11 @@
 #include <QLineEdit>
 #include <QListView>
 #include <QMenu>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QStringListModel>
 #include <QToolButton>
 #include <algorithm>
+#include <iterator>
 #include <limits>
 
 #include "configuration.h"
@@ -49,6 +49,7 @@
 #include "predefinedfilterscombobox.h"
 #include "savefavoritedialog.h"
 #include "savedsearches.h"
+#include "uimessage.h"
 
 SearchToolbar::SearchToolbar( QWidget* parent, SavedSearches* savedSearches )
     : QWidget( parent )
@@ -110,11 +111,11 @@ void SearchToolbar::setupWidgets()
     searchLineEdit_->installEventFilter( this );
     searchLineEdit_->lineEdit()->installEventFilter( this );
 
-    QAction* clearSearchHistoryAction = new QAction( tr( "Clear Search History" ), this );
+    auto* clearSearchHistoryAction = new QAction( tr( "Clear Search History" ), this );
     clearSearchHistoryAction->setObjectName( QStringLiteral( "clearSearchHistoryAction" ) );
-    QAction* editSearchHistoryAction = new QAction( tr( "Edit Search History..." ), this );
+    auto* editSearchHistoryAction = new QAction( tr( "Edit Search History..." ), this );
     editSearchHistoryAction->setObjectName( QStringLiteral( "editSearchHistoryAction" ) );
-    QAction* addFavoriteFilterAction
+    auto* addFavoriteFilterAction
         = new QAction( tr( "Add to Filter Favorites..." ), this );
     addFavoriteFilterAction->setObjectName( QStringLiteral( "addFavoriteFilterAction" ) );
 
@@ -498,19 +499,36 @@ void SearchToolbar::saveCurrentSearchAsFavorite()
             }
         }
 
-        if ( nameMatchCount == 1 ) {
-            return onlyNameMatch;
+        if ( identity != nullptr ) {
+            return identityMatchCount == 1 ? exactIdentityMatch : favorites.end();
         }
-        if ( identityMatchCount == 1 ) {
-            return exactIdentityMatch;
-        }
-        return favorites.end();
+        return nameMatchCount == 1 ? onlyNameMatch : favorites.end();
     };
     const auto warnConflict = [ this, &targetName ] {
-        QMessageBox::warning(
+        klogg::ui::warning(
             this, tr( "klogg" ),
             tr( "Favorite \"%1\" changed while the save dialog was open. Try again." )
                 .arg( targetName ) );
+    };
+    const auto commitFavorites = [ this, &model, &warnConflict ](
+                                     const auto& expected, const auto& replacement ) {
+        const auto result = model.replaceFavorites( expected, replacement );
+        switch ( result.status ) {
+        case PredefinedFiltersCollection::CommitStatus::Success:
+        case PredefinedFiltersCollection::CommitStatus::Unchanged:
+            return true;
+        case PredefinedFiltersCollection::CommitStatus::Conflict:
+            warnConflict();
+            return false;
+        case PredefinedFiltersCollection::CommitStatus::InvalidReplacement:
+        case PredefinedFiltersCollection::CommitStatus::LockError:
+        case PredefinedFiltersCollection::CommitStatus::StorageError:
+        case PredefinedFiltersCollection::CommitStatus::WriteError:
+            klogg::ui::warning( this, tr( "klogg" ),
+                                tr( "Unable to save filter favorites. Try again." ) );
+            return false;
+        }
+        return false;
     };
 
     // The modal can remain open while another window or process changes the
@@ -521,9 +539,18 @@ void SearchToolbar::saveCurrentSearchAsFavorite()
     const int nameMatchCount = countByName( favorites, targetName );
     auto existing = findStableTarget( favorites, targetName, selectedIdentity );
 
-    if ( isCreateNew && nameMatchCount == 0 ) {
+    if ( isCreateNew ) {
+        if ( nameMatchCount != 0 ) {
+            klogg::ui::warning(
+                this, tr( "klogg" ),
+                tr( "A favorite named \"%1\" already exists. Choose a different name." )
+                    .arg( favoriteName ) );
+            return;
+        }
+
+        const auto expectedFavorites = favorites;
         favorites.push_back( { favoriteName, currentText, useRegex } );
-        model.replaceFavorites( favorites );
+        commitFavorites( expectedFavorites, favorites );
         return;
     }
 
@@ -533,11 +560,9 @@ void SearchToolbar::saveCurrentSearchAsFavorite()
     }
 
     if ( existing->pattern == currentText && existing->useRegex == useRegex ) {
-        QMessageBox::information(
+        klogg::ui::information(
             this, tr( "klogg" ),
-            isCreateNew
-                ? tr( "Favorite \"%1\" already exists with the same content." ).arg( existing->name )
-                : tr( "Favorite \"%1\" already has the same content." ).arg( existing->name ) );
+            tr( "Favorite \"%1\" already has the same content." ).arg( existing->name ) );
         return;
     }
 
@@ -560,9 +585,11 @@ void SearchToolbar::saveCurrentSearchAsFavorite()
         return;
     }
 
-    existing->pattern = currentText;
-    existing->useRegex = useRegex;
-    model.replaceFavorites( favorites );
+    const int existingIndex = static_cast<int>( std::distance( favorites.begin(), existing ) );
+    const auto expectedFavorites = favorites;
+    favorites[ existingIndex ].pattern = currentText;
+    favorites[ existingIndex ].useRegex = useRegex;
+    commitFavorites( expectedFavorites, favorites );
 }
 
 void SearchToolbar::loadIcons()

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -821,14 +821,14 @@ void CrawlerTabBar::syncTabButtonGeometry()
 void TabbedCrawlerWidget::showContextMenu( int tab, QPoint globalPoint )
 {
     QMenu menu( this );
-    auto closeThis = menu.addAction( tr( "Close this" ) );
-    auto closeOthers = menu.addAction( tr( "Close others" ) );
-    auto closeLeft = menu.addAction( tr( "Close to the left" ) );
-    auto closeRight = menu.addAction( tr( "Close to the right" ) );
-    auto closeAll = menu.addAction( tr( "Close all" ) );
+    auto closeThis = menu.addAction( tr( "Close This" ) );
+    auto closeOthers = menu.addAction( tr( "Close Others" ) );
+    auto closeLeft = menu.addAction( tr( "Close to the Left" ) );
+    auto closeRight = menu.addAction( tr( "Close to the Right" ) );
+    auto closeAll = menu.addAction( tr( "Close All" ) );
     menu.addSeparator();
-    auto copyFullPath = menu.addAction( tr( "Copy full path" ) );
-    auto openContainingFolder = menu.addAction( tr( "Open containing folder" ) );
+    auto copyFullPath = menu.addAction( tr( "Copy Full Path" ) );
+    auto openContainingFolder = menu.addAction( tr( "Open Containing Folder" ) );
     menu.addSeparator();
 
     // Tab grouping submenu
@@ -850,8 +850,8 @@ void TabbedCrawlerWidget::showContextMenu( int tab, QPoint globalPoint )
     }
 
     menu.addSeparator();
-    auto renameTab = menu.addAction( tr( "Rename tab" ) );
-    auto resetTabName = menu.addAction( tr( "Reset tab name" ) );
+    auto renameTab = menu.addAction( tr( "Rename Tab..." ) );
+    auto resetTabName = menu.addAction( tr( "Reset Tab Name" ) );
 
     connect( closeThis, &QAction::triggered, [ tab, this ] { Q_EMIT tabCloseRequested( tab ); } );
 

--- a/src/ui/src/uimessage.cpp
+++ b/src/ui/src/uimessage.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "uimessage.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <QMessageBox>
+
+namespace klogg::ui {
+namespace {
+struct HandlerEntry {
+    std::uint64_t token = 0;
+    MessageHandler handler;
+};
+
+std::vector<HandlerEntry>& handlerStack()
+{
+    static thread_local std::vector<HandlerEntry> handlers;
+    return handlers;
+}
+
+std::uint64_t nextToken()
+{
+    static thread_local std::uint64_t token = 0;
+    return ++token;
+}
+
+void present( MessageKind kind, QWidget* parent, const QString& title, const QString& text )
+{
+    auto handler = handlerStack().empty() ? MessageHandler{} : handlerStack().back().handler;
+    if ( handler ) {
+        handler( kind, parent, title, text );
+        return;
+    }
+
+    if ( kind == MessageKind::Warning ) {
+        QMessageBox::warning( parent, title, text );
+    }
+    else {
+        QMessageBox::information( parent, title, text );
+    }
+}
+} // namespace
+
+void warning( QWidget* parent, const QString& title, const QString& text )
+{
+    present( MessageKind::Warning, parent, title, text );
+}
+
+void information( QWidget* parent, const QString& title, const QString& text )
+{
+    present( MessageKind::Information, parent, title, text );
+}
+
+ScopedMessageHandler::ScopedMessageHandler( MessageHandler handler )
+    : token_( nextToken() )
+{
+    handlerStack().push_back( { token_, std::move( handler ) } );
+}
+
+ScopedMessageHandler::~ScopedMessageHandler()
+{
+    auto& handlers = handlerStack();
+    const auto entry = std::find_if( handlers.begin(), handlers.end(), [ this ]( const auto& item ) {
+        return item.token == token_;
+    } );
+    if ( entry != handlers.end() ) {
+        handlers.erase( entry );
+    }
+}
+
+} // namespace klogg::ui

--- a/src/ui/src/uimessage.cpp
+++ b/src/ui/src/uimessage.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include <QDialog>
 #include <QMessageBox>
 
 namespace klogg::ui {
@@ -24,9 +25,20 @@ struct HandlerEntry {
     MessageHandler handler;
 };
 
+struct DialogHandlerEntry {
+    std::uint64_t token = 0;
+    DialogHandler handler;
+};
+
 std::vector<HandlerEntry>& handlerStack()
 {
     static thread_local std::vector<HandlerEntry> handlers;
+    return handlers;
+}
+
+std::vector<DialogHandlerEntry>& dialogHandlerStack()
+{
+    static thread_local std::vector<DialogHandlerEntry> handlers;
     return handlers;
 }
 
@@ -63,6 +75,13 @@ void information( QWidget* parent, const QString& title, const QString& text )
     present( MessageKind::Information, parent, title, text );
 }
 
+int execDialog( QDialog& dialog )
+{
+    auto handler = dialogHandlerStack().empty() ? DialogHandler{}
+                                                : dialogHandlerStack().back().handler;
+    return handler ? handler( dialog ) : dialog.exec();
+}
+
 ScopedMessageHandler::ScopedMessageHandler( MessageHandler handler )
     : token_( nextToken() )
 {
@@ -72,6 +91,23 @@ ScopedMessageHandler::ScopedMessageHandler( MessageHandler handler )
 ScopedMessageHandler::~ScopedMessageHandler()
 {
     auto& handlers = handlerStack();
+    const auto entry = std::find_if( handlers.begin(), handlers.end(), [ this ]( const auto& item ) {
+        return item.token == token_;
+    } );
+    if ( entry != handlers.end() ) {
+        handlers.erase( entry );
+    }
+}
+
+ScopedDialogHandler::ScopedDialogHandler( DialogHandler handler )
+    : token_( nextToken() )
+{
+    dialogHandlerStack().push_back( { token_, std::move( handler ) } );
+}
+
+ScopedDialogHandler::~ScopedDialogHandler()
+{
+    auto& handlers = dialogHandlerStack();
     const auto entry = std::find_if( handlers.begin(), handlers.end(), [ this ]( const auto& item ) {
         return item.token == token_;
     } );

--- a/tests/scripts/test_lint_platform_fragile.py
+++ b/tests/scripts/test_lint_platform_fragile.py
@@ -182,6 +182,175 @@ class TestPrivateCurrentCrawlerTest(unittest.TestCase):
             )
 
 
+class TestQMessageBoxInTests(unittest.TestCase):
+    def check(self, text, name="tests/ui/example_test.cpp"):
+        return lint._check_qmessagebox_in_tests(text, Path(name))
+
+    def test_executable_references_are_flagged(self):
+        cases = [
+            'QMessageBox::critical( parent, "failure", error );\n',
+            "QMessageBox messageBox;\n",
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                findings = self.check(text)
+                self.assertEqual(len(findings), 1)
+                self.assertEqual(findings[0][0], 1)
+
+    def test_line_and_block_comments_are_ignored(self):
+        text = (
+            "// QMessageBox::critical( parent, title, error );\n"
+            "/* QMessageBox box;\n"
+            "   QMessageBox::warning( parent, title, error ); */\n"
+            "doThing(); // QMessageBox::information( parent, title, text );\n"
+        )
+        self.assertEqual(self.check(text), [])
+
+    def test_production_code_is_allowed(self):
+        text = 'QMessageBox::warning( parent, "warning", text );\n'
+        self.assertEqual(
+            self.check(text, name="src/ui/src/optionsdialog.cpp"), []
+        )
+
+    def test_allow_marker_suppresses_only_its_line(self):
+        allowed = (
+            'QMessageBox::warning( parent, "warning", text ); '
+            '// lint-allow: platform-fragile\n'
+        )
+        self.assertEqual(self.check(allowed), [])
+
+        text = allowed + 'QMessageBox::critical( parent, "failure", text );\n'
+        findings = self.check(text)
+        self.assertEqual([line for line, _ in findings], [2])
+
+    def test_includes_strings_and_other_qt_code_are_clean(self):
+        text = (
+            "#include <QMessageBox>\n"
+            'const auto documentation = "QMessageBox::warning";\n'
+            'const auto raw = R"tag(QMessageBox::critical // not code)tag";\n'
+            'const auto multiline = R"tag(first line\n'
+            'QMessageBox::warning is still literal\n'
+            ')tag";\n'
+            "const auto mask = 0xFFFF'FFFF; // QMessageBox::warning\n"
+            "QTimer::singleShot( 0, receiver, callback );\n"
+        )
+        self.assertEqual(self.check(text), [])
+
+
+class TestWatchdogTimerInCatchTests(unittest.TestCase):
+    def check(self, text, name="tests/ui/example_test.cpp"):
+        return lint._check_nonzero_watchdog_timer(text, Path(name))
+
+    def test_nonzero_timer_with_watchdog_literal_is_flagged(self):
+        text = (
+            'TEST_CASE( "loads", "[ui]" )\n'
+            "{\n"
+            "    QTimer::singleShot( 30'000, [] {\n"
+            '        FAIL( "watchdog expired" );\n'
+            "    } );\n"
+            "}\n"
+        )
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 3)
+
+    def test_comments_do_not_create_a_watchdog_pair(self):
+        marker_in_comment = (
+            'TEST_CASE( "timer", "[ui]" ) {\n'
+            "    QTimer::singleShot( 25, receiver, callback );\n"
+            '    // FAIL( "watchdog expired" );\n'
+            "}\n"
+        )
+        timer_in_comment = (
+            'TEST_CASE( "marker", "[ui]" ) {\n'
+            "    // QTimer::singleShot( 25, receiver, callback );\n"
+            '    FAIL( "watchdog expired" );\n'
+            "}\n"
+        )
+        self.assertEqual(self.check(marker_in_comment), [])
+        self.assertEqual(self.check(timer_in_comment), [])
+
+    def test_zero_delay_or_unrelated_nonzero_timers_are_clean(self):
+        zero_delay = (
+            'TEST_CASE( "dispatch", "[ui]" ) {\n'
+            "    QTimer::singleShot( 0, receiver, callback );\n"
+            '    INFO( "watchdog expired" );\n'
+            "}\n"
+        )
+        unrelated = (
+            'TEST_CASE( "timer", "[ui]" ) {\n'
+            "    QTimer::singleShot( 25, receiver, callback );\n"
+            '    INFO( "ordinary timeout" );\n'
+            "}\n"
+        )
+        templated_zero = (
+            'TEST_CASE( "dispatch", "[ui]" ) {\n'
+            "    QTimer::singleShot( std::chrono::duration<int, std::milli>{ 0 }, [] {\n"
+            '        FAIL( "watchdog expired" );\n'
+            "    } );\n"
+            "}\n"
+        )
+        character_literal = (
+            'TEST_CASE( "watchdog", "[ui]" ) {\n'
+            "    QTimer::singleShot( 25, [] {\n"
+            "        const auto close = ')';\n"
+            '        FAIL( "watchdog expired" );\n'
+            "    } );\n"
+            "}\n"
+        )
+        self.assertEqual(self.check(zero_delay), [])
+        self.assertEqual(self.check(unrelated), [])
+        self.assertEqual(self.check(templated_zero), [])
+        self.assertEqual(len(self.check(character_literal)), 1)
+
+    def test_timer_and_marker_in_different_test_cases_are_clean(self):
+        text = (
+            'TEST_CASE( "timer", "[ui]" ) {\n'
+            "    QTimer::singleShot( 25, receiver, callback );\n"
+            "}\n"
+            'TEST_CASE( "marker", "[ui]" ) {\n'
+            '    FAIL( "watchdog expired" );\n'
+            "}\n"
+        )
+        self.assertEqual(self.check(text), [])
+
+    def test_allow_marker_suppresses_only_its_timer(self):
+        text = (
+            'TEST_CASE( "watchdog", "[ui]" ) {\n'
+            '    QTimer::singleShot( 25, receiver, [] { FAIL( "watchdog expired" ); } ); '
+            "// lint-allow: platform-fragile\n"
+            "}\n"
+        )
+        self.assertEqual(self.check(text), [])
+
+        text += (
+            'SCENARIO( "second watchdog", "[ui]" ) {\n'
+            '    QTimer::singleShot( 50, receiver, [] { FAIL( "watchdog expired" ); } );\n'
+            "}\n"
+        )
+        findings = self.check(text)
+        self.assertEqual([line for line, _ in findings], [5])
+
+    def test_marker_outside_timer_call_is_clean(self):
+        text = (
+            'TEST_CASE( "timer", "[ui]" ) {\n'
+            "    QTimer::singleShot( 25, receiver, callback );\n"
+            "}\n"
+            'void helper() { FAIL( "watchdog expired" ); }\n'
+        )
+        self.assertEqual(self.check(text), [])
+
+    def test_catch_case_macro_variants_are_checked(self):
+        for macro in ("SCENARIO", "TEST_CASE_METHOD", "TEMPLATE_TEST_CASE"):
+            with self.subTest(macro=macro):
+                text = (
+                    f'{macro}( "watchdog", "[ui]" ) {{\n'
+                    '    QTimer::singleShot( 25, receiver, [] { FAIL( "watchdog expired" ); } );\n'
+                    "}\n"
+                )
+                self.assertEqual(len(self.check(text)), 1)
+
+
 class Qt6IfReTest(unittest.TestCase):
     """_QT6_IF_RE must match Qt-6-only guards (>= 6, > 5) but NOT Qt-5
     guards (e.g. < QT_VERSION_CHECK(6, 0, 0))."""

--- a/tests/scripts/test_run_changed_clang_tidy.py
+++ b/tests/scripts/test_run_changed_clang_tidy.py
@@ -87,6 +87,53 @@ class ChangedClangTidyTest(unittest.TestCase):
         self.assertIn("--line-filter=[{\"name\":\"src/example.H\",\"lines\":[[3,3]]}]", command)
         self.assertIn("-extra-arg=-nostdinc++", command)
 
+    def test_fast_option_is_opt_in(self):
+        required = ["--base", "HEAD", "--build-dir", "build_root"]
+        self.assertFalse(MODULE.parse_arguments(required).fast)
+        self.assertTrue(MODULE.parse_arguments([*required, "--fast"]).fast)
+
+    def test_fast_header_analysis_skips_translation_unit_fan_out(self):
+        with mock.patch.object(MODULE, "run_header_pass") as fan_out, mock.patch.object(
+            MODULE, "run_direct_header_pass", return_value=(0, "direct\n")
+        ) as direct:
+            result = MODULE.run_changed_header_passes(
+                pathlib.Path("/usr/bin/clang-tidy"),
+                pathlib.Path("/workspace/build"),
+                [pathlib.Path("/workspace/src/example.cpp")],
+                [pathlib.Path("/workspace/src/example.h")],
+                '[{"name":"src/example.h","lines":[[3,3]]}]',
+                4,
+                ["-nostdinc++"],
+                {"PATH": "/usr/bin"},
+                fast=True,
+            )
+
+        self.assertEqual(result, (0, "direct\n"))
+        fan_out.assert_not_called()
+        direct.assert_called_once()
+
+    def test_default_header_analysis_preserves_fan_out_and_direct_pass(self):
+        with mock.patch.object(
+            MODULE, "run_header_pass", return_value=(0, "fan-out\n")
+        ) as fan_out, mock.patch.object(
+            MODULE, "run_direct_header_pass", return_value=(0, "direct\n")
+        ) as direct:
+            result = MODULE.run_changed_header_passes(
+                pathlib.Path("/usr/bin/clang-tidy"),
+                pathlib.Path("/workspace/build"),
+                [pathlib.Path("/workspace/src/example.cpp")],
+                [pathlib.Path("/workspace/src/example.h")],
+                '[{"name":"src/example.h","lines":[[3,3]]}]',
+                4,
+                [],
+                {"PATH": "/usr/bin"},
+                fast=False,
+            )
+
+        self.assertEqual(result, (0, "fan-out\ndirect\n"))
+        fan_out.assert_called_once()
+        direct.assert_called_once()
+
     def test_source_regex_accepts_uppercase_extensions(self):
         self.assertRegex("src/example.CPP", MODULE.SOURCE_FILE_RE)
 

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -2253,7 +2253,7 @@ TEST_CASE( "Folder log-view context menu uses app Title Case and semantic ellips
         popupFinished = true;
         menu->close();
     } );
-    QTimer::singleShot( 250, Qt::PreciseTimer, view, [ & ] {
+    QTimer::singleShot( 250, Qt::PreciseTimer, view, [ & ] { // lint-allow: platform-fragile
         if ( !popupFinished ) {
             popupError = QStringLiteral( "Folder log-view context menu watchdog expired" );
             popupFinished = true;

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -25,6 +25,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <QApplication>
 #include <QBoxLayout>
 #include <QByteArray>
 #include <QClipboard>
@@ -43,6 +44,7 @@
 #include <QSplitter>
 #include <QTemporaryDir>
 #include <QTest>
+#include <QTimer>
 #include <QToolButton>
 
 #include <algorithm>
@@ -55,6 +57,7 @@
 #include "abstractcrawlerwidget.h"
 #include "abstractlogview.h"
 #include "configuration.h"
+#include "filterfavoritesmodel.h"
 #include "foldercrawlerwidget.h"
 #include "folderfilteredview.h"
 #include "foldersearchresults.h"
@@ -162,28 +165,27 @@ struct ConfigGuard {
     }
 };
 
-// RAII save/restore of the shared PredefinedFiltersCollection (a Persistable ->
-// QSettings on disk). A failed REQUIRE throws, so the restore must run on stack
-// unwinding; otherwise a test filter leaks into the user's real settings. The
-// ctor also strips any leftover test filter from prior failed runs so this test
-// (and siblings) start from a clean slate.
-struct PredefinedFiltersGuard {
+// RAII save/restore through the observable favorites model. replaceFavorites
+// persists as well as resetting every attached combo, so tests exercise the same
+// production update path without relying on applyConfiguration side effects.
+struct FilterFavoritesGuard {
+    FilterFavoritesModel& model = FilterFavoritesModel::instance();
     PredefinedFiltersCollection::Collection saved;
-    explicit PredefinedFiltersGuard( const QString& testName )
+
+    explicit FilterFavoritesGuard( const QString& testName )
     {
-        auto& c = PredefinedFiltersCollection::getSynced();
-        saved = c.getSyncedFilters();
-        saved.erase( std::remove_if( saved.begin(), saved.end(),
-                                     [ &testName ]( const PredefinedFilter& f ) {
-                                         return f.name == testName;
-                                     } ),
-                     saved.end() );
-        c.saveToStorage( saved ); // clean slate for construction
+        model.synchronizeFromStorage();
+        saved = model.favorites();
+        auto initial = saved;
+        initial.erase( std::remove_if( initial.begin(), initial.end(),
+                                      [ &testName ]( const PredefinedFilter& favorite ) {
+                                          return favorite.name == testName;
+                                      } ),
+                       initial.end() );
+        model.replaceFavorites( initial );
     }
-    ~PredefinedFiltersGuard()
-    {
-        PredefinedFiltersCollection::getSynced().saveToStorage( saved );
-    }
+
+    ~FilterFavoritesGuard() { model.replaceFavorites( saved ); }
 };
 } // namespace
 
@@ -1809,34 +1811,28 @@ TEST_CASE( "FolderCrawlerWidget clearHistoryRequested clears the shared search h
     REQUIRE( ss.recentSearches().isEmpty() );
 }
 
-TEST_CASE( "FolderCrawlerWidget applyConfiguration repopulates predefined filters",
-           "[folder]" )
+TEST_CASE( "FolderCrawlerWidget observes shared favorite model changes", "[folder]" )
 {
-    // applyConfiguration must re-sync the predefined-filters combo from the
-    // shared collection (parity with CrawlerWidget, crawlerwidget.cpp:866), so a
-    // filter saved after construction appears after optionsChanged. Currently
-    // the folder's applyConfiguration skips reloadPredefinedFilters (RED).
     QTemporaryDir dir;
     REQUIRE( dir.isValid() );
     const QString a = writeFile( dir, "a.log", QByteArray( "ERROR one\n" ) );
 
-    // RAII: strips any leftover test filter and restores the user's real
-    // collection on scope exit (even if a REQUIRE throws). Must be constructed
-    // BEFORE the widget so the ctor's reloadPredefinedFilters reads a clean
-    // store.
     const QString testName = QStringLiteral( "zzz_late_filter_test" );
-    PredefinedFiltersGuard guard{ testName };
+    FilterFavoritesGuard guard{ testName };
 
     FolderCrawlerWidget widget;
     widget.setFolder( dir.path(), QStringList{ a } );
 
-    REQUIRE( widget.searchToolbar()->predefinedFilters()->findText( testName ) < 0 );
+    auto* const combo = widget.searchToolbar()->predefinedFilters();
+    REQUIRE( combo->model() == &guard.model );
+    REQUIRE( combo->findText( testName ) < 0 );
 
-    PredefinedFiltersCollection::getSynced().saveToStorage(
-        { { testName, QStringLiteral( "WARN" ), false } } );
+    auto favorites = guard.model.favorites();
+    favorites.push_back( { testName, QStringLiteral( "WARN" ), false } );
+    guard.model.replaceFavorites( favorites );
 
-    widget.applyConfiguration();
-    REQUIRE( widget.searchToolbar()->predefinedFilters()->findText( testName ) >= 0 );
+    REQUIRE( combo->findText( testName ) >= 0 );
+    REQUIRE( combo->currentIndex() == -1 );
 }
 
 
@@ -2171,30 +2167,125 @@ TEST_CASE( "FolderCrawlerWidget hides search-limit actions its search cannot hon
 
     FolderCrawlerWidget widget;
     widget.setFolder( dir.path(), QStringList{ a } );
-    widget.show();
-    QTest::qWait( 100 );
 
-    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
-    const auto searchLimitsActionsVisible = []( const AbstractLogView* view ) {
-        const auto* menu = Access::popupMenu( view );
-        if ( menu == nullptr ) {
-            return false;
+    const auto requireSearchLimitsHidden = []( const AbstractLogView* view ) {
+        const QStringList objectNames{
+            QStringLiteral( "setSearchStartAction" ),
+            QStringLiteral( "setSearchEndAction" ),
+            QStringLiteral( "clearSearchLimitAction" ),
+        };
+        for ( const auto& objectName : objectNames ) {
+            auto* const action = view->findChild<QAction*>( objectName );
+            INFO( "Search-limit action objectName=" << objectName.toStdString() );
+            REQUIRE( action != nullptr );
+            CHECK_FALSE( action->isVisible() );
         }
-        bool anyVisible = false;
-        const auto actions = menu->actions();
-        for ( const auto* action : actions ) {
-            if ( action->text().startsWith( QStringLiteral( "Set search st" ) )
-                 || action->text().startsWith( QStringLiteral( "Clear search limits" ) ) ) {
-                anyVisible = anyVisible || action->isVisible();
-            }
-        }
-        return anyVisible;
     };
 
     REQUIRE( widget.mainView() != nullptr );
     REQUIRE( widget.filteredView() != nullptr );
-    REQUIRE_FALSE( searchLimitsActionsVisible( widget.mainView() ) );
-    REQUIRE_FALSE( searchLimitsActionsVisible( widget.filteredView() ) );
+    requireSearchLimitsHidden( widget.mainView() );
+    requireSearchLimitsHidden( widget.filteredView() );
+}
+
+TEST_CASE( "Folder log-view context menu uses app Title Case and semantic ellipses",
+           "[folder][menu]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = writeFile( dir, "a.log", QByteArray( "line0\nERROR a\nline2\n" ) );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.resize( 800, 600 );
+    widget.show();
+    QCoreApplication::processEvents();
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ] { return !widget.isSearchActive(); } ) );
+
+    auto* const view = widget.filteredView();
+    REQUIRE( view != nullptr );
+    view->selectAndDisplayLine( 1_lnum );
+    view->ensureLineMapFresh();
+
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+    const int charHeight = Access::charHeight( view );
+    REQUIRE( charHeight > 0 );
+    const QPoint menuPoint{ Access::bulletZoneWidth( view ) + 20,
+                            Access::drawingTopOffset( view ) + charHeight + charHeight / 2 };
+    REQUIRE( view->lineAtYForTest( menuPoint.y() ) == 1_lnum );
+
+    QStringList actionTexts;
+    QString popupError;
+    bool popupObserved = false;
+    bool popupFinished = false;
+    QTimer::singleShot( 0, Qt::PreciseTimer, view, [ & ] {
+        auto* const menu = Access::popupMenu( view );
+        if ( menu == nullptr || !menu->isVisible() ) {
+            popupError = QStringLiteral( "Folder log-view context menu was not visible" );
+            popupFinished = true;
+            if ( menu != nullptr ) {
+                menu->close();
+            }
+            if ( auto* popup = QApplication::activePopupWidget() ) {
+                popup->close();
+            }
+            return;
+        }
+
+        popupObserved = true;
+        std::function<void( const QMenu* )> collectMenuTexts;
+        collectMenuTexts = [ &actionTexts, &collectMenuTexts ]( const QMenu* currentMenu ) {
+            for ( const auto* action : currentMenu->actions() ) {
+                if ( action->isSeparator() ) {
+                    continue;
+                }
+
+                auto text = action->text();
+                text.remove( QLatin1Char( '&' ) );
+                actionTexts.push_back( text );
+                if ( action->menu() != nullptr ) {
+                    collectMenuTexts( action->menu() );
+                }
+            }
+        };
+        collectMenuTexts( menu );
+        popupFinished = true;
+        menu->close();
+    } );
+    QTimer::singleShot( 250, Qt::PreciseTimer, view, [ & ] {
+        if ( !popupFinished ) {
+            popupError = QStringLiteral( "Folder log-view context menu watchdog expired" );
+            popupFinished = true;
+            if ( auto* menu = Access::popupMenu( view ) ) {
+                menu->close();
+            }
+            if ( auto* popup = QApplication::activePopupWidget() ) {
+                popup->close();
+            }
+        }
+    } );
+
+    QTest::mouseClick( view->viewport(), Qt::RightButton, Qt::NoModifier, menuPoint );
+    REQUIRE( popupError.isEmpty() );
+    REQUIRE( popupObserved );
+
+    const QStringList expectedTexts{
+        QStringLiteral( "Save to File..." ),
+        QStringLiteral( "Save Selected to File..." ),
+        QStringLiteral( "Find Next" ),
+        QStringLiteral( "Find Previous" ),
+        QStringLiteral( "Set Search Start" ),
+        QStringLiteral( "Set Search End" ),
+        QStringLiteral( "Clear Search Limits" ),
+        QStringLiteral( "Color Labels" ),
+        QStringLiteral( "Ignore Case" ),
+        QStringLiteral( "Whole Word" ),
+    };
+    for ( const auto& expectedText : expectedTexts ) {
+        CAPTURE( expectedText );
+        CHECK( actionTexts.contains( expectedText ) );
+    }
 }
 
 TEST_CASE( "FolderCrawlerWidget mirrors a portion selection into the main view",

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -30,11 +30,11 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 
+#include <QMap>
 #include <QMenu>
 #include <QMenuBar>
 #include <QClipboard>
 #include <QLineEdit>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QScrollBar>
 #include <QSignalSpy>
@@ -44,6 +44,7 @@
 #include <QTest>
 #include <QToolButton>
 #include <QUuid>
+#include <QVariant>
 
 #include <QToolBar>
 
@@ -64,6 +65,7 @@
 #include "session.h"
 #include "sessioninfo.h"
 #include "tabgroup.h"
+#include "uimessage.h"
 
 namespace {
 QString makeTestDir( const QString& prefix )
@@ -203,17 +205,34 @@ class FilterFavoritesRestoreGuard {
     explicit FilterFavoritesRestoreGuard(
         const PredefinedFiltersCollection::Collection& seededFilters )
         : model_( FilterFavoritesModel::instance() )
-        , savedModelFavorites_( model_.favorites() )
         , savedStoredFavorites_( PredefinedFiltersCollection::getSynced().getFilters() )
     {
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.sync();
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        for ( const auto& key : settings.allKeys() ) {
+            savedSettingsValues_.insert( key, settings.value( key ) );
+        }
+        settings.endGroup();
+
         PredefinedFiltersCollection::get().saveToStorage( seededFilters );
         model_.synchronizeFromStorage();
     }
 
     ~FilterFavoritesRestoreGuard()
     {
-        model_.replaceFavorites( savedModelFavorites_ );
-        PredefinedFiltersCollection::get().saveToStorage( savedStoredFavorites_ );
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        settings.remove( QString{} );
+        for ( auto item = savedSettingsValues_.cbegin(); item != savedSettingsValues_.cend(); ++item ) {
+            settings.setValue( item.key(), item.value() );
+        }
+        settings.endGroup();
+        settings.sync();
+
+        auto& collection = PredefinedFiltersCollection::getSynced();
+        collection.setFilters( savedStoredFavorites_ );
+        model_.synchronizeFromStorage();
     }
 
     FilterFavoritesRestoreGuard( const FilterFavoritesRestoreGuard& ) = delete;
@@ -221,8 +240,8 @@ class FilterFavoritesRestoreGuard {
 
   private:
     FilterFavoritesModel& model_;
-    PredefinedFiltersCollection::Collection savedModelFavorites_;
     PredefinedFiltersCollection::Collection savedStoredFavorites_;
+    QMap<QString, QVariant> savedSettingsValues_;
 };
 
 void replaceFavoriteFiles( const QStringList& paths )
@@ -279,18 +298,6 @@ QMenu* findTopLevelMenu( MainWindow* mainWindow, const QString& visibleTitle )
     return nullptr;
 }
 
-QStringList comboItems( const QComboBox* combo )
-{
-    QStringList items;
-    if ( combo == nullptr ) {
-        return items;
-    }
-    for ( int index = 0; index < combo->count(); ++index ) {
-        items.push_back( combo->itemText( index ) );
-    }
-    return items;
-}
-
 PredefinedFiltersCollection::Collection comboFavoriteRows( const QComboBox* combo )
 {
     PredefinedFiltersCollection::Collection favorites;
@@ -306,16 +313,6 @@ PredefinedFiltersCollection::Collection comboFavoriteRows( const QComboBox* comb
               index.data( FilterFavoritesModel::RegexRole ).toBool() } );
     }
     return favorites;
-}
-
-void closeActiveModalOrPopup()
-{
-    if ( auto* popup = QApplication::activePopupWidget() ) {
-        popup->close();
-    }
-    if ( auto* modal = QApplication::activeModalWidget() ) {
-        modal->close();
-    }
 }
 
 QStringList favoriteActionPaths( const QMenu* menu )
@@ -2053,67 +2050,48 @@ SCENARIO( "Tab switches coalesce session persistence into a debounced write",
     REQUIRE( waitUiState( [&] { return !mainWindow->isVisible(); } ) );
 }
 
-TEST_CASE( "Filter Favorites Apply refreshes active and inactive document toolbars",
+TEST_CASE( "Shared Filter Favorites model updates real file and folder toolbars synchronously",
            "[ui][filter-favorites]" )
 {
     TabGroupCleanupGuard tabGroupCleanupGuard;
-    FilterFavoritesRestoreGuard filterFavoritesGuard{
-        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
-          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true } }
-    };
+    const PredefinedFiltersCollection::Collection initial{
+        { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false } };
+    FilterFavoritesRestoreGuard filterFavoritesGuard{ initial };
     auto& sessionInfo = SessionInfo::getSynced();
     SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
 
     auto appSession = std::make_shared<Session>();
-    const auto windowId = QString( "filter-favorites-%1" ).arg(
+    const auto windowId = QString( "filter-favorites-apply-%1" ).arg(
         QUuid::createUuid().toString( QUuid::WithoutBraces ) );
     WindowSession windowSession{ appSession, windowId, 0 };
 
     std::unique_ptr<MainWindow> mainWindow;
     QTimer::singleShot( 0, Qt::PreciseTimer,
-                        [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+                        [ & ] { mainWindow.reset( new MainWindow( windowSession ) ); } );
     QTest::qWait( 100 );
     REQUIRE( mainWindow != nullptr );
     mainWindow->resize( 1600, 900 );
     mainWindow->show();
     QTest::qWait( 100 );
 
-    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
-        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
-                            std::forward<decltype( func )>( func ) );
-        QTest::qWait( 100 );
-    };
+    const auto tempDirPath = makeTestDir( "filterfavoritesapply" );
+    const auto standaloneFile = QDir( tempDirPath ).absoluteFilePath( "standalone.log" );
+    QFile file( standaloneFile );
+    REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    REQUIRE( file.write( "ERROR one\n" ) > 0 );
+    file.close();
 
     auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
     REQUIRE( tabArea != nullptr );
-
-    const auto tempDirPath = makeTestDir( "filterfavorites" );
-    REQUIRE( QDir{ tempDirPath }.exists() );
-    const auto standaloneFile = QDir( tempDirPath ).absoluteFilePath( "standalone.log" );
-    const auto folderFile = QDir( tempDirPath ).absoluteFilePath( "folder.log" );
-    for ( const auto& path : { standaloneFile, folderFile } ) {
-        QFile file( path );
-        REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
-        file.write( "ERROR one\nWARN two\n" );
-    }
-
-    // Open a real file document first, then a real folder document. The folder
-    // must remain current while Filter Favorites is edited so every Apply crosses
-    // MainWindow's production action/slot and still refreshes the hidden file tab.
-    runInUiThread( [ &mainWindow, standaloneFile ] {
-        mainWindow->loadInitialFile( standaloneFile, false );
-    } );
-    REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+    mainWindow->loadInitialFile( standaloneFile, false );
+    REQUIRE( waitUiState( [ tabArea ] { return tabArea->count() == 1; } ) );
     auto* fileCrawler = qobject_cast<CrawlerWidget*>( tabArea->widget( 0 ) );
     REQUIRE( fileCrawler != nullptr );
     REQUIRE( waitUiState( [ fileCrawler ] { return fileCrawler->isFirstLoadDone(); } ) );
     QTest::qWait( 200 );
 
-    runInUiThread( [ &mainWindow, tempDirPath ] {
-        mainWindow->openFolderByPath( tempDirPath );
-    } );
-    REQUIRE( waitUiState( [&] { return tabArea->count() == 2; } ) );
-    REQUIRE( tabArea->currentIndex() == 1 );
+    mainWindow->openFolderByPath( tempDirPath );
+    REQUIRE( waitUiState( [ tabArea ] { return tabArea->count() == 2; } ) );
     auto* folderCrawler = qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() );
     REQUIRE( folderCrawler != nullptr );
     QTest::qWait( 200 );
@@ -2122,128 +2100,17 @@ TEST_CASE( "Filter Favorites Apply refreshes active and inactive document toolba
     auto* folderCombo = folderCrawler->findChild<PredefinedFiltersComboBox*>();
     REQUIRE( fileCombo != nullptr );
     REQUIRE( folderCombo != nullptr );
-    const QStringList initialNames{ QStringLiteral( "Alpha" ), QStringLiteral( "Beta" ) };
-    REQUIRE( comboItems( fileCombo ) == initialNames );
-    REQUIRE( comboItems( folderCombo ) == initialNames );
+    REQUIRE( comboFavoriteRows( fileCombo ) == initial );
+    REQUIRE( comboFavoriteRows( folderCombo ) == initial );
 
-    auto* toolsMenu = findTopLevelMenu( mainWindow.get(), QStringLiteral( "Tools" ) );
-    REQUIRE( toolsMenu != nullptr );
-    auto* filterFavoritesAction = mainWindow->findChild<QAction*>(
-        QStringLiteral( "predefinedFiltersDialogAction" ) );
-    REQUIRE( filterFavoritesAction != nullptr );
-
-    struct DialogResults {
-        QString error;
-        std::vector<PredefinedFiltersCollection::Collection> fileSnapshots;
-        std::vector<PredefinedFiltersCollection::Collection> folderSnapshots;
-        bool finished = false;
-    } results;
-
-    // Schedule the zero-delay callback before triggering the action: trigger()
-    // enters PredefinedFiltersDialog::exec(), and this precise timer runs inside
-    // that modal event loop without wall-clock polling.
-    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        auto* dialog
-            = mainWindow->findChild<QDialog*>( QStringLiteral( "PredefinedFiltersDialog" ) );
-        if ( dialog == nullptr ) {
-            results.error = QStringLiteral( "Filter Favorites dialog was not created" );
-            results.finished = true;
-            closeActiveModalOrPopup();
-            return;
-        }
-
-        auto* table = dialog->findChild<QTableWidget*>(
-            QStringLiteral( "filtersTableWidget" ) );
-        auto* buttonBox
-            = dialog->findChild<QDialogButtonBox*>( QStringLiteral( "buttonBox" ) );
-        auto* addButton
-            = dialog->findChild<QToolButton*>( QStringLiteral( "addFilterButton" ) );
-        auto* removeButton
-            = dialog->findChild<QToolButton*>( QStringLiteral( "removeFilterButton" ) );
-        auto* upButton = dialog->findChild<QToolButton*>( QStringLiteral( "upButton" ) );
-        auto* applyButton
-            = buttonBox != nullptr ? buttonBox->button( QDialogButtonBox::Apply ) : nullptr;
-
-        if ( table == nullptr || buttonBox == nullptr || addButton == nullptr
-             || removeButton == nullptr || upButton == nullptr || applyButton == nullptr ) {
-            results.error = QStringLiteral( "Filter Favorites dialog controls are incomplete" );
-            results.finished = true;
-            dialog->reject();
-            return;
-        }
-
-        const auto settleUi = [] {
-            QCoreApplication::processEvents();
-            QCoreApplication::processEvents();
-        };
-        const auto applyAndCapture = [ & ] {
-            applyButton->click();
-            settleUi();
-            results.fileSnapshots.push_back( comboFavoriteRows( fileCombo ) );
-            results.folderSnapshots.push_back( comboFavoriteRows( folderCombo ) );
-        };
-
-        // Add.
-        addButton->click();
-        settleUi();
-        const int addedRow = table->rowCount() - 1;
-        table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma" ) );
-        table->item( addedRow, 1 )->setText( QStringLiteral( "INFO" ) );
-        applyAndCapture();
-
-        // Rename.
-        table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma Prime" ) );
-        applyAndCapture();
-
-        // Reorder to the front through the dialog's production move slot.
-        table->setCurrentCell( addedRow, 0 );
-        upButton->click();
-        settleUi();
-        upButton->click();
-        settleUi();
-        applyAndCapture();
-
-        // Delete Beta through the dialog's production remove slot.
-        table->setCurrentCell( 2, 0 );
-        removeButton->click();
-        settleUi();
-        applyAndCapture();
-
-        results.finished = true;
-        dialog->reject();
-    } );
-    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        if ( !results.finished ) {
-            results.error = QStringLiteral( "Filter Favorites dialog watchdog expired" );
-            results.finished = true;
-            closeActiveModalOrPopup();
-        }
-    } );
-
-    filterFavoritesAction->trigger();
-
-    REQUIRE( results.error.isEmpty() );
-    const std::vector<PredefinedFiltersCollection::Collection> expectedSnapshots{
-        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
-          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true },
-          { QStringLiteral( "Gamma" ), QStringLiteral( "INFO" ), false } },
-        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
-          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true },
-          { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false } },
-        { { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false },
-          { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
-          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true } },
-        { { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false },
-          { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false } },
-    };
-    REQUIRE( results.fileSnapshots.size() == expectedSnapshots.size() );
-    REQUIRE( results.folderSnapshots.size() == expectedSnapshots.size() );
-    for ( std::size_t index = 0; index < expectedSnapshots.size(); ++index ) {
-        CAPTURE( index );
-        CHECK( results.folderSnapshots.at( index ) == expectedSnapshots.at( index ) );
-        CHECK( results.fileSnapshots.at( index ) == expectedSnapshots.at( index ) );
-        CHECK( tabArea->currentIndex() == 1 );
-    }
+    const PredefinedFiltersCollection::Collection expected{
+        initial.at( 0 ),
+        { QStringLiteral( "Beta" ), QStringLiteral( "WARN" ), false } };
+    const auto commit = FilterFavoritesModel::instance().replaceFavorites( initial, expected );
+    REQUIRE( commit.status == PredefinedFiltersCollection::CommitStatus::Success );
+    REQUIRE( comboFavoriteRows( fileCombo ) == expected );
+    REQUIRE( comboFavoriteRows( folderCombo ) == expected );
+    REQUIRE( tabArea->currentWidget() == folderCrawler );
 }
 
 TEST_CASE( "Filter Favorites import validates before replacing every document toolbar",
@@ -2348,62 +2215,25 @@ TEST_CASE( "Filter Favorites import validates before replacing every document to
         malformedFile.write( "not a filter favorites file\n" );
     }
 
-    QString warningError;
-    QString warningText;
-    bool warningFinished = false;
-    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        auto* warning = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
-        if ( warning == nullptr ) {
-            warningError = QStringLiteral( "Invalid import warning was not shown" );
-            warningFinished = true;
-            closeActiveModalOrPopup();
-            return;
-        }
-
-        warningText = warning->text();
-        warningFinished = true;
-        warning->accept();
-    } );
-    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        if ( !warningFinished ) {
-            warningError = QStringLiteral( "Invalid import warning watchdog expired" );
-            warningFinished = true;
-            closeActiveModalOrPopup();
-        }
-    } );
+    QStringList warningTexts;
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
+        [ &warningTexts ]( klogg::ui::MessageKind kind, QWidget*, const QString&,
+                           const QString& text ) {
+            if ( kind == klogg::ui::MessageKind::Warning ) {
+                warningTexts.push_back( text );
+            }
+        } };
 
     const bool invalidImportInvoked = QMetaObject::invokeMethod(
         mainWindow.get(), "importFilterFavoritesFromFile", Qt::DirectConnection,
         Q_ARG( QString, malformedPath ) );
     REQUIRE( invalidImportInvoked );
-    CHECK( warningError.isEmpty() );
-    CHECK_FALSE( warningText.isEmpty() );
+    REQUIRE( warningTexts.size() == 1 );
+    CHECK_FALSE( warningTexts.front().isEmpty() );
     CHECK( favoritesModel.favorites() == importedFavorites );
     CHECK( PredefinedFiltersCollection::getSynced().getFilters() == importedFavorites );
     CHECK( comboFavoriteRows( fileCombo ) == importedFavorites );
     CHECK( comboFavoriteRows( folderCombo ) == importedFavorites );
-
-    QString exportWarningError;
-    bool exportWarningFinished = false;
-    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        auto* warning = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
-        if ( warning == nullptr ) {
-            exportWarningError = QStringLiteral( "Export failure warning was not shown" );
-            exportWarningFinished = true;
-            closeActiveModalOrPopup();
-            return;
-        }
-
-        exportWarningFinished = true;
-        warning->accept();
-    } );
-    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-        if ( !exportWarningFinished ) {
-            exportWarningError = QStringLiteral( "Export failure warning watchdog expired" );
-            exportWarningFinished = true;
-            closeActiveModalOrPopup();
-        }
-    } );
 
     const auto unwritableExportPath
         = QDir( tempDirPath ).absoluteFilePath( QStringLiteral( "export-destination" ) );
@@ -2413,7 +2243,8 @@ TEST_CASE( "Filter Favorites import validates before replacing every document to
         mainWindow.get(), "exportFilterFavoritesToFile", Qt::DirectConnection,
         Q_ARG( QString, unwritableExportPath ) );
     REQUIRE( failedExportInvoked );
-    CHECK( exportWarningError.isEmpty() );
+    REQUIRE( warningTexts.size() == 2 );
+    CHECK_FALSE( warningTexts.back().isEmpty() );
     CHECK( QFileInfo( blockedExportPath ).isDir() );
 }
 

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -20,6 +20,11 @@
 #include <catch2/catch.hpp>
 
 #include <QAction>
+#include <QApplication>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -29,9 +34,12 @@
 #include <QMenuBar>
 #include <QClipboard>
 #include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
 #include <QScrollBar>
 #include <QSignalSpy>
 #include <QTabBar>
+#include <QTableWidget>
 #include <QTemporaryDir>
 #include <QTest>
 #include <QToolButton>
@@ -45,10 +53,14 @@
 #include "capturestore.h"
 #include "crawlerwidget.h"
 #include "foldercrawlerwidget.h"
+#include "favoritefiles.h"
+#include "filterfavoritesmodel.h"
 #include "folderfilteredview.h"
 #include "log.h"
 #include "mainwindow.h"
 #include "persistentinfo.h"
+#include "predefinedfilters.h"
+#include "predefinedfilterscombobox.h"
 #include "session.h"
 #include "sessioninfo.h"
 #include "tabgroup.h"
@@ -184,6 +196,140 @@ QToolButton* findGroupChipButton( QTabBar* tabBar, int tabIndex )
     }
 
     return nullptr;
+}
+
+class FilterFavoritesRestoreGuard {
+  public:
+    explicit FilterFavoritesRestoreGuard(
+        const PredefinedFiltersCollection::Collection& seededFilters )
+        : model_( FilterFavoritesModel::instance() )
+        , savedModelFavorites_( model_.favorites() )
+        , savedStoredFavorites_( PredefinedFiltersCollection::getSynced().getFilters() )
+    {
+        PredefinedFiltersCollection::get().saveToStorage( seededFilters );
+        model_.synchronizeFromStorage();
+    }
+
+    ~FilterFavoritesRestoreGuard()
+    {
+        model_.replaceFavorites( savedModelFavorites_ );
+        PredefinedFiltersCollection::get().saveToStorage( savedStoredFavorites_ );
+    }
+
+    FilterFavoritesRestoreGuard( const FilterFavoritesRestoreGuard& ) = delete;
+    FilterFavoritesRestoreGuard& operator=( const FilterFavoritesRestoreGuard& ) = delete;
+
+  private:
+    FilterFavoritesModel& model_;
+    PredefinedFiltersCollection::Collection savedModelFavorites_;
+    PredefinedFiltersCollection::Collection savedStoredFavorites_;
+};
+
+void replaceFavoriteFiles( const QStringList& paths )
+{
+    auto& favorites = FavoriteFiles::getSynced();
+    for ( const auto& favorite : favorites.favorites() ) {
+        favorites.remove( favorite.fullPath() );
+    }
+    for ( const auto& path : paths ) {
+        favorites.add( path );
+    }
+    favorites.save();
+}
+
+class FavoriteFilesRestoreGuard {
+  public:
+    explicit FavoriteFilesRestoreGuard( const QStringList& seededPaths )
+    {
+        for ( const auto& favorite : FavoriteFiles::getSynced().favorites() ) {
+            savedPaths_.push_back( favorite.fullPath() );
+        }
+        replaceFavoriteFiles( seededPaths );
+    }
+
+    ~FavoriteFilesRestoreGuard()
+    {
+        replaceFavoriteFiles( savedPaths_ );
+    }
+
+    FavoriteFilesRestoreGuard( const FavoriteFilesRestoreGuard& ) = delete;
+    FavoriteFilesRestoreGuard& operator=( const FavoriteFilesRestoreGuard& ) = delete;
+
+  private:
+    QStringList savedPaths_;
+};
+
+QString visibleMenuText( QString text )
+{
+    const auto escapedAmpersand = QStringLiteral( "\x01" );
+    text.replace( QStringLiteral( "&&" ), escapedAmpersand );
+    text.remove( QLatin1Char( '&' ) );
+    text.replace( escapedAmpersand, QStringLiteral( "&" ) );
+    return text;
+}
+
+QMenu* findTopLevelMenu( MainWindow* mainWindow, const QString& visibleTitle )
+{
+    for ( auto* action : mainWindow->menuBar()->actions() ) {
+        if ( auto* menu = action->menu();
+             menu != nullptr && visibleMenuText( action->text() ) == visibleTitle ) {
+            return menu;
+        }
+    }
+    return nullptr;
+}
+
+QStringList comboItems( const QComboBox* combo )
+{
+    QStringList items;
+    if ( combo == nullptr ) {
+        return items;
+    }
+    for ( int index = 0; index < combo->count(); ++index ) {
+        items.push_back( combo->itemText( index ) );
+    }
+    return items;
+}
+
+PredefinedFiltersCollection::Collection comboFavoriteRows( const QComboBox* combo )
+{
+    PredefinedFiltersCollection::Collection favorites;
+    if ( combo == nullptr || combo->model() == nullptr ) {
+        return favorites;
+    }
+
+    for ( int row = 0; row < combo->model()->rowCount(); ++row ) {
+        const auto index = combo->model()->index( row, 0 );
+        favorites.push_back(
+            { index.data( FilterFavoritesModel::NameRole ).toString(),
+              index.data( FilterFavoritesModel::PatternRole ).toString(),
+              index.data( FilterFavoritesModel::RegexRole ).toBool() } );
+    }
+    return favorites;
+}
+
+void closeActiveModalOrPopup()
+{
+    if ( auto* popup = QApplication::activePopupWidget() ) {
+        popup->close();
+    }
+    if ( auto* modal = QApplication::activeModalWidget() ) {
+        modal->close();
+    }
+}
+
+QStringList favoriteActionPaths( const QMenu* menu )
+{
+    QStringList paths;
+    if ( menu == nullptr ) {
+        return paths;
+    }
+    for ( auto* action : menu->actions() ) {
+        if ( action->data().isValid() && !action->data().toString().isEmpty() ) {
+            paths.push_back( action->data().toString() );
+        }
+    }
+    return paths;
 }
 } // namespace
 
@@ -1905,4 +2051,589 @@ SCENARIO( "Tab switches coalesce session persistence into a debounced write",
 
     runInUiThread( [ &mainWindow ] { mainWindow->close(); } );
     REQUIRE( waitUiState( [&] { return !mainWindow->isVisible(); } ) );
+}
+
+TEST_CASE( "Filter Favorites Apply refreshes active and inactive document toolbars",
+           "[ui][filter-favorites]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    FilterFavoritesRestoreGuard filterFavoritesGuard{
+        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
+          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true } }
+    };
+    auto& sessionInfo = SessionInfo::getSynced();
+    SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "filter-favorites-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, Qt::PreciseTimer,
+                        [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+    mainWindow->resize( 1600, 900 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+
+    const auto tempDirPath = makeTestDir( "filterfavorites" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto standaloneFile = QDir( tempDirPath ).absoluteFilePath( "standalone.log" );
+    const auto folderFile = QDir( tempDirPath ).absoluteFilePath( "folder.log" );
+    for ( const auto& path : { standaloneFile, folderFile } ) {
+        QFile file( path );
+        REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        file.write( "ERROR one\nWARN two\n" );
+    }
+
+    // Open a real file document first, then a real folder document. The folder
+    // must remain current while Filter Favorites is edited so every Apply crosses
+    // MainWindow's production action/slot and still refreshes the hidden file tab.
+    runInUiThread( [ &mainWindow, standaloneFile ] {
+        mainWindow->loadInitialFile( standaloneFile, false );
+    } );
+    REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+    auto* fileCrawler = qobject_cast<CrawlerWidget*>( tabArea->widget( 0 ) );
+    REQUIRE( fileCrawler != nullptr );
+    REQUIRE( waitUiState( [ fileCrawler ] { return fileCrawler->isFirstLoadDone(); } ) );
+    QTest::qWait( 200 );
+
+    runInUiThread( [ &mainWindow, tempDirPath ] {
+        mainWindow->openFolderByPath( tempDirPath );
+    } );
+    REQUIRE( waitUiState( [&] { return tabArea->count() == 2; } ) );
+    REQUIRE( tabArea->currentIndex() == 1 );
+    auto* folderCrawler = qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() );
+    REQUIRE( folderCrawler != nullptr );
+    QTest::qWait( 200 );
+
+    auto* fileCombo = fileCrawler->findChild<PredefinedFiltersComboBox*>();
+    auto* folderCombo = folderCrawler->findChild<PredefinedFiltersComboBox*>();
+    REQUIRE( fileCombo != nullptr );
+    REQUIRE( folderCombo != nullptr );
+    const QStringList initialNames{ QStringLiteral( "Alpha" ), QStringLiteral( "Beta" ) };
+    REQUIRE( comboItems( fileCombo ) == initialNames );
+    REQUIRE( comboItems( folderCombo ) == initialNames );
+
+    auto* toolsMenu = findTopLevelMenu( mainWindow.get(), QStringLiteral( "Tools" ) );
+    REQUIRE( toolsMenu != nullptr );
+    auto* filterFavoritesAction = mainWindow->findChild<QAction*>(
+        QStringLiteral( "predefinedFiltersDialogAction" ) );
+    REQUIRE( filterFavoritesAction != nullptr );
+
+    struct DialogResults {
+        QString error;
+        std::vector<PredefinedFiltersCollection::Collection> fileSnapshots;
+        std::vector<PredefinedFiltersCollection::Collection> folderSnapshots;
+        bool finished = false;
+    } results;
+
+    // Schedule the zero-delay callback before triggering the action: trigger()
+    // enters PredefinedFiltersDialog::exec(), and this precise timer runs inside
+    // that modal event loop without wall-clock polling.
+    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        auto* dialog
+            = mainWindow->findChild<QDialog*>( QStringLiteral( "PredefinedFiltersDialog" ) );
+        if ( dialog == nullptr ) {
+            results.error = QStringLiteral( "Filter Favorites dialog was not created" );
+            results.finished = true;
+            closeActiveModalOrPopup();
+            return;
+        }
+
+        auto* table = dialog->findChild<QTableWidget*>(
+            QStringLiteral( "filtersTableWidget" ) );
+        auto* buttonBox
+            = dialog->findChild<QDialogButtonBox*>( QStringLiteral( "buttonBox" ) );
+        auto* addButton
+            = dialog->findChild<QToolButton*>( QStringLiteral( "addFilterButton" ) );
+        auto* removeButton
+            = dialog->findChild<QToolButton*>( QStringLiteral( "removeFilterButton" ) );
+        auto* upButton = dialog->findChild<QToolButton*>( QStringLiteral( "upButton" ) );
+        auto* applyButton
+            = buttonBox != nullptr ? buttonBox->button( QDialogButtonBox::Apply ) : nullptr;
+
+        if ( table == nullptr || buttonBox == nullptr || addButton == nullptr
+             || removeButton == nullptr || upButton == nullptr || applyButton == nullptr ) {
+            results.error = QStringLiteral( "Filter Favorites dialog controls are incomplete" );
+            results.finished = true;
+            dialog->reject();
+            return;
+        }
+
+        const auto settleUi = [] {
+            QCoreApplication::processEvents();
+            QCoreApplication::processEvents();
+        };
+        const auto applyAndCapture = [ & ] {
+            applyButton->click();
+            settleUi();
+            results.fileSnapshots.push_back( comboFavoriteRows( fileCombo ) );
+            results.folderSnapshots.push_back( comboFavoriteRows( folderCombo ) );
+        };
+
+        // Add.
+        addButton->click();
+        settleUi();
+        const int addedRow = table->rowCount() - 1;
+        table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma" ) );
+        table->item( addedRow, 1 )->setText( QStringLiteral( "INFO" ) );
+        applyAndCapture();
+
+        // Rename.
+        table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma Prime" ) );
+        applyAndCapture();
+
+        // Reorder to the front through the dialog's production move slot.
+        table->setCurrentCell( addedRow, 0 );
+        upButton->click();
+        settleUi();
+        upButton->click();
+        settleUi();
+        applyAndCapture();
+
+        // Delete Beta through the dialog's production remove slot.
+        table->setCurrentCell( 2, 0 );
+        removeButton->click();
+        settleUi();
+        applyAndCapture();
+
+        results.finished = true;
+        dialog->reject();
+    } );
+    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        if ( !results.finished ) {
+            results.error = QStringLiteral( "Filter Favorites dialog watchdog expired" );
+            results.finished = true;
+            closeActiveModalOrPopup();
+        }
+    } );
+
+    filterFavoritesAction->trigger();
+
+    REQUIRE( results.error.isEmpty() );
+    const std::vector<PredefinedFiltersCollection::Collection> expectedSnapshots{
+        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
+          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true },
+          { QStringLiteral( "Gamma" ), QStringLiteral( "INFO" ), false } },
+        { { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
+          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true },
+          { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false } },
+        { { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false },
+          { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
+          { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true } },
+        { { QStringLiteral( "Gamma Prime" ), QStringLiteral( "INFO" ), false },
+          { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false } },
+    };
+    REQUIRE( results.fileSnapshots.size() == expectedSnapshots.size() );
+    REQUIRE( results.folderSnapshots.size() == expectedSnapshots.size() );
+    for ( std::size_t index = 0; index < expectedSnapshots.size(); ++index ) {
+        CAPTURE( index );
+        CHECK( results.folderSnapshots.at( index ) == expectedSnapshots.at( index ) );
+        CHECK( results.fileSnapshots.at( index ) == expectedSnapshots.at( index ) );
+        CHECK( tabArea->currentIndex() == 1 );
+    }
+}
+
+TEST_CASE( "Filter Favorites import validates before replacing every document toolbar",
+           "[ui][filter-favorites][import]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    const PredefinedFiltersCollection::Collection initialFavorites{
+        { QStringLiteral( "Alpha" ), QStringLiteral( "ERROR" ), false },
+        { QStringLiteral( "Beta" ), QStringLiteral( "WARN.*" ), true },
+    };
+    FilterFavoritesRestoreGuard filterFavoritesGuard{ initialFavorites };
+    auto& sessionInfo = SessionInfo::getSynced();
+    SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "filter-favorites-import-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, Qt::PreciseTimer,
+                        [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+    mainWindow->resize( 1600, 900 );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+
+    const auto tempDirPath = makeTestDir( "filterfavoritesimport" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto standaloneFile = QDir( tempDirPath ).absoluteFilePath( "standalone.log" );
+    const auto folderFile = QDir( tempDirPath ).absoluteFilePath( "folder.log" );
+    for ( const auto& path : { standaloneFile, folderFile } ) {
+        QFile file( path );
+        REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        file.write( "ERROR one\nWARN two\n" );
+    }
+
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+    runInUiThread( [ &mainWindow, standaloneFile ] {
+        mainWindow->loadInitialFile( standaloneFile, false );
+    } );
+    REQUIRE( waitUiState( [ tabArea ] { return tabArea->count() == 1; } ) );
+    auto* fileCrawler = qobject_cast<CrawlerWidget*>( tabArea->widget( 0 ) );
+    REQUIRE( fileCrawler != nullptr );
+    REQUIRE( waitUiState( [ fileCrawler ] { return fileCrawler->isFirstLoadDone(); } ) );
+    QTest::qWait( 200 );
+
+    runInUiThread( [ &mainWindow, tempDirPath ] {
+        mainWindow->openFolderByPath( tempDirPath );
+    } );
+    REQUIRE( waitUiState( [ tabArea ] { return tabArea->count() == 2; } ) );
+    auto* folderCrawler = qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() );
+    REQUIRE( folderCrawler != nullptr );
+    QTest::qWait( 200 );
+
+    auto* fileCombo = fileCrawler->findChild<PredefinedFiltersComboBox*>();
+    auto* folderCombo = folderCrawler->findChild<PredefinedFiltersComboBox*>();
+    REQUIRE( fileCombo != nullptr );
+    REQUIRE( folderCombo != nullptr );
+    REQUIRE( comboFavoriteRows( fileCombo ) == initialFavorites );
+    REQUIRE( comboFavoriteRows( folderCombo ) == initialFavorites );
+
+    const PredefinedFiltersCollection::Collection importedFavorites{
+        { QStringLiteral( "Gamma" ), QStringLiteral( "INFO|NOTICE" ), true },
+        { QStringLiteral( "Delta" ), QStringLiteral( "plain text" ), false },
+    };
+    const auto importPath = QDir( tempDirPath ).absoluteFilePath( "valid-import.conf" );
+    REQUIRE( PredefinedFiltersCollection::saveToFile( importPath, importedFavorites ) );
+
+    // Make storage newer than the shared model. Import must first observe this
+    // external state, then replace it authoritatively with the validated file.
+    const PredefinedFiltersCollection::Collection externalFavorites{
+        { QStringLiteral( "External" ), QStringLiteral( "EXTERNAL" ), false },
+    };
+    PredefinedFiltersCollection::getSynced().saveToStorage( externalFavorites );
+    auto& favoritesModel = FilterFavoritesModel::instance();
+    REQUIRE( favoritesModel.favorites() == initialFavorites );
+    QSignalSpy resetSpy( &favoritesModel, &QAbstractItemModel::modelReset );
+
+    const bool validImportInvoked = QMetaObject::invokeMethod(
+        mainWindow.get(), "importFilterFavoritesFromFile", Qt::DirectConnection,
+        Q_ARG( QString, importPath ) );
+    REQUIRE( validImportInvoked );
+    CHECK( resetSpy.count() == 2 );
+    CHECK( favoritesModel.favorites() == importedFavorites );
+    CHECK( comboFavoriteRows( fileCombo ) == importedFavorites );
+    CHECK( comboFavoriteRows( folderCombo ) == importedFavorites );
+    CHECK( tabArea->currentWidget() == folderCrawler );
+
+    const auto malformedPath = QDir( tempDirPath ).absoluteFilePath( "invalid-import.conf" );
+    {
+        QFile malformedFile( malformedPath );
+        REQUIRE( malformedFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        malformedFile.write( "not a filter favorites file\n" );
+    }
+
+    QString warningError;
+    QString warningText;
+    bool warningFinished = false;
+    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        auto* warning = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
+        if ( warning == nullptr ) {
+            warningError = QStringLiteral( "Invalid import warning was not shown" );
+            warningFinished = true;
+            closeActiveModalOrPopup();
+            return;
+        }
+
+        warningText = warning->text();
+        warningFinished = true;
+        warning->accept();
+    } );
+    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        if ( !warningFinished ) {
+            warningError = QStringLiteral( "Invalid import warning watchdog expired" );
+            warningFinished = true;
+            closeActiveModalOrPopup();
+        }
+    } );
+
+    const bool invalidImportInvoked = QMetaObject::invokeMethod(
+        mainWindow.get(), "importFilterFavoritesFromFile", Qt::DirectConnection,
+        Q_ARG( QString, malformedPath ) );
+    REQUIRE( invalidImportInvoked );
+    CHECK( warningError.isEmpty() );
+    CHECK_FALSE( warningText.isEmpty() );
+    CHECK( favoritesModel.favorites() == importedFavorites );
+    CHECK( PredefinedFiltersCollection::getSynced().getFilters() == importedFavorites );
+    CHECK( comboFavoriteRows( fileCombo ) == importedFavorites );
+    CHECK( comboFavoriteRows( folderCombo ) == importedFavorites );
+
+    QString exportWarningError;
+    bool exportWarningFinished = false;
+    QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        auto* warning = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
+        if ( warning == nullptr ) {
+            exportWarningError = QStringLiteral( "Export failure warning was not shown" );
+            exportWarningFinished = true;
+            closeActiveModalOrPopup();
+            return;
+        }
+
+        exportWarningFinished = true;
+        warning->accept();
+    } );
+    QTimer::singleShot( 250, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+        if ( !exportWarningFinished ) {
+            exportWarningError = QStringLiteral( "Export failure warning watchdog expired" );
+            exportWarningFinished = true;
+            closeActiveModalOrPopup();
+        }
+    } );
+
+    const auto unwritableExportPath
+        = QDir( tempDirPath ).absoluteFilePath( QStringLiteral( "export-destination" ) );
+    const auto blockedExportPath = unwritableExportPath + QStringLiteral( ".conf" );
+    REQUIRE( QDir{}.mkpath( blockedExportPath ) );
+    const bool failedExportInvoked = QMetaObject::invokeMethod(
+        mainWindow.get(), "exportFilterFavoritesToFile", Qt::DirectConnection,
+        Q_ARG( QString, unwritableExportPath ) );
+    REQUIRE( failedExportInvoked );
+    CHECK( exportWarningError.isEmpty() );
+    CHECK( QFileInfo( blockedExportPath ).isDir() );
+}
+
+TEST_CASE( "FavoriteFiles removal is idempotent", "[ui][favorite-files]" )
+{
+    const auto tempDirPath = makeTestDir( "favoritefilesremove" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto favoritePath = QDir( tempDirPath ).absoluteFilePath( "favorite.log" );
+    FavoriteFilesRestoreGuard favoriteFilesGuard{ { favoritePath } };
+
+    auto& favorites = FavoriteFiles::getSynced();
+    favorites.remove( QDir( tempDirPath ).absoluteFilePath( "not-a-favorite.log" ) );
+
+    const auto current = favorites.favorites();
+    REQUIRE( current.size() == 1 );
+    CHECK( current.front().fullPath() == favoritePath );
+}
+
+TEST_CASE( "Favorite Files menu has stable commands and refreshes on show", "[ui][menu-text]" )
+{
+    TabGroupCleanupGuard tabGroupCleanupGuard;
+    auto& sessionInfo = SessionInfo::getSynced();
+    SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
+
+    const auto tempDirPath = makeTestDir( "favoritefilesmenu" );
+    REQUIRE( QDir{ tempDirPath }.exists() );
+    const auto firstFavorite = QDir( tempDirPath ).absoluteFilePath( "alpha.log" );
+    const auto replacementFavorite = QDir( tempDirPath ).absoluteFilePath( "beta.log" );
+    const auto folderFile = QDir( tempDirPath ).absoluteFilePath( "folder.log" );
+    for ( const auto& path : { firstFavorite, replacementFavorite, folderFile } ) {
+        QFile file( path );
+        REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        file.write( "line\n" );
+    }
+    FavoriteFilesRestoreGuard favoriteFilesGuard{ { firstFavorite } };
+
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "favorite-files-menu-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, Qt::PreciseTimer,
+                        [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+    mainWindow->show();
+    QTest::qWait( 100 );
+
+    auto* favoritesMenu
+        = mainWindow->findChild<QMenu*>( QStringLiteral( "favoritesMenu" ) );
+    auto* addCurrentFileAction
+        = mainWindow->findChild<QAction*>( QStringLiteral( "addToFavoritesMenuAction" ) );
+    auto* removeFavoriteFileAction
+        = mainWindow->findChild<QAction*>( QStringLiteral( "removeFromFavoritesAction" ) );
+    auto* toggleCurrentFileFavoriteAction
+        = mainWindow->findChild<QAction*>( QStringLiteral( "addToFavoritesAction" ) );
+    REQUIRE( favoritesMenu != nullptr );
+    REQUIRE( addCurrentFileAction != nullptr );
+    REQUIRE( removeFavoriteFileAction != nullptr );
+    REQUIRE( toggleCurrentFileFavoriteAction != nullptr );
+    CHECK( visibleMenuText( favoritesMenu->title() ) == QStringLiteral( "Favorite Files" ) );
+
+    const auto stableActions = favoritesMenu->actions();
+    REQUIRE( stableActions.size() >= 3 );
+    CHECK( stableActions.at( 0 ) == addCurrentFileAction );
+    CHECK( stableActions.at( 1 ) == removeFavoriteFileAction );
+    REQUIRE( stableActions.at( 2 )->isSeparator() );
+    CHECK( visibleMenuText( addCurrentFileAction->text() )
+           == QStringLiteral( "Add Current File" ) );
+    CHECK( visibleMenuText( removeFavoriteFileAction->text() )
+           == QStringLiteral( "Remove Favorite File..." ) );
+    CHECK( visibleMenuText( toggleCurrentFileFavoriteAction->text() )
+           == QStringLiteral( "Add Current File to Favorites" ) );
+    CHECK_FALSE( toggleCurrentFileFavoriteAction->text().endsWith( QStringLiteral( "..." ) ) );
+
+    // No file document is active at construction: Add is unavailable, while
+    // Remove reflects the seeded persistent collection.
+    CHECK_FALSE( addCurrentFileAction->isEnabled() );
+    CHECK( removeFavoriteFileAction->isEnabled() );
+    CHECK( favoriteActionPaths( favoritesMenu ) == QStringList{ firstFavorite } );
+    int dynamicFavoriteActionCount = 0;
+    for ( const auto* action : favoritesMenu->actions() ) {
+        if ( action->objectName() == QStringLiteral( "favoriteFileAction" ) ) {
+            ++dynamicFavoriteActionCount;
+            CHECK( action->menuRole() == QAction::NoRole );
+        }
+    }
+    CHECK( dynamicFavoriteActionCount == 1 );
+
+    auto runInUiThread = [ uiObject = mainWindow.get() ]( auto&& func ) {
+        QTimer::singleShot( 0, Qt::PreciseTimer, uiObject,
+                            std::forward<decltype( func )>( func ) );
+        QTest::qWait( 100 );
+    };
+    auto* tabArea = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabArea != nullptr );
+    runInUiThread( [ &mainWindow, tempDirPath ] {
+        mainWindow->openFolderByPath( tempDirPath );
+    } );
+    REQUIRE( waitUiState( [&] { return tabArea->count() == 1; } ) );
+    REQUIRE( qobject_cast<FolderCrawlerWidget*>( tabArea->currentWidget() ) != nullptr );
+    QTest::qWait( 200 );
+
+    // A folder is not a file document, so showing the menu keeps Add disabled.
+    Q_EMIT favoritesMenu->aboutToShow();
+    QCoreApplication::processEvents();
+    CHECK_FALSE( addCurrentFileAction->isEnabled() );
+    CHECK( removeFavoriteFileAction->isEnabled() );
+
+    // Simulate another window/process changing persisted favorites. aboutToShow
+    // is the menu's synchronization boundary: stale entries and enabled state
+    // must be rebuilt from FavoriteFiles::getSynced() each time.
+    replaceFavoriteFiles( { replacementFavorite } );
+    Q_EMIT favoritesMenu->aboutToShow();
+    QCoreApplication::processEvents();
+    CHECK( favoriteActionPaths( favoritesMenu ) == QStringList{ replacementFavorite } );
+    CHECK_FALSE( addCurrentFileAction->isEnabled() );
+    CHECK( removeFavoriteFileAction->isEnabled() );
+
+    replaceFavoriteFiles( {} );
+    Q_EMIT favoritesMenu->aboutToShow();
+    QCoreApplication::processEvents();
+    CHECK( favoriteActionPaths( favoritesMenu ).isEmpty() );
+    CHECK_FALSE( addCurrentFileAction->isEnabled() );
+    CHECK_FALSE( removeFavoriteFileAction->isEnabled() );
+
+    // The toolbar action is an immediate toggle, not the chooser command used
+    // by the menu. Its text must describe the active-file operation without an
+    // ellipsis in both states.
+    runInUiThread( [ &mainWindow, replacementFavorite ] {
+        mainWindow->loadInitialFile( replacementFavorite, false );
+    } );
+    REQUIRE( waitUiState( [&] { return tabArea->count() == 2; } ) );
+    auto* fileCrawler = qobject_cast<CrawlerWidget*>( tabArea->currentWidget() );
+    REQUIRE( fileCrawler != nullptr );
+    REQUIRE( waitUiState( [ fileCrawler ] { return fileCrawler->isFirstLoadDone(); } ) );
+    QTest::qWait( 200 );
+
+    CHECK( toggleCurrentFileFavoriteAction->isEnabled() );
+    CHECK( visibleMenuText( toggleCurrentFileFavoriteAction->text() )
+           == QStringLiteral( "Add Current File to Favorites" ) );
+
+    // Another window adds the current file after this window rendered its stale
+    // "Add" state. Trigger-time synchronization must derive the operation from
+    // the fresh collection, not QAction::data: this click removes the favorite.
+    replaceFavoriteFiles( { replacementFavorite } );
+    CHECK( visibleMenuText( toggleCurrentFileFavoriteAction->text() )
+           == QStringLiteral( "Add Current File to Favorites" ) );
+    toggleCurrentFileFavoriteAction->trigger();
+    CHECK( FavoriteFiles::getSynced().favorites().empty() );
+    CHECK( visibleMenuText( toggleCurrentFileFavoriteAction->text() )
+           == QStringLiteral( "Add Current File to Favorites" ) );
+
+    // A second click observes the now-empty collection and adds the current file.
+    toggleCurrentFileFavoriteAction->trigger();
+    const auto currentFavorites = FavoriteFiles::getSynced().favorites();
+    REQUIRE( currentFavorites.size() == 1 );
+    CHECK( currentFavorites.front().fullPath() == replacementFavorite );
+    CHECK( visibleMenuText( toggleCurrentFileFavoriteAction->text() )
+           == QStringLiteral( "Remove Current File from Favorites" ) );
+    CHECK_FALSE( toggleCurrentFileFavoriteAction->text().endsWith( QStringLiteral( "..." ) ) );
+}
+
+TEST_CASE( "File and Help menu labels use the public wording contract", "[ui][menu-text]" )
+{
+    auto& sessionInfo = SessionInfo::getSynced();
+    SessionInfoRestoreGuard sessionInfoRestoreGuard{ sessionInfo };
+    auto appSession = std::make_shared<Session>();
+    const auto windowId = QString( "main-menu-text-%1" ).arg(
+        QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    WindowSession windowSession{ appSession, windowId, 0 };
+
+    std::unique_ptr<MainWindow> mainWindow;
+    QTimer::singleShot( 0, Qt::PreciseTimer,
+                        [&] { mainWindow.reset( new MainWindow( windowSession ) ); } );
+    QTest::qWait( 100 );
+    REQUIRE( mainWindow != nullptr );
+
+    auto* fileMenu = findTopLevelMenu( mainWindow.get(), QStringLiteral( "File" ) );
+    auto* helpMenu = findTopLevelMenu( mainWindow.get(), QStringLiteral( "Help" ) );
+    REQUIRE( fileMenu != nullptr );
+    REQUIRE( helpMenu != nullptr );
+
+    auto* openFile = mainWindow->findChild<QAction*>( QStringLiteral( "openAction" ) );
+    auto* openFolder
+        = mainWindow->findChild<QAction*>( QStringLiteral( "openFolderAction" ) );
+    auto* openAdb
+        = mainWindow->findChild<QAction*>( QStringLiteral( "openAdbLogcatAction" ) );
+    auto* openClipboard
+        = mainWindow->findChild<QAction*>( QStringLiteral( "openClipboardAction" ) );
+    auto* openUrl = mainWindow->findChild<QAction*>( QStringLiteral( "openUrlAction" ) );
+    auto* documentation
+        = mainWindow->findChild<QAction*>( QStringLiteral( "showDocumentationAction" ) );
+    auto* reportIssue
+        = mainWindow->findChild<QAction*>( QStringLiteral( "reportIssueAction" ) );
+    auto* goToTop = mainWindow->findChild<QAction*>( QStringLiteral( "goToTopAction" ) );
+    auto* trayIcon = mainWindow->findChild<QSystemTrayIcon*>();
+
+    REQUIRE( openFile != nullptr );
+    REQUIRE( openFolder != nullptr );
+    REQUIRE( openAdb != nullptr );
+    REQUIRE( openClipboard != nullptr );
+    REQUIRE( openUrl != nullptr );
+    REQUIRE( documentation != nullptr );
+    REQUIRE( reportIssue != nullptr );
+    REQUIRE( goToTop != nullptr );
+    REQUIRE( trayIcon != nullptr );
+
+    CHECK( visibleMenuText( openFile->text() ) == QStringLiteral( "Open..." ) );
+    CHECK( visibleMenuText( openFolder->text() ) == QStringLiteral( "Open Folder..." ) );
+    CHECK( visibleMenuText( openAdb->text() ) == QStringLiteral( "Open ADB Logcat..." ) );
+    CHECK( visibleMenuText( openClipboard->text() )
+           == QStringLiteral( "Open from Clipboard" ) );
+    CHECK( visibleMenuText( openUrl->text() ) == QStringLiteral( "Open from URL..." ) );
+    CHECK( visibleMenuText( documentation->text() ) == QStringLiteral( "Documentation" ) );
+    CHECK( visibleMenuText( reportIssue->text() ) == QStringLiteral( "Report Issue" ) );
+    CHECK( trayIcon->toolTip() == QStringLiteral( "klogg log viewer" ) );
+
+    goToTop->setText( QStringLiteral( "stale text" ) );
+    mainWindow->reTranslateUI();
+    CHECK( goToTop->text() == QStringLiteral( "Go to &Top" ) );
 }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(klogg_tests
     configuration_test.cpp
     encodingdetector_test.cpp
     droppathclassification_test.cpp
+    filterfavoritesmodel_test.cpp
     recentfolders_test.cpp
     highlighter_vectorscan_test.cpp
     linehighlight_compose_test.cpp

--- a/tests/unit/configuration_test.cpp
+++ b/tests/unit/configuration_test.cpp
@@ -24,8 +24,11 @@
 #include <QUuid>
 
 #include "configuration.h"
+#include "shortcuts.h"
 
 namespace {
+constexpr auto CtrlGDefaultsMigrationMarker = "shortcuts.ctrlGDefaultsMigrated";
+
 QString makeTestDir( const QString& prefix )
 {
     const auto dirPath = QDir::cleanPath( QDir::currentPath() + QDir::separator()
@@ -34,6 +37,48 @@ QString makeTestDir( const QString& prefix )
                                           + QUuid::createUuid().toString( QUuid::WithoutBraces ) );
     QDir{}.mkpath( dirPath );
     return dirPath;
+}
+
+QStringList legacyFindNextBindings()
+{
+    QStringList bindings;
+    for ( const auto& key : QKeySequence::keyBindings( QKeySequence::FindNext ) ) {
+        const auto portable = key.toString( QKeySequence::PortableText );
+        if ( !portable.isEmpty() && !bindings.contains( portable ) ) {
+            bindings.push_back( portable );
+        }
+    }
+
+    const auto commandG = QKeySequence( commandShortcutModifier() + QStringLiteral( "+G" ) )
+                              .toString( QKeySequence::PortableText );
+    if ( !commandG.isEmpty() && !bindings.contains( commandG ) ) {
+        bindings.push_back( commandG );
+    }
+    return bindings;
+}
+
+QStringList materializedShortcutSlots( QStringList bindings )
+{
+    bindings = bindings.mid( 0, 2 );
+    while ( bindings.size() < 2 ) {
+        bindings.push_back( QString{} );
+    }
+    return bindings;
+}
+
+void writeShortcutArray( QSettings& settings,
+                         const std::map<std::string, QStringList>& shortcuts )
+{
+    settings.beginWriteArray( QStringLiteral( "shortcuts" ) );
+    int index = 0;
+    for ( const auto& [ action, keys ] : shortcuts ) {
+        settings.setArrayIndex( index );
+        settings.setValue( QStringLiteral( "action" ), QString::fromStdString( action ) );
+        settings.setValue( QStringLiteral( "keys" ), keys );
+        ++index;
+    }
+    settings.endArray();
+    settings.sync();
 }
 } // namespace
 
@@ -331,4 +376,147 @@ TEST_CASE( "Configuration migrates stale perf.useBlockScan=false from pre-#41 in
     Configuration config2;
     config2.retrieveFromStorage( migratedSettings );
     REQUIRE_FALSE( config2.useBlockScan() );
+}
+
+TEST_CASE( "Configuration migrates persisted legacy Ctrl+G shortcut defaults" )
+{
+    const auto dirPath = makeTestDir( "configuration_shortcut_migration" );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration.ini" );
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+        writeShortcutArray(
+            settings,
+            { { ShortcutAction::LogViewJumpToLine,
+                materializedShortcutSlots(
+                    { commandShortcutModifier() + QStringLiteral( "+L" ) } ) },
+              { ShortcutAction::LogViewQfForward,
+                materializedShortcutSlots( legacyFindNextBindings() ) } } );
+    }
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+        Configuration migrated;
+        migrated.retrieveFromStorage( settings );
+
+        CHECK( migrated.shortcuts().count( ShortcutAction::LogViewJumpToLine ) == 0 );
+        CHECK( migrated.shortcuts().count( ShortcutAction::LogViewQfForward ) == 0 );
+        REQUIRE( settings.value( CtrlGDefaultsMigrationMarker, false ).toBool() );
+    }
+
+    QSettings restoredSettings( settingsPath, QSettings::IniFormat );
+    Configuration restored;
+    restored.retrieveFromStorage( restoredSettings );
+    CHECK( restored.shortcuts().count( ShortcutAction::LogViewJumpToLine ) == 0 );
+    CHECK( restored.shortcuts().count( ShortcutAction::LogViewQfForward ) == 0 );
+}
+
+TEST_CASE( "Configuration migrates pre-platform-modifier Ctrl shortcut defaults" )
+{
+    const auto dirPath = makeTestDir( "configuration_literal_ctrl_shortcut_migration" );
+    QSettings settings( QDir{ dirPath }.filePath( "configuration.ini" ), QSettings::IniFormat );
+    writeShortcutArray(
+        settings,
+        { { ShortcutAction::LogViewJumpToLine,
+            materializedShortcutSlots( { QStringLiteral( "Ctrl+L" ) } ) },
+          { ShortcutAction::LogViewQfForward,
+            materializedShortcutSlots( { QStringLiteral( "Ctrl+G" ) } ) } } );
+
+    Configuration migrated;
+    migrated.retrieveFromStorage( settings );
+
+    CHECK( migrated.shortcuts().count( ShortcutAction::LogViewJumpToLine ) == 0 );
+    CHECK( migrated.shortcuts().count( ShortcutAction::LogViewQfForward ) == 0 );
+}
+
+TEST_CASE( "Configuration migrates legacy shortcut mapping format selectively" )
+{
+    const auto dirPath = makeTestDir( "configuration_shortcut_mapping_migration" );
+    QSettings settings( QDir{ dirPath }.filePath( "configuration.ini" ), QSettings::IniFormat );
+    QVariantMap legacyMapping;
+    legacyMapping.insert(
+        QString::fromLatin1( ShortcutAction::LogViewJumpToLine ),
+        materializedShortcutSlots( { commandShortcutModifier() + QStringLiteral( "+L" ) } ) );
+    legacyMapping.insert( QString::fromLatin1( ShortcutAction::LogViewQfForward ),
+                          materializedShortcutSlots( legacyFindNextBindings() ) );
+    const auto customAction = QString::fromLatin1( ShortcutAction::MainWindowOpenFile );
+    const auto customKeys = materializedShortcutSlots( { QStringLiteral( "Alt+O" ) } );
+    legacyMapping.insert( customAction, customKeys );
+    settings.setValue( QStringLiteral( "shortcuts.mapping" ), legacyMapping );
+    settings.sync();
+
+    Configuration migrated;
+    migrated.retrieveFromStorage( settings );
+
+    CHECK( migrated.shortcuts().count( ShortcutAction::LogViewJumpToLine ) == 0 );
+    CHECK( migrated.shortcuts().count( ShortcutAction::LogViewQfForward ) == 0 );
+    REQUIRE( migrated.shortcuts().count( ShortcutAction::MainWindowOpenFile ) == 1 );
+    CHECK( migrated.shortcuts().at( ShortcutAction::MainWindowOpenFile ) == customKeys );
+    CHECK_FALSE( settings.contains( QStringLiteral( "shortcuts.mapping" ) ) );
+    CHECK( settings.value( CtrlGDefaultsMigrationMarker, false ).toBool() );
+}
+
+TEST_CASE( "Configuration shortcut migration preserves custom bindings" )
+{
+    const auto dirPath = makeTestDir( "configuration_custom_shortcuts" );
+    QSettings settings( QDir{ dirPath }.filePath( "configuration.ini" ), QSettings::IniFormat );
+    const std::map<std::string, QStringList> custom{
+        { ShortcutAction::LogViewJumpToLine,
+          materializedShortcutSlots( { QStringLiteral( "Alt+L" ) } ) },
+        { ShortcutAction::LogViewQfForward,
+          materializedShortcutSlots( { QStringLiteral( "F6" ) } ) },
+    };
+    writeShortcutArray( settings, custom );
+
+    Configuration restored;
+    restored.retrieveFromStorage( settings );
+
+    CHECK( restored.shortcuts() == custom );
+    CHECK( settings.value( CtrlGDefaultsMigrationMarker, false ).toBool() );
+}
+
+TEST_CASE( "Configuration shortcut migration marker preserves deliberate legacy-looking bindings" )
+{
+    const auto dirPath = makeTestDir( "configuration_marked_shortcuts" );
+    QSettings settings( QDir{ dirPath }.filePath( "configuration.ini" ), QSettings::IniFormat );
+    const std::map<std::string, QStringList> deliberate{
+        { ShortcutAction::LogViewJumpToLine,
+          materializedShortcutSlots( { QStringLiteral( "Ctrl+L" ) } ) },
+        { ShortcutAction::LogViewQfForward,
+          materializedShortcutSlots( { QStringLiteral( "Ctrl+G" ) } ) },
+    };
+    writeShortcutArray( settings, deliberate );
+    settings.setValue( CtrlGDefaultsMigrationMarker, true );
+    settings.sync();
+
+    Configuration restored;
+    restored.retrieveFromStorage( settings );
+
+    CHECK( restored.shortcuts() == deliberate );
+}
+
+TEST_CASE( "Configuration save stamps Ctrl+G shortcut migration marker" )
+{
+    const auto dirPath = makeTestDir( "configuration_saved_shortcuts" );
+    const auto settingsPath = QDir{ dirPath }.filePath( "configuration.ini" );
+    const std::map<std::string, QStringList> deliberate{
+        { ShortcutAction::LogViewJumpToLine,
+          materializedShortcutSlots( { QStringLiteral( "Ctrl+L" ) } ) },
+        { ShortcutAction::LogViewQfForward,
+          materializedShortcutSlots( { QStringLiteral( "Ctrl+G" ) } ) },
+    };
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+        Configuration saved;
+        saved.setShortcuts( deliberate );
+        saved.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.value( CtrlGDefaultsMigrationMarker, false ).toBool() );
+    }
+
+    QSettings settings( settingsPath, QSettings::IniFormat );
+    Configuration restored;
+    restored.retrieveFromStorage( settings );
+    CHECK( restored.shortcuts() == deliberate );
 }

--- a/tests/unit/filterfavoritesmodel_test.cpp
+++ b/tests/unit/filterfavoritesmodel_test.cpp
@@ -19,26 +19,40 @@
 
 #include <catch2/catch.hpp>
 
+#include <memory>
+
 #include <QAbstractItemModel>
-#include <QApplication>
 #include <QDialogButtonBox>
 #include <QFile>
 #include <QMap>
-#include <QMessageBox>
 #include <QModelIndex>
+#include <QLockFile>
 #include <QPushButton>
 #include <QSettings>
 #include <QSignalSpy>
 #include <QTableWidget>
 #include <QTemporaryDir>
 #include <QTest>
-#include <QTimer>
+#include <QToolButton>
 #include <QVariant>
 
 #include "filterfavoritesmodel.h"
 #include "persistentinfo.h"
 #include "predefinedfilters.h"
+#include "predefinedfilterscombobox.h"
 #include "predefinedfiltersdialog.h"
+#include "uimessage.h"
+
+struct PredefinedFiltersCollectionTestAccess {
+    static PredefinedFiltersCollection::CommitResult commitToSettings(
+        QSettings& settings, const QString& lockFile,
+        const PredefinedFiltersCollection::Collection& expected,
+        const PredefinedFiltersCollection::Collection& replacement )
+    {
+        return PredefinedFiltersCollection::commitToSettings( settings, lockFile, expected,
+                                                              replacement );
+    }
+};
 
 namespace {
 using Collection = PredefinedFiltersCollection::Collection;
@@ -74,7 +88,6 @@ void requireFavoritesEqual( const Collection& actual, const Collection& expected
 class PersistedFavoritesGuard {
   public:
     PersistedFavoritesGuard()
-        : savedModelFavorites_( FilterFavoritesModel::instance().favorites() )
     {
         auto& settings = PersistentInfo::getSettings( app_settings{} );
         settings.sync();
@@ -90,10 +103,6 @@ class PersistedFavoritesGuard {
 
     ~PersistedFavoritesGuard()
     {
-        // Restore the observable singleton independently from the persisted
-        // snapshot: tests deliberately exercise model/storage divergence.
-        FilterFavoritesModel::instance().replaceFavorites( savedModelFavorites_ );
-
         auto& settings = PersistentInfo::getSettings( app_settings{} );
         settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
         settings.remove( QString{} );
@@ -107,6 +116,7 @@ class PersistedFavoritesGuard {
         // collection, so restore the decoded storage snapshot explicitly too.
         auto& collection = PredefinedFiltersCollection::getSynced();
         collection.setFilters( savedStoredFavorites_ );
+        FilterFavoritesModel::instance().synchronizeFromStorage();
     }
 
     PersistedFavoritesGuard( const PersistedFavoritesGuard& ) = delete;
@@ -114,7 +124,6 @@ class PersistedFavoritesGuard {
 
   private:
     QMap<QString, QVariant> savedValues_;
-    Collection savedModelFavorites_;
     Collection savedStoredFavorites_;
 };
 
@@ -139,28 +148,64 @@ QPushButton* standardButton( PredefinedFiltersDialog& dialog,
     return box != nullptr ? box->button( standardButton ) : nullptr;
 }
 
-struct ModalResult {
-    bool found = false;
+struct CapturedMessage {
+    klogg::ui::MessageKind kind = klogg::ui::MessageKind::Information;
+    QString title;
     QString text;
+    int count = 0;
 };
 
-void closeNextMessageBox( QObject* context, ModalResult& result )
+klogg::ui::ScopedMessageHandler captureMessages( CapturedMessage& message )
 {
-    QTimer::singleShot( 0, Qt::PreciseTimer, context, [ &result ] {
-        auto* const messageBox = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
-        if ( messageBox != nullptr ) {
-            result.found = true;
-            result.text = messageBox->text();
-            messageBox->accept();
-            return;
-        }
-
-        if ( auto* const modal = qobject_cast<QDialog*>( QApplication::activeModalWidget() ) ) {
-            modal->reject();
-        }
-    } );
+    return klogg::ui::ScopedMessageHandler{
+        [ &message ]( klogg::ui::MessageKind kind, QWidget*, const QString& title,
+                      const QString& text ) {
+            message.kind = kind;
+            message.title = title;
+            message.text = text;
+            ++message.count;
+        } };
 }
 } // namespace
+
+TEST_CASE( "Scoped UI message handlers support reentrancy and non-LIFO cleanup",
+           "[filter-favorites][ui-message]" )
+{
+    int outerCount = 0;
+    int innerCount = 0;
+    auto outer = std::make_unique<klogg::ui::ScopedMessageHandler>(
+        [ & ]( klogg::ui::MessageKind, QWidget*, const QString&, const QString& ) {
+            ++outerCount;
+            [[maybe_unused]] const klogg::ui::ScopedMessageHandler nested{
+                [ & ]( klogg::ui::MessageKind, QWidget*, const QString&, const QString& ) {
+                    ++innerCount;
+                } };
+            klogg::ui::information( nullptr, QStringLiteral( "nested" ), QStringLiteral( "nested" ) );
+        } );
+    auto inner = std::make_unique<klogg::ui::ScopedMessageHandler>(
+        [ & ]( klogg::ui::MessageKind, QWidget*, const QString&, const QString& ) {
+            ++innerCount;
+        } );
+
+    outer.reset();
+    klogg::ui::warning( nullptr, QStringLiteral( "inner" ), QStringLiteral( "inner" ) );
+    REQUIRE( outerCount == 0 );
+    REQUIRE( innerCount == 1 );
+
+    inner.reset();
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler reentrant{
+        [ & ]( klogg::ui::MessageKind, QWidget*, const QString&, const QString& ) {
+            ++outerCount;
+            [[maybe_unused]] const klogg::ui::ScopedMessageHandler nested{
+                [ & ]( klogg::ui::MessageKind, QWidget*, const QString&, const QString& ) {
+                    ++innerCount;
+                } };
+            klogg::ui::information( nullptr, QStringLiteral( "nested" ), QStringLiteral( "nested" ) );
+        } };
+    klogg::ui::warning( nullptr, QStringLiteral( "outer" ), QStringLiteral( "outer" ) );
+    REQUIRE( outerCount == 1 );
+    REQUIRE( innerCount == 2 );
+}
 
 TEST_CASE( "Predefined filter settings roundtrip preserves insertion order",
            "[filter-favorites]" )
@@ -249,6 +294,123 @@ TEST_CASE( "Validated filter favorite import distinguishes empty and invalid fil
     }
 }
 
+TEST_CASE( "Validated filter favorite import rejects unsafe array sizes",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+
+    for ( const int size : { -1, PredefinedFiltersCollection::MaximumFilterCount + 1 } ) {
+        CAPTURE( size );
+        const auto path = dir.filePath( QStringLiteral( "unsafe-%1.conf" ).arg( size ) );
+        QSettings settings( path, QSettings::IniFormat );
+        settings.setValue( QStringLiteral( "PredefinedFiltersCollection/version" ), 2 );
+        settings.setValue( QStringLiteral( "PredefinedFiltersCollection/filters/size" ), size );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+
+        const auto result = PredefinedFiltersCollection::tryLoadFromFile( path );
+        REQUIRE( result.status == PredefinedFiltersCollection::LoadStatus::MalformedFile );
+        REQUIRE( result.filters.isEmpty() );
+    }
+}
+
+TEST_CASE( "Invalid persisted filter favorites keep the last valid collection",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto path = dir.filePath( QStringLiteral( "favorites.conf" ) );
+    QSettings settings( path, QSettings::IniFormat );
+    const auto initial = twoFavorites();
+
+    PredefinedFiltersCollection collection;
+    collection.setFilters( initial );
+    collection.saveToStorage( settings );
+    settings.sync();
+    collection.retrieveFromStorage( settings );
+    requireFavoritesEqual( collection.getFilters(), initial );
+
+    settings.setValue( QStringLiteral( "PredefinedFiltersCollection/filters/size" ),
+                       PredefinedFiltersCollection::MaximumFilterCount + 1 );
+    settings.sync();
+    collection.retrieveFromStorage( settings );
+
+    requireFavoritesEqual( collection.getFilters(), initial );
+}
+
+TEST_CASE( "Filter favorite storage commit is locked and compare-and-replace",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto settingsPath = dir.filePath( QStringLiteral( "favorites.conf" ) );
+    const auto lockPath = dir.filePath( QStringLiteral( "favorites.lock" ) );
+    QSettings settings( settingsPath, QSettings::IniFormat );
+
+    const auto initial = twoFavorites();
+    PredefinedFiltersCollection seed;
+    seed.setFilters( initial );
+    seed.saveToStorage( settings );
+    settings.sync();
+    REQUIRE( settings.status() == QSettings::NoError );
+
+    const auto replacement = orderedFavorites();
+    const auto success = PredefinedFiltersCollectionTestAccess::commitToSettings(
+        settings, lockPath, initial, replacement );
+    REQUIRE( success.status == PredefinedFiltersCollection::CommitStatus::Success );
+    requireFavoritesEqual( success.storedFilters, replacement );
+
+    const auto conflict = PredefinedFiltersCollectionTestAccess::commitToSettings(
+        settings, lockPath, initial, Collection{} );
+    REQUIRE( conflict.status == PredefinedFiltersCollection::CommitStatus::Conflict );
+    requireFavoritesEqual( conflict.storedFilters, replacement );
+
+    {
+        QLockFile heldLock( lockPath );
+        REQUIRE( heldLock.tryLock() );
+        const auto lockError = PredefinedFiltersCollectionTestAccess::commitToSettings(
+            settings, lockPath, replacement, Collection{} );
+        REQUIRE( lockError.status == PredefinedFiltersCollection::CommitStatus::LockError );
+    }
+
+    settings.setValue( QStringLiteral( "PredefinedFiltersCollection/filters/size" ),
+                       PredefinedFiltersCollection::MaximumFilterCount + 1 );
+    settings.sync();
+    const auto repaired = PredefinedFiltersCollectionTestAccess::commitToSettings(
+        settings, lockPath, replacement, initial );
+    REQUIRE( repaired.status == PredefinedFiltersCollection::CommitStatus::Success );
+
+    PredefinedFiltersCollection restored;
+    restored.retrieveFromStorage( settings );
+    requireFavoritesEqual( restored.getFilters(), initial );
+}
+
+TEST_CASE( "Failed filter favorite commit is not published by the shared model",
+           "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto initial = twoFavorites();
+    model.replaceFavorites( initial );
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+
+    Collection oversized;
+    oversized.reserve( PredefinedFiltersCollection::MaximumFilterCount + 1 );
+    const PredefinedFilter favorite{ QStringLiteral( "Name" ), QStringLiteral( "Pattern" ), false };
+    for ( int index = 0; index <= PredefinedFiltersCollection::MaximumFilterCount; ++index ) {
+        oversized.push_back( favorite );
+    }
+
+    const auto result = model.replaceFavorites( oversized );
+
+    REQUIRE( result.status
+             == PredefinedFiltersCollection::CommitStatus::InvalidReplacement );
+    REQUIRE( resetSpy.count() == 0 );
+    requireFavoritesEqual( model.favorites(), initial );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), initial );
+}
+
 TEST_CASE( "Filter favorites model exposes ordered rows and roles", "[filter-favorites]" )
 {
     PersistedFavoritesGuard guard;
@@ -277,42 +439,23 @@ TEST_CASE( "Filter favorites model exposes ordered rows and roles", "[filter-fav
     }
 }
 
-TEST_CASE( "PersistedFavoritesGuard restores model and storage independently",
-           "[filter-favorites]" )
-{
-    PersistedFavoritesGuard outerGuard;
-    auto& model = FilterFavoritesModel::instance();
-    const auto modelBefore = twoFavorites();
-    const auto storageBefore = orderedFavorites();
-    model.replaceFavorites( modelBefore );
-    replaceStoredFavorites( storageBefore );
-
-    {
-        PersistedFavoritesGuard innerGuard;
-        model.replaceFavorites( Collection{ { QStringLiteral( "Temporary" ),
-                                              QStringLiteral( "temporary" ), true } } );
-        replaceStoredFavorites( Collection{} );
-    }
-
-    requireFavoritesEqual( model.favorites(), modelBefore );
-    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), storageBefore );
-}
-
-TEST_CASE( "Authoritative identical replacement repairs divergent storage without reset",
+TEST_CASE( "Stale filter favorites replacement reports conflict and publishes durable state",
            "[filter-favorites]" )
 {
     PersistedFavoritesGuard guard;
     auto& model = FilterFavoritesModel::instance();
-    const auto authoritative = twoFavorites();
-    model.replaceFavorites( authoritative );
-    replaceStoredFavorites( orderedFavorites() );
+    const auto expected = twoFavorites();
+    model.replaceFavorites( expected );
+    const auto concurrent = orderedFavorites();
+    replaceStoredFavorites( concurrent );
     QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
 
-    model.replaceFavorites( authoritative );
+    const auto result = model.replaceFavorites( expected );
 
-    REQUIRE( resetSpy.count() == 0 );
-    requireFavoritesEqual( model.favorites(), authoritative );
-    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), authoritative );
+    REQUIRE( result.status == PredefinedFiltersCollection::CommitStatus::Conflict );
+    REQUIRE( resetSpy.count() == 1 );
+    requireFavoritesEqual( model.favorites(), concurrent );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), concurrent );
 }
 
 TEST_CASE( "Identical model and storage replacement emits no change signals",
@@ -400,7 +543,6 @@ TEST_CASE( "Filter favorites dialog rejects a concurrent full-table overwrite",
     model.replaceFavorites( base );
 
     PredefinedFiltersDialog dialog;
-    dialog.show();
     auto* const table = filtersTable( dialog );
     auto* const apply = standardButton( dialog, QDialogButtonBox::Apply );
     REQUIRE( table != nullptr );
@@ -412,16 +554,82 @@ TEST_CASE( "Filter favorites dialog rejects a concurrent full-table overwrite",
         { QStringLiteral( "External" ), QStringLiteral( "external-pattern" ), false } };
     replaceStoredFavorites( concurrent );
 
-    ModalResult warning;
-    closeNextMessageBox( &dialog, warning );
+    CapturedMessage warning;
+    [[maybe_unused]] const auto messageHandler = captureMessages( warning );
     apply->click();
 
-    REQUIRE( warning.found );
+    REQUIRE( warning.count == 1 );
+    REQUIRE( warning.kind == klogg::ui::MessageKind::Warning );
     REQUIRE_FALSE( warning.text.isEmpty() );
-    REQUIRE( dialog.isVisible() );
+    REQUIRE( dialog.result() == 0 );
     REQUIRE( table->item( 0, 1 )->text() == QStringLiteral( "dialog-edit" ) );
     requireFavoritesEqual( model.favorites(), concurrent );
     requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), concurrent );
+}
+
+TEST_CASE( "Filter favorites dialog updates visible and hidden pickers after every Apply",
+           "[filter-favorites][predefined-filters-dialog]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto initial = twoFavorites();
+    model.replaceFavorites( initial );
+
+    PredefinedFiltersComboBox visiblePicker( nullptr );
+    PredefinedFiltersComboBox hiddenPicker( nullptr );
+    visiblePicker.show();
+    hiddenPicker.hide();
+
+    PredefinedFiltersDialog dialog;
+    auto* const table = filtersTable( dialog );
+    auto* const apply = standardButton( dialog, QDialogButtonBox::Apply );
+    auto* const add = dialog.findChild<QToolButton*>( QStringLiteral( "addFilterButton" ) );
+    auto* const remove
+        = dialog.findChild<QToolButton*>( QStringLiteral( "removeFilterButton" ) );
+    auto* const up = dialog.findChild<QToolButton*>( QStringLiteral( "upButton" ) );
+    REQUIRE( table != nullptr );
+    REQUIRE( apply != nullptr );
+    REQUIRE( add != nullptr );
+    REQUIRE( remove != nullptr );
+    REQUIRE( up != nullptr );
+
+    const auto requirePickers = [ & ]( const Collection& expected ) {
+        requireFavoritesEqual( model.favorites(), expected );
+        REQUIRE( visiblePicker.count() == expected.size() );
+        REQUIRE( hiddenPicker.count() == expected.size() );
+        for ( int index = 0; index < expected.size(); ++index ) {
+            CAPTURE( index );
+            CHECK( visiblePicker.itemText( index ) == expected.at( index ).name );
+            CHECK( hiddenPicker.itemText( index ) == expected.at( index ).name );
+        }
+    };
+
+    add->click();
+    const int addedRow = table->rowCount() - 1;
+    table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma" ) );
+    table->item( addedRow, 1 )->setText( QStringLiteral( "third" ) );
+    apply->click();
+    Collection expected{ initial };
+    expected.push_back( { QStringLiteral( "Gamma" ), QStringLiteral( "third" ), false } );
+    requirePickers( expected );
+
+    table->item( addedRow, 0 )->setText( QStringLiteral( "Gamma Prime" ) );
+    apply->click();
+    expected[ 2 ].name = QStringLiteral( "Gamma Prime" );
+    requirePickers( expected );
+
+    table->setCurrentCell( addedRow, 0 );
+    up->click();
+    up->click();
+    apply->click();
+    expected.move( 2, 0 );
+    requirePickers( expected );
+
+    table->setCurrentCell( 2, 0 );
+    remove->click();
+    apply->click();
+    expected.removeAt( 2 );
+    requirePickers( expected );
 }
 
 TEST_CASE( "Filter favorites dialog advances its conflict base after Apply",
@@ -473,13 +681,14 @@ TEST_CASE( "Filter favorites dialog preserves its table on invalid import",
     const auto originalFirstName = table->item( 0, 0 )->text();
     const auto originalFirstPattern = table->item( 0, 1 )->text();
 
-    ModalResult warning;
-    closeNextMessageBox( &dialog, warning );
+    CapturedMessage warning;
+    [[maybe_unused]] const auto messageHandler = captureMessages( warning );
     const bool invoked = QMetaObject::invokeMethod(
         &dialog, "importFiltersFromFile", Qt::DirectConnection, Q_ARG( QString, invalidPath ) );
 
     REQUIRE( invoked );
-    REQUIRE( warning.found );
+    REQUIRE( warning.count == 1 );
+    REQUIRE( warning.kind == klogg::ui::MessageKind::Warning );
     REQUIRE_FALSE( warning.text.isEmpty() );
     REQUIRE( table->rowCount() == 2 );
     REQUIRE( table->item( 0, 0 )->text() == originalFirstName );
@@ -496,12 +705,13 @@ TEST_CASE( "Filter favorites dialog reports invalid export destinations",
     REQUIRE( dir.isValid() );
     PredefinedFiltersDialog dialog;
 
-    ModalResult warning;
-    closeNextMessageBox( &dialog, warning );
+    CapturedMessage warning;
+    [[maybe_unused]] const auto messageHandler = captureMessages( warning );
     const bool invoked = QMetaObject::invokeMethod(
         &dialog, "exportFiltersToFile", Qt::DirectConnection, Q_ARG( QString, dir.path() ) );
 
     REQUIRE( invoked );
-    REQUIRE( warning.found );
+    REQUIRE( warning.count == 1 );
+    REQUIRE( warning.kind == klogg::ui::MessageKind::Warning );
     REQUIRE_FALSE( warning.text.isEmpty() );
 }

--- a/tests/unit/filterfavoritesmodel_test.cpp
+++ b/tests/unit/filterfavoritesmodel_test.cpp
@@ -1,0 +1,507 @@
+/*
+ * Copyright (C) 2026
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QAbstractItemModel>
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QFile>
+#include <QMap>
+#include <QMessageBox>
+#include <QModelIndex>
+#include <QPushButton>
+#include <QSettings>
+#include <QSignalSpy>
+#include <QTableWidget>
+#include <QTemporaryDir>
+#include <QTest>
+#include <QTimer>
+#include <QVariant>
+
+#include "filterfavoritesmodel.h"
+#include "persistentinfo.h"
+#include "predefinedfilters.h"
+#include "predefinedfiltersdialog.h"
+
+namespace {
+using Collection = PredefinedFiltersCollection::Collection;
+
+Collection orderedFavorites()
+{
+    return { { QStringLiteral( "Bravo" ), QStringLiteral( "bravo-pattern" ), true },
+             { QStringLiteral( "Alpha" ), QStringLiteral( "alpha-pattern" ), false },
+             { QStringLiteral( "Charlie" ), QStringLiteral( "charlie-pattern" ), true } };
+}
+
+Collection twoFavorites()
+{
+    return { { QStringLiteral( "A" ), QStringLiteral( "first" ), false },
+             { QStringLiteral( "B" ), QStringLiteral( "second" ), true } };
+}
+
+void requireFavoritesEqual( const Collection& actual, const Collection& expected )
+{
+    REQUIRE( actual.size() == expected.size() );
+    for ( int i = 0; i < expected.size(); ++i ) {
+        CAPTURE( i );
+        REQUIRE( actual.at( i ).name == expected.at( i ).name );
+        REQUIRE( actual.at( i ).pattern == expected.at( i ).pattern );
+        REQUIRE( actual.at( i ).useRegex == expected.at( i ).useRegex );
+    }
+}
+
+// Model tests exercise the process-wide Persistable singleton and therefore the
+// user's real application QSettings. Snapshot the complete settings group, not
+// merely the decoded collection, so stack unwinding restores the exact persisted
+// representation and order even when a REQUIRE aborts the test.
+class PersistedFavoritesGuard {
+  public:
+    PersistedFavoritesGuard()
+        : savedModelFavorites_( FilterFavoritesModel::instance().favorites() )
+    {
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.sync();
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        const auto keys = settings.allKeys();
+        for ( const auto& key : keys ) {
+            savedValues_.insert( key, settings.value( key ) );
+        }
+        settings.endGroup();
+
+        savedStoredFavorites_ = PredefinedFiltersCollection::getSynced().getFilters();
+    }
+
+    ~PersistedFavoritesGuard()
+    {
+        // Restore the observable singleton independently from the persisted
+        // snapshot: tests deliberately exercise model/storage divergence.
+        FilterFavoritesModel::instance().replaceFavorites( savedModelFavorites_ );
+
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        settings.remove( QString{} );
+        for ( auto it = savedValues_.cbegin(); it != savedValues_.cend(); ++it ) {
+            settings.setValue( it.key(), it.value() );
+        }
+        settings.endGroup();
+        settings.sync();
+
+        // An absent settings group does not clear Persistable's in-memory
+        // collection, so restore the decoded storage snapshot explicitly too.
+        auto& collection = PredefinedFiltersCollection::getSynced();
+        collection.setFilters( savedStoredFavorites_ );
+    }
+
+    PersistedFavoritesGuard( const PersistedFavoritesGuard& ) = delete;
+    PersistedFavoritesGuard& operator=( const PersistedFavoritesGuard& ) = delete;
+
+  private:
+    QMap<QString, QVariant> savedValues_;
+    Collection savedModelFavorites_;
+    Collection savedStoredFavorites_;
+};
+
+void replaceStoredFavorites( const Collection& favorites )
+{
+    PredefinedFiltersCollection::get().saveToStorage( favorites );
+    auto& settings = PersistentInfo::getSettings( app_settings{} );
+    settings.sync();
+    REQUIRE( settings.status() == QSettings::NoError );
+}
+
+QTableWidget* filtersTable( PredefinedFiltersDialog& dialog )
+{
+    return dialog.findChild<QTableWidget*>( QStringLiteral( "filtersTableWidget" ) );
+}
+
+QPushButton* standardButton( PredefinedFiltersDialog& dialog,
+                             QDialogButtonBox::StandardButton standardButton )
+{
+    auto* const box
+        = dialog.findChild<QDialogButtonBox*>( QStringLiteral( "buttonBox" ) );
+    return box != nullptr ? box->button( standardButton ) : nullptr;
+}
+
+struct ModalResult {
+    bool found = false;
+    QString text;
+};
+
+void closeNextMessageBox( QObject* context, ModalResult& result )
+{
+    QTimer::singleShot( 0, Qt::PreciseTimer, context, [ &result ] {
+        auto* const messageBox = qobject_cast<QMessageBox*>( QApplication::activeModalWidget() );
+        if ( messageBox != nullptr ) {
+            result.found = true;
+            result.text = messageBox->text();
+            messageBox->accept();
+            return;
+        }
+
+        if ( auto* const modal = qobject_cast<QDialog*>( QApplication::activeModalWidget() ) ) {
+            modal->reject();
+        }
+    } );
+}
+} // namespace
+
+TEST_CASE( "Predefined filter settings roundtrip preserves insertion order",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto settingsPath = dir.filePath( QStringLiteral( "favorites.ini" ) );
+    const auto expected = orderedFavorites();
+
+    {
+        QSettings settings( settingsPath, QSettings::IniFormat );
+        PredefinedFiltersCollection saved;
+        saved.setFilters( expected );
+        saved.saveToStorage( settings );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+    }
+
+    QSettings settings( settingsPath, QSettings::IniFormat );
+    PredefinedFiltersCollection restored;
+    restored.retrieveFromStorage( settings );
+
+    requireFavoritesEqual( restored.getFilters(), expected );
+}
+
+TEST_CASE( "Predefined filter file export and import preserves insertion order",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto exportPath = dir.filePath( QStringLiteral( "favorites.ini" ) );
+    const auto expected = orderedFavorites();
+
+    REQUIRE( PredefinedFiltersCollection::saveToFile( exportPath, expected ) );
+    requireFavoritesEqual( PredefinedFiltersCollection::loadFromFile( exportPath ), expected );
+}
+
+TEST_CASE( "Validated filter favorite import distinguishes empty and invalid files",
+           "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+
+    SECTION( "valid empty export succeeds" )
+    {
+        const auto path = dir.filePath( QStringLiteral( "empty.conf" ) );
+        REQUIRE( PredefinedFiltersCollection::saveToFile( path, Collection{} ) );
+
+        const auto result = PredefinedFiltersCollection::tryLoadFromFile( path );
+        REQUIRE( result.status == PredefinedFiltersCollection::LoadStatus::Success );
+        REQUIRE( result.filters.isEmpty() );
+    }
+
+    SECTION( "missing file is reported" )
+    {
+        const auto path = dir.filePath( QStringLiteral( "missing.conf" ) );
+        const auto result = PredefinedFiltersCollection::tryLoadFromFile( path );
+        REQUIRE( result.status == PredefinedFiltersCollection::LoadStatus::MissingFile );
+        REQUIRE( result.filters.isEmpty() );
+    }
+
+    SECTION( "malformed file is reported" )
+    {
+        const auto path = dir.filePath( QStringLiteral( "malformed.conf" ) );
+        QFile file( path );
+        REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+        REQUIRE( file.write( "[PredefinedFiltersCollection]\nversion=not-a-number\n" ) > 0 );
+        file.close();
+
+        const auto result = PredefinedFiltersCollection::tryLoadFromFile( path );
+        REQUIRE( result.status == PredefinedFiltersCollection::LoadStatus::MalformedFile );
+        REQUIRE( result.filters.isEmpty() );
+    }
+
+    SECTION( "unsupported version is reported" )
+    {
+        const auto path = dir.filePath( QStringLiteral( "future.conf" ) );
+        QSettings settings( path, QSettings::IniFormat );
+        settings.setValue( QStringLiteral( "PredefinedFiltersCollection/version" ), 999 );
+        settings.sync();
+        REQUIRE( settings.status() == QSettings::NoError );
+
+        const auto result = PredefinedFiltersCollection::tryLoadFromFile( path );
+        REQUIRE( result.status == PredefinedFiltersCollection::LoadStatus::UnsupportedVersion );
+        REQUIRE( result.filters.isEmpty() );
+    }
+}
+
+TEST_CASE( "Filter favorites model exposes ordered rows and roles", "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto expected = orderedFavorites();
+
+    model.replaceFavorites( expected );
+
+    requireFavoritesEqual( model.favorites(), expected );
+    REQUIRE( model.rowCount( QModelIndex{} ) == expected.size() );
+    REQUIRE( model.roleNames().value( FilterFavoritesModel::NameRole ) == QByteArray( "name" ) );
+    REQUIRE( model.roleNames().value( FilterFavoritesModel::PatternRole )
+             == QByteArray( "pattern" ) );
+    REQUIRE( model.roleNames().value( FilterFavoritesModel::RegexRole ) == QByteArray( "regex" ) );
+
+    for ( int row = 0; row < expected.size(); ++row ) {
+        CAPTURE( row );
+        const auto index = model.index( row, 0, QModelIndex{} );
+        REQUIRE( index.isValid() );
+        REQUIRE( model.data( index, FilterFavoritesModel::NameRole ).toString()
+                 == expected.at( row ).name );
+        REQUIRE( model.data( index, FilterFavoritesModel::PatternRole ).toString()
+                 == expected.at( row ).pattern );
+        REQUIRE( model.data( index, FilterFavoritesModel::RegexRole ).toBool()
+                 == expected.at( row ).useRegex );
+    }
+}
+
+TEST_CASE( "PersistedFavoritesGuard restores model and storage independently",
+           "[filter-favorites]" )
+{
+    PersistedFavoritesGuard outerGuard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto modelBefore = twoFavorites();
+    const auto storageBefore = orderedFavorites();
+    model.replaceFavorites( modelBefore );
+    replaceStoredFavorites( storageBefore );
+
+    {
+        PersistedFavoritesGuard innerGuard;
+        model.replaceFavorites( Collection{ { QStringLiteral( "Temporary" ),
+                                              QStringLiteral( "temporary" ), true } } );
+        replaceStoredFavorites( Collection{} );
+    }
+
+    requireFavoritesEqual( model.favorites(), modelBefore );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), storageBefore );
+}
+
+TEST_CASE( "Authoritative identical replacement repairs divergent storage without reset",
+           "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto authoritative = twoFavorites();
+    model.replaceFavorites( authoritative );
+    replaceStoredFavorites( orderedFavorites() );
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+
+    model.replaceFavorites( authoritative );
+
+    REQUIRE( resetSpy.count() == 0 );
+    requireFavoritesEqual( model.favorites(), authoritative );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), authoritative );
+}
+
+TEST_CASE( "Identical model and storage replacement emits no change signals",
+           "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto favorites = orderedFavorites();
+    model.replaceFavorites( favorites );
+    model.synchronizeFromStorage();
+
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+    QSignalSpy dataSpy( &model, &QAbstractItemModel::dataChanged );
+    QSignalSpy insertedSpy( &model, &QAbstractItemModel::rowsInserted );
+    QSignalSpy removedSpy( &model, &QAbstractItemModel::rowsRemoved );
+
+    model.replaceFavorites( favorites );
+
+    REQUIRE( resetSpy.count() == 0 );
+    REQUIRE( dataSpy.count() == 0 );
+    REQUIRE( insertedSpy.count() == 0 );
+    REQUIRE( removedSpy.count() == 0 );
+    requireFavoritesEqual( model.favorites(), favorites );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), favorites );
+}
+
+TEST_CASE( "Replacing changed filter favorites emits one model reset", "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    model.replaceFavorites( twoFavorites() );
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+
+    model.replaceFavorites( orderedFavorites() );
+
+    REQUIRE( resetSpy.count() == 1 );
+}
+
+TEST_CASE( "Replacing identical filter favorites emits no model reset", "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto favorites = orderedFavorites();
+    model.replaceFavorites( favorites );
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+
+    model.replaceFavorites( favorites );
+
+    REQUIRE( resetSpy.count() == 0 );
+}
+
+TEST_CASE( "Reordering filter favorites persists the new order", "[filter-favorites]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto initial = twoFavorites();
+    const Collection reordered{ initial.at( 1 ), initial.at( 0 ) };
+
+    model.replaceFavorites( initial );
+    model.replaceFavorites( reordered );
+
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), reordered );
+
+    model.synchronizeFromStorage();
+    requireFavoritesEqual( model.favorites(), reordered );
+}
+
+TEST_CASE( "Filter favorite export reports QSettings write failures", "[filter-favorites]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+
+    // An existing directory cannot be replaced by an INI file. QSettings only
+    // exposes the failure after sync(), so saveToFile must synchronize and check
+    // status rather than unconditionally reporting success.
+    REQUIRE_FALSE( PredefinedFiltersCollection::saveToFile( dir.path(), orderedFavorites() ) );
+}
+
+TEST_CASE( "Filter favorites dialog rejects a concurrent full-table overwrite",
+           "[filter-favorites][predefined-filters-dialog]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto base = twoFavorites();
+    model.replaceFavorites( base );
+
+    PredefinedFiltersDialog dialog;
+    dialog.show();
+    auto* const table = filtersTable( dialog );
+    auto* const apply = standardButton( dialog, QDialogButtonBox::Apply );
+    REQUIRE( table != nullptr );
+    REQUIRE( apply != nullptr );
+    REQUIRE( table->rowCount() == base.size() );
+    table->item( 0, 1 )->setText( QStringLiteral( "dialog-edit" ) );
+
+    const Collection concurrent{
+        { QStringLiteral( "External" ), QStringLiteral( "external-pattern" ), false } };
+    replaceStoredFavorites( concurrent );
+
+    ModalResult warning;
+    closeNextMessageBox( &dialog, warning );
+    apply->click();
+
+    REQUIRE( warning.found );
+    REQUIRE_FALSE( warning.text.isEmpty() );
+    REQUIRE( dialog.isVisible() );
+    REQUIRE( table->item( 0, 1 )->text() == QStringLiteral( "dialog-edit" ) );
+    requireFavoritesEqual( model.favorites(), concurrent );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), concurrent );
+}
+
+TEST_CASE( "Filter favorites dialog advances its conflict base after Apply",
+           "[filter-favorites][predefined-filters-dialog]" )
+{
+    PersistedFavoritesGuard guard;
+    auto& model = FilterFavoritesModel::instance();
+    const auto base = twoFavorites();
+    model.replaceFavorites( base );
+
+    PredefinedFiltersDialog dialog;
+    auto* const table = filtersTable( dialog );
+    auto* const apply = standardButton( dialog, QDialogButtonBox::Apply );
+    REQUIRE( table != nullptr );
+    REQUIRE( apply != nullptr );
+
+    table->item( 0, 1 )->setText( QStringLiteral( "first-apply" ) );
+    apply->click();
+    auto firstApplied = base;
+    firstApplied[ 0 ].pattern = QStringLiteral( "first-apply" );
+    requireFavoritesEqual( model.favorites(), firstApplied );
+
+    table->item( 0, 1 )->setText( QStringLiteral( "second-apply" ) );
+    apply->click();
+    auto secondApplied = base;
+    secondApplied[ 0 ].pattern = QStringLiteral( "second-apply" );
+    requireFavoritesEqual( model.favorites(), secondApplied );
+    requireFavoritesEqual( PredefinedFiltersCollection::getSynced().getFilters(), secondApplied );
+}
+
+TEST_CASE( "Filter favorites dialog preserves its table on invalid import",
+           "[filter-favorites][predefined-filters-dialog]" )
+{
+    PersistedFavoritesGuard guard;
+    FilterFavoritesModel::instance().replaceFavorites( twoFavorites() );
+
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto invalidPath = dir.filePath( QStringLiteral( "malformed.conf" ) );
+    QFile invalidFile( invalidPath );
+    REQUIRE( invalidFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    REQUIRE( invalidFile.write( "[PredefinedFiltersCollection]\nversion=not-a-number\n" ) > 0 );
+    invalidFile.close();
+
+    PredefinedFiltersDialog dialog;
+    auto* const table = filtersTable( dialog );
+    REQUIRE( table != nullptr );
+    REQUIRE( table->rowCount() == 2 );
+    const auto originalFirstName = table->item( 0, 0 )->text();
+    const auto originalFirstPattern = table->item( 0, 1 )->text();
+
+    ModalResult warning;
+    closeNextMessageBox( &dialog, warning );
+    const bool invoked = QMetaObject::invokeMethod(
+        &dialog, "importFiltersFromFile", Qt::DirectConnection, Q_ARG( QString, invalidPath ) );
+
+    REQUIRE( invoked );
+    REQUIRE( warning.found );
+    REQUIRE_FALSE( warning.text.isEmpty() );
+    REQUIRE( table->rowCount() == 2 );
+    REQUIRE( table->item( 0, 0 )->text() == originalFirstName );
+    REQUIRE( table->item( 0, 1 )->text() == originalFirstPattern );
+}
+
+TEST_CASE( "Filter favorites dialog reports invalid export destinations",
+           "[filter-favorites][predefined-filters-dialog]" )
+{
+    PersistedFavoritesGuard guard;
+    FilterFavoritesModel::instance().replaceFavorites( twoFavorites() );
+
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    PredefinedFiltersDialog dialog;
+
+    ModalResult warning;
+    closeNextMessageBox( &dialog, warning );
+    const bool invoked = QMetaObject::invokeMethod(
+        &dialog, "exportFiltersToFile", Qt::DirectConnection, Q_ARG( QString, dir.path() ) );
+
+    REQUIRE( invoked );
+    REQUIRE( warning.found );
+    REQUIRE_FALSE( warning.text.isEmpty() );
+}

--- a/tests/unit/searchtoolbar_test.cpp
+++ b/tests/unit/searchtoolbar_test.cpp
@@ -41,7 +41,6 @@
 #include <QGuiApplication>
 #include <QLineEdit>
 #include <QMap>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScreen>
@@ -67,6 +66,7 @@
 #include "regularexpression.h"
 #include "regularexpressionpattern.h"
 #include "searchtoolbar.h"
+#include "uimessage.h"
 
 namespace {
 // Helper: drive the widget through the Qt event loop so queued autoRun searches
@@ -93,7 +93,6 @@ class FilterFavoritesRestoreGuard final {
 
     explicit FilterFavoritesRestoreGuard( const Collection& initialFavorites )
         : model_( FilterFavoritesModel::instance() )
-        , savedModelFavorites_( model_.favorites() )
     {
         auto& settings = PersistentInfo::getSettings( app_settings{} );
         settings.sync();
@@ -114,10 +113,6 @@ class FilterFavoritesRestoreGuard final {
 
     ~FilterFavoritesRestoreGuard()
     {
-        // Restore the process-wide observable model, then put the settings group
-        // back byte-for-byte logically (all keys and values, including order).
-        model_.replaceFavorites( savedModelFavorites_ );
-
         auto& settings = PersistentInfo::getSettings( app_settings{} );
         settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
         settings.remove( QString{} );
@@ -129,6 +124,7 @@ class FilterFavoritesRestoreGuard final {
 
         auto& collection = PredefinedFiltersCollection::getSynced();
         collection.setFilters( savedStoredFavorites_ );
+        model_.synchronizeFromStorage();
     }
 
     FilterFavoritesRestoreGuard( const FilterFavoritesRestoreGuard& ) = delete;
@@ -138,7 +134,6 @@ class FilterFavoritesRestoreGuard final {
 
   private:
     FilterFavoritesModel& model_;
-    Collection savedModelFavorites_;
     Collection savedStoredFavorites_;
     QMap<QString, QVariant> savedSettingsValues_;
 };
@@ -276,50 +271,22 @@ void scheduleOverwriteFavoriteAcceptance( QObject* context, const QString& targe
                             existing->setCurrentIndex( targetIndex );
                             beforeAccept();
 
-                            QTimer::singleShot( 0, Qt::PreciseTimer, context, [ &result ] {
-                                auto* const active = QApplication::activeModalWidget();
-                                if ( auto* const warning = qobject_cast<QMessageBox*>( active ) ) {
-                                    result.followupDialogFound = true;
-                                    result.conflictWarningFound = true;
-                                    warning->accept();
-                                    return;
-                                }
-                                if ( auto* const followup = qobject_cast<QDialog*>( active ) ) {
-                                    result.followupDialogFound = true;
-                                    followup->accept();
-                                }
-                            } );
+                            QObject::connect(
+                                dialog, &QDialog::finished, context,
+                                [ context, &result ] {
+                                    QTimer::singleShot(
+                                        1, Qt::PreciseTimer, context, [ &result ] {
+                                            if ( auto* const followup = qobject_cast<QDialog*>(
+                                                     QApplication::activeModalWidget() ) ) {
+                                                result.followupDialogFound = true;
+                                                followup->accept();
+                                            }
+                                        } );
+                                } );
                             ok->click();
                         } );
 }
 } // namespace
-
-TEST_CASE( "SearchToolbar favorites guard restores model and storage independently",
-           "[searchtoolbar][filter-favorites]" )
-{
-    FilterFavoritesRestoreGuard outerGuard( {} );
-    auto& model = outerGuard.model();
-    const auto modelBefore
-        = oneFavorite( QStringLiteral( "Memory" ), QStringLiteral( "memory-pattern" ) );
-    const auto storageBefore
-        = oneFavorite( QStringLiteral( "Storage" ), QStringLiteral( "storage-pattern" ) );
-    model.replaceFavorites( modelBefore );
-    replaceStoredFavorites( storageBefore );
-
-    {
-        FilterFavoritesRestoreGuard innerGuard(
-            oneFavorite( QStringLiteral( "Inner" ), QStringLiteral( "inner-pattern" ) ) );
-        innerGuard.model().replaceFavorites( {} );
-        replaceStoredFavorites( oneFavorite( QStringLiteral( "Temporary" ),
-                                             QStringLiteral( "temporary-pattern" ) ) );
-    }
-
-    requireFavorite( model.favorites(), QStringLiteral( "Memory" ),
-                     QStringLiteral( "memory-pattern" ), false );
-    const auto stored = PredefinedFiltersCollection::getSynced().getFilters();
-    requireFavorite( stored, QStringLiteral( "Storage" ),
-                     QStringLiteral( "storage-pattern" ), false );
-}
 
 TEST_CASE( "SearchToolbar constructs with null SavedSearches (folder mode)",
            "[searchtoolbar]" )
@@ -896,6 +863,38 @@ TEST_CASE( "SearchToolbar star and context action persist a favorite across tool
     SECTION( "Add to Filter Favorites action" ) { exerciseSave( true ); }
 }
 
+TEST_CASE( "SearchToolbar reports duplicate names separately from concurrency conflicts",
+           "[searchtoolbar][filter-favorites]" )
+{
+    const auto initial
+        = oneFavorite( QStringLiteral( "Duplicate" ), QStringLiteral( "old-pattern" ) );
+    FilterFavoritesRestoreGuard restore( initial );
+    auto& model = restore.model();
+    SearchToolbar toolbar( nullptr, nullptr );
+    toolbar.show();
+    REQUIRE( processEventsUntil( [ & ] { return toolbar.isVisible(); } ) );
+    toolbar.searchLineEdit()->setEditText( QStringLiteral( "new-pattern" ) );
+
+    FavoriteModalResult modal;
+    QString warningText;
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
+        [ &warningText ]( klogg::ui::MessageKind kind, QWidget*, const QString&,
+                          const QString& text ) {
+            if ( kind == klogg::ui::MessageKind::Warning ) {
+                warningText = text;
+            }
+        } };
+    scheduleCreateFavoriteAcceptance( &toolbar, QStringLiteral( "duplicate" ), modal );
+    toolbar.favoriteFilterButton()->click();
+
+    REQUIRE( modal.error.isEmpty() );
+    REQUIRE( modal.saveDialogFound );
+    REQUIRE( warningText.contains( QStringLiteral( "already exists" ) ) );
+    REQUIRE_FALSE( warningText.contains( QStringLiteral( "changed while" ) ) );
+    REQUIRE( model.favorites() == initial );
+    REQUIRE( PredefinedFiltersCollection::getSynced().getFilters() == initial );
+}
+
 TEST_CASE( "SearchToolbar favorite creation merges concurrent unrelated favorites",
            "[searchtoolbar][filter-favorites]" )
 {
@@ -959,6 +958,13 @@ TEST_CASE( "SearchToolbar warns when an overwrite target vanishes during the mod
     const FilterFavoritesModel::Collection concurrent{
         { QStringLiteral( "Unrelated" ), QStringLiteral( "unrelated-pattern" ), false } };
     FavoriteModalResult modal;
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
+        [ &modal ]( klogg::ui::MessageKind kind, QWidget*, const QString&, const QString& ) {
+            if ( kind == klogg::ui::MessageKind::Warning ) {
+                modal.followupDialogFound = true;
+                modal.conflictWarningFound = true;
+            }
+        } };
     scheduleOverwriteFavoriteAcceptance(
         &first, QStringLiteral( "Target" ), modal,
         [ & ] { replaceStoredFavorites( concurrent ); } );
@@ -979,6 +985,42 @@ TEST_CASE( "SearchToolbar warns when an overwrite target vanishes during the mod
     REQUIRE( QApplication::activeModalWidget() == nullptr );
 }
 
+TEST_CASE( "SearchToolbar does not rebind a vanished duplicate-name overwrite target",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesModel::Collection initial{
+        { QStringLiteral( "Duplicate" ), QStringLiteral( "first-pattern" ), false },
+        { QStringLiteral( "duplicate" ), QStringLiteral( "second-pattern" ), true },
+        { QStringLiteral( "Unrelated" ), QStringLiteral( "unrelated-pattern" ), false } };
+    FilterFavoritesRestoreGuard restore( initial );
+    auto& model = restore.model();
+    SearchToolbar toolbar( nullptr, nullptr );
+    toolbar.show();
+    REQUIRE( processEventsUntil( [ & ] { return toolbar.isVisible(); } ) );
+    toolbar.searchLineEdit()->setEditText( QStringLiteral( "replacement-pattern" ) );
+
+    const FilterFavoritesModel::Collection concurrent{
+        initial.at( 0 ), initial.at( 2 ) };
+    FavoriteModalResult modal;
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
+        [ &modal ]( klogg::ui::MessageKind kind, QWidget*, const QString&, const QString& ) {
+            if ( kind == klogg::ui::MessageKind::Warning ) {
+                modal.followupDialogFound = true;
+                modal.conflictWarningFound = true;
+            }
+        } };
+    scheduleOverwriteFavoriteAcceptance(
+        &toolbar, QStringLiteral( "Duplicate" ), modal,
+        [ & ] { replaceStoredFavorites( concurrent ); }, 1 );
+    toolbar.favoriteFilterButton()->click();
+
+    REQUIRE( modal.error.isEmpty() );
+    REQUIRE( modal.saveDialogFound );
+    REQUIRE( modal.conflictWarningFound );
+    REQUIRE( model.favorites() == concurrent );
+    REQUIRE( PredefinedFiltersCollection::getSynced().getFilters() == concurrent );
+}
+
 TEST_CASE( "SearchToolbar overwrite preserves the selected duplicate-name target",
            "[searchtoolbar][filter-favorites]" )
 {
@@ -996,6 +1038,13 @@ TEST_CASE( "SearchToolbar overwrite preserves the selected duplicate-name target
     first.searchLineEdit()->setEditText( QStringLiteral( "replacement-pattern" ) );
 
     FavoriteModalResult modal;
+    [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
+        [ &modal ]( klogg::ui::MessageKind kind, QWidget*, const QString&, const QString& ) {
+            if ( kind == klogg::ui::MessageKind::Warning ) {
+                modal.followupDialogFound = true;
+                modal.conflictWarningFound = true;
+            }
+        } };
     scheduleOverwriteFavoriteAcceptance( &first, QStringLiteral( "Duplicate" ), modal, [] {}, 1 );
     first.favoriteFilterButton()->click();
 

--- a/tests/unit/searchtoolbar_test.cpp
+++ b/tests/unit/searchtoolbar_test.cpp
@@ -220,7 +220,7 @@ void scheduleOverwriteFavoriteAcceptance( QObject* context, const QString& targe
                                           int targetOccurrence = 0 )
 {
     QTimer::singleShot( 0, Qt::PreciseTimer, context,
-                        [ context, targetName, &result, beforeAccept, targetOccurrence ] {
+                        [ targetName, &result, beforeAccept, targetOccurrence ] {
                             auto* const dialog
                                 = qobject_cast<QDialog*>( QApplication::activeModalWidget() );
                             if ( dialog == nullptr
@@ -270,19 +270,6 @@ void scheduleOverwriteFavoriteAcceptance( QObject* context, const QString& targe
                             overwrite->setChecked( true );
                             existing->setCurrentIndex( targetIndex );
                             beforeAccept();
-
-                            QObject::connect(
-                                dialog, &QDialog::finished, context,
-                                [ context, &result ] {
-                                    QTimer::singleShot(
-                                        1, Qt::PreciseTimer, context, [ &result ] {
-                                            if ( auto* const followup = qobject_cast<QDialog*>(
-                                                     QApplication::activeModalWidget() ) ) {
-                                                result.followupDialogFound = true;
-                                                followup->accept();
-                                            }
-                                        } );
-                                } );
                             ok->click();
                         } );
 }
@@ -1041,9 +1028,13 @@ TEST_CASE( "SearchToolbar overwrite preserves the selected duplicate-name target
     [[maybe_unused]] const klogg::ui::ScopedMessageHandler messageHandler{
         [ &modal ]( klogg::ui::MessageKind kind, QWidget*, const QString&, const QString& ) {
             if ( kind == klogg::ui::MessageKind::Warning ) {
-                modal.followupDialogFound = true;
                 modal.conflictWarningFound = true;
             }
+        } };
+    [[maybe_unused]] const klogg::ui::ScopedDialogHandler dialogHandler{
+        [ &modal ]( QDialog& ) {
+            modal.followupDialogFound = true;
+            return QDialog::Accepted;
         } };
     scheduleOverwriteFavoriteAcceptance( &first, QStringLiteral( "Duplicate" ), modal, [] {}, 1 );
     first.favoriteFilterButton()->click();

--- a/tests/unit/searchtoolbar_test.cpp
+++ b/tests/unit/searchtoolbar_test.cpp
@@ -26,15 +26,44 @@
 
 #include <catch2/catch.hpp>
 
+#include <QAbstractItemDelegate>
+#include <QAbstractItemModel>
+#include <QAbstractItemView>
+#include <QAction>
+#include <QApplication>
 #include <QComboBox>
+#include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QLineEdit>
+#include <QMap>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QScreen>
+#include <QScrollBar>
+#include <QSettings>
 #include <QSignalSpy>
 #include <QString>
+#include <QStyleOptionViewItem>
 #include <QTest>
+#include <QTimer>
 #include <QToolButton>
+#include <QVariant>
 #include <Qt>
 
+#include <algorithm>
+#include <functional>
 #include <string_view>
 
+#include "filterfavoritesmodel.h"
+#include "persistentinfo.h"
+#include "predefinedfilters.h"
+#include "predefinedfilterscombobox.h"
 #include "regularexpression.h"
 #include "regularexpressionpattern.h"
 #include "searchtoolbar.h"
@@ -46,7 +75,251 @@ void pumpEvents()
 {
     QTest::qWait( 10 );
 }
+
+template <typename Predicate>
+bool processEventsUntil( Predicate predicate )
+{
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( !predicate() && deadline.elapsed() < 500 ) {
+        QCoreApplication::processEvents( QEventLoop::AllEvents, 20 );
+    }
+    return predicate();
+}
+
+class FilterFavoritesRestoreGuard final {
+  public:
+    using Collection = PredefinedFiltersCollection::Collection;
+
+    explicit FilterFavoritesRestoreGuard( const Collection& initialFavorites )
+        : model_( FilterFavoritesModel::instance() )
+        , savedModelFavorites_( model_.favorites() )
+    {
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.sync();
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        const auto keys = settings.allKeys();
+        for ( const auto& key : keys ) {
+            savedSettingsValues_.insert( key, settings.value( key ) );
+        }
+        settings.endGroup();
+        savedStoredFavorites_ = PredefinedFiltersCollection::getSynced().getFilters();
+
+        // Seed storage first, then synchronize the observable singleton. This is
+        // deterministic even when the pre-test model happens to equal the seed
+        // while the persistent store differs.
+        PredefinedFiltersCollection::get().saveToStorage( initialFavorites );
+        model_.synchronizeFromStorage();
+    }
+
+    ~FilterFavoritesRestoreGuard()
+    {
+        // Restore the process-wide observable model, then put the settings group
+        // back byte-for-byte logically (all keys and values, including order).
+        model_.replaceFavorites( savedModelFavorites_ );
+
+        auto& settings = PersistentInfo::getSettings( app_settings{} );
+        settings.beginGroup( QStringLiteral( "PredefinedFiltersCollection" ) );
+        settings.remove( QString{} );
+        for ( auto it = savedSettingsValues_.cbegin(); it != savedSettingsValues_.cend(); ++it ) {
+            settings.setValue( it.key(), it.value() );
+        }
+        settings.endGroup();
+        settings.sync();
+
+        auto& collection = PredefinedFiltersCollection::getSynced();
+        collection.setFilters( savedStoredFavorites_ );
+    }
+
+    FilterFavoritesRestoreGuard( const FilterFavoritesRestoreGuard& ) = delete;
+    FilterFavoritesRestoreGuard& operator=( const FilterFavoritesRestoreGuard& ) = delete;
+
+    FilterFavoritesModel& model() const { return model_; }
+
+  private:
+    FilterFavoritesModel& model_;
+    Collection savedModelFavorites_;
+    Collection savedStoredFavorites_;
+    QMap<QString, QVariant> savedSettingsValues_;
+};
+
+PredefinedFiltersCollection::Collection oneFavorite( const QString& name,
+                                                     const QString& pattern )
+{
+    return { PredefinedFilter{ name, pattern, false } };
+}
+
+void replaceStoredFavorites( const PredefinedFiltersCollection::Collection& favorites )
+{
+    PredefinedFiltersCollection::get().saveToStorage( favorites );
+    PersistentInfo::getSettings( app_settings{} ).sync();
+}
+
+struct FavoriteModalResult {
+    bool saveDialogFound = false;
+    bool followupDialogFound = false;
+    bool conflictWarningFound = false;
+    QString error;
+};
+
+void closeActiveModalOnFailure()
+{
+    if ( auto* const modal = qobject_cast<QDialog*>( QApplication::activeModalWidget() ) ) {
+        modal->reject();
+    }
+}
+
+void scheduleCreateFavoriteAcceptance( QObject* context, const QString& favoriteName,
+                                       FavoriteModalResult& result,
+                                       const std::function<void()>& beforeAccept = {} )
+{
+    QTimer::singleShot( 0, Qt::PreciseTimer, context,
+                        [ favoriteName, &result, beforeAccept ] {
+                            auto* const dialog
+                                = qobject_cast<QDialog*>( QApplication::activeModalWidget() );
+                            if ( dialog == nullptr
+                                 || dialog->objectName() != QStringLiteral( "SaveFavoriteDialog" ) ) {
+                                result.error = QStringLiteral( "Save Favorite dialog was not active" );
+                                closeActiveModalOnFailure();
+                                return;
+                            }
+
+                            result.saveDialogFound = true;
+                            auto* const nameEdit = dialog->findChild<QLineEdit*>(
+                                QStringLiteral( "favoriteNameLineEdit" ) );
+                            auto* const buttonBox = dialog->findChild<QDialogButtonBox*>(
+                                QStringLiteral( "saveFavoriteButtonBox" ) );
+                            auto* const ok = buttonBox != nullptr
+                                                 ? buttonBox->button( QDialogButtonBox::Ok )
+                                                 : nullptr;
+                            if ( nameEdit == nullptr || ok == nullptr ) {
+                                result.error
+                                    = QStringLiteral( "Save Favorite controls were incomplete" );
+                                dialog->reject();
+                                return;
+                            }
+
+                            nameEdit->setText( favoriteName );
+                            if ( beforeAccept ) {
+                                beforeAccept();
+                            }
+                            ok->click();
+                        } );
+}
+
+void requireFavorite( const FilterFavoritesModel::Collection& favorites, const QString& name,
+                      const QString& pattern, bool useRegex )
+{
+    const auto found = std::find_if(
+        favorites.cbegin(), favorites.cend(), [ &name ]( const PredefinedFilter& favorite ) {
+            return favorite.name.compare( name, Qt::CaseInsensitive ) == 0;
+        } );
+    REQUIRE( found != favorites.cend() );
+    REQUIRE( found->pattern == pattern );
+    REQUIRE( found->useRegex == useRegex );
+}
+
+void scheduleOverwriteFavoriteAcceptance( QObject* context, const QString& targetName,
+                                          FavoriteModalResult& result,
+                                          const std::function<void()>& beforeAccept,
+                                          int targetOccurrence = 0 )
+{
+    QTimer::singleShot( 0, Qt::PreciseTimer, context,
+                        [ context, targetName, &result, beforeAccept, targetOccurrence ] {
+                            auto* const dialog
+                                = qobject_cast<QDialog*>( QApplication::activeModalWidget() );
+                            if ( dialog == nullptr
+                                 || dialog->objectName() != QStringLiteral( "SaveFavoriteDialog" ) ) {
+                                result.error = QStringLiteral( "Save Favorite dialog was not active" );
+                                closeActiveModalOnFailure();
+                                return;
+                            }
+
+                            result.saveDialogFound = true;
+                            auto* const overwrite = dialog->findChild<QRadioButton*>(
+                                QStringLiteral( "overwriteFavoriteRadioButton" ) );
+                            auto* const existing = dialog->findChild<QComboBox*>(
+                                QStringLiteral( "existingFavoriteComboBox" ) );
+                            auto* const buttonBox = dialog->findChild<QDialogButtonBox*>(
+                                QStringLiteral( "saveFavoriteButtonBox" ) );
+                            auto* const ok = buttonBox != nullptr
+                                                 ? buttonBox->button( QDialogButtonBox::Ok )
+                                                 : nullptr;
+                            if ( overwrite == nullptr || existing == nullptr || ok == nullptr ) {
+                                result.error
+                                    = QStringLiteral( "Overwrite Favorite controls were incomplete" );
+                                dialog->reject();
+                                return;
+                            }
+
+                            int targetIndex = -1;
+                            int matchingOccurrence = 0;
+                            for ( int index = 0; index < existing->count(); ++index ) {
+                                if ( existing->itemText( index ).compare(
+                                         targetName, Qt::CaseInsensitive )
+                                     != 0 ) {
+                                    continue;
+                                }
+                                if ( matchingOccurrence == targetOccurrence ) {
+                                    targetIndex = index;
+                                    break;
+                                }
+                                ++matchingOccurrence;
+                            }
+                            if ( targetIndex < 0 ) {
+                                result.error = QStringLiteral( "Overwrite target was not listed" );
+                                dialog->reject();
+                                return;
+                            }
+
+                            overwrite->setChecked( true );
+                            existing->setCurrentIndex( targetIndex );
+                            beforeAccept();
+
+                            QTimer::singleShot( 0, Qt::PreciseTimer, context, [ &result ] {
+                                auto* const active = QApplication::activeModalWidget();
+                                if ( auto* const warning = qobject_cast<QMessageBox*>( active ) ) {
+                                    result.followupDialogFound = true;
+                                    result.conflictWarningFound = true;
+                                    warning->accept();
+                                    return;
+                                }
+                                if ( auto* const followup = qobject_cast<QDialog*>( active ) ) {
+                                    result.followupDialogFound = true;
+                                    followup->accept();
+                                }
+                            } );
+                            ok->click();
+                        } );
+}
 } // namespace
+
+TEST_CASE( "SearchToolbar favorites guard restores model and storage independently",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesRestoreGuard outerGuard( {} );
+    auto& model = outerGuard.model();
+    const auto modelBefore
+        = oneFavorite( QStringLiteral( "Memory" ), QStringLiteral( "memory-pattern" ) );
+    const auto storageBefore
+        = oneFavorite( QStringLiteral( "Storage" ), QStringLiteral( "storage-pattern" ) );
+    model.replaceFavorites( modelBefore );
+    replaceStoredFavorites( storageBefore );
+
+    {
+        FilterFavoritesRestoreGuard innerGuard(
+            oneFavorite( QStringLiteral( "Inner" ), QStringLiteral( "inner-pattern" ) ) );
+        innerGuard.model().replaceFavorites( {} );
+        replaceStoredFavorites( oneFavorite( QStringLiteral( "Temporary" ),
+                                             QStringLiteral( "temporary-pattern" ) ) );
+    }
+
+    requireFavorite( model.favorites(), QStringLiteral( "Memory" ),
+                     QStringLiteral( "memory-pattern" ), false );
+    const auto stored = PredefinedFiltersCollection::getSynced().getFilters();
+    requireFavorite( stored, QStringLiteral( "Storage" ),
+                     QStringLiteral( "storage-pattern" ), false );
+}
 
 TEST_CASE( "SearchToolbar constructs with null SavedSearches (folder mode)",
            "[searchtoolbar]" )
@@ -363,4 +636,402 @@ TEST_CASE( "SearchToolbar session round-trip (view-context flags)", "[searchtool
     REQUIRE( toolbar.isInverse() == false );
     REQUIRE( toolbar.isBoolean() == false );
     REQUIRE( toolbar.isAutoRefresh() == false );
+}
+
+TEST_CASE( "New SearchToolbar synchronizes external filter favorite storage changes",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesRestoreGuard restore(
+        oneFavorite( QStringLiteral( "Memory" ), QStringLiteral( "memory-pattern" ) ) );
+    auto& model = restore.model();
+    const auto external
+        = oneFavorite( QStringLiteral( "External" ), QStringLiteral( "external-pattern" ) );
+    replaceStoredFavorites( external );
+
+    SearchToolbar toolbar( nullptr, nullptr );
+
+    REQUIRE( toolbar.predefinedFilters()->model() == &model );
+    REQUIRE( toolbar.predefinedFilters()->count() == 1 );
+    REQUIRE( toolbar.predefinedFilters()->itemText( 0 ) == QStringLiteral( "External" ) );
+    requireFavorite( model.favorites(), QStringLiteral( "External" ),
+                     QStringLiteral( "external-pattern" ), false );
+}
+
+TEST_CASE( "Opening a favorites popup synchronizes every bound SearchToolbar",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesRestoreGuard restore(
+        oneFavorite( QStringLiteral( "Initial" ), QStringLiteral( "initial-pattern" ) ) );
+    auto& model = restore.model();
+    SearchToolbar first( nullptr, nullptr );
+    SearchToolbar second( nullptr, nullptr );
+    first.show();
+    second.show();
+    REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+
+    const auto external
+        = oneFavorite( QStringLiteral( "External" ), QStringLiteral( "external-pattern" ) );
+    replaceStoredFavorites( external );
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+
+    first.predefinedFilters()->showPopup();
+    const bool synchronized = processEventsUntil( [ & ] {
+        return resetSpy.count() == 1 && first.predefinedFilters()->count() == 1
+               && second.predefinedFilters()->count() == 1
+               && first.predefinedFilters()->itemText( 0 ) == QStringLiteral( "External" )
+               && second.predefinedFilters()->itemText( 0 ) == QStringLiteral( "External" );
+    } );
+    first.predefinedFilters()->hidePopup();
+
+    REQUIRE( synchronized );
+    requireFavorite( model.favorites(), QStringLiteral( "External" ),
+                     QStringLiteral( "external-pattern" ), false );
+}
+
+TEST_CASE( "SearchToolbar instances observe the shared filter favorites model",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesRestoreGuard restore(
+        oneFavorite( QStringLiteral( "Short favorite" ), QStringLiteral( "short" ) ) );
+    auto& model = restore.model();
+
+    SearchToolbar first( nullptr, nullptr );
+    SearchToolbar second( nullptr, nullptr );
+    first.show();
+    second.show();
+
+    REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+    REQUIRE( first.predefinedFilters()->model() == &model );
+    REQUIRE( second.predefinedFilters()->model() == &model );
+    REQUIRE( first.predefinedFilters()->model() == second.predefinedFilters()->model() );
+
+    first.predefinedFilters()->setCurrentIndex( 0 );
+    second.predefinedFilters()->setCurrentIndex( 0 );
+    REQUIRE( first.predefinedFilters()->currentIndex() == 0 );
+    REQUIRE( second.predefinedFilters()->currentIndex() == 0 );
+
+    QSignalSpy resetSpy( &model, &QAbstractItemModel::modelReset );
+    const auto replacement = oneFavorite( QStringLiteral( "Replacement favorite" ),
+                                          QStringLiteral( "replacement" ) );
+    model.replaceFavorites( replacement );
+
+    REQUIRE( processEventsUntil( [ & ] {
+        return resetSpy.count() == 1 && first.predefinedFilters()->count() == 1
+               && second.predefinedFilters()->count() == 1
+               && first.predefinedFilters()->itemText( 0 ) == replacement.front().name
+               && second.predefinedFilters()->itemText( 0 ) == replacement.front().name
+               && first.predefinedFilters()->currentIndex() == -1
+               && second.predefinedFilters()->currentIndex() == -1;
+    } ) );
+}
+
+TEST_CASE( "Long filter favorite names do not consume the expanding search input",
+           "[searchtoolbar][filter-favorites]" )
+{
+    const auto shortFavorites
+        = oneFavorite( QStringLiteral( "Short" ), QStringLiteral( "short-pattern" ) );
+    FilterFavoritesRestoreGuard restore( shortFavorites );
+    auto& model = restore.model();
+
+    SearchToolbar toolbar( nullptr, nullptr );
+    auto* const favorites = toolbar.predefinedFilters();
+    auto* const searchInput = toolbar.searchLineEdit();
+
+    const auto initialHint = toolbar.sizeHint();
+    const int fixedWidth = initialHint.width() + searchInput->sizeHint().width();
+    toolbar.setFixedSize( fixedWidth, initialHint.height() );
+    toolbar.show();
+
+    REQUIRE( processEventsUntil( [ & ] {
+        return toolbar.isVisible() && toolbar.width() == fixedWidth && favorites->width() > 0
+               && searchInput->width() > 0;
+    } ) );
+
+    const int shortFavoriteSizeHintWidth = favorites->sizeHint().width();
+    const int shortFavoriteWidth = favorites->width();
+    const int shortSearchInputWidth = searchInput->width();
+
+    const QString longName
+        = QStringLiteral( "Several-hundred-character favorite " )
+          + QString( 384, QLatin1Char( 'x' ) );
+    model.replaceFavorites( oneFavorite( longName, QStringLiteral( "long-pattern" ) ) );
+
+    REQUIRE( processEventsUntil( [ & ] {
+        const auto index = model.index( 0, 0 );
+        return model.data( index, Qt::DisplayRole ).toString() == longName
+               && favorites->sizeHint().width() <= shortFavoriteSizeHintWidth
+               && favorites->width() <= shortFavoriteWidth
+               && searchInput->width() >= shortSearchInputWidth;
+    } ) );
+
+    const auto index = model.index( 0, 0 );
+    REQUIRE( model.data( index, Qt::DisplayRole ).toString() == longName );
+    REQUIRE( model.data( index, Qt::ToolTipRole ).toString() == longName );
+    REQUIRE( favorites->sizeHint().width() <= shortFavoriteSizeHintWidth );
+    REQUIRE( favorites->width() <= shortFavoriteWidth );
+    REQUIRE( searchInput->width() >= shortSearchInputWidth );
+    REQUIRE( toolbar.width() == fixedWidth );
+    REQUIRE( favorites->currentIndex() == -1 );
+
+    REQUIRE( favorites->view()->textElideMode() == Qt::ElideNone );
+    QStyleOptionViewItem option;
+    option.initFrom( favorites->view() );
+    const int fullTextWidth = QFontMetrics( favorites->view()->font() ).horizontalAdvance( longName );
+    const int delegateWidth
+        = favorites->view()->itemDelegate()->sizeHint( option, model.index( 0, 0 ) ).width();
+    REQUIRE( delegateWidth >= fullTextWidth );
+
+    favorites->showPopup();
+    const bool popupReady = processEventsUntil( [ & ] {
+        return favorites->view()->isVisible()
+               && favorites->view()->window()->width() > favorites->width()
+               && favorites->view()->horizontalScrollBar()->maximum() > 0;
+    } );
+    const int popupWidth = favorites->view()->window()->width();
+    const int viewportWidth = favorites->view()->viewport()->width();
+    const int visualItemWidth = favorites->view()->visualRect( model.index( 0, 0 ) ).width();
+    auto* const horizontalScrollBar = favorites->view()->horizontalScrollBar();
+    const int horizontalMaximum = horizontalScrollBar->maximum();
+    horizontalScrollBar->setValue( horizontalMaximum );
+    const int horizontalValue = horizontalScrollBar->value();
+    const auto horizontalPolicy = favorites->view()->horizontalScrollBarPolicy();
+    favorites->hidePopup();
+
+    CAPTURE( popupWidth, favorites->width(), viewportWidth, visualItemWidth,
+             horizontalMaximum, horizontalValue, horizontalPolicy, delegateWidth,
+             fullTextWidth );
+    REQUIRE( popupReady );
+    REQUIRE( popupWidth > favorites->width() );
+    REQUIRE( horizontalMaximum > 0 );
+    REQUIRE( horizontalValue == horizontalMaximum );
+}
+
+TEST_CASE( "Filter favorite popup uses full text width when the screen can fit it",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesRestoreGuard restore( {} );
+    auto& model = restore.model();
+    SearchToolbar toolbar( nullptr, nullptr );
+    toolbar.resize( 620, toolbar.sizeHint().height() );
+    toolbar.show();
+    REQUIRE( processEventsUntil( [ & ] { return toolbar.isVisible(); } ) );
+
+    auto* const combo = toolbar.predefinedFilters();
+    auto* screen = QGuiApplication::screenAt( combo->mapToGlobal( combo->rect().center() ) );
+    if ( screen == nullptr ) {
+        screen = QGuiApplication::primaryScreen();
+    }
+    REQUIRE( screen != nullptr );
+
+    const QFontMetrics metrics( combo->view()->font() );
+    QString longButFittingName = QStringLiteral( "Wide favorite " );
+    const int targetTextWidth
+        = std::min( screen->availableGeometry().width() / 2, combo->width() + 320 );
+    while ( metrics.horizontalAdvance( longButFittingName ) < targetTextWidth ) {
+        longButFittingName.append( QLatin1Char( 'W' ) );
+    }
+    REQUIRE( metrics.horizontalAdvance( longButFittingName )
+             < screen->availableGeometry().width() );
+
+    model.replaceFavorites(
+        oneFavorite( longButFittingName, QStringLiteral( "wide-pattern" ) ) );
+    combo->showPopup();
+    const bool expanded = processEventsUntil( [ & ] {
+        return combo->view()->isVisible() && combo->view()->window()->width() > combo->width()
+               && combo->view()->window()->width()
+                      >= metrics.horizontalAdvance( longButFittingName );
+    } );
+    const int popupWidth = combo->view()->window()->width();
+    combo->hidePopup();
+
+    REQUIRE( expanded );
+    REQUIRE( popupWidth > combo->width() );
+    REQUIRE( popupWidth >= metrics.horizontalAdvance( longButFittingName ) );
+}
+
+TEST_CASE( "SearchToolbar star and context action persist a favorite across toolbars",
+           "[searchtoolbar][filter-favorites]" )
+{
+    const auto exerciseSave = []( bool useContextAction ) {
+        FilterFavoritesRestoreGuard restore( {} );
+        auto& model = restore.model();
+        SearchToolbar first( nullptr, nullptr );
+        SearchToolbar second( nullptr, nullptr );
+        first.show();
+        second.show();
+        REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+
+        const QString pattern = useContextAction ? QStringLiteral( "context-pattern" )
+                                                 : QStringLiteral( "star-pattern" );
+        const QString favoriteName = useContextAction ? QStringLiteral( "Context Favorite" )
+                                                      : QStringLiteral( "Star Favorite" );
+        first.searchLineEdit()->setEditText( pattern );
+        first.setUseRegexp( true );
+
+        FavoriteModalResult modal;
+        scheduleCreateFavoriteAcceptance( &first, favoriteName, modal );
+        if ( useContextAction ) {
+            auto* const action = first.findChild<QAction*>(
+                QStringLiteral( "addFavoriteFilterAction" ) );
+            REQUIRE( action != nullptr );
+            action->trigger();
+        }
+        else {
+            first.favoriteFilterButton()->click();
+        }
+
+        REQUIRE( modal.error.isEmpty() );
+        REQUIRE( modal.saveDialogFound );
+        REQUIRE( processEventsUntil( [ & ] {
+            return model.rowCount() == 1 && second.predefinedFilters()->count() == 1
+                   && second.predefinedFilters()->itemText( 0 ) == favoriteName;
+        } ) );
+        requireFavorite( model.favorites(), favoriteName, pattern, true );
+        requireFavorite( PredefinedFiltersCollection::getSynced().getFilters(), favoriteName,
+                         pattern, true );
+        REQUIRE( QApplication::activeModalWidget() == nullptr );
+    };
+
+    SECTION( "star button" ) { exerciseSave( false ); }
+    SECTION( "Add to Filter Favorites action" ) { exerciseSave( true ); }
+}
+
+TEST_CASE( "SearchToolbar favorite creation merges concurrent unrelated favorites",
+           "[searchtoolbar][filter-favorites]" )
+{
+    const auto initial
+        = oneFavorite( QStringLiteral( "Initial" ), QStringLiteral( "initial-pattern" ) );
+    FilterFavoritesRestoreGuard restore( initial );
+    auto& model = restore.model();
+    SearchToolbar first( nullptr, nullptr );
+    SearchToolbar second( nullptr, nullptr );
+    first.show();
+    second.show();
+    REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+
+    first.searchLineEdit()->setEditText( QStringLiteral( "created-pattern" ) );
+    auto concurrent = initial;
+    concurrent.push_back( { QStringLiteral( "Concurrent" ),
+                            QStringLiteral( "concurrent-pattern" ), false } );
+
+    FavoriteModalResult modal;
+    scheduleCreateFavoriteAcceptance(
+        &first, QStringLiteral( "Created" ), modal,
+        [ & ] { replaceStoredFavorites( concurrent ); } );
+    first.favoriteFilterButton()->click();
+
+    REQUIRE( modal.error.isEmpty() );
+    REQUIRE( modal.saveDialogFound );
+    REQUIRE( processEventsUntil( [ & ] {
+        return model.rowCount() == 3 && second.predefinedFilters()->count() == 3;
+    } ) );
+    requireFavorite( model.favorites(), QStringLiteral( "Initial" ),
+                     QStringLiteral( "initial-pattern" ), false );
+    requireFavorite( model.favorites(), QStringLiteral( "Concurrent" ),
+                     QStringLiteral( "concurrent-pattern" ), false );
+    requireFavorite( model.favorites(), QStringLiteral( "Created" ),
+                     QStringLiteral( "created-pattern" ), false );
+
+    const auto stored = PredefinedFiltersCollection::getSynced().getFilters();
+    REQUIRE( stored.size() == 3 );
+    requireFavorite( stored, QStringLiteral( "Concurrent" ),
+                     QStringLiteral( "concurrent-pattern" ), false );
+    requireFavorite( stored, QStringLiteral( "Created" ),
+                     QStringLiteral( "created-pattern" ), false );
+    REQUIRE( QApplication::activeModalWidget() == nullptr );
+}
+
+TEST_CASE( "SearchToolbar warns when an overwrite target vanishes during the modal",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesModel::Collection initial{
+        { QStringLiteral( "Target" ), QStringLiteral( "old-pattern" ), false },
+        { QStringLiteral( "Unrelated" ), QStringLiteral( "unrelated-pattern" ), false } };
+    FilterFavoritesRestoreGuard restore( initial );
+    auto& model = restore.model();
+    SearchToolbar first( nullptr, nullptr );
+    SearchToolbar second( nullptr, nullptr );
+    first.show();
+    second.show();
+    REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+    first.searchLineEdit()->setEditText( QStringLiteral( "new-pattern" ) );
+
+    const FilterFavoritesModel::Collection concurrent{
+        { QStringLiteral( "Unrelated" ), QStringLiteral( "unrelated-pattern" ), false } };
+    FavoriteModalResult modal;
+    scheduleOverwriteFavoriteAcceptance(
+        &first, QStringLiteral( "Target" ), modal,
+        [ & ] { replaceStoredFavorites( concurrent ); } );
+    first.favoriteFilterButton()->click();
+
+    REQUIRE( modal.error.isEmpty() );
+    REQUIRE( modal.saveDialogFound );
+    REQUIRE( modal.followupDialogFound );
+    REQUIRE( modal.conflictWarningFound );
+    REQUIRE( model.rowCount() == 1 );
+    REQUIRE( second.predefinedFilters()->count() == 1 );
+    requireFavorite( model.favorites(), QStringLiteral( "Unrelated" ),
+                     QStringLiteral( "unrelated-pattern" ), false );
+    const auto stored = PredefinedFiltersCollection::getSynced().getFilters();
+    REQUIRE( stored.size() == 1 );
+    requireFavorite( stored, QStringLiteral( "Unrelated" ),
+                     QStringLiteral( "unrelated-pattern" ), false );
+    REQUIRE( QApplication::activeModalWidget() == nullptr );
+}
+
+TEST_CASE( "SearchToolbar overwrite preserves the selected duplicate-name target",
+           "[searchtoolbar][filter-favorites]" )
+{
+    FilterFavoritesModel::Collection initial{
+        { QStringLiteral( "Duplicate" ), QStringLiteral( "first-pattern" ), false },
+        { QStringLiteral( "duplicate" ), QStringLiteral( "second-pattern" ), true },
+        { QStringLiteral( "Unrelated" ), QStringLiteral( "unrelated-pattern" ), false } };
+    FilterFavoritesRestoreGuard restore( initial );
+    auto& model = restore.model();
+    SearchToolbar first( nullptr, nullptr );
+    SearchToolbar second( nullptr, nullptr );
+    first.show();
+    second.show();
+    REQUIRE( processEventsUntil( [ & ] { return first.isVisible() && second.isVisible(); } ) );
+    first.searchLineEdit()->setEditText( QStringLiteral( "replacement-pattern" ) );
+
+    FavoriteModalResult modal;
+    scheduleOverwriteFavoriteAcceptance( &first, QStringLiteral( "Duplicate" ), modal, [] {}, 1 );
+    first.favoriteFilterButton()->click();
+
+    REQUIRE( modal.error.isEmpty() );
+    REQUIRE( modal.saveDialogFound );
+    REQUIRE( modal.followupDialogFound );
+    REQUIRE_FALSE( modal.conflictWarningFound );
+    REQUIRE( processEventsUntil( [ & ] {
+        return model.rowCount() == initial.size() && second.predefinedFilters()->count() == initial.size();
+    } ) );
+
+    const auto favorites = model.favorites();
+    REQUIRE( favorites.at( 0 ) == initial.at( 0 ) );
+    REQUIRE( favorites.at( 1 ).name == initial.at( 1 ).name );
+    REQUIRE( favorites.at( 1 ).pattern == QStringLiteral( "replacement-pattern" ) );
+    REQUIRE_FALSE( favorites.at( 1 ).useRegex );
+    REQUIRE( favorites.at( 2 ) == initial.at( 2 ) );
+
+    const auto stored = PredefinedFiltersCollection::getSynced().getFilters();
+    REQUIRE( stored == favorites );
+    REQUIRE( QApplication::activeModalWidget() == nullptr );
+}
+
+TEST_CASE( "SearchToolbar custom search context actions use exact labels",
+           "[searchtoolbar][menu-text]" )
+{
+    SearchToolbar toolbar( nullptr, nullptr );
+    QStringList actionTexts;
+    const auto actions = toolbar.findChildren<QAction*>( QString(), Qt::FindDirectChildrenOnly );
+    for ( const auto* action : actions ) {
+        if ( !action->isSeparator() ) {
+            actionTexts.append( action->text() );
+        }
+    }
+
+    REQUIRE( actionTexts.contains( QStringLiteral( "Add to Filter Favorites..." ) ) );
+    REQUIRE( actionTexts.contains( QStringLiteral( "Edit Search History..." ) ) );
+    REQUIRE( actionTexts.contains( QStringLiteral( "Clear Search History" ) ) );
 }

--- a/tests/unit/shortcut_bindings_test.cpp
+++ b/tests/unit/shortcut_bindings_test.cpp
@@ -21,10 +21,35 @@
 
 #include <QKeySequence>
 #include <QString>
+#include <QToolButton>
 
 #include <algorithm>
 
+#include "quickfindwidget.h"
 #include "shortcuts.h"
+
+namespace {
+QKeySequence normalizedRuntimeSequence( const QKeySequence& sequence )
+{
+    return QKeySequence( sequence.toString( QKeySequence::NativeText ), QKeySequence::NativeText );
+}
+
+bool isExactRuntimeMatch( const QKeySequence& left, const QKeySequence& right )
+{
+    const auto normalizedLeft = normalizedRuntimeSequence( left );
+    const auto normalizedRight = normalizedRuntimeSequence( right );
+    return normalizedLeft.matches( normalizedRight ) == QKeySequence::ExactMatch
+           && normalizedRight.matches( normalizedLeft ) == QKeySequence::ExactMatch;
+}
+
+bool containsExactRuntimeMatch( const QStringList& bindings, const QKeySequence& expected )
+{
+    return std::any_of( bindings.cbegin(), bindings.cend(), [ &expected ]( const auto& binding ) {
+        return isExactRuntimeMatch(
+            QKeySequence( binding, QKeySequence::PortableText ), expected );
+    } );
+}
+} // namespace
 
 TEST_CASE( "Shortcut bindings: disconnect and reconnect source have defaults" )
 {
@@ -178,6 +203,66 @@ TEST_CASE( "Shortcut bindings: open from clipboard does not steal text paste" )
     }
 }
 
+TEST_CASE( "Shortcut bindings: Go to Line is the only normalized Ctrl+G runtime owner" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+    const auto ctrlG = QKeySequence( QStringLiteral( "Ctrl+G" ), QKeySequence::PortableText );
+
+    const auto jumpToLine = shortcuts.find( ShortcutAction::LogViewJumpToLine );
+    REQUIRE( jumpToLine != shortcuts.end() );
+    CHECK( jumpToLine->second.keySequence
+           == QStringList{ ctrlG.toString( QKeySequence::PortableText ) } );
+
+    std::vector<std::string> ctrlGOwners;
+    for ( const auto& [ action, shortcut ] : shortcuts ) {
+        if ( containsExactRuntimeMatch( shortcut.keySequence, ctrlG ) ) {
+            ctrlGOwners.push_back( action );
+        }
+    }
+
+    REQUIRE( ctrlGOwners.size() == 1 );
+    CHECK( ctrlGOwners.front() == ShortcutAction::LogViewJumpToLine );
+
+    const auto findNext = shortcuts.find( ShortcutAction::LogViewQfForward );
+    REQUIRE( findNext != shortcuts.end() );
+    REQUIRE_FALSE( findNext->second.keySequence.isEmpty() );
+    CHECK_FALSE( containsExactRuntimeMatch( findNext->second.keySequence, ctrlG ) );
+
+    const auto f3 = QKeySequence( Qt::Key_F3 );
+    CHECK( containsExactRuntimeMatch( findNext->second.keySequence, f3 ) );
+
+    for ( auto left = findNext->second.keySequence.cbegin();
+          left != findNext->second.keySequence.cend(); ++left ) {
+        for ( auto right = std::next( left ); right != findNext->second.keySequence.cend();
+              ++right ) {
+            CHECK_FALSE( isExactRuntimeMatch(
+                QKeySequence( *left, QKeySequence::PortableText ),
+                QKeySequence( *right, QKeySequence::PortableText ) ) );
+        }
+    }
+}
+
+TEST_CASE( "QuickFind next button uses the first safe Find Next binding" )
+{
+    const auto& shortcuts = ShortcutAction::defaultShortcutList();
+    const auto findNext = shortcuts.find( ShortcutAction::LogViewQfForward );
+    REQUIRE( findNext != shortcuts.end() );
+    REQUIRE_FALSE( findNext->second.keySequence.isEmpty() );
+
+    QuickFindWidget quickFind;
+    const auto buttons = quickFind.findChildren<QToolButton*>();
+    const auto nextButton = std::find_if( buttons.cbegin(), buttons.cend(), []( const auto* button ) {
+        return button->text() == QStringLiteral( "Next" );
+    } );
+    REQUIRE( nextButton != buttons.cend() );
+
+    const auto ctrlG = QKeySequence( QStringLiteral( "Ctrl+G" ), QKeySequence::PortableText );
+    CHECK_FALSE( isExactRuntimeMatch( ( *nextButton )->shortcut(), ctrlG ) );
+    CHECK( isExactRuntimeMatch(
+        ( *nextButton )->shortcut(),
+        QKeySequence( findNext->second.keySequence.front(), QKeySequence::PortableText ) ) );
+}
+
 TEST_CASE( "Shortcut bindings: no duplicate key bindings across all default shortcuts" )
 {
     const auto& shortcuts = ShortcutAction::defaultShortcutList();
@@ -204,8 +289,8 @@ TEST_CASE( "Shortcut bindings: no duplicate key bindings across all default shor
                                 commandShortcutModifier() + "+Shift+8",
                                 commandShortcutModifier() + "+Shift+9",
                                 commandShortcutModifier() + "+Shift+D",
-                                commandShortcutModifier() + "+Shift+R",
-                                "Ctrl+Tab", "Ctrl+Shift+Tab" };
+                                commandShortcutModifier() + "+Shift+R", "Ctrl+Tab",
+                                "Ctrl+Shift+Tab" };
 
     for ( const auto& key : keysToCheck ) {
         DYNAMIC_SECTION( "Key " << key.toStdString() << " has at most one binding" )

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -19,9 +19,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <QApplication>
 #include <QCoreApplication>
 #include <QDir>
+#include <QMenu>
 #include <QTabBar>
+#include <QTimer>
 #include <QTranslator>
 #include <QTest>
 #include <QWidget>
@@ -376,6 +379,80 @@ TEST_CASE( "TabbedCrawlerWidget cycles tabs with Ctrl+PageDown/PageUp shortcuts"
 
     QTest::keyClick( &tabWidget, Qt::Key_PageUp, Qt::ControlModifier );
     REQUIRE( tabWidget.currentIndex() == 2 );
+}
+
+TEST_CASE( "TabbedCrawlerWidget context menu uses app Title Case and semantic ellipses" )
+{
+    TabbedCrawlerWidget tabWidget;
+    tabWidget.resize( 640, 240 );
+
+    for ( int i = 0; i < 3; ++i ) {
+        auto* crawler = new DummyCrawlerWidget();
+        tabWidget.addCrawler( crawler, QStringLiteral( "file:///tmp/klogg-menu-%1.log" ).arg( i ),
+                              QStringLiteral( "Tab %1" ).arg( i ),
+                              QStringLiteral( "/tmp/klogg-menu-%1.log" ).arg( i ) );
+    }
+
+    tabWidget.show();
+    QCoreApplication::processEvents();
+
+    QStringList actionTexts;
+    QString popupError;
+    bool popupObserved = false;
+    bool popupFinished = false;
+    QTimer::singleShot( 0, Qt::PreciseTimer, &tabWidget, [ & ] {
+        auto* const menu = qobject_cast<QMenu*>( QApplication::activePopupWidget() );
+        if ( menu == nullptr ) {
+            popupError = QStringLiteral( "Tabbed context menu was not active" );
+            popupFinished = true;
+            if ( auto* popup = QApplication::activePopupWidget() ) {
+                popup->close();
+            }
+            return;
+        }
+
+        popupObserved = true;
+        for ( const auto* action : menu->actions() ) {
+            if ( !action->isSeparator() ) {
+                actionTexts.push_back( action->text() );
+            }
+        }
+        popupFinished = true;
+        menu->close();
+    } );
+    QTimer::singleShot( 250, Qt::PreciseTimer, &tabWidget, [ & ] {
+        if ( !popupFinished ) {
+            popupError = QStringLiteral( "Tabbed context menu watchdog expired" );
+            popupFinished = true;
+            if ( auto* popup = QApplication::activePopupWidget() ) {
+                popup->close();
+            }
+        }
+    } );
+
+    const auto invoked
+        = QMetaObject::invokeMethod( &tabWidget, "showContextMenu", Qt::DirectConnection,
+                                     Q_ARG( int, 1 ),
+                                     Q_ARG( QPoint, tabWidget.mapToGlobal( QPoint( 20, 20 ) ) ) );
+    REQUIRE( invoked );
+    REQUIRE( popupError.isEmpty() );
+    REQUIRE( popupObserved );
+
+    const QStringList expectedTexts{
+        QStringLiteral( "Close This" ),
+        QStringLiteral( "Close Others" ),
+        QStringLiteral( "Close to the Left" ),
+        QStringLiteral( "Close to the Right" ),
+        QStringLiteral( "Close All" ),
+        QStringLiteral( "Copy Full Path" ),
+        QStringLiteral( "Open Containing Folder" ),
+        QStringLiteral( "Rename Tab..." ),
+        QStringLiteral( "Reset Tab Name" ),
+    };
+    for ( const auto& expectedText : expectedTexts ) {
+        CAPTURE( expectedText );
+        CHECK( actionTexts.contains( expectedText ) );
+    }
 }
 
 TEST_CASE( "TabbedCrawlerWidget does not handle Ctrl+Tab in keyPressEvent" )

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -420,7 +420,7 @@ TEST_CASE( "TabbedCrawlerWidget context menu uses app Title Case and semantic el
         popupFinished = true;
         menu->close();
     } );
-    QTimer::singleShot( 250, Qt::PreciseTimer, &tabWidget, [ & ] {
+    QTimer::singleShot( 250, Qt::PreciseTimer, &tabWidget, [ & ] { // lint-allow: platform-fragile
         if ( !popupFinished ) {
             popupError = QStringLiteral( "Tabbed context menu watchdog expired" );
             popupFinished = true;


### PR DESCRIPTION
## Summary
- replace per-widget Filter Favorites snapshots with one ordered observable model shared by file, folder, and live-stream search toolbars
- keep the closed favorites control compact while giving long names a screen-bounded, horizontally scrollable popup
- make dialog, toolbar, and import/export mutations update every bound toolbar immediately while preserving manual order
- persist favorite mutations through a locked compare-and-replace transaction, publish only verified durable state, and report duplicate names, conflicts, lock failures, malformed storage, and write failures distinctly
- bound imported and stored collections before allocation, and preserve the last valid model state when application settings are invalid
- retain the file-path favorites feature as **Favorite Files**, refresh it on menu open, and harden stale multi-window add/remove behavior
- reserve literal `Ctrl+G` for Go to Line on every platform, migrate exact persisted legacy defaults without touching custom bindings, and filter conflicting native Find Next bindings for both shortcut dispatch and QuickFind
- normalize app-owned main, tray, tab, search, path, info, and log-view menu labels to Title Case with semantic ellipses, updating English and Chinese catalogs
- replace platform-sensitive message-box/watchdog tests with deterministic presentation and dialog-lifecycle seams
- add fast changed-line clang-tidy and platform-fragility guards so the PR's CI-only failure classes are exposed locally

## Background
- **Introduced by:** the historical pull-based Filter Favorites implementation and independently evolved menu/action labels; the first PR revision also published model changes before confirming durable storage
- **Use case:** users save and manage named filters across all document types without sacrificing the primary filter input, and expect immediate, durable consistency in every tab
- **How to reproduce:** save a several-hundred-character favorite name; edit favorites while a folder tab is active; import malformed or oversized settings; race edits from two windows; or run the old modal warning tests under Windows Qt5 offscreen or sanitizer builds
- **Root cause:** every combo cached settings independently and refreshed through configuration/tab-switch side effects; the closed control sized itself from the longest item; compare and write were separate operations; Preferences materialized old shortcut defaults as persistent overrides; tests constructed real message boxes or relied on elapsed-time modal callbacks; local verification omitted CI's changed-line clang-tidy sweep
- **How to fix:** centralize ordered state in `FilterFavoritesModel`, put validation and locked durable compare-and-replace in the settings adapter, publish only verified outcomes, separate closed and popup sizing, migrate only exact legacy shortcut defaults, route UI notifications and decision-dialog execution through scoped presenters, share safe Find Next bindings, and centralize/audit app-owned menu text

## Tests
- built all project targets, including the app, portable app, unit/UI tests, vectorscan tests, and benchmarks
- `ctest --test-dir build_root --build-config RelWithDebInfo --output-on-failure` — 4/4 passed
- complete unit suite — 7,986 assertions in 554 test cases passed
- complete UI suite — 3,694 assertions in 162 test cases passed
- focused Filter Favorites unit tests — 460 assertions in 31 test cases passed
- focused Filter Favorites UI tests — 52 assertions in 2 test cases passed
- Python script tests — 251 passed
- `python3 scripts/lint_platform_fragile.py`
- `python3 scripts/lint_header_self_contained.py --all` — 157/157 headers passed
- fast changed clang-tidy against `HEAD` and full CI-equivalent changed-line/header-fan-out clang-tidy against `origin/master`
- English, Simplified Chinese, and Traditional Chinese `lrelease` validation
- targeted cppcheck over the changed Filter Favorites code
- `git diff --check`

The existing untracked `build_root.stale/` and `tests/scripts/__pycache__/` directories remain untouched and are not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added centralized Filter Favorites management with create, edit, import, and export support.
  - Added safeguards for invalid files, duplicate entries, and concurrent changes.
  - Improved filter-favorite menus and popup sizing.
  - Added localized labels and actions for English, Simplified Chinese, and Traditional Chinese.

- **Bug Fixes**
  - Assigned `Ctrl+G` exclusively to Go to Line and improved Find Next shortcut handling.
  - Prevented errors when removing unavailable Favorite Files.

- **Documentation**
  - Updated shortcut and menu documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
