### PR TITLE
Harden live capture publication and make CI releases deterministic

### DIFF
--- a/.github/actions/agent-package-mac/action.yml
+++ b/.github/actions/agent-package-mac/action.yml
@@ -486,6 +486,8 @@ runs:
             "packages": [{"name": dmg.name, "sha256": digest(dmg)}],
         }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         PY
+        cp "$mounted_support/ios-native-package-receipt.json" \
+          "$KLOGG_BUILD_ROOT/packages/ios-native-package-receipt.json"
 
     - name: Sign and verify macOS disk image
       if: ${{ inputs.qualification-mode == 'release' }}
@@ -581,7 +583,6 @@ runs:
           --signing-receipt "$KLOGG_BUILD_ROOT/adb-helper-signing-receipt.json" \
           --notarization-receipt "$KLOGG_BUILD_ROOT/adb-helper-notarization-receipt.json" \
           --package-file "$dmg" \
-          --package-verification-receipt "$KLOGG_BUILD_ROOT/adb-helper-dmg-package-verification.json" \
           --checksum-envelope "$KLOGG_BUILD_ROOT/adb-helper-staged/SHA256SUMS" \
           --require-lock-binding
         mount_dir=$(mktemp -d)
@@ -629,6 +630,26 @@ runs:
           --legal-receipt "$mounted_support/ios-native-legal-receipt.json" \
           --sbom "$mounted_support/ios-native-sbom.spdx.json" \
           --verify-package-receipt "$mounted_support/ios-native-package-receipt.json"
+        mounted_helper="$mounted_app/Contents/MacOS/helpers/adb"
+        python3 scripts/smoke_adb_helper.py \
+          --adb "$mounted_helper" --port 0 --timeout-seconds 15 \
+          --json-output "$KLOGG_BUILD_ROOT/adb-helper-dmg-signed-mounted-smoke.json"
+        python3 scripts/verify_adb_helper_artifact.py \
+          --lock packaging/adb/adb-helper.lock.json \
+          --receipt "$KLOGG_BUILD_ROOT/adb-helper-staged/receipt.json" \
+          --binary-smoke-receipt "$KLOGG_BUILD_ROOT/adb-helper-dmg-signed-mounted-smoke.json" \
+          --package-root "$mount_dir" \
+          --asset-scope package \
+          --source-assets-root "$mounted_app/Contents/SharedSupport/adb-helper" \
+          --layout dmg \
+          --expected-target "${{ matrix.config.adb_target }}" \
+          --package-target "${{ matrix.config.adb_target }}-dmg" \
+          --signing-receipt "$KLOGG_BUILD_ROOT/adb-helper-signing-receipt.json" \
+          --notarization-receipt "$KLOGG_BUILD_ROOT/adb-helper-notarization-receipt.json" \
+          --package-file "$dmg" \
+          --package-verification-receipt "$KLOGG_BUILD_ROOT/adb-helper-dmg-package-verification.json" \
+          --checksum-envelope "$KLOGG_BUILD_ROOT/adb-helper-staged/SHA256SUMS" \
+          --require-lock-binding
         python3 - \
           "$dmg" \
           "$mounted_support/ios-native-package-receipt.json" \
@@ -644,12 +665,15 @@ runs:
         output.write_text(json.dumps({
             "schema_version": 1,
             "receipt_kind": "ios-native-package-verification",
+            "qualification": "signed",
             "release_qualified": True,
             "source_set_receipt_sha256": source_set_hash,
             "ios_native_package_receipt_sha256": digest(package_receipt_path),
             "packages": [{"name": dmg.name, "sha256": digest(dmg)}],
         }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         PY
+        cp "$mounted_support/ios-native-package-receipt.json" \
+          "$KLOGG_BUILD_ROOT/packages/ios-native-package-receipt.json"
         cp "$KLOGG_BUILD_ROOT/adb-helper-dmg-package-verification.json" "$KLOGG_BUILD_ROOT/packages/"
         cp "$KLOGG_BUILD_ROOT/adb-helper-signing-receipt.json" "$KLOGG_BUILD_ROOT/packages/"
         cp "$KLOGG_BUILD_ROOT/adb-helper-notarization-receipt.json" "$KLOGG_BUILD_ROOT/packages/"

--- a/.github/actions/agent-package-mac/action.yml
+++ b/.github/actions/agent-package-mac/action.yml
@@ -1,6 +1,9 @@
 name: "Prepare klogg mac packages"
 description: Deploy, verify, sign, notarize, and package the macOS application
 inputs:
+  qualification-mode:
+    description: validation for secret-neutral CI, release for signing and notarization
+    required: true
   p12-file-base64:
     required: false
   p12-password:
@@ -19,9 +22,24 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Mac release signing and notarization preflight
-      if: ${{ github.event_name != 'pull_request' }}
+    - name: Validate macOS qualification mode
       shell: sh
+      run: |
+        case "${{ inputs.qualification-mode }}" in
+          validation|release) ;;
+          *) echo "::error::qualification-mode must be validation or release"; exit 1 ;;
+        esac
+
+    - name: Mac release signing and notarization preflight
+      if: ${{ inputs.qualification-mode == 'release' }}
+      shell: sh
+      env:
+        KLOGG_P12_FILE_BASE64: ${{ inputs.p12-file-base64 }}
+        KLOGG_P12_PASSWORD: ${{ inputs.p12-password }}
+        KLOGG_CODESIGN_IDENTITY_INPUT: ${{ inputs.codesign-identity }}
+        KLOGG_NOTARIZATION_USERNAME: ${{ inputs.notarization-username }}
+        KLOGG_NOTARIZATION_TEAM: ${{ inputs.notarization-team }}
+        KLOGG_NOTARIZATION_PASSWORD: ${{ inputs.notarization-password }}
       run: |
         set -eu
         missing=0
@@ -33,17 +51,17 @@ runs:
             missing=1
           fi
         }
-        require_input "p12-file-base64" "${{ inputs.p12-file-base64 }}"
-        require_input "p12-password" "${{ inputs.p12-password }}"
-        require_input "codesign-identity" "${{ inputs.codesign-identity }}"
-        require_input "notarization-username" "${{ inputs.notarization-username }}"
-        require_input "notarization-team" "${{ inputs.notarization-team }}"
-        require_input "notarization-password" "${{ inputs.notarization-password }}"
+        require_input "p12-file-base64" "$KLOGG_P12_FILE_BASE64"
+        require_input "p12-password" "$KLOGG_P12_PASSWORD"
+        require_input "codesign-identity" "$KLOGG_CODESIGN_IDENTITY_INPUT"
+        require_input "notarization-username" "$KLOGG_NOTARIZATION_USERNAME"
+        require_input "notarization-team" "$KLOGG_NOTARIZATION_TEAM"
+        require_input "notarization-password" "$KLOGG_NOTARIZATION_PASSWORD"
         test "${missing}" -eq 0
 
     - name: Import macOS release signing certificate
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: apple-actions/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071 # v1
+      if: ${{ inputs.qualification-mode == 'release' }}
+      uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
       with:
         p12-file-base64: ${{ inputs.p12-file-base64 }}
         p12-password: ${{ inputs.p12-password }}
@@ -232,14 +250,17 @@ runs:
 
     - name: Set packaging env
       shell: sh
+      env:
+        KLOGG_CODESIGN_IDENTITY_INPUT: ${{ inputs.codesign-identity }}
+        KLOGG_INSTALLERSIGN_IDENTITY_INPUT: ${{ inputs.installer-sign-identity }}
       run: |
-        echo "KLOGG_CODESIGN=${{ inputs.codesign-identity }}" >> $GITHUB_ENV
-        echo "KLOGG_INSTALLERSIGN=${{ inputs.installer-sign-identity }}" >> $GITHUB_ENV
+        printf 'KLOGG_CODESIGN=%s\n' "$KLOGG_CODESIGN_IDENTITY_INPUT" >> "$GITHUB_ENV"
+        printf 'KLOGG_INSTALLERSIGN=%s\n' "$KLOGG_INSTALLERSIGN_IDENTITY_INPUT" >> "$GITHUB_ENV"
         echo "KLOGG_DMG=klogg-${{ env.KLOGG_VERSION }}-mac-${{ env.KLOGG_ARCH }}-${{ env.KLOGG_PACKAGE_TAG }}.dmg" >> $GITHUB_ENV
         echo "KLOGG_PKG=klogg-${{ env.KLOGG_VERSION }}-mac-${{ env.KLOGG_ARCH }}-${{ env.KLOGG_PACKAGE_TAG }}.pkg" >> $GITHUB_ENV
 
     - name: Sign and verify macOS application bundle
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.qualification-mode == 'release' }}
       shell: sh
       run: |
         set -euo pipefail
@@ -248,7 +269,7 @@ runs:
         codesign --verify --deep --strict --verbose=2 "$KLOGG_MAC_APP"
 
     - name: Bind and reverify signed iOS native closure
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.qualification-mode == 'release' }}
       shell: sh
       run: |
         set -euo pipefail
@@ -377,8 +398,97 @@ runs:
         mv ./packages/klogg-${{ env.KLOGG_VERSION }}-OSX.dmg ./packages/${{ env.KLOGG_DMG }}
         echo "Renamed DMG to: ${{ env.KLOGG_DMG }}"
 
+    - name: Validate unsigned macOS disk image
+      if: ${{ inputs.qualification-mode == 'validation' }}
+      shell: sh
+      run: |
+        set -euo pipefail
+        dmg="$KLOGG_BUILD_ROOT/packages/$KLOGG_DMG"
+        mount_dir=$(mktemp -d)
+        mounted_device=""
+        cleanup_mounted_dmg() {
+          if [ -n "${mounted_device}" ]; then
+            if ! hdiutil detach "${mounted_device}" -force >/dev/null; then
+              echo "warning: failed to detach mounted DMG device ${mounted_device}" >&2
+            fi
+          fi
+          rm -rf "${mount_dir}"
+        }
+        trap cleanup_mounted_dmg EXIT
+        attach_output=$(hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mount_dir")
+        mounted_device=$(printf '%s\n' "$attach_output" | awk '$1 ~ /^\/dev\// { device=$1 } END { print device }')
+        test -n "$mounted_device" || { echo "::error::failed to identify mounted DMG device"; exit 1; }
+        mounted_app=$(find "$mount_dir" -maxdepth 1 -type d -name '*.app' -print -quit)
+        test -n "$mounted_app" || { echo "::error::mounted DMG has no application bundle"; exit 1; }
+        mounted_stack="$mounted_app/Contents/Frameworks/ios-native"
+        mounted_support="$mounted_app/Contents/SharedSupport/ios-native"
+        case "${KLOGG_ARCH}" in
+          x64) native_arch=x86_64 ;;
+          arm64) native_arch=arm64 ;;
+          *) echo "::error::unsupported macOS validation architecture: ${KLOGG_ARCH}"; exit 1 ;;
+        esac
+        python3 scripts/verify_macos_qt_bundle.py \
+          --app "$mounted_app" \
+          --expected-architecture "$native_arch" \
+          --smoke cocoa \
+          --smoke-if-present offscreen \
+          --runtime-log-output "$KLOGG_BUILD_ROOT/macos-qt-mounted-dmg-smoke.log"
+        python3 scripts/verify_ios_native_stack.py \
+          --lock 3rdparty/libimobiledevice/libimobiledevice.lock.json \
+          --stack-root "$mounted_stack" \
+          --architecture "$native_arch" \
+          --receipt "$KLOGG_IOS_NATIVE_STACK_ROOT/ios-native-build-receipt.json" \
+          --app-executable "$mounted_app/Contents/MacOS/klogg" \
+          --source-receipt "$mounted_support/ios-native-source-set-receipt.json" \
+          --asset-scope package \
+          --source-assets-root "$mounted_support" \
+          --legal-receipt "$mounted_support/ios-native-legal-receipt.json" \
+          --sbom "$mounted_support/ios-native-sbom.spdx.json" \
+          --verify-package-receipt "$mounted_support/ios-native-package-receipt.json" \
+          --unsigned-package-stage
+        mounted_helper="$mounted_app/Contents/MacOS/helpers/adb"
+        python3 scripts/smoke_adb_helper.py \
+          --adb "$mounted_helper" --port 0 --timeout-seconds 15 \
+          --json-output "$KLOGG_BUILD_ROOT/adb-helper-dmg-validation-smoke.json"
+        python3 scripts/verify_adb_helper_artifact.py \
+          --lock packaging/adb/adb-helper.lock.json \
+          --receipt "$KLOGG_BUILD_ROOT/adb-helper-staged/receipt.json" \
+          --binary-smoke-receipt "$KLOGG_BUILD_ROOT/adb-helper-dmg-validation-smoke.json" \
+          --package-root "$mount_dir" \
+          --asset-scope package \
+          --source-assets-root "$mounted_app/Contents/SharedSupport/adb-helper" \
+          --layout dmg \
+          --expected-target "${{ matrix.config.adb_target }}" \
+          --package-target "${{ matrix.config.adb_target }}-dmg" \
+          --package-file "$dmg" \
+          --package-verification-receipt "$KLOGG_BUILD_ROOT/packages/adb-helper-dmg-package-verification.json" \
+          --checksum-envelope "$KLOGG_BUILD_ROOT/adb-helper-staged/SHA256SUMS" \
+          --require-lock-binding
+        python3 - \
+          "$dmg" \
+          "$mounted_support/ios-native-package-receipt.json" \
+          "$mounted_support/ios-native-source-set-receipt.json" \
+          "$KLOGG_BUILD_ROOT/packages/ios-native-dmg-package-verification.json" <<'PY'
+        import hashlib, json, pathlib, sys
+        dmg, package_receipt_path, source_set_path, output = map(pathlib.Path, sys.argv[1:5])
+        digest = lambda path: hashlib.sha256(path.read_bytes()).hexdigest()
+        package_receipt = json.loads(package_receipt_path.read_text(encoding="utf-8"))
+        source_set_hash = digest(source_set_path)
+        if package_receipt.get("source_set_receipt_sha256") != source_set_hash:
+            raise SystemExit("iOS package receipt source-set binding mismatch")
+        output.write_text(json.dumps({
+            "schema_version": 1,
+            "receipt_kind": "ios-native-package-verification",
+            "qualification": "validation",
+            "release_qualified": False,
+            "source_set_receipt_sha256": source_set_hash,
+            "ios_native_package_receipt_sha256": digest(package_receipt_path),
+            "packages": [{"name": dmg.name, "sha256": digest(dmg)}],
+        }, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        PY
+
     - name: Sign and verify macOS disk image
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.qualification-mode == 'release' }}
       shell: sh
       run: |
         set -euo pipefail
@@ -387,15 +497,19 @@ runs:
         codesign --verify --strict --verbose=2 "./packages/$KLOGG_DMG"
 
     - name: Notarize staple and validate macOS disk image
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ inputs.qualification-mode == 'release' }}
       shell: sh
+      env:
+        KLOGG_NOTARIZATION_USERNAME: ${{ inputs.notarization-username }}
+        KLOGG_NOTARIZATION_TEAM: ${{ inputs.notarization-team }}
+        KLOGG_NOTARIZATION_PASSWORD: ${{ inputs.notarization-password }}
       run: |
         set -euo pipefail
         dmg="$KLOGG_BUILD_ROOT/packages/$KLOGG_DMG"
         xcrun notarytool submit --wait --output-format json \
-          --apple-id "${{ inputs.notarization-username }}" \
-          --team-id "${{ inputs.notarization-team }}" \
-          --password "${{ inputs.notarization-password }}" \
+          --apple-id "$KLOGG_NOTARIZATION_USERNAME" \
+          --team-id "$KLOGG_NOTARIZATION_TEAM" \
+          --password "$KLOGG_NOTARIZATION_PASSWORD" \
           "$dmg" | tee "$KLOGG_BUILD_ROOT/dmg-notarytool-receipt.json"
         xcrun stapler staple "$dmg"
         xcrun stapler validate "$dmg"
@@ -409,7 +523,7 @@ runs:
           "$KLOGG_BUILD_ROOT/adb-helper-signing-receipt.json" \
           "$KLOGG_BUILD_ROOT/adb-helper-notarization-receipt.json" \
           "$KLOGG_CODESIGN" \
-          "${{ inputs.notarization-team }}" \
+          "$KLOGG_NOTARIZATION_TEAM" \
           "${{ matrix.config.adb_target }}" <<'PY'
         import hashlib, json, pathlib, sys
         dmg, helper, notary_path, build_receipt_path, signing_path, notarization_path = map(pathlib.Path, sys.argv[1:7])
@@ -474,7 +588,9 @@ runs:
         mounted_device=""
         cleanup_mounted_dmg() {
           if [ -n "${mounted_device}" ]; then
-            hdiutil detach "${mounted_device}" -force >/dev/null
+            if ! hdiutil detach "${mounted_device}" -force >/dev/null; then
+              echo "warning: failed to detach mounted DMG device ${mounted_device}" >&2
+            fi
           fi
           rm -rf "${mount_dir}"
         }
@@ -537,37 +653,6 @@ runs:
         cp "$KLOGG_BUILD_ROOT/adb-helper-dmg-package-verification.json" "$KLOGG_BUILD_ROOT/packages/"
         cp "$KLOGG_BUILD_ROOT/adb-helper-signing-receipt.json" "$KLOGG_BUILD_ROOT/packages/"
         cp "$KLOGG_BUILD_ROOT/adb-helper-notarization-receipt.json" "$KLOGG_BUILD_ROOT/packages/"
-
-    #- name: "Mac build pkg"
-    #  if: ${{ github.event_name != 'pull_request' }}
-    #  shell: sh
-    #  run: |
-    #    cd $KLOGG_BUILD_ROOT
-    #    mkdir -p packages
-    #    mkdir -p pkg_resources/en.lproj
-    #    cp ../COPYING pkg_resources/en.lproj
-    #    cp ../packaging/description.txt pkg_resources/en.lproj
-    #    sed -e s/%klogg_version%/${{ env.KLOGG_VERSION }}/ -e s/%klogg_pkg%/klogg-${{ env.KLOGG_VERSION }}-OSX.pkg/ ./generated/distribution.xml > distribution.xml
-    #    pkgbuild --component "$KLOGG_MAC_APP" --install-location /Applications --version ${{ env.KLOGG_VERSION }} --sign "${{ env.KLOGG_INSTALLERSIGN }}" --timestamp ./output/klogg-${{ env.KLOGG_VERSION }}-OSX.pkg
-    #    productbuild --package-path ./output --distribution distribution.xml --resources ./pkg_resources --sign "${{ env.KLOGG_INSTALLERSIGN }}" --timestamp ./output/klogg-${{ env.KLOGG_VERSION }}-OSX-product.pkg
-    #    pkgutil --expand ./output/klogg-${{ env.KLOGG_VERSION }}-OSX-product.pkg ./output/klogg_product_pkg
-    #    pkgutil --flatten ./output/klogg_product_pkg ./output/klogg-${{ env.KLOGG_VERSION }}-OSX-flatten.pkg
-    #    productsign --sign "${{ env.KLOGG_INSTALLERSIGN }}" --timestamp ./output/klogg-${{ env.KLOGG_VERSION }}-OSX-flatten.pkg ./packages/${{ env.KLOGG_PKG }}
-
-    #- name: Mac notarize PKG 
-    #  if: ${{ github.event_name != 'pull_request' }} 
-    #  shell: sh
-    #  run: |
-    #    xcrun notarytool submit  --wait --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_PKG }}" | tee pkg_notary.log
-    #    pkg_notary_id=$(awk '$1=="id:"{id=$2} END{print id}' pkg_notary.log)
-    #    xcrun notarytool log --apple-id "${{ inputs.notarization-username }}" --team-id "${{ inputs.notarization-team }}" --password "${{ inputs.notarization-password }}" "$pkg_notary_id" "pkg_notary.log.json"
-    #    cat "pkg_notary.log.json"
-
-    #- name: Mac staple PKG 
-    #  if: ${{ github.event_name != 'pull_request' }} 
-    #  shell: sh 
-    #  run: |
-    #    xcrun stapler staple "${{ env.KLOGG_BUILD_ROOT }}/packages/${{ env.KLOGG_PKG }}"
 
     - name: Mac symbols
       shell: sh

--- a/.github/actions/agent-package-win/action.yml
+++ b/.github/actions/agent-package-win/action.yml
@@ -41,10 +41,15 @@ runs:
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Win installer
-      uses: joncloud/makensis-action@971ef20f43e4f9f3af2c7f276cb7348d033da1cd # v5.0
-      with:
-        script-file: klogg.nsi
-        arguments: "-DVERSION=%KLOGG_VERSION% -DPLATFORM=%KLOGG_ARCH% -DQT_MAJOR=%KLOGG_QT%" 
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $makensis = (Get-Command makensis.exe -ErrorAction Stop).Source
+        & $makensis "/V3" "/DVERSION=$env:KLOGG_VERSION" `
+          "/DPLATFORM=$env:KLOGG_ARCH" "/DQT_MAJOR=$env:KLOGG_QT" "klogg.nsi"
+        if ($LASTEXITCODE -ne 0) {
+          throw "makensis failed with exit code $LASTEXITCODE"
+        }
     
     - name: Win package
       shell: cmd

--- a/.github/actions/agent-package-win/action.yml
+++ b/.github/actions/agent-package-win/action.yml
@@ -1,12 +1,5 @@
 name: "Prepare windows packages"
 description: Verify and package the target-matched Windows application and ADB helper
-inputs:
-  s3-key-id:
-    required: true
-  s3-secret:
-    required: true
-  s3-bucket:
-    required: true
 runs:
   using: "composite"
   steps:
@@ -48,7 +41,7 @@ runs:
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Win installer
-      uses: joncloud/makensis-action@v3.3
+      uses: joncloud/makensis-action@971ef20f43e4f9f3af2c7f276cb7348d033da1cd # v5.0
       with:
         script-file: klogg.nsi
         arguments: "-DVERSION=%KLOGG_VERSION% -DPLATFORM=%KLOGG_ARCH% -DQT_MAJOR=%KLOGG_QT%" 

--- a/.github/actions/agent-setup/action.yml
+++ b/.github/actions/agent-setup/action.yml
@@ -1,14 +1,17 @@
 name: "Setup agent"
-description: ""
+description: Install the pinned CMake, Ninja, Qt, Boost, and CPM build dependencies
 runs:
   using: "composite"
   steps:
-    - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+    - name: Install CMake and Ninja
+      uses: lukka/get-cmake@fffaaafeea488556c2c12dad60690008bc1caacb # v4.4.2
+      with:
+        cmakeVersion: 3.31.6
+        ninjaVersion: 1.12.1
 
     - name: Install Qt
       if: ${{ matrix.config.qt_arch }}
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
       with:
         version: ${{ matrix.config.qt_version }}
         arch: ${{ matrix.config.qt_arch }}
@@ -24,7 +27,7 @@ runs:
 
     - name: Restore Boost cache
       if: ${{ env.KLOGG_REQUIRE_PREFETCHED_BOOST != 'ON' }}
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
@@ -32,7 +35,7 @@ runs:
 
     - name: Restore CPM cache
       if: ${{ env.KLOGG_REQUIRE_PREFETCHED_CPM != 'ON' }}
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ${{ github.workspace }}/cpm_cache
         key: CPM-${{ hashFiles('3rdparty/CMakeLists.txt', 'cmake/CPM.cmake', '3rdparty/patches/**', 'cmake/prefetch_cpm/CMakeLists.txt') }}${{ env.KLOGG_CPM_CACHE_KEY_SUFFIX }}

--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -1,0 +1,55 @@
+name: Setup MSVC environment
+description: Initialize a pinned GitHub-hosted Visual Studio toolchain without a Node action runtime
+inputs:
+  arch:
+    description: Target architecture (x64 or x86)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Initialize Visual Studio developer shell
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        $target = "${{ inputs.arch }}"
+        if ($target -notin @("x64", "x86")) {
+          throw "Unsupported MSVC target architecture: $target"
+        }
+
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        if (!(Test-Path $vswhere)) {
+          throw "vswhere is missing: $vswhere"
+        }
+        $installation = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        if (!$installation) {
+          throw "Visual Studio with the MSVC x86/x64 tools was not found"
+        }
+        $launcher = Join-Path $installation "Common7\Tools\Launch-VsDevShell.ps1"
+        if (!(Test-Path $launcher)) {
+          throw "Visual Studio developer-shell launcher is missing: $launcher"
+        }
+
+        $developerShellArch = if ($target -eq "x64") { "amd64" } else { "x86" }
+        $before = @{}
+        Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
+        & $launcher -Arch $developerShellArch -HostArch amd64 -SkipAutomaticLocation
+
+        Get-ChildItem Env: | ForEach-Object {
+          if (!$before.ContainsKey($_.Name) -or $before[$_.Name] -ne $_.Value) {
+            if ($_.Value -match "`r|`n") {
+              throw "MSVC environment variable contains a newline: $($_.Name)"
+            }
+            "$($_.Name)=$($_.Value)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
+        }
+
+        $probe = Join-Path $env:RUNNER_TEMP "klogg-msvc-probe.c"
+        $object = Join-Path $env:RUNNER_TEMP "klogg-msvc-probe.obj"
+        "int main(void) { return 0; }" | Set-Content -Path $probe -Encoding ascii
+        & cl /nologo /Bv /c $probe "/Fo$object"
+        if ($LASTEXITCODE -ne 0 -or !(Test-Path $object)) {
+          throw "MSVC compiler probe failed with exit code $LASTEXITCODE"
+        }
+        if ($env:VSCMD_ARG_TGT_ARCH -ne $target) {
+          throw "MSVC target architecture mismatch: expected $target, got $env:VSCMD_ARG_TGT_ARCH"
+        }

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -32,8 +32,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  attestations: write
 
 concurrency:
   # Release qualification must not share a queue with ordinary master pushes.
@@ -60,6 +58,10 @@ jobs:
           KLOGG_NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
         run: |
           set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/master" || {
+            echo "::error::Signed release qualification must run from master"
+            exit 1
+          }
           missing=0
           for name in \
             KLOGG_P12_FILE_BASE64 \
@@ -76,7 +78,6 @@ jobs:
           test "$missing" -eq 0
 
   SaveVersion:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-22.04
     outputs:
@@ -104,7 +105,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchCpmCache:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch CPM cache"
     runs-on: ubuntu-22.04
@@ -137,7 +137,6 @@ jobs:
           compression-level: 0
 
   PrefetchBoost:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Boost"
     runs-on: ubuntu-22.04
@@ -203,7 +202,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchOpenSsl:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Windows Qt 5 OpenSSL"
     runs-on: ubuntu-22.04
@@ -252,7 +250,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchLinuxDeployQt:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch linuxdeployqt"
     runs-on: ubuntu-22.04
@@ -300,7 +297,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchCmakeInstaller:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Linux CMake installer"
     runs-on: ubuntu-22.04
@@ -351,7 +347,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchWindowsTools:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Windows MSYS2 tools"
     runs-on: windows-2022
@@ -474,7 +469,6 @@ jobs:
           if-no-files-found: error
 
   PrefetchAdbHelperSources:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch locked ADB helper source closure"
     runs-on: ubuntu-24.04
@@ -553,7 +547,11 @@ jobs:
           compression-level: 0
 
   BuildAdbHelpers:
-    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    needs: [BuildAdbHelperLegalAssets]
+    permissions: &artifact_attestation_permissions
+      contents: read
+      id-token: write
+      attestations: write
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Source-built ADB helper ${{ matrix.target }}"
     strategy:
@@ -670,7 +668,8 @@ jobs:
           subject-path: ${{ runner.temp }}/adb-helper-artifact/SHA256SUMS
 
   BuildAdbLinuxArm64:
-    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    needs: [BuildAdbHelperLegalAssets]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Source-built ADB helper ${{ matrix.target }}"
     strategy:
@@ -684,7 +683,8 @@ jobs:
     steps: *adb_helper_steps
 
   BuildAdbWindowsX64:
-    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    needs: [BuildAdbHelperLegalAssets]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Source-built ADB helper ${{ matrix.target }}"
     strategy:
@@ -698,7 +698,8 @@ jobs:
     steps: *adb_helper_steps
 
   BuildAdbMacX64:
-    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    needs: [BuildAdbHelperLegalAssets]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Source-built ADB helper ${{ matrix.target }}"
     strategy:
@@ -712,7 +713,8 @@ jobs:
     steps: *adb_helper_steps
 
   BuildAdbMacArm64:
-    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    needs: [BuildAdbHelperLegalAssets]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Source-built ADB helper ${{ matrix.target }}"
     strategy:
@@ -727,6 +729,9 @@ jobs:
 
   LinuxPackages:
     needs: [SaveVersion, PrefetchCpmCache, PrefetchLinuxDeployQt, PrefetchCmakeInstaller, BuildAdbHelpers]
+    permissions: &artifact_verification_permissions
+      contents: read
+      attestations: read
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Linux ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -740,6 +745,8 @@ jobs:
             os_version: 22.04
             arch: x64
             label: ubuntu-22.04-deb
+            cache_write: true
+            cache_scope: klogg-linux-ubuntu22.04
             package_tag: vs-gen
             cpack_gen: DEB
             artifacts_id: jammy
@@ -756,6 +763,8 @@ jobs:
             os_version: 24.04
             arch: x64
             label: ubuntu-24.04-deb
+            cache_write: true
+            cache_scope: klogg-linux-ubuntu24.04
             package_tag: vs-gen
             check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
             cpack_gen: DEB
@@ -772,6 +781,8 @@ jobs:
             os_version: 26.04
             arch: x64
             label: ubuntu-26.04-deb
+            cache_write: true
+            cache_scope: klogg-linux-ubuntu26.04
             package_tag: vs-gen
             check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
             cpack_gen: DEB
@@ -792,6 +803,8 @@ jobs:
             os_version: 20.04
             arch: x64
             label: ubuntu-20.04-appimage
+            cache_write: true
+            cache_scope: klogg-linux-ubuntu20.04
             package_tag: vs-gen
             artifacts_id: appimage
             package_suffix: AppImage
@@ -828,8 +841,9 @@ jobs:
           archive="$archive_root/adb-helper-linux-x86_64.tar.gz"
           test -f "$archive"
           rm -rf "$artifact_root"
-          mkdir -p "$artifact_root"
-          tar -xzf "$archive" -C "$artifact_root"
+          python3 scripts/extract_verified_tar.py \
+            --archive "$archive" \
+            --destination "$artifact_root"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
@@ -902,7 +916,7 @@ jobs:
           load: true
           tags: ${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}
           cache-from: type=gha,scope=klogg-qt5-tsan
-          cache-to: type=gha,mode=max,scope=klogg-qt5-tsan
+          cache-to: ${{ github.event_name == 'push' && matrix.config.cache_write && 'type=gha,mode=max,scope=klogg-qt5-tsan' || '' }}
 
       - name: Set up Buildx for the Linux build images
         if: ${{ matrix.config.sanitizer != 'thread' }}
@@ -924,8 +938,8 @@ jobs:
           # single-stage images, so no intermediate stages are lost, and the
           # smaller footprint keeps the shared 10GB repo cache budget from
           # evicting the per-leg ccache entries that the restore step relies on.
-          cache-from: type=gha,scope=klogg-linux-${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}
-          cache-to: type=gha,mode=min,scope=klogg-linux-${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}
+          cache-from: type=gha,scope=${{ matrix.config.cache_scope }}
+          cache-to: ${{ github.event_name == 'push' && matrix.config.cache_write && format('type=gha,mode=min,scope={0}', matrix.config.cache_scope) || '' }}
 
       - name: Compute bounded ccache generation
         id: ccache-generation
@@ -1141,6 +1155,8 @@ jobs:
             os_version: 22.04
             arch: x64
             label: ubuntu-22.04-asan-lsan
+            cache_write: false
+            cache_scope: klogg-linux-ubuntu22.04
             package_tag: asan
             container_root: docker/ubuntu22.04
             container_suffix: _ubuntu22.04
@@ -1160,6 +1176,8 @@ jobs:
             os_version: 22.04
             arch: x64
             label: ubuntu-22.04-ubsan
+            cache_write: false
+            cache_scope: klogg-linux-ubuntu22.04
             package_tag: ubsan
             container_root: docker/ubuntu22.04
             container_suffix: _ubuntu22.04
@@ -1193,6 +1211,8 @@ jobs:
             os_version: 22.04
             arch: x64
             label: ubuntu-22.04-tsan
+            cache_write: true
+            cache_scope: klogg-qt5-tsan
             package_tag: tsan
             container_root: docker/ubuntu22.04-tsan
             container_suffix: _ubuntu22.04-tsan
@@ -1211,7 +1231,6 @@ jobs:
     steps: *linux_steps
 
   PrefetchIosNativeSources:
-    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch locked iOS native sources"
     runs-on: ubuntu-24.04
@@ -1243,6 +1262,7 @@ jobs:
 
   BuildIosNativeStacks:
     needs: [SaveVersion, PrefetchIosNativeSources]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "iOS native stack ${{ matrix.architecture }}"
     env:
@@ -1368,6 +1388,7 @@ jobs:
 
   BuildIosNativeArm64:
     needs: [SaveVersion, PrefetchIosNativeSources]
+    permissions: *artifact_attestation_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "iOS native stack ${{ matrix.architecture }}"
     env:
@@ -1384,7 +1405,8 @@ jobs:
     steps: *ios_native_steps
 
   MacPackages:
-    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacX64, BuildIosNativeStacks]
+    needs: [ReleaseQualificationPreflight, SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacX64, BuildIosNativeStacks]
+    permissions: *artifact_verification_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "macOS ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -1457,8 +1479,9 @@ jobs:
           archive="$archive_root/ios-native-${{ matrix.config.arch == 'x64' && 'x86_64' || 'arm64' }}.tar.gz"
           test -f "$archive"
           rm -rf "$stack_root"
-          mkdir -p "$stack_root"
-          tar -xzf "$archive" -C "$stack_root"
+          python3 scripts/extract_verified_tar.py \
+            --archive "$archive" \
+            --destination "$stack_root"
 
       - name: Verify target-bound iOS native checksum envelope and Mach-O closure
         if: ${{ matrix.config.package != false }}
@@ -1706,7 +1729,8 @@ jobs:
           key: ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.current }}
 
   MacArmPackages:
-    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacArm64, BuildIosNativeArm64]
+    needs: [ReleaseQualificationPreflight, SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacArm64, BuildIosNativeArm64]
+    permissions: *artifact_verification_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "macOS ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -1792,6 +1816,7 @@ jobs:
 
   WindowsPackages:
     needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, PrefetchWindowsTools, BuildAdbWindowsX64]
+    permissions: *artifact_verification_permissions
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -2286,7 +2311,7 @@ jobs:
 
   ci-gate:
     if: always()
-    needs: [BuildAdbHelpers, BuildAdbLinuxArm64, BuildAdbWindowsX64, BuildAdbMacX64, BuildAdbMacArm64, BuildIosNativeStacks, BuildIosNativeArm64, LinuxPackages, LinuxSanitizers, LinuxTsan, MacPackages, MacArmPackages, MacSanitizers, WindowsPackages, WindowsX86, WindowsAsan]
+    needs: [BuildAdbLinuxArm64, LinuxPackages, LinuxSanitizers, LinuxTsan, MacPackages, MacArmPackages, MacSanitizers, WindowsPackages, WindowsX86, WindowsAsan]
     runs-on: ubuntu-22.04
     steps:
       - name: Check CI results

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1353,11 +1353,23 @@ jobs:
           tar -czf "${{ runner.temp }}/${{ matrix.artifact }}.tar.gz" \
             -C "${{ runner.temp }}/ios-native-stack" .
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload iOS native stack
+        id: upload_ios_stack
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: ${{ runner.temp }}/${{ matrix.artifact }}.tar.gz
           if-no-files-found: error
+
+      - name: Retry iOS native stack upload after artifact-service failure
+        if: ${{ steps.upload_ios_stack.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ runner.temp }}/${{ matrix.artifact }}.tar.gz
+          if-no-files-found: error
+          overwrite: true
 
       - name: Upload architecture-independent iOS source set
         if: ${{ matrix.architecture == 'arm64' }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,6 +20,15 @@ on:
       - README.md
       - .gitignore
   workflow_dispatch:
+    inputs:
+      qualification-mode:
+        description: Secret-neutral validation, or explicit signed/notarized release qualification
+        required: true
+        default: validation
+        type: choice
+        options:
+          - validation
+          - release
 
 permissions:
   contents: read
@@ -27,23 +36,53 @@ permissions:
   attestations: write
 
 concurrency:
-  # Cancel superseded PR validation, but serialize master publication runs.
-  # A master run replaces the continuous tag/release; canceling it between
-  # deletion and recreation could leave the release missing indefinitely.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Release qualification must not share a queue with ordinary master pushes.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.qualification-mode == 'validation') }}
 
 env:
   KLOGG_CI_IMAGE_PREFIX: zeacent/klogg
 
 jobs:
+  ReleaseQualificationPreflight:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify release qualification inputs
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.qualification-mode == 'release' }}
+        shell: bash
+        env:
+          KLOGG_P12_FILE_BASE64: ${{ secrets.CODESIGN_BASE64 }}
+          KLOGG_P12_PASSWORD: ${{ secrets.CODESIGN_PASSWORD }}
+          KLOGG_CODESIGN_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          KLOGG_NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+          KLOGG_NOTARIZATION_TEAM: ${{ secrets.NOTARIZATION_TEAM }}
+          KLOGG_NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            KLOGG_P12_FILE_BASE64 \
+            KLOGG_P12_PASSWORD \
+            KLOGG_CODESIGN_IDENTITY \
+            KLOGG_NOTARIZATION_USERNAME \
+            KLOGG_NOTARIZATION_TEAM \
+            KLOGG_NOTARIZATION_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Missing release qualification secret: $name"
+              missing=1
+            fi
+          done
+          test "$missing" -eq 0
+
   SaveVersion:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-22.04
     outputs:
       klogg_version: ${{ steps.save-version.outputs.klogg_version }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/klogg-version
@@ -56,7 +95,7 @@ jobs:
           echo "$KLOGG_VERSION" > klogg_version.txt
           echo "$GITHUB_SHA" > klogg_commit.txt
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: klogg_version
           path: |
@@ -65,18 +104,19 @@ jobs:
           if-no-files-found: error
 
   PrefetchCpmCache:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch CPM cache"
     runs-on: ubuntu-22.04
     env:
       KLOGG_WORKSPACE: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Restore shared CPM cache
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ github.workspace }}/cpm_cache
           key: CPM-${{ hashFiles('3rdparty/CMakeLists.txt', 'cmake/CPM.cmake', '3rdparty/patches/**', 'cmake/prefetch_cpm/CMakeLists.txt') }}
@@ -89,7 +129,7 @@ jobs:
           tar -czf "$KLOGG_WORKSPACE/cpm-cache.tar.gz" \
             -C "$KLOGG_WORKSPACE" cpm_cache
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cpm-cache
           path: cpm-cache.tar.gz
@@ -97,6 +137,7 @@ jobs:
           compression-level: 0
 
   PrefetchBoost:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Boost"
     runs-on: ubuntu-22.04
@@ -106,7 +147,7 @@ jobs:
     steps:
       - name: Restore Boost prefetch cache
         id: cache-boost-prefetch
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ github.workspace }}/prefetch_artifacts/boost
           key: boost-prefetch-1-86-0
@@ -155,13 +196,14 @@ jobs:
           # reliably and tar is deterministic.
           tar -czf "$PREFETCH_ROOT/boost.tar.gz" -C "$PREFETCH_ROOT/boost" .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: boost-root
           path: prefetch_artifacts/boost.tar.gz
           if-no-files-found: error
 
   PrefetchOpenSsl:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Windows Qt 5 OpenSSL"
     runs-on: ubuntu-22.04
@@ -171,7 +213,7 @@ jobs:
     steps:
       - name: Restore OpenSSL prefetch cache
         id: cache-openssl-prefetch
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ github.workspace }}/prefetch_artifacts/openssl.zip
           key: openssl-prefetch-1-1-1w
@@ -203,13 +245,14 @@ jobs:
             sleep $((attempt * 10))
           done
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openssl-archive
           path: prefetch_artifacts/openssl.zip
           if-no-files-found: error
 
   PrefetchLinuxDeployQt:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch linuxdeployqt"
     runs-on: ubuntu-22.04
@@ -250,13 +293,14 @@ jobs:
             sleep $((attempt * 10))
           done
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: linuxdeployqt
           path: prefetch_artifacts/linuxdeployqt-continuous-x86_64.AppImage
           if-no-files-found: error
 
   PrefetchCmakeInstaller:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Linux CMake installer"
     runs-on: ubuntu-22.04
@@ -300,20 +344,21 @@ jobs:
             sleep $((attempt * 10))
           done
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cmake-installer
           path: prefetch_artifacts/cmake-3.20.2-linux-x86_64.sh
           if-no-files-found: error
 
   PrefetchWindowsTools:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch Windows MSYS2 tools"
     runs-on: windows-2022
     steps:
       - name: Restore MSYS2 tools cache
         id: cache-msys2-tools
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: prefetch_artifacts/msys2-tools.zip
           key: msys2-tools-mingw64-ragel-pkgconf-v1
@@ -422,20 +467,28 @@ jobs:
             exit 1
           }
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: msys2-tools
           path: prefetch_artifacts/msys2-tools.zip
           if-no-files-found: error
 
   PrefetchAdbHelperSources:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch locked ADB helper source closure"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Restore exact locked ADB source closure
+        id: cache-adb-sources
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: prefetch_artifacts/adb-helper-sources
+          key: adb-helper-sources-v1-${{ hashFiles('packaging/adb/adb-helper.lock.json', 'scripts/prefetch_adb_helper_sources.py') }}
 
       - name: Prefetch and hash immutable ADB sources
         shell: bash
@@ -445,7 +498,14 @@ jobs:
             --lock packaging/adb/adb-helper.lock.json \
             --download-root prefetch_artifacts/adb-helper-sources
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - name: Save exact locked ADB source closure
+        if: ${{ github.event_name == 'push' && steps.cache-adb-sources.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: prefetch_artifacts/adb-helper-sources
+          key: adb-helper-sources-v1-${{ hashFiles('packaging/adb/adb-helper.lock.json', 'scripts/prefetch_adb_helper_sources.py') }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: adb-helper-source-cache
           path: prefetch_artifacts/adb-helper-sources/*
@@ -460,11 +520,11 @@ jobs:
     env:
       KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: adb-helper-source-cache
           path: prefetch_artifacts/adb-helper-sources
@@ -485,7 +545,7 @@ jobs:
             --base-url "https://github.com/${GITHUB_REPOSITORY}" \
             --output prefetch_artifacts/adb-helper-release
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: adb-helper-legal-assets
           path: prefetch_artifacts/adb-helper-release/*
@@ -503,19 +563,9 @@ jobs:
           - target: linux-x86_64
             runner: ubuntu-24.04
             container_image: quay.io/pypa/manylinux2014_x86_64@sha256:95440e0e72dd3a81dc8d2cf59a84d57af661456620f5bc821ff92048d0e54ff9
-          - target: linux-arm64
-            runner: ubuntu-24.04-arm
-            container_image: quay.io/pypa/manylinux2014_aarch64@sha256:b63ff749fee6f3f2a6b67ed3101a073db3211df1791da19e9acf96f43c0dd6ff
-          - target: windows-x86_64
-            runner: windows-2022
-            container_image: ""
-          - target: macos-x86_64
-            runner: macos-15-intel
-          - target: macos-arm64
-            runner: macos-15
     runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    steps: &adb_helper_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -528,7 +578,7 @@ jobs:
 
       - name: Prepare MSVC for source-built AdbWinApi DLLs
         if: ${{ matrix.target == 'windows-x86_64' }}
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        uses: ./.github/actions/setup-msvc
         with:
           arch: x64
 
@@ -542,12 +592,12 @@ jobs:
           install: >-
             mingw-w64-ucrt-x86_64-pkgconf
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: adb-helper-source-cache
           path: ${{ runner.temp }}/adb-helper-prefetch
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: adb-helper-legal-assets
           path: ${{ runner.temp }}/adb-helper-release
@@ -607,7 +657,7 @@ jobs:
           fi
           tar -czf "$archive" -C "$artifact_root" .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: adb-helper-${{ matrix.target }}
           path: ${{ runner.temp }}/adb-helper-${{ matrix.target }}.tar.gz
@@ -615,11 +665,67 @@ jobs:
 
       - name: Attest target-bound ADB helper build provenance
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/adb-helper-artifact/SHA256SUMS
 
-  Linux:
+  BuildAdbLinuxArm64:
+    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Source-built ADB helper ${{ matrix.target }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            container_image: quay.io/pypa/manylinux2014_aarch64@sha256:b63ff749fee6f3f2a6b67ed3101a073db3211df1791da19e9acf96f43c0dd6ff
+    runs-on: ${{ matrix.runner }}
+    steps: *adb_helper_steps
+
+  BuildAdbWindowsX64:
+    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Source-built ADB helper ${{ matrix.target }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-x86_64
+            runner: windows-2022
+            container_image: ""
+    runs-on: ${{ matrix.runner }}
+    steps: *adb_helper_steps
+
+  BuildAdbMacX64:
+    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Source-built ADB helper ${{ matrix.target }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: macos-x86_64
+            runner: macos-15-intel
+            container_image: ""
+    runs-on: ${{ matrix.runner }}
+    steps: *adb_helper_steps
+
+  BuildAdbMacArm64:
+    needs: [PrefetchAdbHelperSources, BuildAdbHelperLegalAssets]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Source-built ADB helper ${{ matrix.target }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: macos-arm64
+            runner: macos-15
+            container_image: ""
+    runs-on: ${{ matrix.runner }}
+    steps: *adb_helper_steps
+
+  LinuxPackages:
     needs: [SaveVersion, PrefetchCpmCache, PrefetchLinuxDeployQt, PrefetchCmakeInstaller, BuildAdbHelpers]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Linux ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
@@ -644,7 +750,8 @@ jobs:
             cmake_opts: -DKLOGG_GENERIC_CPU=ON
             package: true
             check_command: for attempt in 1 2 3; do apt-get update -o Acquire::Retries=3 -o APT::Update::Error-Mode=any && break; if [ "$attempt" = 3 ]; then exit 1; fi; sleep $((attempt * 10)); done; DEBIAN_FRONTEND=noninteractive apt-get install -y /usr/local/klogg*.deb; QT_QPA_PLATFORM=offscreen klogg -v
-
+            sanitizer: ""
+            timeout_minutes: 60
           - os: ubuntu_noble
             os_version: 24.04
             arch: x64
@@ -659,7 +766,8 @@ jobs:
             container_suffix: _ubuntu24.04
             cmake_opts: -DENABLE_CPPCHECK=ON -DKLOGG_GENERIC_CPU=ON
             package: true
-
+            sanitizer: ""
+            timeout_minutes: 60
           - os: ubuntu_resolute
             os_version: 26.04
             arch: x64
@@ -678,7 +786,8 @@ jobs:
             container_suffix: _ubuntu26.04
             cmake_opts: -DENABLE_CPPCHECK=ON -DKLOGG_GENERIC_CPU=ON
             package: true
-
+            sanitizer: ""
+            timeout_minutes: 60
           - os: ubuntu_appimage
             os_version: 20.04
             arch: x64
@@ -690,62 +799,20 @@ jobs:
             container_suffix: _ubuntu20.04
             cmake_opts: -DKLOGG_GENERIC_CPU=ON
             package: true
-
-          # Sanitizer legs: build + test only (no packaging, no artifacts).
-          # Folded into the Linux matrix so ci-gate (needs: [Linux]) covers them.
-          # The former combined asan-ubsan-lsan leg was the matrix's critical
-          # path (~46 min); it is split into two parallel legs so the sanitizer
-          # compile runs on two runners. asan-lsan carries ASan + LeakSanitizer
-          # (detect_leaks=1 in ASAN_OPTIONS); ubsan carries the full UBSan
-          # suite (incl. -fno-sanitize=vptr handling). Union == combined leg.
-          - os: ubuntu_jammy
-            os_version: 22.04
-            arch: x64
-            label: ubuntu-22.04-asan-lsan
-            package_tag: asan
-            container_root: docker/ubuntu22.04
-            container_suffix: _ubuntu22.04
-            cmake_opts: -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON -DKLOGG_CI_LIGHT_DEBUG=ON
-            sanitizer: address
-            # ASan instrumentation + the full test suite is the longest pole in
-            # the matrix; leave headroom over the default 60 min for runner CPU
-            # contention (the deb legs hit the 60-min timeout on a slow runner).
-            timeout_minutes: 90
-            package: false
-
-          - os: ubuntu_jammy
-            os_version: 22.04
-            arch: x64
-            label: ubuntu-22.04-ubsan
-            package_tag: ubsan
-            container_root: docker/ubuntu22.04
-            container_suffix: _ubuntu22.04
-            cmake_opts: -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DKLOGG_CI_LIGHT_DEBUG=ON
-            sanitizer: undefined
+            cpack_gen:
+            check_container:
+            check_command:
+            sanitizer: ""
             timeout_minutes: 60
-            package: false
-
-          - os: ubuntu_jammy
-            os_version: 22.04
-            arch: x64
-            label: ubuntu-22.04-tsan
-            package_tag: tsan
-            container_root: docker/ubuntu22.04-tsan
-            container_suffix: _ubuntu22.04-tsan
-            cmake_opts: -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_PREFIX_PATH=/opt/qt5-tsan -DQt5_DIR=/opt/qt5-tsan/lib/cmake/Qt5 -DKLOGG_TSAN_QT_PREFIX=/opt/qt5-tsan -DKLOGG_TSAN_QT_VERSION=5.15.19 -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON
-            sanitizer: thread
-            timeout_minutes: 120
-            package: false
-
 
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ matrix.config.timeout_minutes || 60 }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    steps: &linux_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-linux-x86_64
@@ -764,7 +831,7 @@ jobs:
           mkdir -p "$artifact_root"
           tar -xzf "$archive" -C "$artifact_root"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-legal-assets
@@ -787,19 +854,19 @@ jobs:
               --repo "$GITHUB_REPOSITORY"
           fi
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cpm-cache
           path: ${{ github.workspace }}
       - uses: ./.github/actions/restore-cpm-cache
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.os == 'ubuntu_appimage' }}
         with:
           name: linuxdeployqt
           path: ${{ github.workspace }}/tools
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.sanitizer != 'thread' }}
         with:
           name: cmake-installer
@@ -813,10 +880,6 @@ jobs:
           printf '%s  %s\n' "$CMAKE_INSTALLER_SHA256" "$installer" \
             | sha256sum --check --strict
           cp "$installer" "${{ matrix.config.container_root }}/"
-
-      #- uses: satackey/action-docker-layer-caching@v0.0.11
-      #  # Ignore the failure of a step and avoid terminating the job.
-      #  continue-on-error: true
 
       - name: Set up Buildx for the TSan Qt image
         if: ${{ matrix.config.sanitizer == 'thread' }}
@@ -864,22 +927,36 @@ jobs:
           cache-from: type=gha,scope=klogg-linux-${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}
           cache-to: type=gha,mode=min,scope=klogg-linux-${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}
 
+      - name: Compute bounded ccache generation
+        id: ccache-generation
+        if: ${{ matrix.config.sanitizer != 'thread' }}
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import datetime
+          today = datetime.datetime.now(datetime.timezone.utc).date()
+          previous = today - datetime.timedelta(days=1)
+          print(f"current={today.isoformat()}")
+          print(f"previous={previous.isoformat()}")
+          PY
+
       - name: Restore ccache for the Linux build
         id: restore-ccache
         if: ${{ matrix.config.sanitizer != 'thread' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           # The container compiles with CCACHE_DIR=/usr/local/.ccache, which is
           # the workspace mounted at /usr/local, so restoring this host path
           # warms the in-container cache. The key is stable per config (no
           # per-commit SHA): per-sha entries exhausted the repo-wide 10GB cache
-          # budget, evicting every restore before the next run. restore-keys
-          # selects the most recent matching entry; the Save step below
-          # refreshes it on master pushes only, so PRs restore master's warm
-          # cache without writing throwaway entries of their own.
+          # budget, evicting every restore before the next run. The bounded v2
+          # generation tries the current UTC day, then only the previous day.
+          # The first successful master push each day seeds that immutable key;
+          # PRs restore it but never write throwaway cache entries of their own.
           path: ${{ github.workspace }}/.ccache
-          key: ${{ matrix.config.label }}-ccache-v1
-          restore-keys: ${{ matrix.config.label }}-ccache-v1-
+          key: ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.current }}
+          restore-keys: |
+            ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.previous }}
 
       - uses: ./.github/actions/prepare-workspace-env
       - name: Require verified source-built ADB helper for Linux packages
@@ -942,18 +1019,6 @@ jobs:
           docker run --rm -v "$KLOGG_WORKSPACE":/usr/local \
             "${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}" \
             /bin/bash -c 'ccache -s 2>/dev/null || echo "ccache stats unavailable"'
-
-      - name: Save ccache for the Linux build
-        if: ${{ success() && matrix.config.sanitizer != 'thread' && github.event_name == 'push' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/.ccache
-          # Cache keys are immutable; a constant key (e.g. ...-${{ github.ref }})
-          # would make save silently skip after the first push and every PR would
-          # restore that first, forever-stale cache. run_id keeps each master push
-          # refreshing, while the stable label-ccache-v1- restore-keys prefix still
-          # picks the most recent entry on PR restore.
-          key: ${{ matrix.config.label }}-ccache-v1-${{ github.run_id }}
 
       - name: Verify ASan-instrumented test binaries
         if: ${{ matrix.config.sanitizer == 'address' }}
@@ -1034,24 +1099,129 @@ jobs:
           tar -czf "$KLOGG_WORKSPACE/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C "$KLOGG_BUILD_ROOT/packages" .
 
 # Final upload of all packages
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
           path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
+      - name: Bound Linux ccache before save
+        if: ${{ success() && matrix.config.sanitizer != 'thread' && github.event_name == 'push' }}
+        shell: bash
+        run: |
+          docker run --rm -v "$KLOGG_WORKSPACE":/usr/local \
+            "${{ env.KLOGG_CI_IMAGE_PREFIX }}${{ matrix.config.container_suffix }}" \
+            /bin/bash -c 'ccache --set-config=compression=true && ccache --set-config=compression_level=6 && ccache --max-size=250M && ccache --cleanup'
+
+      - name: Save ccache for the Linux build
+        if: ${{ success() && matrix.config.sanitizer != 'thread' && github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}/.ccache
+          # Cache keys are immutable. The daily v2 generation deliberately lets
+          # the first successful master push seed the day, bounds each entry to
+          # 250M above, and rolls forward without per-commit cache churn. PRs are
+          # restore-only and may fall back only to the previous daily generation.
+          key: ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.current }}
+
+  LinuxSanitizers:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchCmakeInstaller]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Linux ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+      CMAKE_INSTALLER_SHA256: ea497b4658816010e5850a3ed53845e430654640aabbe10d93fe67def9503e4d
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # Package-free sanitizer legs start without mobile artifact producers.
+          - os: ubuntu_jammy
+            os_version: 22.04
+            arch: x64
+            label: ubuntu-22.04-asan-lsan
+            package_tag: asan
+            container_root: docker/ubuntu22.04
+            container_suffix: _ubuntu22.04
+            cmake_opts: -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON -DKLOGG_CI_LIGHT_DEBUG=ON
+            sanitizer: address
+            # ASan instrumentation + the full test suite is the longest pole in
+            # the matrix; leave headroom over the default 60 min for runner CPU
+            # contention (the deb legs hit the 60-min timeout on a slow runner).
+            timeout_minutes: 90
+            package: false
+            cpack_gen: NONE
+            artifacts_id: unused
+            package_suffix: unused
+            check_container: unused
+            check_command: "true"
+          - os: ubuntu_jammy
+            os_version: 22.04
+            arch: x64
+            label: ubuntu-22.04-ubsan
+            package_tag: ubsan
+            container_root: docker/ubuntu22.04
+            container_suffix: _ubuntu22.04
+            cmake_opts: -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DKLOGG_CI_LIGHT_DEBUG=ON
+            sanitizer: undefined
+            timeout_minutes: 60
+            package: false
+            cpack_gen: NONE
+            artifacts_id: unused
+            package_suffix: unused
+            check_container: unused
+            check_command: "true"
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: ${{ matrix.config.timeout_minutes || 60 }}
+    steps: *linux_steps
+
+  LinuxTsan:
+    needs: [SaveVersion, PrefetchCpmCache]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Linux ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+      CMAKE_INSTALLER_SHA256: ea497b4658816010e5850a3ed53845e430654640aabbe10d93fe67def9503e4d
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # TSan uses its source-built Qt image and does not need the CMake installer.
+          - os: ubuntu_jammy
+            os_version: 22.04
+            arch: x64
+            label: ubuntu-22.04-tsan
+            package_tag: tsan
+            container_root: docker/ubuntu22.04-tsan
+            container_suffix: _ubuntu22.04-tsan
+            cmake_opts: -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_PREFIX_PATH=/opt/qt5-tsan -DQt5_DIR=/opt/qt5-tsan/lib/cmake/Qt5 -DKLOGG_TSAN_QT_PREFIX=/opt/qt5-tsan -DKLOGG_TSAN_QT_VERSION=5.15.19 -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON
+            sanitizer: thread
+            timeout_minutes: 120
+            package: false
+            cpack_gen: NONE
+            artifacts_id: unused
+            package_suffix: unused
+            check_container: unused
+            check_command: "true"
+
+    runs-on: ubuntu-22.04
+    timeout-minutes: ${{ matrix.config.timeout_minutes || 60 }}
+    steps: *linux_steps
+
   PrefetchIosNativeSources:
+    needs: [ReleaseQualificationPreflight]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Prefetch locked iOS native sources"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Restore checksum-locked iOS source archives
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
           path: ${{ github.workspace }}/ios-native-sources
           key: ios-native-sources-${{ hashFiles('3rdparty/libimobiledevice/libimobiledevice.lock.json') }}
@@ -1064,7 +1234,7 @@ jobs:
             --lock 3rdparty/libimobiledevice/libimobiledevice.lock.json \
             --output "${{ github.workspace }}/ios-native-sources"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-native-source-cache
           path: ${{ github.workspace }}/ios-native-sources/*
@@ -1084,13 +1254,10 @@ jobs:
           - runner: macos-15-intel
             architecture: x86_64
             artifact: ios-native-x86_64
-          - runner: macos-15
-            architecture: arm64
-            artifact: ios-native-arm64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    steps: &ios_native_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -1101,9 +1268,15 @@ jobs:
           export HOMEBREW_NO_ANALYTICS=1
           export HOMEBREW_NO_AUTO_UPDATE=1
           export HOMEBREW_NO_INSTALL_CLEANUP=1
+          if brew list --formula aws-sam-cli >/dev/null 2>&1; then
+            brew uninstall --ignore-dependencies aws-sam-cli || true
+          fi
+          if brew tap | grep -Fx aws/tap >/dev/null; then
+            brew untap aws/tap
+          fi
           brew install autoconf automake libtool pkg-config cmake ninja
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ios-native-source-cache
           path: ${{ github.workspace }}/ios-native-sources
@@ -1167,7 +1340,7 @@ jobs:
           tar -czf "${{ runner.temp }}/${{ matrix.artifact }}.tar.gz" \
             -C "${{ runner.temp }}/ios-native-stack" .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: ${{ runner.temp }}/${{ matrix.artifact }}.tar.gz
@@ -1175,7 +1348,7 @@ jobs:
 
       - name: Upload architecture-independent iOS source set
         if: ${{ matrix.architecture == 'arm64' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ios-native-source-assets
           path: |
@@ -1189,12 +1362,29 @@ jobs:
 
       - name: Attest target-bound iOS native stack provenance
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/ios-native-stack/SHA256SUMS
 
-  Mac:
-    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbHelpers, BuildIosNativeStacks]
+  BuildIosNativeArm64:
+    needs: [SaveVersion, PrefetchIosNativeSources]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "iOS native stack ${{ matrix.architecture }}"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            architecture: arm64
+            artifact: ios-native-arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps: *ios_native_steps
+
+  MacPackages:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacX64, BuildIosNativeStacks]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "macOS ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -1217,62 +1407,16 @@ jobs:
             ios_native_architecture: x86_64
             cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0
             package: true
-          - os: macos-latest
-            qt_version: 6.9.3
-            qt_modules: qt5compat qtimageformats
-            qt_archives: qtbase icu qtsvg qttools qttranslations
-            qt_arch: clang_64
-            arch: arm64
-            label: arm64-qt6
-            package_tag: vs-arm64
-            artifacts_id: macos-arm-qt6
-            adb_target: macos-arm64
-            ios_native_artifact: ios-native-arm64
-            ios_native_architecture: arm64
-            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=14.0
-            package: true
-
-          # Sanitizer legs: build + test only (no packaging, no artifacts).
-          # Folded into the Mac matrix so ci-gate (needs: [Mac]) covers them.
-          # macOS TSan covers first-party and source-built dependencies; prebuilt Qt 6 is not TSan-instrumented.
-          # The Linux source-built Qt TSan leg is authoritative for Qt-internal races.
-          # Run on the Intel runner so TSan's 2x threading overhead is stable.
-          - os: macos-15-intel
-            qt_version: 6.9.3
-            qt_modules: qt5compat qtimageformats
-            qt_archives: qtbase icu qtsvg qttools qttranslations
-            qt_arch: clang_64
-            arch: x64
-            label: intel-qt6-asan-ubsan
-            package_tag: asan-ubsan
-            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DKLOGG_CI_LIGHT_DEBUG=ON
-            sanitizer: address-undefined
-            package: false
-
-          - os: macos-15-intel
-            qt_version: 6.9.3
-            qt_modules: qt5compat qtimageformats
-            qt_archives: qtbase icu qtsvg qttools qttranslations
-            qt_arch: clang_64
-            arch: x64
-            label: intel-qt6-first-party-tsan
-            package_tag: tsan
-            # KLOGG_CI_LIGHT_DEBUG=ON (-g1 instead of -g): same treatment as the
-            # asan-ubsan leg and the Linux tsan leg. Line tables suffice to
-            # symbolize TSan reports, and the smaller DWARF shrinks both compile
-            # time (vectorscan dominates) and the ccache entry footprint.
-            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON -DKLOGG_CI_LIGHT_DEBUG=ON
-            sanitizer: thread
-            package: false
+            sanitizer: ""
 
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    steps: &mac_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-${{ matrix.config.adb_target }}
@@ -1286,18 +1430,18 @@ jobs:
           archive_root="${{ github.workspace }}/prefetch_artifacts/adb-helper-archive"
           artifact_root="${{ github.workspace }}/prefetch_artifacts/adb-helper"
           archive="$archive_root/adb-helper-${{ matrix.config.adb_target }}.tar.gz"
-          test -f "$archive"
           rm -rf "$artifact_root"
-          mkdir -p "$artifact_root"
-          tar -xzf "$archive" -C "$artifact_root"
+          python3 scripts/extract_verified_tar.py \
+            --archive "$archive" \
+            --destination "$artifact_root"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-legal-assets
           path: ${{ github.workspace }}/prefetch_artifacts/adb-helper/release
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: ios-native-${{ matrix.config.arch == 'x64' && 'x86_64' || 'arm64' }}
@@ -1392,20 +1536,39 @@ jobs:
           # the critical path (~11 min of a 27-30 min build). A warm ccache
           # collapses that to near zero. brew install is idempotent and fast
           # (~1s) when the formula is already present.
+          if brew list --formula aws-sam-cli >/dev/null 2>&1; then
+            brew uninstall --ignore-dependencies aws-sam-cli || true
+          fi
+          if brew tap | grep -Fx aws/tap >/dev/null; then
+            brew untap aws/tap
+          fi
           brew install ragel ccache
+
+      - name: Compute bounded ccache generation
+        id: ccache-generation
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import datetime
+          today = datetime.datetime.now(datetime.timezone.utc).date()
+          previous = today - datetime.timedelta(days=1)
+          print(f"current={today.isoformat()}")
+          print(f"previous={previous.isoformat()}")
+          PY
 
       - name: Restore ccache for the macOS build
         id: restore-ccache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
         with:
-          # Same keying strategy as the Linux legs: stable label key +
-          # restore-keys prefix so a PR restores master's warm cache, and the
-          # run_id-suffixed save key refreshes it on master pushes only.
+          # Same bounded daily v2 strategy as Linux: restore the current UTC
+          # day, then only the previous day. The first successful master push
+          # seeds the immutable daily key; pull requests remain restore-only.
           path: ${{ github.workspace }}/.ccache
-          key: ${{ matrix.config.label }}-ccache-v1
-          restore-keys: ${{ matrix.config.label }}-ccache-v1-
+          key: ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.current }}
+          restore-keys: |
+            ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.previous }}
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: boost-root
           path: ${{ github.workspace }}
@@ -1425,7 +1588,7 @@ jobs:
           echo "KLOGG_REQUIRE_PREFETCHED_CPM=ON" >> $GITHUB_ENV
 
       - uses: ./.github/actions/agent-setup
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cpm-cache
           path: ${{ github.workspace }}
@@ -1472,16 +1635,6 @@ jobs:
         shell: sh
         run: ccache -s 2>/dev/null || echo "ccache stats unavailable"
 
-      - name: Save ccache for the macOS build
-        if: ${{ success() && github.event_name == 'push' }}
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/.ccache
-          # run_id-suffixed save key (same as Linux): refreshes the shared
-          # cache on each master push while the label-ccache-v1- restore-keys
-          # prefix keeps PR restores hitting the most recent master entry.
-          key: ${{ matrix.config.label }}-ccache-v1-${{ github.run_id }}
-
       - name: Verify ASan/UBSan-instrumented test binaries
         if: ${{ matrix.config.sanitizer == 'address-undefined' }}
         shell: bash
@@ -1505,10 +1658,10 @@ jobs:
       - uses: ./.github/actions/agent-package-mac
         if: ${{ matrix.config.package != false }}
         with:
+          qualification-mode: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && inputs.qualification-mode == 'release' && 'release' || 'validation' }}
           p12-file-base64: ${{ secrets.CODESIGN_BASE64 }}
           p12-password: ${{ secrets.CODESIGN_PASSWORD }}
           codesign-identity: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
-          installer-sign-identity: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}
           notarization-username: ${{ secrets.NOTARIZATION_USERNAME }}
           notarization-team: ${{ secrets.NOTARIZATION_TEAM }}
           notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
@@ -1526,15 +1679,119 @@ jobs:
           [ -n "$(find "$KLOGG_BUILD_ROOT/packages" -mindepth 1 2>/dev/null)" ] || { echo "::error::packages directory is empty"; exit 1; }
           tar -czf "$KLOGG_WORKSPACE/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz" -C "$KLOGG_BUILD_ROOT/packages" .
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
           path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: warn
 
-  Windows:
-    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, PrefetchOpenSsl, PrefetchWindowsTools, BuildAdbHelpers]
+      - name: Bound macOS ccache before save
+        if: ${{ success() && github.event_name == 'push' }}
+        shell: sh
+        run: |
+          ccache --set-config=compression=true
+          ccache --set-config=compression_level=6
+          ccache --max-size=250M
+          ccache --cleanup
+
+      - name: Save ccache for the macOS build
+        if: ${{ success() && github.event_name == 'push' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}/.ccache
+          # The first successful master push seeds this day's immutable key
+          # after the cache is compressed and bounded to 250M above. Later runs
+          # reuse it instead of creating per-commit entries; PRs never save it.
+          key: ${{ matrix.config.label }}-ccache-v2-${{ steps.ccache-generation.outputs.current }}
+
+  MacArmPackages:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, BuildAdbMacArm64, BuildIosNativeArm64]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "macOS ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - os: macos-latest
+            qt_version: 6.9.3
+            qt_modules: qt5compat qtimageformats
+            qt_archives: qtbase icu qtsvg qttools qttranslations
+            qt_arch: clang_64
+            arch: arm64
+            label: arm64-qt6
+            package_tag: vs-arm64
+            artifacts_id: macos-arm-qt6
+            adb_target: macos-arm64
+            ios_native_artifact: ios-native-arm64
+            ios_native_architecture: arm64
+            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=14.0
+            package: true
+            sanitizer: ""
+
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 60
+    steps: *mac_steps
+
+  MacSanitizers:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "macOS ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # Package-free sanitizer legs start without ADB or iOS native producers.
+          # macOS TSan covers first-party and source-built dependencies;
+          # prebuilt Qt 6 is not TSan-instrumented.
+          # The Linux source-built Qt TSan leg is authoritative for Qt-internal races.
+          # Run on the Intel runner so TSan's
+          # threading overhead stays stable.
+          - os: macos-15-intel
+            qt_version: 6.9.3
+            qt_modules: qt5compat qtimageformats
+            qt_archives: qtbase icu qtsvg qttools qttranslations
+            qt_arch: clang_64
+            arch: x64
+            label: intel-qt6-asan-ubsan
+            package_tag: asan-ubsan
+            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON -DENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON -DKLOGG_CI_LIGHT_DEBUG=ON
+            sanitizer: address-undefined
+            package: false
+            artifacts_id: unused
+            adb_target: unused
+            ios_native_artifact: unused
+            ios_native_architecture: unused
+          - os: macos-15-intel
+            qt_version: 6.9.3
+            qt_modules: qt5compat qtimageformats
+            qt_archives: qtbase icu qtsvg qttools qttranslations
+            qt_arch: clang_64
+            arch: x64
+            label: intel-qt6-first-party-tsan
+            package_tag: tsan
+            # KLOGG_CI_LIGHT_DEBUG=ON (-g1 instead of -g): same treatment as the
+            # asan-ubsan leg and the Linux tsan leg. Line tables suffice to
+            # symbolize TSan reports, and the smaller DWARF shrinks both compile
+            # time (vectorscan dominates) and the ccache entry footprint.
+            cmake_opts: -DKLOGG_OSX_DEPLOYMENT_TARGET=15.0 -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_THREAD=ON -DKLOGG_CI_LIGHT_DEBUG=ON
+            sanitizer: thread
+            package: false
+            artifacts_id: unused
+            adb_target: unused
+            ios_native_artifact: unused
+            ios_native_architecture: unused
+
+    runs-on: ${{ matrix.config.os }}
+    timeout-minutes: 60
+    steps: *mac_steps
+
+  WindowsPackages:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, PrefetchWindowsTools, BuildAdbWindowsX64]
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
     env:
@@ -1557,72 +1814,42 @@ jobs:
             artifacts_id: windows-x64-qt6
             adb_target: windows-x86_64
             package: true
-
-          - os: windows
-            os_version: 2022
-            qt_version: 5.15.2
-            qt_modules:
-            qt_archives: qtbase qtimageformats qttools qttranslations icu qtsvg
-            qt_arch: win32_msvc2019
-            arch: x86
-            ssl_arch: ""
-            package_tag: QTRegex
-            cmake_opts: -DKLOGG_USE_SENTRY=OFF -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_VECTORSCAN=OFF
-            label: x86-qt5
-            artifacts_id: windows-x86-qt5
-            package: false
-
-          # Sanitizer leg: build + test only (no packaging, no artifacts).
-          # MSVC ASan is x64-only, so this rides on the x64-qt6 leg. x86-qt5
-          # cannot run ASan and is intentionally left without a sanitizer leg.
-          - os: windows
-            os_version: 2022
-            qt_version: 6.9.3
-            qt_modules: qt5compat qtimageformats
-            qt_archives: qtbase icu qtsvg qttools qttranslations
-            qt_arch: win64_msvc2022_64
-            arch: x64
-            ssl_arch: -x64
-            package_tag: asan
-            cmake_opts: -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON
-            label: x64-qt6-asan
-            sanitizer: address
-            package: false
+            sanitizer: ""
 
     runs-on: ${{ matrix.config.os }}-${{ matrix.config.os_version }}
     timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    steps: &windows_steps
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-${{ matrix.config.adb_target }}
           path: ${{ github.workspace }}/prefetch_artifacts/adb-helper-archive
 
       - name: Extract mode-preserving ADB helper artifact
-        if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}
+        if: ${{ matrix.config.package != false }}
         shell: bash
         run: |
           set -euo pipefail
           archive_root="${{ github.workspace }}/prefetch_artifacts/adb-helper-archive"
           artifact_root="${{ github.workspace }}/prefetch_artifacts/adb-helper"
           archive="$archive_root/adb-helper-${{ matrix.config.adb_target }}.tar.gz"
-          test -f "$archive"
           rm -rf "$artifact_root"
-          mkdir -p "$artifact_root"
-          tar -xzf "$archive" -C "$artifact_root"
+          python3 scripts/extract_verified_tar.py \
+            --archive "$archive" \
+            --destination "$artifact_root"
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: ${{ matrix.config.package != false }}
         with:
           name: adb-helper-legal-assets
           path: ${{ github.workspace }}/prefetch_artifacts/adb-helper/release
 
       - name: Verify target-bound ADB helper checksum envelope and provenance
-        if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}
+        if: ${{ matrix.config.package != false }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -1633,10 +1860,12 @@ jobs:
             --lock packaging/adb/adb-helper.lock.json \
             --artifact-root "$artifact_root" \
             --expected-target "${{ matrix.config.adb_target }}"
-          gh attestation verify "$artifact_root/SHA256SUMS" \
-            --repo "$GITHUB_REPOSITORY"
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            gh attestation verify "$artifact_root/SHA256SUMS" \
+              --repo "$GITHUB_REPOSITORY"
+          fi
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ startsWith(matrix.config.qt_version, '5') }}
         with:
           name: openssl-archive
@@ -1652,7 +1881,7 @@ jobs:
           }
           7z x openssl.zip
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: msys2-tools
           path: ${{ github.workspace }}
@@ -1677,7 +1906,7 @@ jobs:
           echo "SSL_DIR=${{ github.workspace }}\openssl-1.1\${{ matrix.config.arch }}\bin" >> $GITHUB_ENV
           echo "SSL_ARCH=${{ matrix.config.ssl_arch }}" >> $GITHUB_ENV
 
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: boost-root
           path: ${{ github.workspace }}
@@ -1699,7 +1928,7 @@ jobs:
           echo "KLOGG_REQUIRE_PREFETCHED_CPM=ON" >> $GITHUB_ENV
 
       - uses: ./.github/actions/agent-setup
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cpm-cache
           path: ${{ github.workspace }}
@@ -1707,7 +1936,7 @@ jobs:
       - uses: ./.github/actions/prepare-workspace-env
 
       - name: Require verified source-built ADB helper for Windows packages
-        if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}
+        if: ${{ matrix.config.package != false }}
         shell: sh
         run: |
           echo "KLOGG_ADB_HELPER_TARGET=${{ matrix.config.adb_target }}" >> $GITHUB_ENV
@@ -1719,7 +1948,7 @@ jobs:
           echo "KLOGG_CMAKE_OPTS=$KLOGG_CMAKE_OPTS -DFETCHCONTENT_FULLY_DISCONNECTED=ON" >> $GITHUB_ENV
 
       - name: Prepare dev cmd
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
+        uses: ./.github/actions/setup-msvc
         with:
           arch: ${{ matrix.config.arch }}
 
@@ -1913,7 +2142,7 @@ jobs:
 
       - name: Upload Windows diagnostics artifact
         if: ${{ steps.run-tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Use label (defined on every config, including the asan leg which
           # has no artifacts_id) so the diagnostics artifact name is unique per
@@ -1945,7 +2174,7 @@ jobs:
 
       - name: Upload Windows ASan diagnostics artifact
         if: ${{ matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-x64-asan-diagnostics
           path: '${{ github.workspace }}\build_root\asan_diagnostics\**\*'
@@ -1957,14 +2186,10 @@ jobs:
         run: exit 1
 
       - uses: ./.github/actions/agent-package-win
-        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false && github.event_name != 'pull_request' }}
-        with:
-          s3-key-id: ${{ secrets.WIN_CS_KEY_ID }}
-          s3-secret: ${{ secrets.WIN_CS_SECRET }}
-          s3-bucket: ${{ secrets.WIN_CS_BUCKET }}
+        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
 
       - name: Verify SSL/TLS packaging
-        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false && github.event_name != 'pull_request' }}
+        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
         shell: pwsh
         run: |
           $releaseDir = Join-Path $env:GITHUB_WORKSPACE "release"
@@ -1974,7 +2199,7 @@ jobs:
 # Upload packages as a single-file tarball to avoid GitHub's artifact backend
 # intermittently corrupting multi-file zip64 archives (same class as fe4859ca).
       - name: Package tarball for upload
-        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false && github.event_name != 'pull_request' }}
+        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
         shell: pwsh
         run: |
           $tarName = "packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz"
@@ -1990,16 +2215,78 @@ jobs:
           tar -czf $tarPath -C $pkgDir .
 
 # Final upload of all packages
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false && github.event_name != 'pull_request' }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ steps.run-tests.outcome == 'success' && matrix.config.package != false }}
         with:
           name: packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}
           path: '${{ env.KLOGG_WORKSPACE }}/packages-${{ matrix.config.artifacts_id }}-${{ matrix.config.package_tag }}.tar.gz'
           if-no-files-found: error
 
+  WindowsX86:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, PrefetchOpenSsl, PrefetchWindowsTools]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # The Qt 5 x86 portability leg is package-free and needs OpenSSL only.
+          - os: windows
+            os_version: 2022
+            qt_version: 5.15.2
+            qt_modules:
+            qt_archives: qtbase qtimageformats qttools qttranslations icu qtsvg
+            qt_arch: win32_msvc2019
+            arch: x86
+            ssl_arch: ""
+            package_tag: QTRegex
+            cmake_opts: -DKLOGG_USE_SENTRY=OFF -DKLOGG_GENERIC_CPU=ON -DKLOGG_USE_VECTORSCAN=OFF
+            label: x86-qt5
+            artifacts_id: windows-x86-qt5
+            package: false
+            adb_target: unused
+            sanitizer: ""
+
+    runs-on: ${{ matrix.config.os }}-${{ matrix.config.os_version }}
+    timeout-minutes: 60
+    steps: *windows_steps
+
+  WindowsAsan:
+    needs: [SaveVersion, PrefetchCpmCache, PrefetchBoost, PrefetchWindowsTools]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: "Windows ${{ matrix.config.label }} [${{ matrix.config.package_tag }}]"
+    env:
+      KLOGG_VERSION: ${{ needs.SaveVersion.outputs.klogg_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # The x64 ASan leg is package-free and does not wait for ADB or Qt 5 OpenSSL.
+          - os: windows
+            os_version: 2022
+            qt_version: 6.9.3
+            qt_modules: qt5compat qtimageformats
+            qt_archives: qtbase icu qtsvg qttools qttranslations
+            qt_arch: win64_msvc2022_64
+            arch: x64
+            ssl_arch: -x64
+            package_tag: asan
+            cmake_opts: -DKLOGG_USE_LTO=OFF -DKLOGG_USE_SENTRY=OFF -DENABLE_SANITIZER_ADDRESS=ON
+            label: x64-qt6-asan
+            sanitizer: address
+            package: false
+            artifacts_id: unused
+            adb_target: unused
+
+    runs-on: ${{ matrix.config.os }}-${{ matrix.config.os_version }}
+    timeout-minutes: 60
+    steps: *windows_steps
+
   ci-gate:
     if: always()
-    needs: [Linux, Mac, Windows]
+    needs: [BuildAdbHelpers, BuildAdbLinuxArm64, BuildAdbWindowsX64, BuildAdbMacX64, BuildAdbMacArm64, BuildIosNativeStacks, BuildIosNativeArm64, LinuxPackages, LinuxSanitizers, LinuxTsan, MacPackages, MacArmPackages, MacSanitizers, WindowsPackages, WindowsX86, WindowsAsan]
     runs-on: ubuntu-22.04
     steps:
       - name: Check CI results
@@ -2012,475 +2299,3 @@ jobs:
             fi
           done
           echo "CI passed: $results"
-
-  CreatePreRelease:
-    if: "!contains(github.event.head_commit.message, '[skip ci]') && github.event_name == 'push'"
-    needs: [ci-gate]
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Generate Changelog
-        id: changelog
-        shell: bash
-        run: |
-          CHANGELOG="$(python3 scripts/gen_changelog.py --mode prerelease --to-ref HEAD --print-range)"
-          
-          # Escape newlines for GITHUB_ENV
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "CHANGELOG<<$EOF" >> $GITHUB_ENV
-          echo "$CHANGELOG" >> $GITHUB_ENV
-          echo "$EOF" >> $GITHUB_ENV
-      
-      - name: Download version artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: klogg_version
-          path: klogg_version
-
-      - name: Set version and source commit
-        shell: bash
-        run: |
-          echo "KLOGG_VERSION=$(cat klogg_version/klogg_version.txt)" >> "$GITHUB_ENV"
-          echo "KLOGG_SOURCE_COMMIT=$(cat klogg_version/klogg_commit.txt)" >> "$GITHUB_ENV"
-
-      - name: Download all package artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          pattern: packages-*
-          path: ./packages-all
-
-      - name: Download ADB helper source and legal assets
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: adb-helper-legal-assets
-          path: ./packages-all/adb-helper-legal-assets
-
-      - name: Download architecture-independent iOS source assets
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: ios-native-source-assets
-          path: ./packages-all/ios-native-source-assets
-
-      - name: Verify ADB helper release assets before publication
-        shell: bash
-        run: |
-          set -euo pipefail
-          cd ./packages-all/adb-helper-legal-assets
-          sha256sum --check --strict ./*.sha256
-
-      # Package artifacts are uploaded as single-file tarballs; restore the
-      # per-artifact directory layout the cleanup below expects.
-      - name: Extract package tarballs
-        shell: bash
-        run: |
-          set -euo pipefail
-          while IFS= read -r -d '' t; do
-            echo "Extracting: $t"
-            staging=$(mktemp -d)
-            python3 scripts/extract_verified_tar.py --archive "$t" --destination "$staging"
-            cp -a "$staging"/. "$(dirname "$t")"/
-            rm -rf "$staging" "$t"
-          done < <(find ./packages-all -name 'packages-*.tar.gz' -type f -print0)
-
-      - name: Require package qualification receipts before continuous publication
-        shell: sh
-        run: |
-          set -eu
-          required="
-            ./packages-all/packages-jammy-vs-gen/adb-helper-deb-package-verification.json
-            ./packages-all/packages-noble-vs-gen/adb-helper-deb-package-verification.json
-            ./packages-all/packages-resolute-vs-gen/adb-helper-deb-package-verification.json
-            ./packages-all/packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
-            ./packages-all/packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
-            ./packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
-            ./packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-signing-receipt.json
-            ./packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-notarization-receipt.json
-            ./packages-all/packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
-            ./packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
-            ./packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-signing-receipt.json
-            ./packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-notarization-receipt.json
-            ./packages-all/packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
-          "
-          for receipt in $required; do
-            test -f "$receipt" || { echo "Missing continuous qualification receipt: $receipt"; exit 1; }
-          done
-          python3 - <<'PY'
-          import hashlib, json, pathlib
-          package_receipts = [
-              pathlib.Path("packages-all/packages-jammy-vs-gen/adb-helper-deb-package-verification.json"),
-              pathlib.Path("packages-all/packages-noble-vs-gen/adb-helper-deb-package-verification.json"),
-              pathlib.Path("packages-all/packages-resolute-vs-gen/adb-helper-deb-package-verification.json"),
-              pathlib.Path("packages-all/packages-appimage-vs-gen/adb-helper-appimage-package-verification.json"),
-              pathlib.Path("packages-all/packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json"),
-              pathlib.Path("packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json"),
-              pathlib.Path("packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json"),
-          ]
-          for path in package_receipts:
-              receipt = json.loads(path.read_text(encoding="utf-8"))
-              if receipt.get("receipt_kind") != "package-verification":
-                  raise SystemExit(f"invalid package qualification receipt kind: {path}")
-              if receipt.get("release_qualified") is not True:
-                  raise SystemExit(f"package is not evidence-qualified for continuous publication: {path}")
-              required = set(receipt.get("required_receipts", []))
-              verified = set(receipt.get("verified_receipts", []))
-              if not required or not required.issubset(verified):
-                  raise SystemExit(f"package qualification receipt is incomplete: {path}")
-              packages = receipt.get("packages")
-              if not isinstance(packages, list) or not packages:
-                  raise SystemExit(f"package qualification receipt has no final package hashes: {path}")
-              for package in packages:
-                  name = package.get("name") if isinstance(package, dict) else None
-                  if not isinstance(name, str) or pathlib.PurePath(name).name != name:
-                      raise SystemExit(f"unsafe qualified package name in {path}: {name}")
-                  published = path.parent / name
-                  if not published.is_file():
-                      raise SystemExit(f"qualified package is missing: {published}")
-                  actual = hashlib.sha256(published.read_bytes()).hexdigest()
-                  if package.get("sha256") != actual:
-                      raise SystemExit(f"qualified package hash mismatch: {published}")
-          for package_dir in (
-              "packages-all/packages-macos-intel-qt6-vs-gen",
-              "packages-all/packages-macos-arm-qt6-vs-arm64",
-          ):
-              directory = pathlib.Path(package_dir)
-              dmgs = list(directory.glob("*.dmg"))
-              if len(dmgs) != 1:
-                  raise SystemExit(f"expected one qualified DMG in {directory}, got {len(dmgs)}")
-              dmg_hash = hashlib.sha256(dmgs[0].read_bytes()).hexdigest()
-              qualification_path = directory / "adb-helper-dmg-package-verification.json"
-              qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
-              if qualification.get("package_sha256") != dmg_hash:
-                  raise SystemExit(f"macOS qualification receipt is not bound to continuous DMG: {qualification_path}")
-              for name in ("signing", "notarization"):
-                  path = directory / f"adb-helper-{name}-receipt.json"
-                  receipt = json.loads(path.read_text(encoding="utf-8"))
-                  if receipt.get("receipt_kind") != name or receipt.get("status") != "passed":
-                      raise SystemExit(f"invalid macOS {name} receipt: {path}")
-                  if receipt.get("package_sha256", receipt.get("dmg_sha256")) != dmg_hash:
-                      raise SystemExit(f"macOS {name} receipt is not bound to continuous DMG: {path}")
-                  if receipt.get("signed_helper_sha256") != qualification.get("helper_sha256"):
-                      raise SystemExit(f"macOS {name} receipt is not bound to qualified helper: {path}")
-                  if receipt.get("source_helper_sha256") != qualification.get("source_helper_sha256"):
-                      raise SystemExit(f"macOS {name} receipt is not bound to source-built helper: {path}")
-          PY
-
-      - name: Prepare coherent rolling package and source publication
-        shell: bash
-        run: |
-          set -euo pipefail
-          qualification_args=(
-            --qualification-receipt packages-all/packages-jammy-vs-gen/adb-helper-deb-package-verification.json
-            --qualification-receipt packages-all/packages-noble-vs-gen/adb-helper-deb-package-verification.json
-            --qualification-receipt packages-all/packages-resolute-vs-gen/adb-helper-deb-package-verification.json
-            --qualification-receipt packages-all/packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
-            --qualification-receipt packages-all/packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
-            --qualification-receipt packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
-            --qualification-receipt packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
-            --ios-qualification-receipt packages-all/packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
-            --ios-qualification-receipt packages-all/packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
-          )
-          python3 scripts/prepare_source_publication.py \
-            --channel continuous \
-            --tag continuous \
-            --version "${KLOGG_VERSION}" \
-            --commit "${KLOGG_SOURCE_COMMIT}" \
-            --base-url "https://github.com/${GITHUB_REPOSITORY}" \
-            --adb-source-root ./packages-all/adb-helper-legal-assets \
-            --ios-source-root ./packages-all/ios-native-source-assets \
-            "${qualification_args[@]}" \
-            --output ./packages-publication
-
-      - name: Clean up package artifacts
-        shell: sh
-        run: |
-          # Source assets are published from the coherent, content-addressed
-          # packages-publication set rather than their internal build-artifact names.
-          rm -rf ./packages-all/adb-helper-legal-assets ./packages-all/ios-native-source-assets
-          # Remove macOS app bundles and internal files that shouldn't be uploaded to GitHub Release
-          # These files are inside DMG packages and shouldn't be uploaded as separate assets
-          find ./packages-all -type d -name "*.app" -exec rm -rf {} + 2>/dev/null || true
-          find ./packages-all -type f \( -name "Info.plist" -o -name "libq*.dylib" -o -name "klogg.icns" -o -name "qt.conf" \) -delete 2>/dev/null || true
-          # Remove Qt framework files that are inside app bundles (not package files)
-          find ./packages-all -type f -name "Qt*" ! -name "*.dmg" ! -name "*.deb" ! -name "*.rpm" ! -name "*.AppImage" -delete 2>/dev/null || true
-          # Remove standalone klogg binary (should be inside packages, not standalone)
-          find ./packages-all -type f -name "klogg" ! -name "*.AppImage" ! -name "*.deb" ! -name "*.rpm" -delete 2>/dev/null || true
-          # Keep final packages plus the mandatory ADB corresponding-source,
-          # license, notice, SPDX SBOM, source-offer, manifest, and checksum assets.
-          find ./packages-all -type f ! \( -name "*.dmg" -o -name "*.deb" -o -name "*.rpm" -o -name "*.AppImage" -o -name "*.exe" -o -name "*.zip" -o -name "*.xz" -o -name "*.tar.xz" -o -name "*.tar.gz" -o -name "*.json" -o -name "*.txt" -o -name "*.sha256" \) -delete 2>/dev/null || true
-
-      - name: Clean stale continuous candidate draft
-        if: env.GITHUB_TOKEN != ''
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          candidate_tag="continuous-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          lookup_error=$(mktemp)
-          if release_id=$(gh api "/repos/${repo}/releases/tags/${candidate_tag}" --jq '.id' 2>"$lookup_error"); then
-            draft=$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')
-            test "${draft}" = "true" || {
-              echo "::error::refusing to replace published candidate ${candidate_tag}"
-              exit 1
-            }
-            gh api -X DELETE "/repos/${repo}/releases/${release_id}"
-            gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null 2>&1 || true
-          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
-
-      - name: Create continuous candidate draft
-        id: candidate_release
-        if: env.GITHUB_TOKEN != ''
-        uses: softprops/action-gh-release@v1
-        with:
-          token: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-          tag_name: continuous-candidate-${{ github.run_id }}-${{ github.run_attempt }}
-          target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}
-          name: Continuous Candidate ${{ env.KLOGG_VERSION }}
-          body: |
-            Continuous Build ${{ env.KLOGG_VERSION }}
-
-            This is an automated rolling pre-release build. Its package/source publication set is mutable=true and is replaced as one verified coherent set by each successful master run. A parked prior release is restored if promotion verification fails. For the latest stable release, see [latest release](https://github.com/ZEACENT/klogg/releases/latest).
-
-            ## Changes
-            ${{ env.CHANGELOG }}
-
-            ## Downloads
-
-            ### Windows
-            - Windows x64 (Qt 6, Vectorscan AVX2): [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-setup.exe)
-            - Windows x64 (Qt 6, Vectorscan AVX2) portable: [klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-x64-Qt6-vs-avx2-portable.zip)
-
-            ### Linux
-            - Ubuntu 22.04 (Jammy, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-jammy-vs-gen.deb)
-            - Ubuntu 24.04 (Noble, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-noble-vs-gen.deb)
-            - Ubuntu 26.04 (Resolute, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb)
-            - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
-
-            ### macOS
-            - Intel (x64, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg)
-            - Apple Silicon (ARM64, Vectorscan): [klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg](https://github.com/ZEACENT/klogg/releases/download/continuous/klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg)
-          prerelease: true
-          files: |
-            ./packages-all/**/*
-            ./packages-publication/klogg-v*-adb-helper-source-*.tar.gz
-            ./packages-publication/klogg-v*-adb-helper-source-*.tar.gz.sha256
-            ./packages-publication/klogg-v*-ios-native-source-*.tar.gz
-            ./packages-publication/klogg-v*-ios-native-source-*.tar.gz.sha256
-            ./packages-publication/adb-helper-source-set-receipt.json
-            ./packages-publication/ios-native-source-set-receipt.json
-            ./packages-publication/ios-native-*.sha256
-            ./packages-publication/NOTICE-ios-native.txt.sha256
-            ./packages-publication/klogg-source-publication-manifest.json
-            ./packages-publication/*.qualification.json
-            ./packages-publication/*.ios-qualification.json
-            ./packages-publication/adb-helper-licenses.tar.gz
-            ./packages-publication/adb-helper-notices.tar.gz
-            ./packages-publication/adb-helper-sbom.spdx.json
-            ./packages-publication/ADB-HELPER-SOURCE-OFFER.txt
-            ./packages-publication/adb-helper-source-manifest.json
-            ./packages-publication/adb-helper-*.sha256
-            ./packages-publication/ADB-HELPER-*.sha256
-            ./packages-publication/ios-native-source-offer.txt
-            ./packages-publication/ios-native-lgpl-replacement.txt
-            ./packages-publication/NOTICE-ios-native.txt
-          draft: true
-
-      - name: Verify rolling source publication after upload
-        if: env.GITHUB_TOKEN != ''
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
-        run: |
-          set -euo pipefail
-          test -n "${RELEASE_ID}" || { echo "::error::Missing candidate release ID"; exit 1; }
-          verification_root=$(mktemp -d)
-          while IFS=$'\t' read -r asset_id asset_name; do
-            gh api -H "Accept: application/octet-stream" \
-              "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "$verification_root/$asset_name"
-          done < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
-            --jq '.[] | [.id, .name] | @tsv')
-          python3 scripts/verify_source_publication_manifest.py \
-            --manifest "$verification_root/klogg-source-publication-manifest.json" \
-            --assets-root "$verification_root" \
-            --expected-channel continuous \
-            --expected-tag continuous \
-            --expected-version "${KLOGG_VERSION}" \
-            --expected-commit "${KLOGG_SOURCE_COMMIT}" \
-            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
-
-      - name: Park existing continuous release for rollback
-        if: env.GITHUB_TOKEN != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          tag="continuous"
-          backup_tag="continuous-rollback-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          lookup_error=$(mktemp)
-          if ! release_id=$(gh api "/repos/${repo}/releases/tags/${tag}" --jq '.id' 2>"$lookup_error"); then
-            if grep -Eq '404|Not Found' "$lookup_error"; then
-              echo "No existing continuous release to park"
-              rm -f "$lookup_error"
-              exit 0
-            fi
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
-          old_sha=$(gh api "/repos/${repo}/git/ref/tags/${tag}" --jq '.object.sha')
-          {
-            echo "KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID=${release_id}"
-            echo "KLOGG_PREVIOUS_CONTINUOUS_SHA=${old_sha}"
-            echo "KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG=${backup_tag}"
-          } >> "$GITHUB_ENV"
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/${backup_tag}" >/dev/null 2>&1 || true
-          gh api -X POST "/repos/${repo}/git/refs" \
-            -f ref="refs/tags/${backup_tag}" \
-            -f sha="${old_sha}" >/dev/null
-          gh api -X PATCH "/repos/${repo}/releases/${release_id}" \
-            -f tag_name="${backup_tag}" \
-            -F draft=true \
-            -F prerelease=true >/dev/null
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null 2>&1 || true
-
-      - name: Promote verified continuous candidate
-        if: env.GITHUB_TOKEN != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          release_id="${RELEASE_ID}"
-          if [ -z "${release_id}" ]; then
-            echo "::error::No release ID from create_release step"
-            exit 1
-          fi
-          echo "Enforcing flags on release ${release_id}"
-          gh api -X PATCH "/repos/${repo}/releases/${release_id}" \
-            -f tag_name=continuous \
-            -f draft=false \
-            -f prerelease=true >/dev/null
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/continuous-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            >/dev/null 2>&1 || true
-
-      - name: Verify continuous release flags
-        if: env.GITHUB_TOKEN != ''
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          release_id="${RELEASE_ID}"
-          if [ -z "${release_id}" ]; then
-            echo "::error::No release ID from create_release step"
-            exit 1
-          fi
-          tag_name="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.tag_name')"
-          draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
-          prerelease="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.prerelease')"
-
-          echo "continuous release flags: tag_name=${tag_name} draft=${draft} prerelease=${prerelease}"
-          if [ "${tag_name}" != "continuous" ] || [ "${draft}" != "false" ] || [ "${prerelease}" != "true" ]; then
-            gh api "/repos/${repo}/releases/${release_id}" --jq '{id,tag_name,html_url,draft,prerelease,target_commitish}'
-            exit 1
-          fi
-
-      - name: Reverify promoted continuous release
-        if: env.GITHUB_TOKEN != ''
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          tag_name="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.tag_name')"
-          test "${tag_name}" = "continuous" || { echo "::error::continuous release tag mismatch"; exit 1; }
-          ref_sha="$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')"
-          test "${ref_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
-            echo "::error::continuous ref ${ref_sha} != source commit ${KLOGG_SOURCE_COMMIT}"
-            exit 1
-          }
-          candidate_ref="continuous-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          candidate_error=$(mktemp)
-          if gh api "/repos/${repo}/git/ref/tags/${candidate_ref}" >/dev/null 2>"$candidate_error"; then
-            echo "::error::candidate tag was not cleaned up: ${candidate_ref}"
-            exit 1
-          elif ! grep -Eq '404|Not Found' "$candidate_error"; then
-            cat "$candidate_error"
-            exit 1
-          fi
-          rm -f "$candidate_error"
-          verification_root=$(mktemp -d)
-          gh release download continuous --repo "${repo}" --dir "$verification_root"
-          python3 scripts/verify_source_publication_manifest.py \
-            --manifest "$verification_root/klogg-source-publication-manifest.json" \
-            --assets-root "$verification_root" \
-            --expected-channel continuous \
-            --expected-tag continuous \
-            --expected-version "${KLOGG_VERSION}" \
-            --expected-commit "${KLOGG_SOURCE_COMMIT}" \
-            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
-
-      - name: Roll back failed continuous promotion
-        if: failure() && env.GITHUB_TOKEN != ''
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-          CANDIDATE_RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
-        run: |
-          set -euo pipefail
-          repo="${GITHUB_REPOSITORY}"
-          candidate_id="${CANDIDATE_RELEASE_ID:-}"
-          previous_id="${KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID:-}"
-          previous_sha="${KLOGG_PREVIOUS_CONTINUOUS_SHA:-}"
-          backup_tag="${KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG:-}"
-          if [ -n "$candidate_id" ]; then
-            candidate_tag=$(gh api "/repos/${repo}/releases/${candidate_id}" --jq '.tag_name' 2>/dev/null || true)
-            gh api -X DELETE "/repos/${repo}/releases/${candidate_id}" >/dev/null 2>&1 || true
-            if [ -n "$candidate_tag" ]; then
-              gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null 2>&1 || true
-            fi
-          fi
-          if [ -z "$previous_id" ]; then
-            echo "No previous continuous release was parked; removed failed candidate without changing the live release"
-            exit 0
-          fi
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/continuous" >/dev/null 2>&1 || true
-          test -n "$previous_sha" && test -n "$backup_tag"
-          gh api -X POST "/repos/${repo}/git/refs" \
-            -f ref="refs/tags/continuous" \
-            -f sha="$previous_sha" >/dev/null
-          gh api -X PATCH "/repos/${repo}/releases/${previous_id}" \
-            -f tag_name=continuous \
-            -F draft=false \
-            -F prerelease=true >/dev/null
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/${backup_tag}" >/dev/null 2>&1 || true
-          restored_id=$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')
-          test "$restored_id" = "$previous_id"
-
-      - name: Remove parked continuous release after promotion
-        if: success() && env.GITHUB_TOKEN != '' && env.KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID != ''
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        run: |
-          repo="${GITHUB_REPOSITORY}"
-          gh api -X DELETE "/repos/${repo}/releases/${KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID}" \
-            >/dev/null 2>&1 || echo "::warning::failed to delete parked continuous release"
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/${KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG}" \
-            >/dev/null 2>&1 || true

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,13 +3,6 @@ name: "CI Build"
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - 'website/**'
-      - BUILD.md
-      - CODE_OF_CONDUCT.md
-      - CONTRIBUTING.md
-      - README.md
-      - .gitignore
   pull_request:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -1,0 +1,579 @@
+name: "Publish Continuous Release"
+
+on:
+  workflow_run:
+    workflows: ["CI Build"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: continuous-release-publisher
+  cancel-in-progress: false
+
+jobs:
+  select:
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event == 'push'
+      && github.event.workflow_run.head_branch == 'master'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      KLOGG_CI_RUN_ID: ${{ github.event.workflow_run.id }}
+      KLOGG_CI_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+    outputs:
+      should-publish: ${{ steps.selection.outputs.should-publish }}
+    steps:
+      - name: Verify triggering CI run and current master tip
+        id: selection
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          run_api="/repos/${repo}/actions/runs/${KLOGG_CI_RUN_ID}"
+          test "$(gh api "$run_api" --jq '.path')" = ".github/workflows/ci-build.yml"
+          test "$(gh api "$run_api" --jq '.head_repository.full_name // empty')" = "$repo"
+          test "$(gh api "$run_api" --jq '.head_branch')" = "master"
+          test "$(gh api "$run_api" --jq '.event')" = "push"
+          test "$(gh api "$run_api" --jq '.conclusion')" = "success"
+          test "$(gh api "$run_api" --jq '.head_sha')" = "$KLOGG_CI_RUN_SHA"
+          master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+          if [ "$master_sha" != "$KLOGG_CI_RUN_SHA" ]; then
+            echo "::notice::Skipping stale continuous run ${KLOGG_CI_RUN_ID}: ${KLOGG_CI_RUN_SHA} != ${master_sha}"
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should-publish=true" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: select
+    if: ${{ needs.select.outputs.should-publish == 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      KLOGG_CI_RUN_ID: ${{ github.event.workflow_run.id }}
+      KLOGG_CI_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+      KLOGG_EVIDENCE_LEVEL: validation
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Download package artifacts from exact CI run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          pattern: packages-*
+          path: packages-all
+
+      - name: Download version artifact from exact CI run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: klogg_version
+          path: klogg_version
+
+      - name: Download ADB legal assets from exact CI run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: adb-helper-legal-assets
+          path: adb-helper-legal-assets
+
+      - name: Download iOS source assets from exact CI run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: ios-native-source-assets
+          path: ios-native-source-assets
+
+      - name: Bind downloaded artifacts to the triggering SHA
+        shell: bash
+        run: |
+          set -euo pipefail
+          KLOGG_VERSION="$(cat klogg_version/klogg_version.txt)"
+          KLOGG_SOURCE_COMMIT="$(cat klogg_version/klogg_commit.txt)"
+          test "${KLOGG_SOURCE_COMMIT}" = "${KLOGG_CI_RUN_SHA}" || {
+            echo "::error::Artifact commit ${KLOGG_SOURCE_COMMIT} != triggering run ${KLOGG_CI_RUN_SHA}"
+            exit 1
+          }
+          git fetch --no-tags origin master
+          git checkout --detach "$KLOGG_SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$KLOGG_SOURCE_COMMIT"
+          {
+            echo "KLOGG_VERSION=$KLOGG_VERSION"
+            echo "KLOGG_SOURCE_COMMIT=$KLOGG_SOURCE_COMMIT"
+          } >> "$GITHUB_ENV"
+
+      - name: Extract package tarballs
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' archive; do
+            directory="$(dirname "$archive")"
+            staging="$(mktemp -d)"
+            python3 scripts/extract_verified_tar.py --archive "$archive" --destination "$staging"
+            cp -a "$staging"/. "$directory"/
+            rm -rf "$staging" "$archive"
+          done < <(find packages-all -name 'packages-*.tar.gz' -type f -print0)
+
+      - name: Generate continuous changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          changelog="$(python3 scripts/gen_changelog.py --mode prerelease --to-ref "$KLOGG_SOURCE_COMMIT" --print-range)"
+          delimiter="$(openssl rand -hex 16)"
+          {
+            echo "CHANGELOG<<$delimiter"
+            echo "$changelog"
+            echo "$delimiter"
+          } >> "$GITHUB_ENV"
+
+      - name: Prepare coherent rolling validation publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          qualification_args=(
+            --qualification-receipt packages-all/packages-jammy-vs-gen/adb-helper-deb-package-verification.json
+            --qualification-receipt packages-all/packages-noble-vs-gen/adb-helper-deb-package-verification.json
+            --qualification-receipt packages-all/packages-resolute-vs-gen/adb-helper-deb-package-verification.json
+            --qualification-receipt packages-all/packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
+            --qualification-receipt packages-all/packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
+            --qualification-receipt packages-all/packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
+            --qualification-receipt packages-all/packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
+            --ios-qualification-receipt packages-all/packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
+            --ios-qualification-receipt packages-all/packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
+          )
+          python3 scripts/prepare_source_publication.py \
+            --channel continuous \
+            --evidence-level "$KLOGG_EVIDENCE_LEVEL" \
+            --tag continuous \
+            --version "$KLOGG_VERSION" \
+            --commit "$KLOGG_SOURCE_COMMIT" \
+            --base-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --adb-source-root adb-helper-legal-assets \
+            --ios-source-root ios-native-source-assets \
+            "${qualification_args[@]}" \
+            --output packages-publication
+
+      - name: Recheck master tip before continuous candidate creation
+        shell: bash
+        run: |
+          set -euo pipefail
+          master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+          test "$master_sha" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Master advanced before candidate creation: ${master_sha}"
+            exit 1
+          }
+
+      - name: Recover interrupted continuous transaction
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+
+          delete_ref_if_present() {
+            local tag="$1"
+            local lookup_error
+            lookup_error="$(mktemp)"
+            if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
+              gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+              cat "$lookup_error"
+              rm -f "$lookup_error"
+              return 1
+            fi
+            rm -f "$lookup_error"
+          }
+
+          verify_release() {
+            local release_id="$1"
+            local ref_tag="$2"
+            local expected_draft="$3"
+            local verification_root asset_list ref_sha manifest_commit manifest_version
+            test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = "$expected_draft" || return 1
+            test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.prerelease')" = true || return 1
+            ref_sha="$(gh api "/repos/${repo}/git/ref/tags/${ref_tag}" --jq '.object.sha')" || return 1
+            verification_root="$(mktemp -d)" || return 1
+            asset_list="$(mktemp)" || return 1
+            gh api --paginate "/repos/${repo}/releases/${release_id}/assets" \
+              --jq '.[] | [.id, .name] | @tsv' > "$asset_list" || return 1
+            while IFS=$'\t' read -r asset_id asset_name; do
+              gh api -H "Accept: application/octet-stream" \
+                "/repos/${repo}/releases/assets/${asset_id}" > "$verification_root/$asset_name" || return 1
+            done < "$asset_list"
+            read -r manifest_commit manifest_version < <(
+              python3 - "$verification_root/klogg-source-publication-manifest.json" <<'PY'
+          import json, pathlib, sys
+          release = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))["release"]
+          print(release["commit"], release["version"])
+          PY
+            )
+            test "$ref_sha" = "$manifest_commit" || return 1
+            python3 scripts/verify_source_publication_manifest.py \
+              --manifest "$verification_root/klogg-source-publication-manifest.json" \
+              --assets-root "$verification_root" \
+              --expected-channel continuous \
+              --expected-evidence-level validation \
+              --expected-tag continuous \
+              --expected-version "$manifest_version" \
+              --expected-commit "$manifest_commit" \
+              --expected-base-url "https://github.com/${repo}" || return 1
+            rm -rf "$verification_root" "$asset_list"
+          }
+
+          restore_parked_release() {
+            local live_id="${1:-}"
+            echo "Restore parked continuous release ${parked_tag}"
+            if [ -n "$live_id" ]; then
+              gh api -X DELETE "/repos/${repo}/releases/${live_id}" >/dev/null
+            fi
+            delete_ref_if_present continuous
+            gh api -X POST "/repos/${repo}/git/refs" \
+              -f ref=refs/tags/continuous -f sha="$parked_sha" >/dev/null
+            gh api -X PATCH "/repos/${repo}/releases/${parked_id}" \
+              -f tag_name=continuous -F draft=false -F prerelease=true >/dev/null
+            delete_ref_if_present "$parked_tag"
+            test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$parked_id"
+            test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$parked_sha"
+          }
+
+          mapfile -t parked < <(
+            gh api --paginate "/repos/${repo}/releases?per_page=100" \
+              --jq '.[] | select(.tag_name | startswith("continuous-rollback-")) | [.id, .tag_name] | @tsv'
+          )
+          if [ "${#parked[@]}" -gt 1 ]; then
+            echo "::error::Multiple parked continuous releases require manual reconciliation"
+            printf '%s\n' "${parked[@]}"
+            exit 1
+          fi
+          if [ "${#parked[@]}" -eq 0 ]; then
+            exit 0
+          fi
+          IFS=$'\t' read -r parked_id parked_tag <<< "${parked[0]}"
+          parked_sha="$(gh api "/repos/${repo}/git/ref/tags/${parked_tag}" --jq '.object.sha')"
+          verify_release "$parked_id" "$parked_tag" true
+
+          lookup_error="$(mktemp)"
+          if live_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
+            if verify_release "$live_id" continuous false; then
+              echo "Remove stale parked continuous release ${parked_tag}; live continuous release is coherent"
+              gh api -X DELETE "/repos/${repo}/releases/${parked_id}" >/dev/null
+              delete_ref_if_present "$parked_tag"
+            else
+              restore_parked_release "$live_id"
+            fi
+          elif grep -Eq '404|Not Found' "$lookup_error"; then
+            restore_parked_release
+          else
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+      - name: Clean stale continuous candidate draft
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
+          release_id=""
+          lookup_error="$(mktemp)"
+          if release_id="$(gh api "/repos/${repo}/releases/tags/${candidate_tag}" --jq '.id' 2>"$lookup_error")"; then
+            test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = true
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/${candidate_tag}" >/dev/null 2>"$lookup_error"; then
+            gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null
+          elif [ -n "$release_id" ] || ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+          if [ -n "$release_id" ]; then
+            gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
+          fi
+
+      - name: Create continuous candidate draft
+        id: candidate_release
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+        with:
+          token: ${{ github.token }}
+          tag_name: continuous-candidate-${{ env.KLOGG_CI_RUN_ID }}
+          target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}
+          name: Continuous Candidate ${{ env.KLOGG_VERSION }}
+          body: |
+            Continuous Build ${{ env.KLOGG_VERSION }}
+
+            This rolling release is built from a successful trusted master push. Windows and Linux packages are CI-validated. The macOS disk images are unsigned validation artifacts, not signed or notarized releases.
+
+            ## Changes
+            ${{ env.CHANGELOG }}
+
+            ## Downloads
+            - Windows x64 installer and portable archive
+            - Ubuntu 22.04, 24.04, and 26.04 packages
+            - AppImage
+            - macOS Intel and Apple Silicon unsigned disk images
+            - Content-addressed ADB helper and iOS native corresponding source
+          prerelease: true
+          draft: true
+          files: |
+            ./packages-publication/*
+
+      - name: Verify continuous candidate after upload
+        shell: bash
+        env:
+          RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          test -n "$RELEASE_ID"
+          verification_root="$(mktemp -d)"
+          while IFS=$'\t' read -r asset_id asset_name; do
+            gh api -H "Accept: application/octet-stream" \
+              "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "$verification_root/$asset_name"
+          done < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" --jq '.[] | [.id, .name] | @tsv')
+          python3 scripts/verify_source_publication_manifest.py \
+            --manifest "$verification_root/klogg-source-publication-manifest.json" \
+            --assets-root "$verification_root" \
+            --expected-channel continuous \
+            --expected-evidence-level validation \
+            --expected-tag continuous \
+            --expected-version "$KLOGG_VERSION" \
+            --expected-commit "$KLOGG_SOURCE_COMMIT" \
+            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
+
+      - name: Recheck master tip before continuous promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+          test "$master_sha" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Master advanced before continuous promotion: ${master_sha}"
+            exit 1
+          }
+
+      - name: Park existing continuous release for rollback
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          backup_tag="continuous-rollback-${KLOGG_CI_RUN_ID}"
+          lookup_error="$(mktemp)"
+          if release_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
+            :
+          elif grep -Eq '404|Not Found' "$lookup_error"; then
+            echo "No existing continuous release to park"
+            rm -f "$lookup_error"
+            exit 0
+          else
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+          test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.prerelease')" = true
+          old_sha="$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')"
+          {
+            echo "KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID=$release_id"
+            echo "KLOGG_PREVIOUS_CONTINUOUS_SHA=$old_sha"
+            echo "KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG=$backup_tag"
+          } >> "$GITHUB_ENV"
+
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/${backup_tag}" >/dev/null 2>"$lookup_error"; then
+            gh api -X DELETE "/repos/${repo}/git/refs/tags/${backup_tag}" >/dev/null
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+          gh api -X POST "/repos/${repo}/git/refs" \
+            -f ref="refs/tags/${backup_tag}" -f sha="$old_sha" >/dev/null
+          test "$(gh api "/repos/${repo}/git/ref/tags/${backup_tag}" --jq '.object.sha')" = "$old_sha"
+          gh api -X PATCH "/repos/${repo}/releases/${release_id}" \
+            -f tag_name="$backup_tag" -F draft=true -F prerelease=true >/dev/null
+          test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.tag_name')" = "$backup_tag"
+          test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = true
+          gh api -X DELETE "/repos/${repo}/git/refs/tags/continuous" >/dev/null
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/continuous" >/dev/null 2>"$lookup_error" \
+            || ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+      - name: Promote verified continuous candidate
+        shell: bash
+        env:
+          RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
+          test -n "$RELEASE_ID"
+          master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+          test "$master_sha" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Master advanced inside continuous promotion: ${master_sha}"
+            exit 1
+          }
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/continuous" >/dev/null 2>"$lookup_error" \
+            || ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            echo "::error::Continuous ref must be absent before promotion"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+          gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" \
+            -f tag_name=continuous -F draft=false -F prerelease=true >/dev/null
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$RELEASE_ID"
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/${candidate_tag}" >/dev/null 2>"$lookup_error"; then
+            gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+      - name: Reverify promoted continuous release
+        shell: bash
+        run: |
+          set -euo pipefail
+          master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+          test "$master_sha" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Master advanced before continuous re-verification: ${master_sha}"
+            exit 1
+          }
+          test "$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/continuous" --jq '.prerelease')" = true
+          ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/continuous" --jq '.object.sha')"
+          test "$ref_sha" = "$KLOGG_SOURCE_COMMIT"
+          verification_root="$(mktemp -d)"
+          gh release download continuous --repo "$GITHUB_REPOSITORY" --dir "$verification_root"
+          python3 scripts/verify_source_publication_manifest.py \
+            --manifest "$verification_root/klogg-source-publication-manifest.json" \
+            --assets-root "$verification_root" \
+            --expected-channel continuous \
+            --expected-evidence-level validation \
+            --expected-tag continuous \
+            --expected-version "$KLOGG_VERSION" \
+            --expected-commit "$KLOGG_SOURCE_COMMIT" \
+            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
+          master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+          test "$master_sha" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Master advanced during continuous re-verification: ${master_sha}"
+            exit 1
+          }
+
+      - name: Roll back failed continuous promotion
+        if: ${{ failure() || cancelled() }}
+        shell: bash
+        env:
+          CANDIDATE_RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          candidate_id="${CANDIDATE_RELEASE_ID:-}"
+          candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
+          previous_id="${KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID:-}"
+          previous_sha="${KLOGG_PREVIOUS_CONTINUOUS_SHA:-}"
+          backup_tag="${KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG:-}"
+
+          delete_ref_if_present() {
+            local tag="$1"
+            local lookup_error
+            lookup_error="$(mktemp)"
+            if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
+              gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+              cat "$lookup_error"
+              rm -f "$lookup_error"
+              return 1
+            fi
+            rm -f "$lookup_error"
+          }
+
+          published_tag=""
+          if [ -n "$candidate_id" ]; then
+            lookup_error="$(mktemp)"
+            if published_tag="$(gh api "/repos/${repo}/releases/${candidate_id}" --jq '.tag_name' 2>"$lookup_error")"; then
+              gh api -X DELETE "/repos/${repo}/releases/${candidate_id}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+              cat "$lookup_error"
+              exit 1
+            fi
+            rm -f "$lookup_error"
+          fi
+          delete_ref_if_present "$candidate_tag"
+          if [ "$published_tag" = continuous ]; then
+            delete_ref_if_present continuous
+          fi
+
+          if [ -z "$previous_id" ]; then
+            exit 0
+          fi
+          test -n "$previous_sha" && test -n "$backup_tag"
+
+          live_id=""
+          lookup_error="$(mktemp)"
+          if live_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
+            if [ "$live_id" = "$previous_id" ]; then
+              test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$previous_sha"
+              delete_ref_if_present "$backup_tag"
+              exit 0
+            fi
+            gh api -X DELETE "/repos/${repo}/releases/${live_id}" >/dev/null
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            exit 1
+          fi
+          rm -f "$lookup_error"
+
+          delete_ref_if_present continuous
+          test "$(gh api "/repos/${repo}/releases/${previous_id}" --jq '.tag_name')" = "$backup_tag"
+          test "$(gh api "/repos/${repo}/git/ref/tags/${backup_tag}" --jq '.object.sha')" = "$previous_sha"
+          gh api -X POST "/repos/${repo}/git/refs" \
+            -f ref=refs/tags/continuous -f sha="$previous_sha" >/dev/null
+          gh api -X PATCH "/repos/${repo}/releases/${previous_id}" \
+            -f tag_name=continuous -F draft=false -F prerelease=true >/dev/null
+          delete_ref_if_present "$backup_tag"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$previous_id"
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$previous_sha"
+
+      - name: Remove parked continuous release after promotion
+        if: success() && env.KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          gh api -X DELETE "/repos/${repo}/git/refs/tags/${KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG}" >/dev/null
+          if ! gh api -X DELETE "/repos/${repo}/releases/${KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID}" >/dev/null; then
+            gh api -X POST "/repos/${repo}/git/refs" \
+              -f ref="refs/tags/${KLOGG_PREVIOUS_CONTINUOUS_BACKUP_TAG}" \
+              -f sha="$KLOGG_PREVIOUS_CONTINUOUS_SHA" >/dev/null
+            echo "::error::Failed to remove parked continuous release; restored its rollback ref"
+            exit 1
+          fi

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -29,9 +29,9 @@ jobs:
       actions: read
       contents: write
     env:
-      SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+      KLOGG_HAS_SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN != '' && 'true' || 'false' }}
+      KLOGG_HAS_DISCORD_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK != '' && 'true' || 'false' }}
       GITHUB_TOKEN: ${{ github.token }}
-      DISCORD_NEW_VERSIONS_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
       KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}
       KLOGG_EVIDENCE_LEVEL: ${{ github.event.inputs.evidence-level }}
     steps:
@@ -70,7 +70,6 @@ jobs:
         run_repository="$(gh api "$run_api" --jq '.head_repository.full_name // empty')"
         run_branch="$(gh api "$run_api" --jq '.head_branch // empty')"
         run_event="$(gh api "$run_api" --jq '.event')"
-        run_qualification="$(gh api "$run_api" --jq '.inputs["qualification-mode"] // empty')"
         run_conclusion="$(gh api "$run_api" --jq '.conclusion')"
         run_sha="$(gh api "$run_api" --jq '.head_sha')"
         test "$run_path" = ".github/workflows/ci-build.yml" || { echo "::error::Selected run uses ${run_path}"; exit 1; }
@@ -84,21 +83,9 @@ jobs:
             }
             ;;
           workflow_dispatch)
-            case "$run_qualification" in
-              validation|release) ;;
-              *) echo "::error::Selected dispatch has unknown qualification mode: ${run_qualification}"; exit 1 ;;
-            esac
-            if [ "$run_qualification" = release ]; then
-              test "$KLOGG_EVIDENCE_LEVEL" = signed || {
-                echo "::error::Release-qualified CI artifacts must be published with signed evidence"
-                exit 1
-              }
-            else
-              test "$KLOGG_EVIDENCE_LEVEL" = validation || {
-                echo "::error::Validation CI artifacts cannot satisfy signed evidence"
-                exit 1
-              }
-            fi
+            # The workflow-run API does not expose workflow_dispatch inputs.
+            # Bind the requested evidence level after download from the SHA-bound
+            # package, iOS, signing, and notarization receipts instead.
             ;;
           *) echo "::error::Selected run event is ${run_event}"; exit 1 ;;
         esac
@@ -245,6 +232,13 @@ jobs:
             qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
             if qualification.get("package_sha256") != dmg_hash:
                 raise SystemExit(f"macOS qualification receipt is not bound to published DMG: {qualification_path}")
+            ios_path = directory / "ios-native-dmg-package-verification.json"
+            ios_qualification = json.loads(ios_path.read_text(encoding="utf-8"))
+            if (
+                ios_qualification.get("qualification") != evidence_level
+                or ios_qualification.get("release_qualified") != (evidence_level == "signed")
+            ):
+                raise SystemExit(f"iOS qualification evidence level mismatch: {ios_path}")
             if evidence_level != "signed":
                 continue
             for name in ("signing", "notarization"):
@@ -300,7 +294,7 @@ jobs:
         fi
 
     - name: Setup Sentry CLI
-      if: env.SENTRY_TOKEN != ''
+      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
       uses: mathrix-education/setup-sentry-cli@ff4fff773f5e628fa214ebd19e46fb7289454ee2 # v3.0.0
       with:
         token: ${{ secrets.SENTRY_TOKEN }}
@@ -308,14 +302,14 @@ jobs:
         project: klogg
 
     - name: Create Sentry release
-      if: env.SENTRY_TOKEN != ''
+      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
       shell: sh
       run: |
         sentry-cli releases new $KLOGG_VERSION
         sentry-cli releases set-commits --auto $KLOGG_VERSION
 
     - name: Upload symbols linux
-      if: env.SENTRY_TOKEN != ''
+      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
       shell: sh
       run: |
         if [ -f ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug ] && [ -f ./packages-jammy-vs-gen/klogg_jammy_vs-gen ]; then
@@ -340,7 +334,7 @@ jobs:
         fi
 
     - name: Upload symbols mac
-      if: env.SENTRY_TOKEN != ''
+      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
       shell: sh
       run: |
         if [ -d ./packages-macos-intel-qt6-vs-gen ] && [ -f ./packages-macos-intel-qt6-vs-gen/klogg-x64.app/Contents/MacOS/klogg ]; then
@@ -355,7 +349,7 @@ jobs:
         fi
 
     - name: Upload symbols win
-      if: env.SENTRY_TOKEN != ''
+      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
       shell: sh
       run: |
         sentry-cli upload-dif ./packages-windows-x64-qt6-vs-avx2/klogg-$KLOGG_VERSION-x64-Qt6-vs-avx2-pdb.zip
@@ -580,9 +574,9 @@ jobs:
         test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
         release_tag="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')"
         test "${release_tag}" = "v${KLOGG_VERSION}-candidate" || { echo "::error::Stable candidate tag mismatch"; exit 1; }
-        ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${KLOGG_VERSION}-candidate" --jq '.object.sha')"
-        test "${ref_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
-          echo "::error::Stable release ref ${ref_sha} != source commit ${KLOGG_SOURCE_COMMIT}"
+        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.target_commitish')"
+        test "${candidate_target}" = "${KLOGG_SOURCE_COMMIT}" || {
+          echo "::error::Stable candidate target ${candidate_target} != source commit ${KLOGG_SOURCE_COMMIT}"
           exit 1
         }
         verification_root=$(mktemp -d)
@@ -692,7 +686,7 @@ jobs:
         trap - ERR
 
     - name: Discord notification
-      if: env.DISCORD_NEW_VERSIONS_WEBHOOK != ''
+      if: env.KLOGG_HAS_DISCORD_WEBHOOK == 'true'
       env:
         DISCORD_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
         DISCORD_EMBEDS: '[{"title": "Release v${{ env.KLOGG_VERSION }}", "url": "https://github.com/ZEACENT/klogg/releases/tag/v${{ env.KLOGG_VERSION }}"}]'

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,17 +4,46 @@ on:
   workflow_dispatch:
     inputs:
       ci-run-id:
-        description: "Run ID of an explicit CI Build workflow_dispatch with qualification-mode=release"
+        description: "Optional successful trusted master CI Build run ID; defaults to latest successful master push"
+        required: false
+        type: string
+      evidence-level:
+        description: "Publish secret-neutral validation artifacts, or require signed/notarized macOS evidence"
         required: true
+        default: validation
+        type: choice
+        options:
+          - validation
+          - signed
+
+permissions: {}
+
+concurrency:
+  group: stable-release-publisher
+  cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     env:
       SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
       DISCORD_NEW_VERSIONS_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
+      KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}
+      KLOGG_EVIDENCE_LEVEL: ${{ github.event.inputs.evidence-level }}
     steps:
+    - name: Reject non-master stable dispatch
+      shell: bash
+      run: |
+        set -euo pipefail
+        test "${GITHUB_REF}" = "refs/heads/master" || {
+          echo "::error::Stable releases must be dispatched from refs/heads/master"
+          exit 1
+        }
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
@@ -25,24 +54,61 @@ jobs:
       run: |
         set -euo pipefail
         repo="${GITHUB_REPOSITORY}"
-        run_id="${{ github.event.inputs.ci-run-id }}"
-        test -n "$run_id" || { echo "::error::A release-qualified CI run ID is required"; exit 1; }
+        requested_run_id="${KLOGG_REQUESTED_CI_RUN_ID}"
+        if [ -n "$requested_run_id" ]; then
+          [[ "$requested_run_id" =~ ^[0-9]+$ ]] || {
+            echo "::error::ci-run-id must contain digits only"
+            exit 1
+          }
+          run_id="$requested_run_id"
+        else
+          run_id="$(gh api "/repos/${repo}/actions/workflows/ci-build.yml/runs?branch=master&event=push&status=success&per_page=1" --jq '.workflow_runs[0].id // empty')"
+        fi
+        test -n "$run_id" || { echo "::error::No successful trusted master CI Build run found"; exit 1; }
         run_api="/repos/${repo}/actions/runs/${run_id}"
         run_path="$(gh api "$run_api" --jq '.path')"
         run_repository="$(gh api "$run_api" --jq '.head_repository.full_name // empty')"
         run_branch="$(gh api "$run_api" --jq '.head_branch // empty')"
         run_event="$(gh api "$run_api" --jq '.event')"
+        run_qualification="$(gh api "$run_api" --jq '.inputs["qualification-mode"] // empty')"
         run_conclusion="$(gh api "$run_api" --jq '.conclusion')"
         run_sha="$(gh api "$run_api" --jq '.head_sha')"
         test "$run_path" = ".github/workflows/ci-build.yml" || { echo "::error::Selected run uses ${run_path}"; exit 1; }
         test "$run_repository" = "${GITHUB_REPOSITORY}" || { echo "::error::Selected run is from ${run_repository}"; exit 1; }
         test "$run_branch" = "master" || { echo "::error::Selected run branch is ${run_branch}"; exit 1; }
-        test "$run_event" = "workflow_dispatch" || {
-          echo "::error::Selected run must be an explicit release-qualification dispatch, got ${run_event}"
-          exit 1
-        }
+        case "$run_event" in
+          push)
+            test "$KLOGG_EVIDENCE_LEVEL" = validation || {
+              echo "::error::Push CI runs contain validation evidence, not signed evidence"
+              exit 1
+            }
+            ;;
+          workflow_dispatch)
+            case "$run_qualification" in
+              validation|release) ;;
+              *) echo "::error::Selected dispatch has unknown qualification mode: ${run_qualification}"; exit 1 ;;
+            esac
+            if [ "$run_qualification" = release ]; then
+              test "$KLOGG_EVIDENCE_LEVEL" = signed || {
+                echo "::error::Release-qualified CI artifacts must be published with signed evidence"
+                exit 1
+              }
+            else
+              test "$KLOGG_EVIDENCE_LEVEL" = validation || {
+                echo "::error::Validation CI artifacts cannot satisfy signed evidence"
+                exit 1
+              }
+            fi
+            ;;
+          *) echo "::error::Selected run event is ${run_event}"; exit 1 ;;
+        esac
         test "$run_conclusion" = "success" || { echo "::error::Selected run conclusion is ${run_conclusion}"; exit 1; }
         test "$run_sha" != "null" && test -n "$run_sha"
+        master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+        test "$run_sha" = "$master_sha" || {
+          echo "::error::Selected CI run is stale: ${run_sha} != current master ${master_sha}"
+          exit 1
+        }
         {
           echo "KLOGG_CI_RUN_ID=${run_id}"
           echo "KLOGG_CI_RUN_SHA=${run_sha}"
@@ -53,6 +119,7 @@ jobs:
       with:
         workflow: ci-build.yml
         run_id: ${{ env.KLOGG_CI_RUN_ID }}
+        github_token: ${{ github.token }}
         # Download only the artifacts the release consumes. Without a filter,
         # dawidd6 downloads ALL run artifacts, including the
         # "<owner>~<repo>~<id>.dockerbuild" build records that
@@ -99,8 +166,8 @@ jobs:
           rm -rf "$staging" "$t"
         done < <(find . -maxdepth 2 -name 'packages-*.tar.gz' -type f -print0)
 
-    - name: Require package qualification receipts before publication
-      shell: sh
+    - name: Validate package evidence before publication
+      shell: bash
       run: |
         set -eu
         required="
@@ -110,19 +177,24 @@ jobs:
           packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
           packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
           packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
-          packages-macos-intel-qt6-vs-gen/adb-helper-signing-receipt.json
-          packages-macos-intel-qt6-vs-gen/adb-helper-notarization-receipt.json
           packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
           packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
-          packages-macos-arm-qt6-vs-arm64/adb-helper-signing-receipt.json
-          packages-macos-arm-qt6-vs-arm64/adb-helper-notarization-receipt.json
           packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
         "
+        if [ "$KLOGG_EVIDENCE_LEVEL" = signed ]; then
+          required="$required
+            packages-macos-intel-qt6-vs-gen/adb-helper-signing-receipt.json
+            packages-macos-intel-qt6-vs-gen/adb-helper-notarization-receipt.json
+            packages-macos-arm-qt6-vs-arm64/adb-helper-signing-receipt.json
+            packages-macos-arm-qt6-vs-arm64/adb-helper-notarization-receipt.json
+          "
+        fi
         for receipt in $required; do
           test -f "$receipt" || { echo "Missing release qualification receipt: $receipt"; exit 1; }
         done
         python3 - <<'PY'
-        import hashlib, json, pathlib
+        import hashlib, json, os, pathlib
+        evidence_level = os.environ["KLOGG_EVIDENCE_LEVEL"]
         package_receipts = [
             pathlib.Path("packages-jammy-vs-gen/adb-helper-deb-package-verification.json"),
             pathlib.Path("packages-noble-vs-gen/adb-helper-deb-package-verification.json"),
@@ -136,12 +208,20 @@ jobs:
             receipt = json.loads(path.read_text(encoding="utf-8"))
             if receipt.get("receipt_kind") != "package-verification":
                 raise SystemExit(f"invalid package qualification receipt kind: {path}")
-            if receipt.get("release_qualified") is not True:
-                raise SystemExit(f"package is not evidence-qualified for release: {path}")
+            if not isinstance(receipt.get("release_qualified"), bool):
+                raise SystemExit(f"package has an invalid release claim: {path}")
             required = set(receipt.get("required_receipts", []))
             verified = set(receipt.get("verified_receipts", []))
-            if not required or not required.issubset(verified):
-                raise SystemExit(f"package qualification receipt is incomplete: {path}")
+            mandatory = {"binary-build", "binary-smoke", "package-verification"}
+            if not mandatory.issubset(required) or not mandatory.issubset(verified):
+                raise SystemExit(f"package validation receipt is incomplete: {path}")
+            if not verified.issubset(required):
+                raise SystemExit(f"package receipt verifies evidence outside policy: {path}")
+            if evidence_level == "signed" and (
+                receipt.get("release_qualified") is not True
+                or not required.issubset(verified)
+            ):
+                raise SystemExit(f"package is not signed/release-qualified: {path}")
             packages = receipt.get("packages")
             if not isinstance(packages, list) or not packages:
                 raise SystemExit(f"package qualification receipt has no final package hashes: {path}")
@@ -165,6 +245,8 @@ jobs:
             qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
             if qualification.get("package_sha256") != dmg_hash:
                 raise SystemExit(f"macOS qualification receipt is not bound to published DMG: {qualification_path}")
+            if evidence_level != "signed":
+                continue
             for name in ("signing", "notarization"):
                 path = directory / f"adb-helper-{name}-receipt.json"
                 receipt = json.loads(path.read_text(encoding="utf-8"))
@@ -338,6 +420,7 @@ jobs:
         )
         python3 scripts/prepare_source_publication.py \
           --channel stable \
+          --evidence-level "${KLOGG_EVIDENCE_LEVEL}" \
           --tag "v${KLOGG_VERSION}" \
           --version "${KLOGG_VERSION}" \
           --commit "${KLOGG_SOURCE_COMMIT}" \
@@ -372,40 +455,59 @@ jobs:
       if: env.GITHUB_TOKEN != ''
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         repo="${GITHUB_REPOSITORY}"
-        tag="v${KLOGG_VERSION}"
-        lookup_error=$(mktemp)
-        if release_id=$(gh api "/repos/${repo}/releases/tags/${tag}" --jq '.id' 2>"$lookup_error"); then
-          draft=$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')
-          test "${draft}" = "true" || {
-            echo "::error::refusing to replace existing published release ${tag}"
+        final_tag="v${KLOGG_VERSION}"
+        candidate_tag="${final_tag}-candidate"
+        for tag in "$candidate_tag" "$final_tag"; do
+          release_id=""
+          lookup_error="$(mktemp)"
+          if release_id="$(gh api "/repos/${repo}/releases/tags/${tag}" --jq '.id' 2>"$lookup_error")"; then
+            draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
+            test "$draft" = true || {
+              echo "::error::refusing to replace existing published release ${tag}"
+              exit 1
+            }
+            gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
             exit 1
-          }
-          gh api -X DELETE "/repos/${repo}/releases/${release_id}"
-          ref_error=$(mktemp)
+          fi
+          rm -f "$lookup_error"
+
+          ref_error="$(mktemp)"
           if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$ref_error"; then
+            if [ "$tag" = "$final_tag" ] && [ -z "$release_id" ]; then
+              echo "::error::refusing to remove orphan stable tag ${tag}"
+              exit 1
+            fi
             gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
           elif ! grep -Eq '404|Not Found' "$ref_error"; then
             cat "$ref_error"
             exit 1
           fi
           rm -f "$ref_error"
-        elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-          cat "$lookup_error"
+        done
+
+    - name: Recheck master tip before stable draft creation
+      shell: bash
+      run: |
+        set -euo pipefail
+        master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
+          echo "::error::Master advanced before stable draft creation: ${master_sha}"
           exit 1
-        fi
-        rm -f "$lookup_error"
+        }
 
     - name: Create GitHub Release
       id: create_release
       if: env.GITHUB_TOKEN != ''
       uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
       with:
-        token: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        tag_name: v${{ env.KLOGG_VERSION }}
+        token: ${{ github.token }}
+        tag_name: v${{ env.KLOGG_VERSION }}-candidate
         target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}
         name: Release v${{ env.KLOGG_VERSION }}
         body: |
@@ -426,7 +528,8 @@ jobs:
           - Ubuntu 26.04 (Resolute, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-resolute-vs-gen.deb)
           - AppImage (Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-appimage-vs-gen.AppImage)
 
-          ### macOS
+          ### macOS (${{ env.KLOGG_EVIDENCE_LEVEL }} evidence)
+          Validation evidence publishes unsigned CI-validated disk images. Signed evidence is accepted only when signing and notarization receipts are complete.
           - Intel (x64, Vectorscan generic): [klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-mac-x64-vs-gen.dmg)
           - Apple Silicon (ARM64, Vectorscan): [klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg](https://github.com/ZEACENT/klogg/releases/download/v${{ env.KLOGG_VERSION }}/klogg-${{ env.KLOGG_VERSION }}-mac-arm64-vs-arm64.dmg)
         prerelease: false
@@ -449,6 +552,9 @@ jobs:
           ./packages-publication/klogg-source-publication-manifest.json
           ./packages-publication/*.qualification.json
           ./packages-publication/*.ios-qualification.json
+          ./packages-publication/*.ios-package.json
+          ./packages-publication/*.signing.json
+          ./packages-publication/*.notarization.json
           ./packages-publication/adb-helper-licenses.tar.gz
           ./packages-publication/adb-helper-notices.tar.gz
           ./packages-publication/adb-helper-sbom.spdx.json
@@ -467,14 +573,14 @@ jobs:
       if: env.GITHUB_TOKEN != ''
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         RELEASE_ID: ${{ steps.create_release.outputs.id }}
       run: |
         set -euo pipefail
         test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
         release_tag="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')"
-        test "${release_tag}" = "v${KLOGG_VERSION}" || { echo "::error::Stable release tag mismatch"; exit 1; }
-        ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${KLOGG_VERSION}" --jq '.object.sha')"
+        test "${release_tag}" = "v${KLOGG_VERSION}-candidate" || { echo "::error::Stable candidate tag mismatch"; exit 1; }
+        ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${KLOGG_VERSION}-candidate" --jq '.object.sha')"
         test "${ref_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
           echo "::error::Stable release ref ${ref_sha} != source commit ${KLOGG_SOURCE_COMMIT}"
           exit 1
@@ -489,23 +595,101 @@ jobs:
           --manifest "$verification_root/klogg-source-publication-manifest.json" \
           --assets-root "$verification_root" \
           --expected-channel stable \
+          --expected-evidence-level "${KLOGG_EVIDENCE_LEVEL}" \
           --expected-tag "v${KLOGG_VERSION}" \
           --expected-version "${KLOGG_VERSION}" \
           --expected-commit "${KLOGG_SOURCE_COMMIT}" \
           --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
 
+    - name: Recheck master tip before stable promotion
+      shell: bash
+      run: |
+        set -euo pipefail
+        master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
+        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
+          echo "::error::Master advanced before stable promotion: ${master_sha}"
+          exit 1
+        }
+
     - name: Publish verified stable release
       if: env.GITHUB_TOKEN != ''
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         RELEASE_ID: ${{ steps.create_release.outputs.id }}
       run: |
         set -euo pipefail
+        repo="$GITHUB_REPOSITORY"
+        final_tag="v${KLOGG_VERSION}"
+        candidate_tag="${final_tag}-candidate"
+        promoted=false
+        delete_ref_if_present() {
+          local tag="$1"
+          local lookup_error
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
+            gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            rm -f "$lookup_error"
+            return 1
+          fi
+          rm -f "$lookup_error"
+        }
+        rollback_stable_promotion() {
+          local original_status=$?
+          trap - ERR
+          if [ "$promoted" = true ]; then
+            echo "Roll back failed stable promotion ${final_tag}"
+            set +e
+            cleanup_status=0
+            gh api -X DELETE "/repos/${repo}/releases/${RELEASE_ID}" >/dev/null \
+              || cleanup_status=1
+            delete_ref_if_present "$final_tag" || cleanup_status=1
+            delete_ref_if_present "$candidate_tag" || cleanup_status=1
+            if [ "$cleanup_status" -ne 0 ]; then
+              echo "::error::Stable promotion rollback was incomplete"
+            fi
+            exit 1
+          fi
+          exit "$original_status"
+        }
+        trap rollback_stable_promotion ERR
+
         test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
-        gh api -X PATCH "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
-          -f draft=false \
-          -f prerelease=false >/dev/null
+        master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
+          echo "::error::Master advanced inside stable promotion: ${master_sha}"
+          exit 1
+        }
+        lookup_error="$(mktemp)"
+        if gh api "/repos/${repo}/git/ref/tags/${final_tag}" >/dev/null 2>"$lookup_error" \
+          || ! grep -Eq '404|Not Found' "$lookup_error"; then
+          cat "$lookup_error"
+          echo "::error::Stable tag already exists: ${final_tag}"
+          exit 1
+        fi
+        rm -f "$lookup_error"
+        gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" \
+          -f tag_name="$final_tag" -F draft=false -F prerelease=false >/dev/null
+        promoted=true
+        test "$(gh api "/repos/${repo}/releases/tags/${final_tag}" --jq '.id')" = "$RELEASE_ID"
+        test "$(gh api "/repos/${repo}/git/ref/tags/${final_tag}" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+        lookup_error="$(mktemp)"
+        if gh api "/repos/${repo}/git/ref/tags/${candidate_tag}" >/dev/null 2>"$lookup_error"; then
+          gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null
+        elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+          cat "$lookup_error"
+          exit 1
+        fi
+        rm -f "$lookup_error"
+        if ! master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" \
+          || [ "${master_sha}" != "${KLOGG_SOURCE_COMMIT}" ]; then
+          echo "::error::Master advanced while stable release was being published: ${master_sha:-unknown}"
+          false
+        fi
+        promoted=false
+        trap - ERR
 
     - name: Discord notification
       if: env.DISCORD_NEW_VERSIONS_WEBHOOK != ''

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       ci-run-id:
-        description: "Run ID of CI workflow"
-        required: false
+        description: "Run ID of an explicit CI Build workflow_dispatch with qualification-mode=release"
+        required: true
 
 jobs:
   release:
@@ -15,7 +15,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
       DISCORD_NEW_VERSIONS_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
     steps:
-    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
         fetch-depth: 0
@@ -25,13 +25,8 @@ jobs:
       run: |
         set -euo pipefail
         repo="${GITHUB_REPOSITORY}"
-        requested_run_id="${{ github.event.inputs.ci-run-id }}"
-        if [ -n "$requested_run_id" ]; then
-          run_id="$requested_run_id"
-        else
-          run_id="$(gh api "/repos/${repo}/actions/workflows/ci-build.yml/runs?branch=master&status=success&per_page=1" --jq '.workflow_runs[0].id // empty')"
-        fi
-        test -n "$run_id" || { echo "::error::No successful master CI run found"; exit 1; }
+        run_id="${{ github.event.inputs.ci-run-id }}"
+        test -n "$run_id" || { echo "::error::A release-qualified CI run ID is required"; exit 1; }
         run_api="/repos/${repo}/actions/runs/${run_id}"
         run_path="$(gh api "$run_api" --jq '.path')"
         run_repository="$(gh api "$run_api" --jq '.head_repository.full_name // empty')"
@@ -42,10 +37,10 @@ jobs:
         test "$run_path" = ".github/workflows/ci-build.yml" || { echo "::error::Selected run uses ${run_path}"; exit 1; }
         test "$run_repository" = "${GITHUB_REPOSITORY}" || { echo "::error::Selected run is from ${run_repository}"; exit 1; }
         test "$run_branch" = "master" || { echo "::error::Selected run branch is ${run_branch}"; exit 1; }
-        case "$run_event" in
-          push|workflow_dispatch) ;;
-          *) echo "::error::Selected run event is ${run_event}"; exit 1 ;;
-        esac
+        test "$run_event" = "workflow_dispatch" || {
+          echo "::error::Selected run must be an explicit release-qualification dispatch, got ${run_event}"
+          exit 1
+        }
         test "$run_conclusion" = "success" || { echo "::error::Selected run conclusion is ${run_conclusion}"; exit 1; }
         test "$run_sha" != "null" && test -n "$run_sha"
         {
@@ -54,7 +49,7 @@ jobs:
         } >> "$GITHUB_ENV"
 
     - name: Download artifacts for selected CI workflow
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
       with:
         workflow: ci-build.yml
         run_id: ${{ env.KLOGG_CI_RUN_ID }}
@@ -224,9 +219,7 @@ jobs:
 
     - name: Setup Sentry CLI
       if: env.SENTRY_TOKEN != ''
-      uses: mathrix-education/setup-sentry-cli@0.1.0
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+      uses: mathrix-education/setup-sentry-cli@ff4fff773f5e628fa214ebd19e46fb7289454ee2 # v3.0.0
       with:
         token: ${{ secrets.SENTRY_TOKEN }}
         organization: anton-filimonov
@@ -409,7 +402,7 @@ jobs:
     - name: Create GitHub Release
       id: create_release
       if: env.GITHUB_TOKEN != ''
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
       with:
         token: ${{ secrets.KLOGG_GITHUB_TOKEN }}
         tag_name: v${{ env.KLOGG_VERSION }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,15 +7,20 @@ on:
     branches: [master]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  security-events: write
-
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      # CodeQL's remotely enabled overlay experiment supports only build-mode:none.
+      # Disable it explicitly so the required traced CMake build remains warning-free
+      # and continues to cover generated MOC/RCC units and configuration branches.
+      CODEQL_ACTION_OVERLAY_ANALYSIS: "false"
+      CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"
 
     # Expose values that agent-setup reads via matrix.config.*
     strategy:
@@ -29,44 +34,44 @@ jobs:
             qt_archives: qtbase icu qtsvg qttools qttranslations
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-      with:
-        languages: c-cpp
-        build-mode: manual
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: c-cpp
+          build-mode: manual
 
-    - uses: ./.github/actions/agent-setup
-    - name: Install Linux deps
-      run: |
-        # Explicit timeouts/retries: apt's default can hold a dead mirror
-        # TCP connection open for tens of minutes (seen 2026-08-19).
-        sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 update
-        sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 install -y libxkbcommon-dev libxkbcommon-x11-dev
+      - uses: ./.github/actions/agent-setup
 
-    - name: Prepare compiler env
-      run: |
-        echo "CC=gcc-13" >> $GITHUB_ENV
-        echo "CXX=g++-13" >> $GITHUB_ENV
+      - name: Install Linux deps
+        run: |
+          # Explicit timeouts/retries: apt's default can hold a dead mirror
+          # TCP connection open for tens of minutes (seen 2026-08-19).
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3 install -y libxkbcommon-dev libxkbcommon-x11-dev
 
-    - name: configure
-      run: |
-        cmake -S "$GITHUB_WORKSPACE" -B build -G Ninja \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-          -DKLOGG_GENERIC_CPU=ON \
-          -DKLOGG_USE_SENTRY=OFF \
-          -DKLOGG_USE_VECTORSCAN=OFF \
-          -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" \
-          -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
-          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - name: Prepare compiler env
+        run: |
+          echo "CC=gcc-13" >> "$GITHUB_ENV"
+          echo "CXX=g++-13" >> "$GITHUB_ENV"
 
-    - name: build
-      run: |
-        cmake --build build -t klogg
+      - name: Configure traced build
+        run: |
+          cmake -S "$GITHUB_WORKSPACE" -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DKLOGG_GENERIC_CPU=ON \
+            -DKLOGG_USE_SENTRY=OFF \
+            -DKLOGG_USE_VECTORSCAN=OFF \
+            -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" \
+            -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+      - name: Build traced application
+        run: cmake --build build -t klogg
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,9 +1,15 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
 
 jobs:
   analyze:
@@ -24,14 +30,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: c-cpp
+        build-mode: manual
 
     - uses: ./.github/actions/agent-setup
     - name: Install Linux deps
@@ -62,4 +69,4 @@ jobs:
         cmake --build build -t klogg
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3.37.3
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       KLOGG_WORKSPACE: ${{ github.workspace }}
       KLOGG_BUILD_ROOT: build_root
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: coverage_report/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,15 +17,11 @@ jobs:
     name: platform-fragile patterns
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.8'
-      - name: Run lint
-        run: |
-          python3 scripts/lint_platform_fragile.py
-          python3 scripts/lint_linux_package_runtime.py
-          python3 scripts/lint_ci_quality.py
-          python3 -m unittest discover -s tests/scripts -p 'test_*.py'
+      - name: Run complete fast CI quality gate
+        run: python3 scripts/run_ci_quality.py

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -213,7 +213,12 @@ jobs:
           BASE="${KLOGG_ANALYSIS_BASE:-}"
           # Filter compile_commands.json to first-party src/ TUs (cppcheck's -i
           # does not exclude paths under --project, so we hand it a filtered DB).
-          python3 -c "import json,os,sys; src=os.path.abspath(os.path.join(os.getcwd(),'src'))+os.sep; db=json.load(open(sys.argv[1])); g=lambda e: e['file'] if 'file' in e else (e.get('files') or [''])[0]; kept=[e for e in db if g(e).startswith(src)]; json.dump(kept, open(sys.argv[2],'w')); print(f'cppcheck: {len(kept)}/{len(db)} first-party src/ TUs')" "$KLOGG_BUILD_ROOT/compile_commands.json" /tmp/cc_src.json
+          python3 scripts/first_party_compile_units.py \
+            "$KLOGG_BUILD_ROOT/compile_commands.json" \
+            "$KLOGG_WORKSPACE/src" --null > /tmp/cppcheck_files.nul
+          python3 scripts/filter_compile_database.py \
+            "$KLOGG_BUILD_ROOT/compile_commands.json" "$KLOGG_WORKSPACE" \
+            /tmp/cppcheck_files.nul /tmp/cc_src.json
 
           if [ "$KLOGG_ANALYSIS_MODE" = "changed-strict" ] && [ -n "$BASE" ]; then
             # PRs and pushes scope cppcheck to their authoritative changed src/

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,17 +1,15 @@
 name: "Static analysis"
 
-# Per-PR clang-tidy + cppcheck gate.  Configures once
+# Event-aware clang-tidy + cppcheck gate. Configures once
 # (CMAKE_EXPORT_COMPILE_COMMANDS) to produce build_root/compile_commands.json,
 # then runs two independent analyses:
-#   * clang-tidy via clang-tidy-diff on PRs with a CHANGED-LINES-ONLY policy:
-#     strict on NEW code while ignoring the pre-existing style findings (hundreds
-#     of them across transitively-included headers) that make whole-file
-#     --warnings-as-errors unworkable on a legacy codebase.  On push-to-master /
-#     workflow_dispatch the full src/ audit runs NON-FATAL (report-only).
+#   * clang-tidy via clang-tidy-diff on PRs, pushes, and manual runs with a
+#     CHANGED-LINES-ONLY policy that is strict on new code. A weekly schedule
+#     performs the legacy full-source report-only audit outside the merge path.
 #   * cppcheck --enable=warning,style --error-exitcode=1 over the first-party
 #     src/ compile units.
-# cppcheck returning non-zero, or a clang-tidy-diff finding on a changed PR
-# line, fails the job.  Setup mirrors the Coverage workflow (gcc-13 leg +
+# cppcheck returning non-zero, or a clang-tidy-diff finding on a changed
+# PR/push/manual line, fails the job. Setup mirrors Coverage (gcc-13 leg +
 # agent-setup for Qt/Boost/CPM cache).
 
 on:
@@ -34,20 +32,35 @@ on:
       - README.md
       - .gitignore
   workflow_dispatch:
+    inputs:
+      analysis-mode:
+        description: Run the full report-only audit, or a strict diff from an explicit base SHA
+        required: true
+        default: full-report
+        type: choice
+        options:
+          - full-report
+          - changed-strict
+      base-sha:
+        description: Required only for changed-strict manual analysis
+        required: false
+        type: string
+  schedule:
+    - cron: '17 4 * * 0'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Full audits and strict event qualification must never cancel one another.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   static-analysis:
     name: "clang-tidy + cppcheck"
     runs-on: ubuntu-24.04
-    # Historical full-run ceiling is ~22 min (cold cache); 45 min leaves
-    # headroom while bounding runner-side apt/network hangs that would
-    # otherwise sit in_progress forever (2026-08-19: two jobs spent 30+ min
-    # stuck in apt-get on dead mirror connections).
-    timeout-minutes: 45
+    # Strict changed-scope runs normally finish well below this bound. The
+    # weekly full report-only audit gets enough cold-cache headroom without
+    # forcing master pushes through the same whole-tree workload.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -62,16 +75,54 @@ jobs:
     env:
       KLOGG_WORKSPACE: ${{ github.workspace }}
       KLOGG_BUILD_ROOT: build_root
-      # Sentry/Crashpad expands the CPM dependency set. Keep this cache mutable
-      # independently from the smaller default profile used by Coverage.
-      KLOGG_CPM_CACHE_KEY_SUFFIX: -sentry-vectorscan
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # Full history so the clang-tidy-diff step can diff the PR branch
           # against its exact base SHA (changed-LINES-ONLY policy).
           fetch-depth: 0
+
+      - name: Resolve authoritative analysis base
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          MANUAL_MODE: ${{ inputs.analysis-mode }}
+          MANUAL_BASE_SHA: ${{ inputs.base-sha }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request) base_sha="$PR_BASE_SHA" ;;
+            push) base_sha="$PUSH_BASE_SHA" ;;
+            workflow_dispatch)
+              if [ "$MANUAL_MODE" = "full-report" ]; then
+                echo "KLOGG_ANALYSIS_MODE=full-report" >> "$GITHUB_ENV"
+                exit 0
+              fi
+              test "$MANUAL_MODE" = "changed-strict" || {
+                echo "::error::unsupported manual analysis mode: $MANUAL_MODE"
+                exit 1
+              }
+              base_sha="$MANUAL_BASE_SHA"
+              ;;
+            schedule)
+              echo "KLOGG_ANALYSIS_MODE=full-report" >> "$GITHUB_ENV"
+              exit 0
+              ;;
+            *) echo "::error::unsupported static-analysis event: $EVENT_NAME"; exit 1 ;;
+          esac
+          test -n "$base_sha" && test "$base_sha" != "0000000000000000000000000000000000000000" || {
+            echo "::error::changed-strict analysis requires an authoritative non-zero base SHA"
+            exit 1
+          }
+          if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
+            git fetch --no-tags origin "$base_sha"
+          fi
+          git cat-file -e "$base_sha^{commit}"
+          echo "KLOGG_ANALYSIS_BASE=$base_sha" >> "$GITHUB_ENV"
+          echo "KLOGG_ANALYSIS_MODE=changed-strict" >> "$GITHUB_ENV"
 
       - name: Install gcc-13, clang-tidy and cppcheck
         run: |
@@ -99,67 +150,6 @@ jobs:
 
       - uses: ./.github/actions/agent-setup
 
-      - name: Build clang-tidy review scope
-        id: targets
-        shell: bash
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # CHANGED-LINES-ONLY policy: source and header scopes are independent.
-            # A mixed PR must run both passes so a changed header included only by
-            # unchanged translation units cannot bypass analysis.
-            BASE='${{ github.event.pull_request.base.sha }}'
-            changed_paths_file=$(mktemp)
-            trap 'rm -f "$changed_paths_file"' EXIT
-            if ! git -c core.quotePath=false diff --name-only -z --diff-filter=d "$BASE" HEAD -- src/ \
-                 > "$changed_paths_file"; then
-              echo "::error::failed to discover changed C/C++ analysis paths"
-              exit 1
-            fi
-            mapfile -d '' -t changed_paths < "$changed_paths_file"
-            source_count=0
-            header_count=0
-            for file in "${changed_paths[@]}"; do
-              if [[ "$file" == *[[:cntrl:]]* || "$file" == *'"'* || "$file" == *'\'* ]]; then
-                echo "::error file=$file::C/C++ analysis does not support quoted/control characters in paths"
-                exit 1
-              fi
-              case "${file,,}" in
-                *.c|*.cc|*.cpp|*.cxx) ((source_count+=1)) ;;
-                *.h|*.hh|*.hpp|*.hxx) ((header_count+=1)) ;;
-              esac
-            done
-            if ! git -c core.quotePath=false diff -U0 "$BASE" HEAD -- src/ \
-                 > tidy_patch.diff; then
-              echo "::error::failed to build the changed-line analysis patch"
-              exit 1
-            fi
-            echo "source_count=$source_count" >> "$GITHUB_OUTPUT"
-            echo "header_count=$header_count" >> "$GITHUB_OUTPUT"
-            header_lines=false
-
-            if [ "$header_count" -gt 0 ]; then
-              python3 scripts/clang_tidy_header_filter.py tidy_patch.diff > tidy_header_filter.json
-              if [ "$(cat tidy_header_filter.json)" != "[]" ]; then
-                header_lines=true
-              fi
-              echo "clang-tidy: $header_count changed header(s); checking added lines through all configured first-party TUs."
-            fi
-            echo "header_lines=$header_lines" >> "$GITHUB_OUTPUT"
-
-            if [ "$source_count" -eq 0 ] && [ "$header_count" -eq 0 ]; then
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              echo "No changed C/C++ files under src/; skipping clang-tidy."
-            else
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-              echo "clang-tidy-diff: $source_count changed src/ TU(s)."
-            fi
-          else
-            # push-to-master / workflow_dispatch: audit every configured first-party
-            # translation unit, NON-FATAL (report-only), so pre-existing findings
-            # never block the branch.
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Configure (generate compile_commands.json)
         shell: bash
         run: |
@@ -177,7 +167,6 @@ jobs:
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
       - name: Build first-party clang-tidy TU list
-        if: steps.targets.outputs.skip != 'true'
         shell: bash
         run: |
           python3 scripts/first_party_compile_units.py \
@@ -188,35 +177,26 @@ jobs:
           echo "clang-tidy: configured first-party TU list is ready."
 
       - name: Generate Qt UI headers for analysis
-        if: steps.targets.outputs.skip != 'true'
         shell: bash
         run: cmake --build "$KLOGG_BUILD_ROOT" --target klogg_ui_autogen -j"$(nproc)"
 
-      - name: Run clang-tidy (changed lines on PRs; report-only on master)
-        if: steps.targets.outputs.skip != 'true'
+      - name: Run clang-tidy
         shell: bash
         run: |
-          set -u
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Use the same PR-base-aware changed-line gate locally and in CI.
-            # The helper runs clang-tidy-diff for changed source files, analyzes
-            # added header lines through every configured first-party TU, and
-            # fails only for diagnostics in this PR's changed src/ paths.
-            python3 scripts/run_changed_clang_tidy.py \
-              --base '${{ github.event.pull_request.base.sha }}' \
-              --build-dir "$KLOGG_BUILD_ROOT" \
-              --clang-tidy-diff "$CLANG_TIDY_DIFF" \
-              --jobs "$(nproc)"
-          else
-            # Full src/ audit on push-to-master / workflow_dispatch is
-            # report-only for diagnostics because warnings-as-errors is absent,
-            # but compiler/configuration/tool failures still fail the job.
+          set -euo pipefail
+          if [ "$KLOGG_ANALYSIS_MODE" = "full-report" ]; then
             export KLOGG_BUILD_ROOT
             xargs -0 -P "$(nproc)" -n 1 bash -c '
               clang-tidy -p "$KLOGG_BUILD_ROOT" \
                 --extra-arg=-Wno-unknown-warning-option "$1"
             ' _ < tidy_files.nul
-            echo "clang-tidy: full src/ audit complete (findings report-only)."
+            echo "clang-tidy: scheduled full src/ audit complete (findings report-only)."
+          else
+            python3 scripts/run_changed_clang_tidy.py \
+              --base "$KLOGG_ANALYSIS_BASE" \
+              --build-dir "$KLOGG_BUILD_ROOT" \
+              --clang-tidy-diff "$CLANG_TIDY_DIFF" \
+              --jobs "$(nproc)"
           fi
 
       - name: Run cppcheck (warning+style over src/)
@@ -230,14 +210,14 @@ jobs:
           # are cppcheck Qt/preprocessor limitations. Every legacy warning/style
           # baseline entry is location-qualified in tests/cppcheck_suppressions.txt
           # so the same diagnostic ID at any new location still fails the gate.
-          BASE='${{ github.event.pull_request.base.sha }}'
+          BASE="${KLOGG_ANALYSIS_BASE:-}"
           # Filter compile_commands.json to first-party src/ TUs (cppcheck's -i
           # does not exclude paths under --project, so we hand it a filtered DB).
           python3 -c "import json,os,sys; src=os.path.abspath(os.path.join(os.getcwd(),'src'))+os.sep; db=json.load(open(sys.argv[1])); g=lambda e: e['file'] if 'file' in e else (e.get('files') or [''])[0]; kept=[e for e in db if g(e).startswith(src)]; json.dump(kept, open(sys.argv[2],'w')); print(f'cppcheck: {len(kept)}/{len(db)} first-party src/ TUs')" "$KLOGG_BUILD_ROOT/compile_commands.json" /tmp/cc_src.json
 
-          if [ "${{ github.event_name }}" = "pull_request" ] && [ -n "$BASE" ]; then
-            # PR: scope cppcheck to THIS PR's changed src/ TUs (consistent with
-            # the clang-tidy-diff changed-lines policy) so pre-existing findings
+          if [ "$KLOGG_ANALYSIS_MODE" = "changed-strict" ] && [ -n "$BASE" ]; then
+            # PRs and pushes scope cppcheck to their authoritative changed src/
+            # TUs so the same strict policy protects both event paths.
             # in UNCHANGED files -- e.g. a redundantInitialization false positive
             # in styles.cpp's theme logic -- don't block the gate. New issues in
             # touched files are still caught (the whole changed TU is checked).
@@ -273,8 +253,8 @@ jobs:
             fi
             CC_EXTRA="--error-exitcode=1"
           else
-            # push-to-master / workflow_dispatch: full src/ audit, REPORT-ONLY
-            # (no --error-exitcode) so pre-existing findings never block master.
+            # The weekly whole-tree audit reports legacy findings without making
+            # them a merge gate; configuration and tool failures remain fatal.
             CC_PROJECT=/tmp/cc_src.json
             CC_EXTRA=""
           fi

--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ This project uses [Calendar Versioning](https://calver.org/). For a list of avai
 
 Binaries for all platforms are available from [GitHub Releases](https://github.com/ZEACENT/klogg/releases/latest).
 
-### Continuous builds
-
-Automated pre-release builds for all platforms are available from the [continuous release](https://github.com/ZEACENT/klogg/releases/tag/continuous).
+CI validates unsigned packages on every pull request and master update. Signed and notarized binaries are published only through an explicit release-qualification run and appear on the [GitHub Releases](https://github.com/ZEACENT/klogg/releases) page.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ This project uses [Calendar Versioning](https://calver.org/). For a list of avai
 
 Binaries for all platforms are available from [GitHub Releases](https://github.com/ZEACENT/klogg/releases/latest).
 
-CI validates unsigned packages on every pull request and master update. Signed and notarized binaries are published only through an explicit release-qualification run and appear on the [GitHub Releases](https://github.com/ZEACENT/klogg/releases) page.
+### Continuous builds
+
+Automated rolling builds are available from the [continuous release](https://github.com/ZEACENT/klogg/releases/tag/continuous). Windows and Linux packages are CI-validated; macOS disk images are unsigned CI validation artifacts and may require local Gatekeeper approval.
+
+Stable releases default to the same secret-neutral validation evidence. A stable release explicitly published with signed evidence requires both macOS signing and notarization receipts; unsigned macOS artifacts are never described as signed or notarized.
 
 ## Building
 

--- a/packaging/windows/prepare_release.cmd
+++ b/packaging/windows/prepare_release.cmd
@@ -105,11 +105,28 @@ xcopy %KLOGG_WORKSPACE%\README.md %KLOGG_WORKSPACE%\release\ /y
 xcopy %KLOGG_WORKSPACE%\DOCUMENTATION.md %KLOGG_WORKSPACE%\release\ /y
 
 echo "Copying vc runtime..."
-xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140.dll" %KLOGG_WORKSPACE%\release\ /y
-xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140_1.dll" %KLOGG_WORKSPACE%\release\ /y
-xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\msvcp140_2.dll" %KLOGG_WORKSPACE%\release\ /y
-xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140.dll" %KLOGG_WORKSPACE%\release\ /y
-xcopy "%VCToolsRedistDir%%platform%\Microsoft.VC143.CRT\vcruntime140_1.dll" %KLOGG_WORKSPACE%\release\ /y
+set "KLOGG_VC_RUNTIME_DIR=%VCToolsRedistDir%%KLOGG_ARCH%\Microsoft.VC143.CRT"
+for %%R in (
+    msvcp140.dll
+    msvcp140_1.dll
+    msvcp140_2.dll
+    vcruntime140.dll
+    vcruntime140_1.dll
+) do (
+    if not exist "%KLOGG_VC_RUNTIME_DIR%\%%R" (
+        echo ERROR: required VC runtime missing: %KLOGG_VC_RUNTIME_DIR%\%%R
+        exit /b 1
+    )
+    xcopy "%KLOGG_VC_RUNTIME_DIR%\%%R" "%KLOGG_WORKSPACE%\release\" /y
+    if errorlevel 1 (
+        echo ERROR: failed to stage required VC runtime: %%R
+        exit /b 1
+    )
+    if not exist "%KLOGG_WORKSPACE%\release\%%R" (
+        echo ERROR: staged VC runtime missing: %KLOGG_WORKSPACE%\release\%%R
+        exit /b 1
+    )
+)
 
 echo "Copying ssl..."
 if "%KLOGG_QT%"=="Qt5" (

--- a/scripts/build_adb_helper_legal_assets.py
+++ b/scripts/build_adb_helper_legal_assets.py
@@ -280,7 +280,6 @@ def main() -> int:
     source_archive_hash = sha256(source_archive)
     published_archive = published_source_name(version, "adb-helper", source_archive_hash)
     stable_url = source_asset_url(base_url, f"v{version}", published_archive)
-    continuous_url = source_asset_url(base_url, "continuous", published_archive)
     source_offer.write_text(
         "Klogg ADB Helper Corresponding Source Offer\n"
         "==========================================\n\n"
@@ -290,11 +289,8 @@ def main() -> int:
         "Google Platform-Tools binary is redistributed.\n\n"
         f"Published archive: {published_archive}\n"
         f"SHA-256: {source_archive_hash}\n"
-        f"Stable release URL: {stable_url}\n"
-        f"Rolling continuous URL: {continuous_url}\n\n"
+        f"Stable release URL: {stable_url}\n\n"
         "Stable versioned releases retain their matching source asset for at least three years.\n"
-        "The continuous endpoint is rolling and mutable: each successful continuous publication\n"
-        "replaces its packages and source assets together and does not provide archival retention.\n"
         "Verify downloaded bytes with:\n"
         f"  shasum -a 256 {published_archive}\n"
         "and compare the result with the SHA-256 above. Build instructions are included in the\n"

--- a/scripts/build_adb_helper_legal_assets.py
+++ b/scripts/build_adb_helper_legal_assets.py
@@ -17,7 +17,6 @@ import tarfile
 from source_publication_identity import (
     normalize_base_url,
     published_source_name,
-    source_asset_url,
     validate_version,
 )
 
@@ -279,7 +278,8 @@ def main() -> int:
     source_offer = args.output / by_kind["source-offer"]["file_name"]
     source_archive_hash = sha256(source_archive)
     published_archive = published_source_name(version, "adb-helper", source_archive_hash)
-    stable_url = source_asset_url(base_url, f"v{version}", published_archive)
+    versioned_releases_page = f"{base_url}/releases"
+    continuous_release_page = f"{base_url}/releases/tag/continuous"
     source_offer.write_text(
         "Klogg ADB Helper Corresponding Source Offer\n"
         "==========================================\n\n"
@@ -289,8 +289,13 @@ def main() -> int:
         "Google Platform-Tools binary is redistributed.\n\n"
         f"Published archive: {published_archive}\n"
         f"SHA-256: {source_archive_hash}\n"
-        f"Stable release URL: {stable_url}\n\n"
+        f"Versioned releases page: {versioned_releases_page}\n"
+        f"Rolling continuous release page: {continuous_release_page}\n\n"
         "Stable versioned releases retain their matching source asset for at least three years.\n"
+        "The continuous endpoint is rolling and mutable: each successful continuous publication\n"
+        "replaces its packages and source assets together and does not provide archival retention.\n"
+        "Use the release page above to locate the content-addressed source asset included in the\n"
+        "current rolling publication; a stable-only asset is not promised under the mutable tag.\n"
         "Verify downloaded bytes with:\n"
         f"  shasum -a 256 {published_archive}\n"
         "and compare the result with the SHA-256 above. Build instructions are included in the\n"

--- a/scripts/build_ios_native_legal_assets.py
+++ b/scripts/build_ios_native_legal_assets.py
@@ -15,7 +15,6 @@ import tarfile
 from source_publication_identity import (
     normalize_base_url,
     published_source_name,
-    source_asset_url,
     validate_version,
 )
 
@@ -217,7 +216,8 @@ def main() -> int:
     )
     source_archive_hash = sha256(source_archive)
     published_archive = published_source_name(version, "ios-native", source_archive_hash)
-    stable_url = source_asset_url(base_url, f"v{version}", published_archive)
+    versioned_releases_page = f"{base_url}/releases"
+    continuous_release_page = f"{base_url}/releases/tag/continuous"
     (args.output / "ios-native-source-offer.txt").write_text(
         "Klogg iOS Native Stack Corresponding Source Offer\n"
         "================================================\n\n"
@@ -228,8 +228,13 @@ def main() -> int:
         "framework, or command-line tool is included in the application package.\n\n"
         f"Published archive: {published_archive}\n"
         f"SHA-256: {source_archive_hash}\n"
-        f"Stable release URL: {stable_url}\n\n"
+        f"Versioned releases page: {versioned_releases_page}\n"
+        f"Rolling continuous release page: {continuous_release_page}\n\n"
         "Stable versioned releases retain their matching source asset for at least three years.\n"
+        "The continuous endpoint is rolling and mutable: each successful continuous publication\n"
+        "replaces its packages and source assets together and does not provide archival retention.\n"
+        "Use the release page above to locate the content-addressed source asset included in the\n"
+        "current rolling publication; a stable-only asset is not promised under the mutable tag.\n"
         "Verify downloaded bytes with:\n"
         f"  shasum -a 256 {published_archive}\n"
         "and compare the result with the SHA-256 above. See ios-native-lgpl-replacement.txt for\n"

--- a/scripts/build_ios_native_legal_assets.py
+++ b/scripts/build_ios_native_legal_assets.py
@@ -218,7 +218,6 @@ def main() -> int:
     source_archive_hash = sha256(source_archive)
     published_archive = published_source_name(version, "ios-native", source_archive_hash)
     stable_url = source_asset_url(base_url, f"v{version}", published_archive)
-    continuous_url = source_asset_url(base_url, "continuous", published_archive)
     (args.output / "ios-native-source-offer.txt").write_text(
         "Klogg iOS Native Stack Corresponding Source Offer\n"
         "================================================\n\n"
@@ -229,11 +228,8 @@ def main() -> int:
         "framework, or command-line tool is included in the application package.\n\n"
         f"Published archive: {published_archive}\n"
         f"SHA-256: {source_archive_hash}\n"
-        f"Stable release URL: {stable_url}\n"
-        f"Rolling continuous URL: {continuous_url}\n\n"
+        f"Stable release URL: {stable_url}\n\n"
         "Stable versioned releases retain their matching source asset for at least three years.\n"
-        "The continuous endpoint is rolling and mutable: each successful continuous publication\n"
-        "replaces its packages and source assets together and does not provide archival retention.\n"
         "Verify downloaded bytes with:\n"
         f"  shasum -a 256 {published_archive}\n"
         "and compare the result with the SHA-256 above. See ios-native-lgpl-replacement.txt for\n"

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -12,9 +12,40 @@ from pathlib import Path
 
 
 CHECKOUT_SHA_RE = re.compile(r"actions/checkout@[0-9a-f]{40}")
+REMOTE_ACTION_SHA_RE = re.compile(r"[^\s@]+@[0-9a-f]{40}")
 CODEQL_ACTION_SHA_RE = re.compile(
     r"github/codeql-action/(?P<action>init|analyze)@(?P<sha>[0-9a-f]{40})"
 )
+CODEQL_CURRENT_SHA = "cdf488f595d80d6e07e03d4674febd5ab45fa938"
+REVIEWED_ACTION_REVISIONS = {
+    "actions/attest-build-provenance": "4d101475d8b20a2381f78447822ac1eab6504dd8",
+    "actions/cache": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+    "actions/checkout": "3d3c42e5aac5ba805825da76410c181273ba90b1",
+    "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    "actions/setup-python": "5fda3b95a4ea91299a34e894583c3862153e4b97",
+    "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    "apple-actions/import-codesign-certs": "5142e029c445c10ffc7149d172e540235a065466",
+    "dawidd6/action-download-artifact": "d63b86af1b34672e53c440b1b83979861906bad7",
+    "docker/build-push-action": "53b7df96c91f9c12dcc8a07bcb9ccacbed38856a",
+    "docker/setup-buildx-action": "bb05f3f5519dd87d3ba754cc423b652a5edd6d2c",
+    "github/codeql-action": "cdf488f595d80d6e07e03d4674febd5ab45fa938",
+    "ilshidur/action-discord": "d2594079a10f1d6739ee50a2471f0ca57418b554",
+    "joncloud/makensis-action": "971ef20f43e4f9f3af2c7f276cb7348d033da1cd",
+    "jurplel/install-qt-action": "48d3ad6db93f3627c8ee7a0454bc6f3744f7e730",
+    "lukka/get-cmake": "fffaaafeea488556c2c12dad60690008bc1caacb",
+    "mathrix-education/setup-sentry-cli": "ff4fff773f5e628fa214ebd19e46fb7289454ee2",
+    "msys2/setup-msys2": "66cd2cce69caa17b53920067426061ca1de3a884",
+    "softprops/action-gh-release": "efb35369e0ad2afab669f228072c1b0d510eae64",
+}
+
+KNOWN_NODE20_ACTION_REFS = {
+    "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+    "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+    "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+    "github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07",
+    "github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07",
+    "ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756",
+}
 LIST_ITEM_RE = re.compile(r"^(?P<indent>\s*)-(?:\s+|$)")
 KEY_VALUE_RE = re.compile(r"^(?P<indent>\s*)(?:-\s*)?(?P<key>[\w-]+):\s*(?P<value>.*)$")
 BROAD_SUPPRESSION_RE = re.compile(
@@ -37,15 +68,16 @@ BROAD_CPPCHECK_IDS = (
 )
 
 CI_BUILD_JOB_NEEDS = {
-    "SaveVersion": set(),
-    "PrefetchCpmCache": set(),
-    "PrefetchBoost": set(),
-    "PrefetchOpenSsl": set(),
-    "PrefetchLinuxDeployQt": set(),
-    "PrefetchCmakeInstaller": set(),
-    "PrefetchWindowsTools": set(),
-    "PrefetchAdbHelperSources": set(),
-    "PrefetchIosNativeSources": set(),
+    "ReleaseQualificationPreflight": set(),
+    "SaveVersion": {"ReleaseQualificationPreflight"},
+    "PrefetchCpmCache": {"ReleaseQualificationPreflight"},
+    "PrefetchBoost": {"ReleaseQualificationPreflight"},
+    "PrefetchOpenSsl": {"ReleaseQualificationPreflight"},
+    "PrefetchLinuxDeployQt": {"ReleaseQualificationPreflight"},
+    "PrefetchCmakeInstaller": {"ReleaseQualificationPreflight"},
+    "PrefetchWindowsTools": {"ReleaseQualificationPreflight"},
+    "PrefetchAdbHelperSources": {"ReleaseQualificationPreflight"},
+    "PrefetchIosNativeSources": {"ReleaseQualificationPreflight"},
     "BuildAdbHelperLegalAssets": {
         "SaveVersion",
         "PrefetchAdbHelperSources",
@@ -54,34 +86,103 @@ CI_BUILD_JOB_NEEDS = {
         "PrefetchAdbHelperSources",
         "BuildAdbHelperLegalAssets",
     },
+    "BuildAdbLinuxArm64": {
+        "PrefetchAdbHelperSources",
+        "BuildAdbHelperLegalAssets",
+    },
+    "BuildAdbWindowsX64": {
+        "PrefetchAdbHelperSources",
+        "BuildAdbHelperLegalAssets",
+    },
+    "BuildAdbMacX64": {
+        "PrefetchAdbHelperSources",
+        "BuildAdbHelperLegalAssets",
+    },
+    "BuildAdbMacArm64": {
+        "PrefetchAdbHelperSources",
+        "BuildAdbHelperLegalAssets",
+    },
     "BuildIosNativeStacks": {
         "SaveVersion",
         "PrefetchIosNativeSources",
     },
-    "Linux": {
+    "BuildIosNativeArm64": {
+        "SaveVersion",
+        "PrefetchIosNativeSources",
+    },
+    "LinuxPackages": {
         "SaveVersion",
         "PrefetchCpmCache",
         "PrefetchLinuxDeployQt",
         "PrefetchCmakeInstaller",
         "BuildAdbHelpers",
     },
-    "Mac": {
+    "LinuxSanitizers": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+        "PrefetchCmakeInstaller",
+    },
+    "LinuxTsan": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+    },
+    "MacPackages": {
         "SaveVersion",
         "PrefetchCpmCache",
         "PrefetchBoost",
-        "BuildAdbHelpers",
+        "BuildAdbMacX64",
         "BuildIosNativeStacks",
     },
-    "Windows": {
+    "MacArmPackages": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+        "PrefetchBoost",
+        "BuildAdbMacArm64",
+        "BuildIosNativeArm64",
+    },
+    "MacSanitizers": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+        "PrefetchBoost",
+    },
+    "WindowsPackages": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+        "PrefetchBoost",
+        "PrefetchWindowsTools",
+        "BuildAdbWindowsX64",
+    },
+    "WindowsX86": {
         "SaveVersion",
         "PrefetchCpmCache",
         "PrefetchBoost",
         "PrefetchOpenSsl",
         "PrefetchWindowsTools",
-        "BuildAdbHelpers",
     },
-    "ci-gate": {"Linux", "Mac", "Windows"},
-    "CreatePreRelease": {"ci-gate"},
+    "WindowsAsan": {
+        "SaveVersion",
+        "PrefetchCpmCache",
+        "PrefetchBoost",
+        "PrefetchWindowsTools",
+    },
+    "ci-gate": {
+        "BuildAdbHelpers",
+        "BuildAdbLinuxArm64",
+        "BuildAdbWindowsX64",
+        "BuildAdbMacX64",
+        "BuildAdbMacArm64",
+        "BuildIosNativeStacks",
+        "BuildIosNativeArm64",
+        "LinuxPackages",
+        "LinuxSanitizers",
+        "LinuxTsan",
+        "MacPackages",
+        "MacArmPackages",
+        "MacSanitizers",
+        "WindowsPackages",
+        "WindowsX86",
+        "WindowsAsan",
+    },
 }
 
 CI_BUILD_ARTIFACT_PRODUCERS = {
@@ -95,44 +196,74 @@ CI_BUILD_ARTIFACT_PRODUCERS = {
     "adb-helper-source-cache": "PrefetchAdbHelperSources",
     "adb-helper-legal-assets": "BuildAdbHelperLegalAssets",
     "ios-native-source-cache": "PrefetchIosNativeSources",
-    "ios-native-source-assets": "BuildIosNativeStacks",
+    "ios-native-source-assets": "BuildIosNativeArm64",
 }
 
 CI_BUILD_REQUIRED_ARTIFACT_CONSUMERS = {
-    "klogg_version": {"CreatePreRelease"},
-    "cpm-cache": {"Linux", "Mac", "Windows"},
-    "boost-root": {"Mac", "Windows"},
-    "openssl-archive": {"Windows"},
-    "linuxdeployqt": {"Linux"},
-    "cmake-installer": {"Linux"},
-    "msys2-tools": {"Windows"},
-    "adb-helper-source-cache": {"BuildAdbHelperLegalAssets", "BuildAdbHelpers"},
+    "cpm-cache": {
+        "LinuxPackages",
+        "LinuxSanitizers",
+        "LinuxTsan",
+        "MacPackages",
+        "MacArmPackages",
+        "MacSanitizers",
+        "WindowsPackages",
+        "WindowsX86",
+        "WindowsAsan",
+    },
+    "boost-root": {
+        "MacPackages",
+        "MacArmPackages",
+        "MacSanitizers",
+        "WindowsPackages",
+        "WindowsX86",
+        "WindowsAsan",
+    },
+    "openssl-archive": {"WindowsX86"},
+    "linuxdeployqt": {"LinuxPackages"},
+    "cmake-installer": {"LinuxPackages", "LinuxSanitizers"},
+    "msys2-tools": {"WindowsPackages", "WindowsX86", "WindowsAsan"},
+    "adb-helper-source-cache": {
+        "BuildAdbHelperLegalAssets",
+        "BuildAdbHelpers",
+        "BuildAdbLinuxArm64",
+        "BuildAdbWindowsX64",
+        "BuildAdbMacX64",
+        "BuildAdbMacArm64",
+    },
     "adb-helper-legal-assets": {
         "BuildAdbHelpers",
-        "Linux",
-        "Mac",
-        "Windows",
-        "CreatePreRelease",
+        "BuildAdbLinuxArm64",
+        "BuildAdbWindowsX64",
+        "BuildAdbMacX64",
+        "BuildAdbMacArm64",
+        "LinuxPackages",
+        "MacPackages",
+        "MacArmPackages",
+        "WindowsPackages",
     },
-    "ios-native-source-cache": {"BuildIosNativeStacks"},
-    "ios-native-source-assets": {"CreatePreRelease"},
+    "ios-native-source-cache": {"BuildIosNativeStacks", "BuildIosNativeArm64"},
 }
 
 CI_BUILD_ARTIFACT_CONDITIONS = {
-    ("BuildIosNativeStacks", "uploads", "ios-native-source-assets"):
+    ("BuildIosNativeArm64", "uploads", "ios-native-source-assets"):
         "${{ matrix.architecture == 'arm64' }}",
-    ("Linux", "downloads", "linuxdeployqt"):
+    ("LinuxPackages", "downloads", "linuxdeployqt"):
         "${{ matrix.config.os == 'ubuntu_appimage' }}",
-    ("Linux", "downloads", "cmake-installer"):
+    ("LinuxPackages", "downloads", "cmake-installer"):
         "${{ matrix.config.sanitizer != 'thread' }}",
-    ("Linux", "downloads", "adb-helper-legal-assets"):
+    ("LinuxSanitizers", "downloads", "cmake-installer"):
+        "${{ matrix.config.sanitizer != 'thread' }}",
+    ("LinuxPackages", "downloads", "adb-helper-legal-assets"):
         "${{ matrix.config.package != false }}",
-    ("Mac", "downloads", "adb-helper-legal-assets"):
+    ("MacPackages", "downloads", "adb-helper-legal-assets"):
         "${{ matrix.config.package != false }}",
-    ("Windows", "downloads", "openssl-archive"):
+    ("MacArmPackages", "downloads", "adb-helper-legal-assets"):
+        "${{ matrix.config.package != false }}",
+    ("WindowsX86", "downloads", "openssl-archive"):
         "${{ startswith(matrix.config.qt_version, '5') }}",
-    ("Windows", "downloads", "adb-helper-legal-assets"):
-        "${{ matrix.config.package != false && github.event_name != 'pull_request' }}",
+    ("WindowsPackages", "downloads", "adb-helper-legal-assets"):
+        "${{ matrix.config.package != false }}",
 }
 
 
@@ -369,13 +500,130 @@ def workflow_step_blocks(job_block: list[str]) -> list[list[str]]:
     return result
 
 
+def workflow_job_matrix_values(block: list[str]) -> dict[str, set[str]]:
+    if not block:
+        return {}
+    header = KEY_VALUE_RE.match(block[0])
+    if header is None:
+        return {}
+    job_indent = len(header.group("indent"))
+    matrix_index: int | None = None
+    matrix_indent = 0
+    for index, line in enumerate(block[1:], start=1):
+        entry = KEY_VALUE_RE.match(line)
+        if (
+            entry is not None
+            and entry.group("key") == "matrix"
+            and len(entry.group("indent")) == job_indent + 4
+        ):
+            matrix_index = index
+            matrix_indent = len(entry.group("indent"))
+            break
+    if matrix_index is None:
+        return {}
+
+    values: dict[str, set[str]] = {}
+    for line in block[matrix_index + 1 :]:
+        active = strip_yaml_comment(line)
+        if not active:
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= matrix_indent:
+            break
+        entry = KEY_VALUE_RE.match(line)
+        if entry is None or entry.group("key") in {"config", "include", "exclude"}:
+            continue
+        value = scalar(entry.group("value")).lower()
+        values.setdefault(entry.group("key"), set()).add(value)
+    return values
+
+
+def workflow_job_is_package_free(block: list[str]) -> bool:
+    return workflow_job_matrix_values(block).get("package") == {"false"}
+
+
+def artifact_condition_is_statically_false(
+    condition: str | None, matrix_values: dict[str, set[str]]
+) -> bool:
+    if condition is None or "||" in condition:
+        return False
+
+    equality = re.compile(
+        r"matrix\.(?:config\.)?(?P<key>[\w-]+)\s*(?P<operator>==|!=)\s*"
+        r"(?P<value>'[^']*'|\"[^\"]*\"|true|false)"
+    )
+    for match in equality.finditer(condition):
+        values = matrix_values.get(match.group("key"))
+        if not values:
+            continue
+        expected = scalar(match.group("value")).lower()
+        if match.group("operator") == "==" and all(
+            value != expected for value in values
+        ):
+            return True
+        if match.group("operator") == "!=" and all(
+            value == expected for value in values
+        ):
+            return True
+
+    startswith = re.compile(
+        r"startswith\(matrix\.(?:config\.)?(?P<key>[\w-]+),\s*"
+        r"(?P<prefix>'[^']*'|\"[^\"]*\")\)"
+    )
+    for match in startswith.finditer(condition):
+        values = matrix_values.get(match.group("key"))
+        prefix = scalar(match.group("prefix")).lower()
+        if values and all(not value.startswith(prefix) for value in values):
+            return True
+
+    return False
+
+
+def workflow_job_steps(
+    text: str,
+) -> dict[str, list[list[str]]]:
+    job_blocks = workflow_job_blocks(text)
+    anchors: dict[str, list[list[str]]] = {}
+    direct_steps: dict[str, list[list[str]]] = {}
+    aliases: dict[str, str] = {}
+
+    for job, block in job_blocks.items():
+        steps_value = workflow_job_direct_value(block, "steps")
+        if steps_value is None:
+            direct_steps[job] = []
+            continue
+        if steps_value.startswith("&"):
+            anchor = steps_value[1:].strip()
+            if not anchor or anchor in anchors:
+                raise ValueError(f"workflow steps anchor is invalid or duplicated: {steps_value}")
+            steps = workflow_step_blocks(block)
+            anchors[anchor] = steps
+            direct_steps[job] = steps
+        elif steps_value.startswith("*"):
+            alias = steps_value[1:].strip()
+            if not alias:
+                raise ValueError(f"workflow steps alias is invalid: {steps_value}")
+            aliases[job] = alias
+        else:
+            direct_steps[job] = workflow_step_blocks(block)
+
+    for job, alias in aliases.items():
+        if alias not in anchors:
+            raise ValueError(f"workflow job {job} uses unknown steps alias {alias}")
+        direct_steps[job] = anchors[alias]
+
+    return direct_steps
+
+
 def workflow_artifact_records(
     text: str,
 ) -> dict[str, list[tuple[str, str, str | None]]]:
     records: dict[str, list[tuple[str, str, str | None]]] = {}
-    for job, block in workflow_job_blocks(text).items():
+    job_blocks = workflow_job_blocks(text)
+    for job, steps in workflow_job_steps(text).items():
         job_records: list[tuple[str, str, str | None]] = []
-        for step in workflow_step_blocks(block):
+        matrix_values = workflow_job_matrix_values(job_blocks.get(job, []))
+        for step in steps:
             item = LIST_ITEM_RE.match(step[0])
             if item is None:
                 continue
@@ -413,6 +661,8 @@ def workflow_artifact_records(
                 continue
             if continue_on_error not in {None, "false"}:
                 continue
+            if artifact_condition_is_statically_false(condition, matrix_values):
+                continue
             if action.startswith("actions/upload-artifact@"):
                 job_records.append(("uploads", artifact_name, condition))
             elif action.startswith("actions/download-artifact@"):
@@ -442,6 +692,9 @@ def workflow_artifact_actions(text: str) -> dict[str, dict[str, set[str]]]:
 def ci_build_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
     needs = workflow_job_needs(text)
+    unexpected_jobs = set(needs) - set(CI_BUILD_JOB_NEEDS)
+    if unexpected_jobs:
+        issues.append("CI build workflow contains unmodeled jobs outside the reviewed gate")
     for job, expected in CI_BUILD_JOB_NEEDS.items():
         if job not in needs:
             issues.append(f"CI build workflow must define job {job}")
@@ -461,8 +714,12 @@ def ci_build_workflow_issues(text: str) -> list[str]:
         issues.append(str(error))
         return issues
 
-    artifact_records = workflow_artifact_records(text)
-    artifacts = workflow_artifact_actions(text)
+    try:
+        artifact_records = workflow_artifact_records(text)
+        artifacts = workflow_artifact_actions(text)
+    except ValueError as error:
+        issues.append(str(error))
+        return issues
     for artifact, producer in CI_BUILD_ARTIFACT_PRODUCERS.items():
         owners = {
             job
@@ -514,7 +771,18 @@ def ci_build_workflow_issues(text: str) -> list[str]:
     job_blocks = workflow_job_blocks(text)
     if workflow_job_direct_value(job_blocks.get("ci-gate", []), "if") != "always()":
         issues.append("CI gate must run with if: always()")
-    for job in ("Linux", "Mac", "Windows", "ci-gate"):
+    for job in (
+        "LinuxPackages",
+        "LinuxSanitizers",
+        "LinuxTsan",
+        "MacPackages",
+        "MacArmPackages",
+        "MacSanitizers",
+        "WindowsPackages",
+        "WindowsX86",
+        "WindowsAsan",
+        "ci-gate",
+    ):
         continue_on_error = workflow_job_direct_value(
             job_blocks.get(job, []), "continue-on-error"
         )
@@ -540,6 +808,107 @@ def ci_build_workflow_issues(text: str) -> list[str]:
     )
     if ios_prefetch_count != 1:
         issues.append("iOS native sources must be prefetched exactly once")
+
+    active_text = "\n".join(
+        active for line in text.splitlines() if (active := strip_yaml_comment(line))
+    )
+    windows_active = "\n".join(
+        active
+        for line in job_blocks.get("WindowsPackages", [])
+        if (active := strip_yaml_comment(line))
+    )
+    if "github.event_name" in windows_active and any(
+        marker in windows_active
+        for marker in (
+            "adb-helper-",
+            "agent-package-win",
+            "Package tarball for upload",
+            "upload-artifact@",
+        )
+    ):
+        issues.append(
+            "Windows package preparation and artifact upload must run on pull requests"
+        )
+
+    release_secret_re = re.compile(
+        r"secrets\.(?:CODESIGN|NOTARIZATION|APPLE_DEVELOPER)"
+    )
+    release_mode_expression = (
+        "qualification-mode: ${{ github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/master' && inputs.qualification-mode == "
+        "'release' && 'release' || 'validation' }}"
+    )
+    active_lines = [
+        active for line in text.splitlines() if (active := strip_yaml_comment(line))
+    ]
+    has_release_dispatch_input = all(
+        marker in active_text
+        for marker in (
+            "workflow_dispatch:",
+            "qualification-mode:",
+            "type: choice",
+            "- validation",
+            "- release",
+        )
+    )
+    unsafe_release_secret = False
+    for index, line in enumerate(active_lines):
+        if release_secret_re.search(line) is None:
+            continue
+        context = "\n".join(active_lines[max(0, index - 12) : index + 1])
+        mac_qualification_input = (
+            "uses: ./.github/actions/agent-package-mac" in context
+            and release_mode_expression in context
+        )
+        release_preflight_input = (
+            "name: Verify release qualification inputs" in context
+            and "inputs.qualification-mode == 'release'" in context
+        )
+        if not (mac_qualification_input or release_preflight_input):
+            unsafe_release_secret = True
+            break
+    if release_secret_re.search(active_text) and (
+        not has_release_dispatch_input or unsafe_release_secret
+    ):
+        issues.append(
+            "required CI validation must not require signing or notarization secrets"
+        )
+
+    if "CreatePreRelease" in job_blocks or "softprops/action-gh-release@" in active_text:
+        issues.append("release publication must run outside the required CI workflow")
+
+    mobile_jobs = {
+        job
+        for job in needs
+        if job.startswith("BuildAdb") or job.startswith("BuildIos")
+    }
+    package_free_with_mobile = False
+    for job, block in job_blocks.items():
+        block_active = "\n".join(
+            active for line in block if (active := strip_yaml_comment(line))
+        )
+        if "package: false" not in block_active:
+            continue
+        ancestors = workflow_job_ancestors(needs, job) if job in needs else set()
+        if ancestors & mobile_jobs:
+            package_free_with_mobile = True
+            break
+    if package_free_with_mobile:
+        issues.append("package-free CI legs must not depend on mobile artifact producers")
+
+    if any(
+        "github.run_id" in line and "ccache" in line.lower()
+        for line in active_lines
+    ):
+        issues.append("ccache keys must be bounded and must not use github.run_id")
+
+    if ".ccache" in active_text and "actions/cache/save@" in active_text:
+        ccache_limits = [
+            int(value)
+            for value in re.findall(r"ccache\s+--max-size=(\d+)M", active_text)
+        ]
+        if not ccache_limits or any(value > 250 for value in ccache_limits):
+            issues.append("ccache entries must be capped at 250M")
 
     return issues
 
@@ -693,6 +1062,42 @@ def unique_cmake_option_value(tokens: list[str], option: str) -> str | None:
     return values[0] if len(values) == 1 else None
 
 
+def yaml_scalar_body_lines(lines: list[str]) -> set[int]:
+    body: set[int] = set()
+    for index, line in enumerate(lines):
+        entry = KEY_VALUE_RE.match(line)
+        if entry is None or scalar(entry.group("value")) not in {"|", "|-", "|+", ">", ">-", ">+"}:
+            continue
+        indent = len(entry.group("indent"))
+        for following in range(index + 1, len(lines)):
+            candidate = lines[following]
+            if not candidate.strip():
+                body.add(following)
+                continue
+            candidate_indent = len(candidate) - len(candidate.lstrip())
+            if candidate_indent <= indent:
+                break
+            body.add(following)
+    return body
+
+
+def workflow_action_refs(text: str) -> list[tuple[int, str]]:
+    lines = text.splitlines()
+    scalar_body = yaml_scalar_body_lines(lines)
+    actions: list[tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        if index in scalar_body:
+            continue
+        entry = KEY_VALUE_RE.match(line)
+        if entry is None or entry.group("key") != "uses":
+            continue
+        value = yaml_value(lines, index, entry.group("value"), len(entry.group("indent")))
+        value = value.strip()
+        if value:
+            actions.append((index + 1, value))
+    return actions
+
+
 def checkout_steps(text: str) -> list[tuple[int, str, str | None]]:
     lines = text.splitlines()
     checkouts: list[tuple[int, str, str | None]] = []
@@ -772,6 +1177,28 @@ def check_checkout_blocks(path: Path, text: str) -> list[str]:
             issues.append(
                 f"{path}:{line}: checkout must set with.persist-credentials to false"
             )
+
+    for line, uses in workflow_action_refs(text):
+        if uses.startswith("./") or uses.startswith("docker://"):
+            continue
+        if uses in KNOWN_NODE20_ACTION_REFS:
+            issues.append(f"{path}:{line}: remote action uses a known Node20 action generation")
+            continue
+        pinned = REMOTE_ACTION_SHA_RE.fullmatch(uses)
+        if uses.startswith("actions/checkout@") and pinned is None:
+            continue
+        if pinned is None:
+            issues.append(
+                f"{path}:{line}: remote actions must use a reviewed 40-char SHA"
+            )
+            continue
+        action, sha = uses.rsplit("@", 1)
+        repository = "/".join(action.split("/")[:2]).lower()
+        expected = REVIEWED_ACTION_REVISIONS.get(repository)
+        if expected is None or sha != expected:
+            issues.append(
+                f"{path}:{line}: remote action SHA is not the reviewed revision"
+            )
     return issues
 
 
@@ -832,6 +1259,20 @@ def codeql_workflow_issues(text: str) -> list[str]:
     if any(key == "continue-on-error" for key, _ in nested_entries):
         issues.append("CodeQL workflow must not use continue-on-error")
 
+    jobs_position = next(
+        (index for index, line in enumerate(lines) if re.match(r"^jobs:\s*(?:#.*)?$", line)),
+        len(lines),
+    )
+    trigger_text = "\n".join(
+        f"{' ' * (len(line) - len(line.lstrip()))}{active}"
+        for line in lines[:jobs_position]
+        if (active := strip_yaml_comment(line))
+    )
+    if not re.search(r"(?m)^\s{2}push:\s*$", trigger_text) or not re.search(
+        r"(?m)^\s{4}branches:\s*\[\s*master\s*\]\s*$", trigger_text
+    ):
+        issues.append("CodeQL workflow must run on pushes to master")
+
     action_refs: dict[str, list[str]] = {"init": [], "analyze": []}
     for key, value in nested_entries:
         if key != "uses" or not value.startswith("github/codeql-action/"):
@@ -852,8 +1293,29 @@ def codeql_workflow_issues(text: str) -> list[str]:
             continue
         pinned_shas[action] = match.group("sha")
 
-    if len(pinned_shas) == 2 and pinned_shas["init"] != pinned_shas["analyze"]:
+    matching_codeql_revision = (
+        len(pinned_shas) == 2 and pinned_shas["init"] == pinned_shas["analyze"]
+    )
+    if len(pinned_shas) == 2 and not matching_codeql_revision:
         issues.append("CodeQL init and analyze must use the same reviewed SHA")
+    if (
+        matching_codeql_revision
+        and pinned_shas["init"] != CODEQL_CURRENT_SHA
+    ):
+        issues.append("CodeQL actions must use the current reviewed generation")
+
+    active_text = "\n".join(
+        active for line in text.splitlines() if (active := strip_yaml_comment(line))
+    )
+    init_position = active_text.find("github/codeql-action/init@")
+    analyze_position = active_text.find("github/codeql-action/analyze@")
+    build_mode_position = active_text.find("build-mode: manual")
+    if not (
+        init_position >= 0
+        and build_mode_position > init_position
+        and analyze_position > build_mode_position
+    ):
+        issues.append("CodeQL init must set build-mode: manual")
 
     cmake_configures = []
     for command in shell_commands(text):
@@ -924,6 +1386,15 @@ def has_unsupported_macos_lsan(text: str) -> bool:
     return re.search(r"ASAN_OPTIONS=.*detect_leaks=1", text) is not None
 
 
+def windows_package_action_issues(text: str) -> list[str]:
+    active = "\n".join(
+        line for line in text.splitlines() if strip_yaml_comment(line)
+    )
+    if "github.event_name" in active:
+        return ["Windows package composite must remain event-neutral"]
+    return []
+
+
 def static_analysis_workflow_issues(text: str) -> list[str]:
     commands = shell_commands(text)
     issues: list[str] = []
@@ -958,7 +1429,7 @@ def static_analysis_workflow_issues(text: str) -> list[str]:
             and tokens[:2]
             == ["python3", "scripts/run_changed_clang_tidy.py"]
             and unique_option_value(tokens, "--base")
-            == "${{ github.event.pull_request.base.sha }}"
+            in {"${{ github.event.pull_request.base.sha }}", "$KLOGG_ANALYSIS_BASE"}
             and unique_option_value(tokens, "--build-dir") == "$KLOGG_BUILD_ROOT"
             and unique_option_value(tokens, "--clang-tidy-diff")
             == "$CLANG_TIDY_DIFF"
@@ -1085,14 +1556,25 @@ def static_analysis_workflow_issues(text: str) -> list[str]:
             "static analysis configure must use the prefetched CPM cache fully disconnected"
         )
 
-    if not re.search(
-        r"^\s*KLOGG_CPM_CACHE_KEY_SUFFIX:\s*-sentry-vectorscan\s*$",
-        text,
-        re.MULTILINE,
-    ):
-        issues.append(
-            "static analysis must use a Sentry-and-Vectorscan-specific CPM cache key"
+    full_audit_isolated = all(
+        marker in text
+        for marker in (
+            "group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}",
+            "cancel-in-progress: ${{ github.event_name != 'schedule' }}",
+            'if [ "$KLOGG_ANALYSIS_MODE" = "full-report" ]; then',
+            'pull_request) base_sha="$PR_BASE_SHA"',
+            'push) base_sha="$PUSH_BASE_SHA"',
+            'MANUAL_BASE_SHA: ${{ inputs.base-sha }}',
+            'git fetch --no-tags origin "$base_sha"',
         )
+    )
+    if (
+        report_only_consumers
+        and "github.event_name" in text
+        and "pull_request" in text
+        and not full_audit_isolated
+    ):
+        issues.append("clang-tidy findings must fail both pull requests and master pushes")
 
     # A PR that deletes a src/ file must not feed the deleted path to
     # clang-tidy/cppcheck: both tools fail on the nonexistent file and the
@@ -1263,7 +1745,7 @@ def check_repo(root: Path) -> list[str]:
         f".github/workflows/coverage.yml: {issue}"
         for issue in coverage_workflow_issues(coverage_text)
     )
-    if "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" not in coverage_text:
+    if "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" not in coverage_text:
         issues.append(
             ".github/workflows/coverage.yml: coverage artifact upload must use a reviewed commit SHA"
         )
@@ -1281,6 +1763,13 @@ def check_repo(root: Path) -> list[str]:
         f".github/actions/agent-setup/action.yml: {issue}"
         for issue in agent_setup_cpm_issues(agent_setup_path.read_text())
     )
+    windows_package_path = (
+        root / ".github" / "actions" / "agent-package-win" / "action.yml"
+    )
+    issues.extend(
+        f".github/actions/agent-package-win/action.yml: {issue}"
+        for issue in windows_package_action_issues(windows_package_path.read_text())
+    )
 
     static_text = (workflows / "static-analysis.yml").read_text()
     issues.extend(
@@ -1294,10 +1783,11 @@ def check_repo(root: Path) -> list[str]:
         issues.append(
             ".github/workflows/static-analysis.yml: clang-tidy-diff must use the discovered Ubuntu tool path"
         )
-    for extension in ("*.cxx", "*.hh", "*.hxx"):
-        if extension not in static_text:
+    changed_tidy_runner = (root / "scripts" / "run_changed_clang_tidy.py").read_text()
+    for extension in (".cxx", ".hh", ".hxx"):
+        if extension not in changed_tidy_runner:
             issues.append(
-                f".github/workflows/static-analysis.yml: static analysis must include {extension} files"
+                f"scripts/run_changed_clang_tidy.py: static analysis must include {extension} files"
             )
     if not re.search(
         r"git(?: -c core\.quotePath=false)? diff --name-only -z", static_text
@@ -1326,15 +1816,21 @@ def check_repo(root: Path) -> list[str]:
         f".github/workflows/ci-build.yml: {issue}"
         for issue in ci_build_workflow_issues(ci_text)
     )
-    if "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" not in ci_text:
+    if not all(
+        marker in ci_text
+        for marker in (
+            "github.event_name == 'workflow_dispatch' && github.run_id || github.ref",
+            "inputs.qualification-mode == 'validation'",
+        )
+    ):
         issues.append(
-            ".github/workflows/ci-build.yml: master publication runs must not be cancelable"
+            ".github/workflows/ci-build.yml: release qualification must use an isolated non-cancelable concurrency group"
         )
     if "detect_container_overflow=0" in ci_text:
         issues.append(
             ".github/workflows/ci-build.yml: container-overflow detection must not be disabled globally"
         )
-    mac_section = ci_text.partition("  Mac:")[2].partition("  Windows:")[0]
+    mac_section = ci_text.partition("  MacPackages:")[2].partition("  WindowsPackages:")[0]
     if has_unsupported_macos_lsan(mac_section):
         issues.append(
             ".github/workflows/ci-build.yml: Apple ASan does not support detect_leaks=1"

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -623,6 +623,13 @@ def workflow_artifact_actions(text: str) -> dict[str, dict[str, set[str]]]:
 
 def ci_build_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
+    trigger_prefix = text.split("jobs:", 1)[0]
+    push_section = trigger_prefix.partition("  push:")[2].partition("  pull_request:")[0]
+    if any(
+        strip_yaml_comment(line).startswith("paths-ignore:")
+        for line in push_section.splitlines()
+    ):
+        issues.append("master pushes must not skip CI Build by path")
     needs = workflow_job_needs(text)
     missing_jobs = CI_BUILD_REQUIRED_JOBS - set(needs)
     unexpected_jobs = set(needs) - CI_BUILD_REQUIRED_JOBS
@@ -664,6 +671,10 @@ def ci_build_workflow_issues(text: str) -> list[str]:
         output_dependencies = set(
             re.findall(r"needs\.([A-Za-z0-9_-]+)\.outputs\.", block)
         )
+        for dependency in sorted(output_dependencies - direct_dependencies):
+            issues.append(
+                f"CI build job {job} references outputs from {dependency} without a direct need"
+            )
         for dependency in direct_dependencies - output_dependencies:
             other_ancestors: set[str] = set()
             for other in direct_dependencies - {dependency}:
@@ -1910,6 +1921,16 @@ def stable_release_workflow_issues(text: str) -> list[str]:
         or "[[ \"$requested_run_id\" =~ ^[0-9]+$ ]]" not in text
     ):
         issues.append("stable release run ID must use validated environment input")
+    if '.inputs["qualification-mode"]' in text:
+        issues.append("stable release evidence must come from downloaded receipts, not run API inputs")
+    draft_verification = text.partition(
+        "- name: Verify stable source publication after upload"
+    )[2].partition("- name: Recheck master tip before stable promotion")[0]
+    if (
+        ".target_commitish" not in draft_verification
+        or "/git/ref/tags/" in draft_verification
+    ):
+        issues.append("stable draft verification must not require an unpublished Git tag")
     if (
         "rollback_stable_promotion" not in text
         or "trap rollback_stable_promotion ERR" not in text

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -16,7 +16,6 @@ REMOTE_ACTION_SHA_RE = re.compile(r"[^\s@]+@[0-9a-f]{40}")
 CODEQL_ACTION_SHA_RE = re.compile(
     r"github/codeql-action/(?P<action>init|analyze)@(?P<sha>[0-9a-f]{40})"
 )
-CODEQL_CURRENT_SHA = "cdf488f595d80d6e07e03d4674febd5ab45fa938"
 REVIEWED_ACTION_REVISIONS = {
     "actions/attest-build-provenance": "4d101475d8b20a2381f78447822ac1eab6504dd8",
     "actions/cache": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
@@ -67,122 +66,47 @@ BROAD_CPPCHECK_IDS = (
     "missingOverride",
 )
 
-CI_BUILD_JOB_NEEDS = {
-    "ReleaseQualificationPreflight": set(),
-    "SaveVersion": {"ReleaseQualificationPreflight"},
-    "PrefetchCpmCache": {"ReleaseQualificationPreflight"},
-    "PrefetchBoost": {"ReleaseQualificationPreflight"},
-    "PrefetchOpenSsl": {"ReleaseQualificationPreflight"},
-    "PrefetchLinuxDeployQt": {"ReleaseQualificationPreflight"},
-    "PrefetchCmakeInstaller": {"ReleaseQualificationPreflight"},
-    "PrefetchWindowsTools": {"ReleaseQualificationPreflight"},
-    "PrefetchAdbHelperSources": {"ReleaseQualificationPreflight"},
-    "PrefetchIosNativeSources": {"ReleaseQualificationPreflight"},
-    "BuildAdbHelperLegalAssets": {
-        "SaveVersion",
-        "PrefetchAdbHelperSources",
-    },
-    "BuildAdbHelpers": {
-        "PrefetchAdbHelperSources",
-        "BuildAdbHelperLegalAssets",
-    },
-    "BuildAdbLinuxArm64": {
-        "PrefetchAdbHelperSources",
-        "BuildAdbHelperLegalAssets",
-    },
-    "BuildAdbWindowsX64": {
-        "PrefetchAdbHelperSources",
-        "BuildAdbHelperLegalAssets",
-    },
-    "BuildAdbMacX64": {
-        "PrefetchAdbHelperSources",
-        "BuildAdbHelperLegalAssets",
-    },
-    "BuildAdbMacArm64": {
-        "PrefetchAdbHelperSources",
-        "BuildAdbHelperLegalAssets",
-    },
-    "BuildIosNativeStacks": {
-        "SaveVersion",
-        "PrefetchIosNativeSources",
-    },
-    "BuildIosNativeArm64": {
-        "SaveVersion",
-        "PrefetchIosNativeSources",
-    },
-    "LinuxPackages": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchLinuxDeployQt",
-        "PrefetchCmakeInstaller",
-        "BuildAdbHelpers",
-    },
-    "LinuxSanitizers": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchCmakeInstaller",
-    },
-    "LinuxTsan": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-    },
-    "MacPackages": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-        "BuildAdbMacX64",
-        "BuildIosNativeStacks",
-    },
-    "MacArmPackages": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-        "BuildAdbMacArm64",
-        "BuildIosNativeArm64",
-    },
-    "MacSanitizers": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-    },
-    "WindowsPackages": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-        "PrefetchWindowsTools",
-        "BuildAdbWindowsX64",
-    },
-    "WindowsX86": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-        "PrefetchOpenSsl",
-        "PrefetchWindowsTools",
-    },
-    "WindowsAsan": {
-        "SaveVersion",
-        "PrefetchCpmCache",
-        "PrefetchBoost",
-        "PrefetchWindowsTools",
-    },
-    "ci-gate": {
-        "BuildAdbHelpers",
-        "BuildAdbLinuxArm64",
-        "BuildAdbWindowsX64",
-        "BuildAdbMacX64",
-        "BuildAdbMacArm64",
-        "BuildIosNativeStacks",
-        "BuildIosNativeArm64",
-        "LinuxPackages",
-        "LinuxSanitizers",
-        "LinuxTsan",
-        "MacPackages",
-        "MacArmPackages",
-        "MacSanitizers",
-        "WindowsPackages",
-        "WindowsX86",
-        "WindowsAsan",
-    },
+CI_BUILD_REQUIRED_JOBS = {
+    "ReleaseQualificationPreflight",
+    "SaveVersion",
+    "PrefetchCpmCache",
+    "PrefetchBoost",
+    "PrefetchOpenSsl",
+    "PrefetchLinuxDeployQt",
+    "PrefetchCmakeInstaller",
+    "PrefetchWindowsTools",
+    "PrefetchAdbHelperSources",
+    "PrefetchIosNativeSources",
+    "BuildAdbHelperLegalAssets",
+    "BuildAdbHelpers",
+    "BuildAdbLinuxArm64",
+    "BuildAdbWindowsX64",
+    "BuildAdbMacX64",
+    "BuildAdbMacArm64",
+    "BuildIosNativeStacks",
+    "BuildIosNativeArm64",
+    "LinuxPackages",
+    "LinuxSanitizers",
+    "LinuxTsan",
+    "MacPackages",
+    "MacArmPackages",
+    "MacSanitizers",
+    "WindowsPackages",
+    "WindowsX86",
+    "WindowsAsan",
+    "ci-gate",
+}
+
+CI_BUILD_ROOT_JOBS = {
+    "SaveVersion",
+    "PrefetchCpmCache",
+    "PrefetchBoost",
+    "PrefetchOpenSsl",
+    "PrefetchLinuxDeployQt",
+    "PrefetchCmakeInstaller",
+    "PrefetchWindowsTools",
+    "PrefetchAdbHelperSources",
+    "PrefetchIosNativeSources",
 }
 
 CI_BUILD_ARTIFACT_PRODUCERS = {
@@ -244,6 +168,14 @@ CI_BUILD_REQUIRED_ARTIFACT_CONSUMERS = {
     },
     "ios-native-source-cache": {"BuildIosNativeStacks", "BuildIosNativeArm64"},
 }
+
+CI_BUILD_REQUIRED_MOBILE_ANCESTORS = {
+    "LinuxPackages": {"BuildAdbHelpers"},
+    "MacPackages": {"BuildAdbMacX64", "BuildIosNativeStacks"},
+    "MacArmPackages": {"BuildAdbMacArm64", "BuildIosNativeArm64"},
+    "WindowsPackages": {"BuildAdbWindowsX64"},
+}
+
 
 CI_BUILD_ARTIFACT_CONDITIONS = {
     ("BuildIosNativeArm64", "uploads", "ios-native-source-assets"):
@@ -692,27 +624,75 @@ def workflow_artifact_actions(text: str) -> dict[str, dict[str, set[str]]]:
 def ci_build_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
     needs = workflow_job_needs(text)
-    unexpected_jobs = set(needs) - set(CI_BUILD_JOB_NEEDS)
+    missing_jobs = CI_BUILD_REQUIRED_JOBS - set(needs)
+    unexpected_jobs = set(needs) - CI_BUILD_REQUIRED_JOBS
+    for job in sorted(missing_jobs):
+        issues.append(f"CI build workflow must define job {job}")
     if unexpected_jobs:
-        issues.append("CI build workflow contains unmodeled jobs outside the reviewed gate")
-    for job, expected in CI_BUILD_JOB_NEEDS.items():
-        if job not in needs:
-            issues.append(f"CI build workflow must define job {job}")
-            continue
-        if needs[job] != expected:
-            issues.append(
-                f"CI build job {job} must need exactly {sorted(expected)}, got {sorted(needs[job])}"
-            )
+        issues.append(
+            "CI build workflow contains unmodeled jobs outside the reviewed gate: "
+            + ", ".join(sorted(unexpected_jobs))
+        )
 
     if "PrefetchDeps" in needs:
         issues.append("CI build workflow must split the monolithic PrefetchDeps job")
 
     try:
-        for job in needs:
-            workflow_job_ancestors(needs, job)
+        ancestors = {
+            job: workflow_job_ancestors(needs, job)
+            for job in needs
+        }
     except ValueError as error:
         issues.append(str(error))
         return issues
+
+    job_blocks = workflow_job_blocks(text)
+    for consumer, producers in CI_BUILD_REQUIRED_MOBILE_ANCESTORS.items():
+        if consumer not in needs:
+            continue
+        missing_producers = producers - ancestors[consumer]
+        for producer in sorted(missing_producers):
+            issues.append(
+                f"CI native artifact producer {producer} must be an ancestor of {consumer}"
+            )
+    for job in CI_BUILD_ROOT_JOBS & set(needs):
+        if needs[job]:
+            issues.append(f"CI root job {job} must not have dependencies")
+
+    for job, direct_dependencies in needs.items():
+        block = "\n".join(job_blocks.get(job, []))
+        output_dependencies = set(
+            re.findall(r"needs\.([A-Za-z0-9_-]+)\.outputs\.", block)
+        )
+        for dependency in direct_dependencies - output_dependencies:
+            other_ancestors: set[str] = set()
+            for other in direct_dependencies - {dependency}:
+                other_ancestors.add(other)
+                other_ancestors.update(ancestors.get(other, set()))
+            if dependency in other_ancestors:
+                issues.append(
+                    f"CI build job {job} directly needs transitive ancestor {dependency}"
+                )
+
+    gate = "ci-gate"
+    if gate in needs:
+        consumed_before_gate = {
+            dependency
+            for job, dependencies in needs.items()
+            if job != gate
+            for dependency in dependencies
+        }
+        terminal_jobs = (set(needs) - {gate}) - consumed_before_gate
+        if needs[gate] != terminal_jobs:
+            issues.append(
+                "CI gate must directly need exactly terminal validation jobs, got "
+                f"{sorted(needs[gate])}, expected {sorted(terminal_jobs)}"
+            )
+        missing_from_gate = (set(needs) - {gate}) - ancestors[gate]
+        if missing_from_gate:
+            issues.append(
+                "CI gate does not cover jobs: " + ", ".join(sorted(missing_from_gate))
+            )
 
     try:
         artifact_records = workflow_artifact_records(text)
@@ -841,6 +821,62 @@ def ci_build_workflow_issues(text: str) -> list[str]:
     active_lines = [
         active for line in text.splitlines() if (active := strip_yaml_comment(line))
     ]
+    workflow_permissions: list[str] = []
+    workflow_lines = text.splitlines()
+    jobs_index = next(
+        (
+            index
+            for index, line in enumerate(workflow_lines)
+            if re.match(r"^jobs:\s*(?:#.*)?$", line)
+        ),
+        len(workflow_lines),
+    )
+    for index, line in enumerate(workflow_lines[:jobs_index]):
+        entry = KEY_VALUE_RE.match(line)
+        if (
+            entry is None
+            or entry.group("key") != "permissions"
+            or len(entry.group("indent")) != 0
+        ):
+            continue
+        for permission_line in workflow_lines[index + 1 : jobs_index]:
+            active = strip_yaml_comment(permission_line)
+            if not active:
+                continue
+            if len(permission_line) - len(permission_line.lstrip()) == 0:
+                break
+            workflow_permissions.append(active)
+        break
+    if "id-token: write" in workflow_permissions or "attestations: write" in workflow_permissions:
+        issues.append("CI attestation write permissions must be scoped to producer jobs")
+
+    workflow_lines = text.splitlines()
+    cache_to_values = [
+        yaml_value(
+            workflow_lines,
+            index,
+            entry.group("value"),
+            len(entry.group("indent")),
+        )
+        for index, line in enumerate(workflow_lines)
+        if (entry := KEY_VALUE_RE.match(line)) is not None
+        and entry.group("key") == "cache-to"
+    ]
+    if not cache_to_values:
+        issues.append("BuildKit cache exports must run only on default-branch pushes")
+    elif any(
+        not value.startswith(
+            "${{ github.event_name == 'push' && matrix.config.cache_write && "
+        )
+        or not value.endswith(" || '' }}")
+        or value.count("github.event_name") != 1
+        or "pull_request" in value
+        for value in cache_to_values
+    ):
+        issues.append("BuildKit cache exports must run only on default-branch pushes")
+    if any("matrix.config.cache_write" not in value for value in cache_to_values):
+        issues.append("shared BuildKit scopes must have one designated exporter")
+
     has_release_dispatch_input = all(
         marker in active_text
         for marker in (
@@ -873,6 +909,12 @@ def ci_build_workflow_issues(text: str) -> list[str]:
         issues.append(
             "required CI validation must not require signing or notarization secrets"
         )
+    release_master_guard = 'test "$GITHUB_REF" = "refs/heads/master" || {'
+    if (
+        "Signed release qualification must run from master" not in active_text
+        or shell_commands(text).count(release_master_guard) != 1
+    ):
+        issues.append("signed release qualification must reject non-master dispatches")
 
     if "CreatePreRelease" in job_blocks or "softprops/action-gh-release@" in active_text:
         issues.append("release publication must run outside the required CI workflow")
@@ -1259,19 +1301,80 @@ def codeql_workflow_issues(text: str) -> list[str]:
     if any(key == "continue-on-error" for key, _ in nested_entries):
         issues.append("CodeQL workflow must not use continue-on-error")
 
+    permission_entries: list[tuple[str, str]] = []
+    permission_blocks = []
+    for index, line in enumerate(job_lines):
+        entry = KEY_VALUE_RE.match(line)
+        if (
+            entry is not None
+            and entry.group("key") == "permissions"
+            and len(entry.group("indent")) == direct_indent
+        ):
+            permission_blocks.append(index)
+    if len(permission_blocks) == 1:
+        permission_index = permission_blocks[0]
+        for line in job_lines[permission_index + 1 :]:
+            active = strip_yaml_comment(line)
+            if not active:
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent <= direct_indent:
+                break
+            entry = KEY_VALUE_RE.match(line)
+            if entry is not None and indent == direct_indent + 2:
+                permission_entries.append(
+                    (entry.group("key"), scalar(entry.group("value")).lower())
+                )
+    expected_permissions = {
+        "contents": "read",
+        "security-events": "write",
+    }
+    permission_issue = (
+        "CodeQL analyze job must grant only contents: read and "
+        "security-events: write permissions"
+    )
+    if (
+        len(permission_blocks) != 1
+        or len(permission_entries) != len(expected_permissions)
+        or dict(permission_entries) != expected_permissions
+    ):
+        issues.append(permission_issue)
+
     jobs_position = next(
         (index for index, line in enumerate(lines) if re.match(r"^jobs:\s*(?:#.*)?$", line)),
         len(lines),
     )
+    workflow_scoped_permissions = any(
+        entry.group("key") == "permissions" and len(entry.group("indent")) == 0
+        for line in lines[:jobs_position]
+        if (entry := KEY_VALUE_RE.match(line)) is not None
+    )
+    if workflow_scoped_permissions and permission_issue not in issues:
+        issues.append(permission_issue)
+
     trigger_text = "\n".join(
         f"{' ' * (len(line) - len(line.lstrip()))}{active}"
         for line in lines[:jobs_position]
         if (active := strip_yaml_comment(line))
     )
-    if not re.search(r"(?m)^\s{2}push:\s*$", trigger_text) or not re.search(
-        r"(?m)^\s{4}branches:\s*\[\s*master\s*\]\s*$", trigger_text
-    ):
+    master_branch_blocks = re.compile(
+        r"(?m)^\s{2}(?P<trigger>push|pull_request):\s*$\n"
+        r"(?P<body>(?:^\s{4,}.*$\n?)*)"
+    )
+    configured_branches = {
+        match.group("trigger")
+        for match in master_branch_blocks.finditer(trigger_text)
+        if re.search(
+            r"(?m)^\s{4}branches:\s*\[\s*master\s*\]\s*$",
+            match.group("body"),
+        )
+    }
+    if "push" not in configured_branches:
         issues.append("CodeQL workflow must run on pushes to master")
+    if "pull_request" not in configured_branches:
+        issues.append("CodeQL workflow must run on pull requests to master")
+    if re.search(r"(?m)^\s{2}workflow_dispatch:\s*$", trigger_text) is None:
+        issues.append("CodeQL workflow must support manual dispatch")
 
     action_refs: dict[str, list[str]] = {"init": [], "analyze": []}
     for key, value in nested_entries:
@@ -1300,33 +1403,83 @@ def codeql_workflow_issues(text: str) -> list[str]:
         issues.append("CodeQL init and analyze must use the same reviewed SHA")
     if (
         matching_codeql_revision
-        and pinned_shas["init"] != CODEQL_CURRENT_SHA
+        and pinned_shas["init"] != REVIEWED_ACTION_REVISIONS["github/codeql-action"]
     ):
         issues.append("CodeQL actions must use the current reviewed generation")
 
-    active_text = "\n".join(
-        active for line in text.splitlines() if (active := strip_yaml_comment(line))
-    )
-    init_position = active_text.find("github/codeql-action/init@")
-    analyze_position = active_text.find("github/codeql-action/analyze@")
-    build_mode_position = active_text.find("build-mode: manual")
-    if not (
-        init_position >= 0
-        and build_mode_position > init_position
-        and analyze_position > build_mode_position
-    ):
+    job_block = lines[job_start:job_end]
+    step_actions: list[tuple[str, list[str], int]] = []
+    has_run_step = False
+    for step in workflow_step_blocks(job_block):
+        item = LIST_ITEM_RE.match(step[0])
+        if item is None:
+            continue
+        item_indent = len(item.group("indent"))
+        action = None
+        with_indent = None
+        for offset, line in enumerate(step):
+            entry = KEY_VALUE_RE.match(line)
+            if entry is None:
+                continue
+            key = entry.group("key")
+            indent = len(entry.group("indent"))
+            if key == "uses" and indent in {item_indent, item_indent + 2}:
+                action = yaml_value(step, offset, entry.group("value"), indent)
+            elif key == "run" and indent in {item_indent, item_indent + 2}:
+                has_run_step = True
+            elif key == "with" and indent == item_indent + 2:
+                with_indent = indent
+        if action is not None:
+            step_actions.append((action, step, with_indent or -1))
+
+    init_steps = [
+        (step, with_indent)
+        for action, step, with_indent in step_actions
+        if action.startswith("github/codeql-action/init@")
+    ]
+    init_build_modes: list[str] = []
+    if len(init_steps) == 1:
+        init_step, with_indent = init_steps[0]
+        for line in init_step:
+            entry = KEY_VALUE_RE.match(line)
+            if (
+                entry is not None
+                and entry.group("key") == "build-mode"
+                and len(entry.group("indent")) == with_indent + 2
+            ):
+                init_build_modes.append(scalar(entry.group("value")).lower())
+    if init_build_modes != ["manual"]:
         issues.append("CodeQL init must set build-mode: manual")
 
+    job_active = "\n".join(
+        active for line in job_lines if (active := strip_yaml_comment(line))
+    )
+    for marker in (
+        'CODEQL_ACTION_OVERLAY_ANALYSIS: "false"',
+        'CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"',
+    ):
+        if marker not in job_active:
+            issues.append(
+                "CodeQL traced build must explicitly disable overlay analysis"
+            )
+            break
+
+    if "uses: ./.github/actions/agent-setup" not in job_active:
+        issues.append("CodeQL manual build must restore the shared dependency closure")
+
     cmake_configures = []
-    for command in shell_commands(text):
+    has_application_build = False
+    for command in shell_commands("\n".join(job_block)):
         tokens = shell_tokens(command)
-        if (
-            tokens
-            and tokens[0] == "cmake"
-            and "--build" not in tokens
-            and "-P" not in tokens
-        ):
+        if not tokens or tokens[0] != "cmake":
+            continue
+        if "--build" in tokens:
+            if "build" in tokens and "klogg" in tokens:
+                has_application_build = True
+            continue
+        if "-P" not in tokens:
             cmake_configures.append(tokens)
+
     cpm_source_caches = [
         value
         for tokens in cmake_configures
@@ -1346,6 +1499,8 @@ def codeql_workflow_issues(text: str) -> list[str]:
         issues.append(
             "CodeQL configure must use the restored CPM source cache fully disconnected"
         )
+    if not has_application_build:
+        issues.append("CodeQL manual build must trace the klogg application target")
 
     return issues
 
@@ -1418,6 +1573,33 @@ def static_analysis_workflow_issues(text: str) -> list[str]:
         issues.append(
             "clang-tidy TU scope must come from the configured compile database"
         )
+
+    if "/tmp/cc_src.json" in text:
+        has_cppcheck_unit_list = any(
+            tokens[:2] == ["python3", "scripts/first_party_compile_units.py"]
+            and "$KLOGG_BUILD_ROOT/compile_commands.json" in tokens
+            and "$KLOGG_WORKSPACE/src" in tokens
+            and "--null" in tokens
+            and option_value(tokens, ">") == "/tmp/cppcheck_files.nul"
+            for command in commands
+            if (tokens := shell_tokens(command))
+        )
+        has_cppcheck_database_filter = any(
+            tokens[:2] == ["python3", "scripts/filter_compile_database.py"]
+            and tokens[2:6]
+            == [
+                "$KLOGG_BUILD_ROOT/compile_commands.json",
+                "$KLOGG_WORKSPACE",
+                "/tmp/cppcheck_files.nul",
+                "/tmp/cc_src.json",
+            ]
+            for command in commands
+            if (tokens := shell_tokens(command))
+        )
+        if not has_cppcheck_unit_list or not has_cppcheck_database_filter:
+            issues.append(
+                "cppcheck TU scope must resolve relative compile database entries"
+            )
 
     strict_consumers = []
     strict_runners = []
@@ -1717,6 +1899,51 @@ def cppcheck_suppression_issues(text: str) -> list[str]:
     return issues
 
 
+def stable_release_workflow_issues(text: str) -> list[str]:
+    issues: list[str] = []
+    commands = shell_commands(text)
+    master_guard = 'test "${GITHUB_REF}" = "refs/heads/master" || {'
+    if commands.count(master_guard) != 1:
+        issues.append("stable release dispatch must fail closed outside master")
+    if (
+        "KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}" not in text
+        or "[[ \"$requested_run_id\" =~ ^[0-9]+$ ]]" not in text
+    ):
+        issues.append("stable release run ID must use validated environment input")
+    if (
+        "rollback_stable_promotion" not in text
+        or "trap rollback_stable_promotion ERR" not in text
+    ):
+        issues.append("stable release promotion must roll back every post-publish failure")
+    return issues
+
+
+def continuous_release_workflow_issues(text: str) -> list[str]:
+    issues: list[str] = []
+    blocks = workflow_job_blocks(text)
+    select = blocks.get("select")
+    publish = blocks.get("publish")
+    expected_select = (
+        "github.event.workflow_run.conclusion == 'success' "
+        "&& github.event.workflow_run.event == 'push' "
+        "&& github.event.workflow_run.head_branch == 'master' "
+        "&& github.event.workflow_run.head_repository.full_name == github.repository"
+    )
+    if select is None or workflow_job_direct_value(select, "if") != expected_select:
+        issues.append("continuous release selection must require a trusted successful master push")
+    if (
+        publish is None
+        or workflow_job_direct_value(publish, "if")
+        != "${{ needs.select.outputs.should-publish == 'true' }}"
+    ):
+        issues.append("continuous release publication must require the verified selection output")
+    if "cancel-in-progress: false" not in text:
+        issues.append("continuous release transaction must not be canceled in progress")
+    if "${{ failure() || cancelled() }}" not in text:
+        issues.append("continuous release rollback must cover failure and cancellation")
+    return issues
+
+
 def ci_manifests(root: Path) -> list[Path]:
     paths = set()
     for pattern in ("*.yml", "*.yaml"):
@@ -1809,6 +2036,17 @@ def check_repo(root: Path) -> list[str]:
         cppcheck_suppression_issues(
             (root / "tests" / "cppcheck_suppressions.txt").read_text()
         )
+    )
+
+    stable_release_text = (workflows / "ci-release.yml").read_text()
+    issues.extend(
+        f".github/workflows/ci-release.yml: {issue}"
+        for issue in stable_release_workflow_issues(stable_release_text)
+    )
+    continuous_release_text = (workflows / "ci-continuous.yml").read_text()
+    issues.extend(
+        f".github/workflows/ci-continuous.yml: {issue}"
+        for issue in continuous_release_workflow_issues(continuous_release_text)
     )
 
     ci_text = (workflows / "ci-build.yml").read_text()

--- a/scripts/prefetch_adb_helper_sources.py
+++ b/scripts/prefetch_adb_helper_sources.py
@@ -83,12 +83,24 @@ def validated_archive_members(
     *,
     omit_excluded_symlinks: bool,
     validate_symlink_targets: bool,
-) -> tuple[dict[tuple[str, ...], tarfile.TarInfo], list[dict[str, str]]]:
+) -> tuple[
+    dict[tuple[str, ...], tarfile.TarInfo], list[dict[str, str]], bool
+]:
     exclusions = locked_symlink_exclusions(excluded_build_symlinks)
     matched_exclusions: set[tuple[str, ...]] = set()
     seen: set[tuple[str, ...]] = set()
     by_name: dict[tuple[str, ...], tarfile.TarInfo] = {}
+    root_directory_seen = False
     for member in tar.getmembers():
+        if member.name.rstrip("/") == ".":
+            if not member.isdir():
+                raise RuntimeError(
+                    f"archive contains normalized-empty non-directory member: {member.name}"
+                )
+            if root_directory_seen:
+                raise RuntimeError("archive contains duplicate root directory member")
+            root_directory_seen = True
+            continue
         parts = normalized_archive_parts(member.name, "member")
         if parts in seen:
             raise RuntimeError(f"archive contains duplicate member path: {member.name}")
@@ -110,11 +122,18 @@ def validated_archive_members(
                 normalized_archive_parts(link_path.as_posix(), "symlink target")
         by_name[parts] = member
 
+    if not by_name:
+        raise RuntimeError("archive contains no real members")
+
     missing_exclusions = exclusions.keys() - matched_exclusions
     if missing_exclusions:
         missing = ", ".join(exclusions[parts]["path"] for parts in missing_exclusions)
         raise RuntimeError(f"excluded build symlink is missing from archive: {missing}")
-    return by_name, [exclusions[parts] for parts in exclusions if parts in matched_exclusions]
+    return (
+        by_name,
+        [exclusions[parts] for parts in exclusions if parts in matched_exclusions],
+        root_directory_seen,
+    )
 
 
 @contextlib.contextmanager
@@ -140,7 +159,7 @@ def canonicalize_tar_gz(
         temporary = pathlib.Path(stream.name)
     try:
         with tarfile.open(archive, "r:*") as source:
-            members, _ = validated_archive_members(
+            members, _, _ = validated_archive_members(
                 source,
                 excluded_build_symlinks,
                 omit_excluded_symlinks=False,
@@ -244,7 +263,7 @@ def safe_extract(
         raise RuntimeError(f"archive extraction destination must be an empty directory: {destination}")
 
     with tarfile.open(archive, "r:*") as tar:
-        by_name, matched_exclusions = validated_archive_members(
+        by_name, matched_exclusions, explicit_root = validated_archive_members(
             tar,
             excluded_build_symlinks,
             omit_excluded_symlinks=True,
@@ -287,7 +306,7 @@ def safe_extract(
             )
 
     children = [path for path in destination.iterdir() if path.name != ".DS_Store"]
-    if len(children) == 1 and children[0].is_dir():
+    if not explicit_root and len(children) == 1 and children[0].is_dir():
         top = children[0]
         temporary = destination.with_name(destination.name + ".flatten")
         if temporary.exists():

--- a/scripts/prepare_source_publication.py
+++ b/scripts/prepare_source_publication.py
@@ -17,7 +17,12 @@ from source_publication_identity import (
     validate_asset_file_name,
     validate_version,
 )
-from verify_source_publication_manifest import PublicationError, verify_manifest
+from verify_source_publication_manifest import (
+    EVIDENCE_LEVELS,
+    PublicationError,
+    verify_manifest,
+    verify_package_receipt_evidence,
+)
 
 
 def sha256(path: pathlib.Path) -> str:
@@ -64,7 +69,8 @@ def publish_component(
     archive_record = receipt.get("archive")
     if not isinstance(archive_record, dict):
         raise PublicationError(f"source-set receipt lacks archive: {component}")
-    archive_source = root / str(archive_record.get("file_name", ""))
+    archive_name = validate_asset_file_name(archive_record.get("file_name"))
+    archive_source = root / archive_name
     archive_hash = sha256(archive_source)
     if archive_record.get("sha256") != archive_hash:
         raise PublicationError(f"source-set archive hash mismatch: {component}")
@@ -125,6 +131,7 @@ def publish_component(
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--channel", choices=("stable", "continuous"), required=True)
+    parser.add_argument("--evidence-level", choices=tuple(sorted(EVIDENCE_LEVELS)), required=True)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--commit", required=True)
@@ -172,7 +179,12 @@ def main() -> int:
         receipt = read_json(receipt_path, "iOS package qualification receipt")
         if (
             receipt.get("receipt_kind") != "ios-native-package-verification"
-            or receipt.get("release_qualified") is not True
+            or receipt.get("qualification") != args.evidence_level
+            or not isinstance(receipt.get("release_qualified"), bool)
+            or (
+                args.evidence_level == "signed"
+                and receipt.get("release_qualified") is not True
+            )
             or receipt.get("source_set_receipt_sha256") != source_hashes["ios-native"]
             or re.fullmatch(
                 r"[0-9a-f]{64}",
@@ -203,10 +215,11 @@ def main() -> int:
     packages = []
     for receipt_path in args.qualification_receipt:
         receipt = read_json(receipt_path, "package qualification receipt")
-        if receipt.get("receipt_kind") != "package-verification" or receipt.get(
-            "release_qualified"
-        ) is not True:
-            raise PublicationError(f"package is not release-qualified: {receipt_path}")
+        if receipt.get("receipt_kind") != "package-verification":
+            raise PublicationError(f"invalid package qualification receipt: {receipt_path}")
+        verify_package_receipt_evidence(
+            receipt, receipt_path.name, args.evidence_level
+        )
         if receipt.get("source_set_receipt_sha256") != source_hashes["adb-helper"]:
             raise PublicationError(
                 f"ADB package qualification source-set binding mismatch: {receipt_path}"
@@ -230,6 +243,7 @@ def main() -> int:
             )
             applicable = {"adb-helper": source_hashes["adb-helper"]}
             ios_qualification_record = None
+            ios_package_receipt_record = None
             if package.suffix.lower() == ".dmg":
                 applicable["ios-native"] = source_hashes["ios-native"]
                 ios_evidence = ios_qualifications.pop(package.name, None)
@@ -237,7 +251,7 @@ def main() -> int:
                     raise PublicationError(
                         f"missing external iOS qualification for DMG: {package.name}"
                     )
-                ios_path, _, ios_package = ios_evidence
+                ios_path, ios_receipt, ios_package = ios_evidence
                 if ios_package.get("sha256") != sha256(package):
                     raise PublicationError(
                         f"iOS qualification package hash mismatch: {package.name}"
@@ -252,6 +266,31 @@ def main() -> int:
                     "file_name": ios_copy.name,
                     "sha256": sha256(ios_copy),
                 }
+                ios_package_source = ios_path.parent / "ios-native-package-receipt.json"
+                ios_package_receipt = read_json(
+                    ios_package_source, f"iOS package receipt for {package.name}"
+                )
+                if (
+                    ios_package_receipt.get("receipt_kind") != "ios-native-package"
+                    or ios_package_receipt.get("status") != "passed"
+                    or ios_package_receipt.get("source_set_receipt_sha256")
+                    != source_hashes["ios-native"]
+                    or sha256(ios_package_source)
+                    != ios_receipt.get("ios_native_package_receipt_sha256")
+                ):
+                    raise PublicationError(
+                        f"iOS package receipt evidence mismatch: {package.name}"
+                    )
+                ios_package_name = f"{package.name}.ios-package.json"
+                ios_package_copy = copy_regular(
+                    ios_package_source,
+                    args.output / ios_package_name,
+                    f"iOS package receipt for {package.name}",
+                )
+                ios_package_receipt_record = {
+                    "file_name": ios_package_copy.name,
+                    "sha256": sha256(ios_package_copy),
+                }
             package_record = {
                 "file_name": package.name,
                 "sha256": sha256(package),
@@ -263,6 +302,20 @@ def main() -> int:
             }
             if ios_qualification_record is not None:
                 package_record["ios_qualification_receipt"] = ios_qualification_record
+                package_record["ios_package_receipt"] = ios_package_receipt_record
+            if args.evidence_level == "signed" and package.suffix.lower() == ".dmg":
+                for kind in ("signing", "notarization"):
+                    evidence_source = receipt_path.parent / f"adb-helper-{kind}-receipt.json"
+                    evidence_name = f"{package.name}.{kind}.json"
+                    evidence_copy = copy_regular(
+                        evidence_source,
+                        args.output / evidence_name,
+                        f"{kind} receipt for {package.name}",
+                    )
+                    package_record[f"{kind}_receipt"] = {
+                        "file_name": evidence_copy.name,
+                        "sha256": sha256(evidence_copy),
+                    }
             packages.append(package_record)
 
     if ios_qualifications:
@@ -275,6 +328,7 @@ def main() -> int:
         "schema_version": 1,
         "manifest_kind": "klogg-source-publication",
         "channel": args.channel,
+        "evidence_level": args.evidence_level,
         "release": {
             "tag": args.tag,
             "version": args.version,
@@ -292,12 +346,15 @@ def main() -> int:
         manifest_path,
         args.output,
         args.channel,
+        args.evidence_level,
         args.tag,
         args.version,
         args.commit,
         args.base_url,
     )
-    print(f"prepared coherent {args.channel} publication in {args.output}")
+    print(
+        f"prepared coherent {args.channel}/{args.evidence_level} publication in {args.output}"
+    )
     return 0
 
 

--- a/scripts/run_ci_quality.py
+++ b/scripts/run_ci_quality.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run the repository's complete fast CI-quality gate through one entry point."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def quality_commands(root: pathlib.Path) -> list[list[str]]:
+    del root
+    return [
+        [sys.executable, "scripts/lint_platform_fragile.py"],
+        [sys.executable, "scripts/lint_linux_package_runtime.py"],
+        [sys.executable, "scripts/lint_ci_quality.py"],
+        [sys.executable, "scripts/lint_translation_catalogs.py"],
+        [
+            sys.executable,
+            "-m",
+            "unittest",
+            "discover",
+            "-s",
+            "tests/scripts",
+            "-p",
+            "test_*.py",
+        ],
+    ]
+
+
+def repository_identity(root: pathlib.Path) -> tuple[str, bool]:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return commit, bool(status.strip())
+
+
+def run_quality_checks(root: pathlib.Path) -> dict[str, Any]:
+    checks: list[dict[str, Any]] = []
+    returncode = 0
+    for command in quality_commands(root):
+        started = time.monotonic()
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        duration = time.monotonic() - started
+        checks.append(
+            {
+                "command": command,
+                "durationSeconds": round(duration, 3),
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            }
+        )
+        if completed.returncode != 0:
+            returncode = completed.returncode
+            break
+    return {"returncode": returncode, "checks": checks}
+
+
+def render_human(payload: dict[str, Any]) -> None:
+    print(f"CI quality base: {payload['commit']} (dirty={str(payload['dirty']).lower()})")
+    for check in payload["checks"]:
+        command = " ".join(check["command"])
+        print(f"\n==> {command}")
+        if check["stdout"]:
+            print(check["stdout"], end="" if check["stdout"].endswith("\n") else "\n")
+        if check["stderr"]:
+            print(
+                check["stderr"],
+                end="" if check["stderr"].endswith("\n") else "\n",
+                file=sys.stderr,
+            )
+        print(
+            f"<== exit {check['returncode']} in {check['durationSeconds']:.3f}s"
+        )
+    if payload["returncode"] == 0:
+        print("\nCI quality checks passed.")
+    else:
+        print("\nCI quality checks failed; remaining commands were not run.", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit a JSON result receipt.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = pathlib.Path(__file__).resolve().parents[1]
+    commit, dirty = repository_identity(root)
+    result = run_quality_checks(root)
+    payload = {"commit": commit, "dirty": dirty, **result}
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        render_human(payload)
+    return int(result["returncode"])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_ios_native_stack.py
+++ b/scripts/verify_ios_native_stack.py
@@ -408,9 +408,22 @@ def main() -> int:
     parser.add_argument("--sbom", type=pathlib.Path)
     parser.add_argument("--app-executable", type=pathlib.Path)
     parser.add_argument("--signed-package-stage", action="store_true")
+    parser.add_argument(
+        "--unsigned-package-stage",
+        action="store_true",
+        help="Verify a validation package receipt without requiring code signatures.",
+    )
     args = parser.parse_args()
 
     try:
+        if args.signed_package_stage and args.unsigned_package_stage:
+            raise VerificationError(
+                "signed and unsigned package-stage modes are mutually exclusive"
+            )
+        if args.unsigned_package_stage and args.verify_package_receipt is None:
+            raise VerificationError(
+                "unsigned package-stage mode requires --verify-package-receipt"
+            )
         lock = read_json(args.lock, "iOS native lock")
         receipt_path = args.receipt or args.stack_root / "ios-native-build-receipt.json"
         receipt = read_json(receipt_path, "iOS native build receipt")
@@ -420,8 +433,17 @@ def main() -> int:
             args.stack_root,
             args.architecture,
             receipt,
-            enforce_build_hashes=not args.signed_package_stage and args.verify_package_receipt is None,
-            require_code_signature=args.signed_package_stage or args.verify_package_receipt is not None,
+            enforce_build_hashes=(
+                not args.signed_package_stage
+                and (
+                    args.verify_package_receipt is None
+                    or args.unsigned_package_stage
+                )
+            ),
+            require_code_signature=args.signed_package_stage
+            or (
+                args.verify_package_receipt is not None and not args.unsigned_package_stage
+            ),
         )
         application = (
             verify_application_rpath(lock, args.app_executable)

--- a/scripts/verify_source_publication_manifest.py
+++ b/scripts/verify_source_publication_manifest.py
@@ -17,6 +17,14 @@ class PublicationError(RuntimeError):
     pass
 
 
+EVIDENCE_LEVELS = {"validation", "signed"}
+MANDATORY_PACKAGE_RECEIPTS = {
+    "binary-build",
+    "binary-smoke",
+    "package-verification",
+}
+
+
 def sha256(path: pathlib.Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
@@ -171,10 +179,75 @@ def verify_component(
     return receipt_hash, referenced_assets
 
 
+def verify_package_receipt_evidence(
+    receipt: dict, package_name: str, evidence_level: str
+) -> None:
+    required = receipt.get("required_receipts")
+    verified = receipt.get("verified_receipts")
+    if not isinstance(required, list) or not all(isinstance(item, str) for item in required):
+        raise PublicationError(f"qualification required-receipt list is invalid: {package_name}")
+    if not isinstance(verified, list) or not all(isinstance(item, str) for item in verified):
+        raise PublicationError(f"qualification verified-receipt list is invalid: {package_name}")
+    required_set = set(required)
+    verified_set = set(verified)
+    if not MANDATORY_PACKAGE_RECEIPTS.issubset(required_set):
+        raise PublicationError(f"qualification receipt policy is incomplete: {package_name}")
+    if not MANDATORY_PACKAGE_RECEIPTS.issubset(verified_set):
+        raise PublicationError(f"qualification validation evidence is incomplete: {package_name}")
+    if not verified_set.issubset(required_set):
+        raise PublicationError(f"qualification verified evidence is outside policy: {package_name}")
+    release_qualified = receipt.get("release_qualified")
+    if not isinstance(release_qualified, bool):
+        raise PublicationError(f"qualification release claim is invalid: {package_name}")
+    if evidence_level == "signed" and (
+        release_qualified is not True or verified_set != required_set
+    ):
+        raise PublicationError(f"qualification receipt is not signed/release-qualified: {package_name}")
+
+
+def verify_signed_receipt(
+    package: dict,
+    qualification_receipt: dict,
+    package_path: pathlib.Path,
+    package_hash: str,
+    assets_root: pathlib.Path,
+    kind: str,
+) -> None:
+    record = package.get(f"{kind}_receipt")
+    if not isinstance(record, dict):
+        raise PublicationError(f"signed evidence lacks {kind} receipt: {package_path.name}")
+    path = regular_asset(assets_root, record.get("file_name"), f"{kind} receipt")
+    require_hash(path, record.get("sha256"), f"{kind} receipt")
+    receipt = read_json(path, f"{kind} receipt")
+    if receipt.get("receipt_kind") != kind or receipt.get("status") != "passed":
+        raise PublicationError(f"invalid {kind} receipt: {package_path.name}")
+    identity_fields = (
+        ("identity",)
+        if kind == "signing"
+        else ("team_id", "submission_id")
+    )
+    if any(
+        not isinstance(receipt.get(field), str) or not receipt[field].strip()
+        for field in identity_fields
+    ):
+        raise PublicationError(f"{kind} receipt identity is missing: {package_path.name}")
+    if receipt.get("target") != qualification_receipt.get("target"):
+        raise PublicationError(f"{kind} receipt target mismatch: {package_path.name}")
+    if receipt.get("package_sha256", receipt.get("dmg_sha256")) != package_hash:
+        raise PublicationError(f"{kind} receipt package hash mismatch: {package_path.name}")
+    if receipt.get("source_helper_sha256") != qualification_receipt.get(
+        "source_helper_sha256"
+    ):
+        raise PublicationError(f"{kind} receipt source-helper binding mismatch: {package_path.name}")
+    if receipt.get("signed_helper_sha256") != qualification_receipt.get("helper_sha256"):
+        raise PublicationError(f"{kind} receipt helper binding mismatch: {package_path.name}")
+
+
 def verify_manifest(
     manifest_path: pathlib.Path,
     assets_root: pathlib.Path,
     expected_channel: str,
+    expected_evidence_level: str,
     expected_tag: str,
     expected_version: str,
     expected_commit: str,
@@ -185,6 +258,11 @@ def verify_manifest(
         raise PublicationError("unsupported source publication manifest schema")
     if document.get("channel") != expected_channel:
         raise PublicationError("publication channel mismatch")
+    if (
+        expected_evidence_level not in EVIDENCE_LEVELS
+        or document.get("evidence_level") != expected_evidence_level
+    ):
+        raise PublicationError("publication evidence level mismatch")
     release = document.get("release")
     if not isinstance(release, dict):
         raise PublicationError("publication release identity is missing")
@@ -229,7 +307,9 @@ def verify_manifest(
         if package_path.name in seen_packages:
             raise PublicationError(f"duplicate publication package: {package_path.name}")
         seen_packages.add(package_path.name)
-        require_hash(package_path, package.get("sha256"), f"package {package_path.name}")
+        package_hash = require_hash(
+            package_path, package.get("sha256"), f"package {package_path.name}"
+        )
 
         qualification = package.get("qualification_receipt")
         if not isinstance(qualification, dict):
@@ -247,13 +327,13 @@ def verify_manifest(
         qualification_receipt = read_json(
             qualification_path, f"qualification receipt for {package_path.name}"
         )
-        if (
-            qualification_receipt.get("receipt_kind") != "package-verification"
-            or qualification_receipt.get("release_qualified") is not True
-        ):
+        if qualification_receipt.get("receipt_kind") != "package-verification":
             raise PublicationError(
-                f"qualification receipt is not release-qualified: {package_path.name}"
+                f"invalid qualification receipt kind: {package_path.name}"
             )
+        verify_package_receipt_evidence(
+            qualification_receipt, package_path.name, expected_evidence_level
+        )
         qualified_packages = qualification_receipt.get("packages")
         if not isinstance(qualified_packages, list):
             raise PublicationError(
@@ -311,9 +391,43 @@ def verify_manifest(
                 ios_qualification_path,
                 f"iOS qualification receipt for {package_path.name}",
             )
+            ios_package_record = package.get("ios_package_receipt")
+            if not isinstance(ios_package_record, dict):
+                raise PublicationError(
+                    f"iOS package receipt is missing: {package_path.name}"
+                )
+            ios_package_path = regular_asset(
+                assets_root,
+                ios_package_record.get("file_name"),
+                f"iOS package receipt for {package_path.name}",
+            )
+            ios_package_hash = require_hash(
+                ios_package_path,
+                ios_package_record.get("sha256"),
+                f"iOS package receipt {package_path.name}",
+            )
+            ios_package_receipt = read_json(
+                ios_package_path, f"iOS package receipt for {package_path.name}"
+            )
+            if (
+                ios_package_receipt.get("receipt_kind") != "ios-native-package"
+                or ios_package_receipt.get("status") != "passed"
+                or ios_package_receipt.get("source_set_receipt_sha256")
+                != bound_sources["ios-native"]
+                or ios_receipt.get("ios_native_package_receipt_sha256")
+                != ios_package_hash
+            ):
+                raise PublicationError(
+                    f"iOS package receipt evidence mismatch: {package_path.name}"
+                )
             if (
                 ios_receipt.get("receipt_kind") != "ios-native-package-verification"
-                or ios_receipt.get("release_qualified") is not True
+                or ios_receipt.get("qualification") != expected_evidence_level
+                or not isinstance(ios_receipt.get("release_qualified"), bool)
+                or (
+                    expected_evidence_level == "signed"
+                    and ios_receipt.get("release_qualified") is not True
+                )
                 or ios_receipt.get("source_set_receipt_sha256")
                 != bound_sources["ios-native"]
                 or re.fullmatch(
@@ -341,9 +455,36 @@ def verify_manifest(
                 raise PublicationError(
                     f"iOS qualification package filename/hash mismatch: {package_path.name}"
                 )
-        elif ios_qualification is not None:
+        elif (
+            ios_qualification is not None
+            or package.get("ios_package_receipt") is not None
+        ):
             raise PublicationError(
                 f"unexpected iOS qualification receipt: {package_path.name}"
+            )
+
+        if expected_evidence_level == "signed" and package_path.suffix.lower() == ".dmg":
+            verify_signed_receipt(
+                package,
+                qualification_receipt,
+                package_path,
+                package_hash,
+                assets_root,
+                "signing",
+            )
+            verify_signed_receipt(
+                package,
+                qualification_receipt,
+                package_path,
+                package_hash,
+                assets_root,
+                "notarization",
+            )
+        elif package.get("signing_receipt") is not None or package.get(
+            "notarization_receipt"
+        ) is not None:
+            raise PublicationError(
+                f"unexpected signed evidence for validation publication: {package_path.name}"
             )
 
         for component, expected_hash in bound_sources.items():
@@ -360,6 +501,13 @@ def verify_manifest(
         ios_qualification = package.get("ios_qualification_receipt")
         if isinstance(ios_qualification, dict):
             referenced_publication_assets.add(ios_qualification["file_name"])
+        ios_package_receipt = package.get("ios_package_receipt")
+        if isinstance(ios_package_receipt, dict):
+            referenced_publication_assets.add(ios_package_receipt["file_name"])
+        for kind in ("signing", "notarization"):
+            evidence = package.get(f"{kind}_receipt")
+            if isinstance(evidence, dict):
+                referenced_publication_assets.add(evidence["file_name"])
     publication_assets = {
         path.name
         for path in assets_root.iterdir()
@@ -370,6 +518,9 @@ def verify_manifest(
             or re.fullmatch(r"klogg-v.+-.+-source-[0-9a-f]{12}\.tar\.gz(?:\.sha256)?", path.name)
             or path.name.endswith(".qualification.json")
             or path.name.endswith(".ios-qualification.json")
+            or path.name.endswith(".ios-package.json")
+            or path.name.endswith(".signing.json")
+            or path.name.endswith(".notarization.json")
             or path.name.endswith("source-publication-manifest.json")
         )
     }
@@ -402,6 +553,9 @@ def main() -> int:
     parser.add_argument("--manifest", required=True, type=pathlib.Path)
     parser.add_argument("--assets-root", required=True, type=pathlib.Path)
     parser.add_argument("--expected-channel", choices=("stable", "continuous"), required=True)
+    parser.add_argument(
+        "--expected-evidence-level", choices=tuple(sorted(EVIDENCE_LEVELS)), required=True
+    )
     parser.add_argument("--expected-tag", required=True)
     parser.add_argument("--expected-version", required=True)
     parser.add_argument("--expected-commit", required=True)
@@ -412,13 +566,15 @@ def main() -> int:
             args.manifest,
             args.assets_root,
             args.expected_channel,
+            args.expected_evidence_level,
             args.expected_tag,
             args.expected_version,
             args.expected_commit,
             args.expected_base_url,
         )
         print(
-            f"verified coherent {args.expected_channel} package/source publication: "
+            f"verified coherent {args.expected_channel}/{args.expected_evidence_level} "
+            "package/source publication: "
             f"{args.manifest}"
         )
         return 0

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -851,9 +851,10 @@ void IosNativeStreamWorker::stop( Generation generation ) noexcept
         state->retired = true;
         state->acceptingCallbacks = false;
     }
-    if ( !state->scheduleCleanup() ) {
-        state->publishStopped();
-    }
+    // scheduleCleanup() retains State when neither the configured executor nor
+    // the emergency thread can accept cleanup. Do not acknowledge stopped until
+    // runCleanup() has actually quiesced callbacks and released native clients.
+    static_cast<void>( state->scheduleCleanup() );
 }
 
 void IosNativeStreamWorker::shutdown() noexcept

--- a/src/logdata/include/rollingfilemanager.h
+++ b/src/logdata/include/rollingfilemanager.h
@@ -9,6 +9,8 @@
 #include <optional>
 #include <vector>
 
+#include "platform/platform_files.h"
+
 // Manages a rolling output file that rotates when it reaches a size limit.
 // When the current file exceeds maxFileSize, it is renamed as a numbered backup
 // and a new file is opened with the original name. Old backups beyond backupCount
@@ -29,7 +31,8 @@ class RollingFileManager {
 
     bool isValid() const;
     bool open( bool truncate = false );
-    bool openExisting();
+    bool openExisting(
+        const std::optional<klogg::platform::FileIdentity>& expectedIdentity = std::nullopt );
     void close();
     bool flush();
 

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -2480,8 +2480,14 @@ bool CaptureStore::bindOutputFile( const QString& outputPath, bool preserveExist
                             return writeSegmentToDevice( segment, output );
                         } );
                 } );
-            switch ( stagedResult ) {
+            std::optional<klogg::platform::FileIdentity> publishedIdentity;
+            switch ( stagedResult.result ) {
             case klogg::stagedoutput::Result::Published:
+                publishedIdentity = stagedResult.identity;
+                if ( !publishedIdentity.has_value() ) {
+                    return failBinding( OutputFailure::Open );
+                }
+                break;
             case klogg::stagedoutput::Result::DestinationExists:
                 break;
             case klogg::stagedoutput::Result::WriteFailure:
@@ -2494,7 +2500,7 @@ bool CaptureStore::bindOutputFile( const QString& outputPath, bool preserveExist
             }
             candidateOutput = RollingFileManager(
                 outputPath, limits_.rollingMaxFileSize, limits_.rollingBackupCount );
-            if ( !candidateOutput.openExisting() ) {
+            if ( !candidateOutput.openExisting( publishedIdentity ) ) {
                 return failBinding( OutputFailure::Open );
             }
         }
@@ -2512,10 +2518,15 @@ bool CaptureStore::bindOutputFile( const QString& outputPath, bool preserveExist
                 return failBinding( OutputFailure::Write );
             }
         }
+        const auto publishedIdentity = klogg::platform::fileIdentity( stagedOutput );
+        if ( !publishedIdentity.has_value() ) {
+            stagedOutput.cancelWriting();
+            return failBinding( OutputFailure::Open );
+        }
         if ( !stagedOutput.commit() ) {
             return failBinding( OutputFailure::Flush );
         }
-        if ( !candidateOutput.openExisting() ) {
+        if ( !candidateOutput.openExisting( publishedIdentity ) ) {
             return failBinding( OutputFailure::Open );
         }
     }

--- a/src/logdata/src/rollingfilemanager.cpp
+++ b/src/logdata/src/rollingfilemanager.cpp
@@ -295,7 +295,8 @@ bool RollingFileManager::open( bool truncate )
     return openNewFile( truncate );
 }
 
-bool RollingFileManager::openExisting()
+bool RollingFileManager::openExisting(
+    const std::optional<klogg::platform::FileIdentity>& expectedIdentity )
 {
     if ( !isValid() ) {
         return false;
@@ -307,6 +308,13 @@ bool RollingFileManager::openExisting()
     if ( !currentFile_->open( QIODevice::WriteOnly | QIODevice::ExistingOnly
                              | QIODevice::Append ) ) {
         return false;
+    }
+    if ( expectedIdentity.has_value() ) {
+        const auto openedIdentity = klogg::platform::fileIdentity( *currentFile_ );
+        if ( !openedIdentity.has_value() || openedIdentity.value() != expectedIdentity.value() ) {
+            currentFile_->close();
+            return false;
+        }
     }
     currentBytes_ = currentFile_->size();
     openedNewFile_ = false;

--- a/src/logdata/src/stagedoutputfile.h
+++ b/src/logdata/src/stagedoutputfile.h
@@ -3,12 +3,15 @@
 
 #include <cstdint>
 #include <functional>
+#include <optional>
 
 #include <QDir>
 #include <QFileInfo>
 #include <QIODevice>
 #include <QString>
 #include <QTemporaryFile>
+
+#include "platform/platform_files.h"
 
 namespace klogg::stagedoutput {
 
@@ -21,28 +24,37 @@ enum class Result : std::uint8_t {
     PublishFailure,
 };
 
-inline Result publishSibling( const QString& destination,
-                              const std::function<bool( QIODevice* )>& write )
+struct Publication {
+    Result result = Result::OpenFailure;
+    std::optional<klogg::platform::FileIdentity> identity;
+};
+
+inline Publication publishSibling( const QString& destination,
+                                   const std::function<bool( QIODevice* )>& write )
 {
     const auto directory = QFileInfo( destination ).absoluteDir();
     QTemporaryFile staged( directory.filePath( QStringLiteral( ".klogg-output-XXXXXX" ) ) );
     if ( !staged.open() ) {
-        return Result::OpenFailure;
+        return { Result::OpenFailure, std::nullopt };
     }
     if ( !write( &staged ) ) {
-        return Result::WriteFailure;
+        return { Result::WriteFailure, std::nullopt };
     }
     if ( !staged.flush() ) {
-        return Result::FlushFailure;
+        return { Result::FlushFailure, std::nullopt };
+    }
+    const auto stagedIdentity = klogg::platform::fileIdentity( staged );
+    if ( !stagedIdentity.has_value() ) {
+        return { Result::PublishFailure, std::nullopt };
     }
     if ( staged.rename( destination ) ) {
         staged.setAutoRemove( false );
-        return Result::Published;
+        return { Result::Published, stagedIdentity };
     }
     if ( QFileInfo::exists( destination ) ) {
-        return Result::DestinationExists;
+        return { Result::DestinationExists, std::nullopt };
     }
-    return Result::PublishFailure;
+    return { Result::PublishFailure, std::nullopt };
 }
 
 } // namespace klogg::stagedoutput

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -620,8 +620,14 @@ StreamingLogData::openDisplayOutputFile( const QString& outputPath, bool preserv
                     replayError = replay.error;
                     return replay.success;
                 } );
-            switch ( stagedResult ) {
+            std::optional<klogg::platform::FileIdentity> publishedIdentity;
+            switch ( stagedResult.result ) {
             case klogg::stagedoutput::Result::Published:
+                publishedIdentity = stagedResult.identity;
+                if ( !publishedIdentity.has_value() ) {
+                    return { false, CaptureOutputError::Open };
+                }
+                break;
             case klogg::stagedoutput::Result::DestinationExists:
                 break;
             case klogg::stagedoutput::Result::WriteFailure:
@@ -634,7 +640,7 @@ StreamingLogData::openDisplayOutputFile( const QString& outputPath, bool preserv
             }
             candidateOutput = RollingFileManager(
                 outputPath, rollingMaxFileSize_, rollingBackupCount_ );
-            if ( !candidateOutput.openExisting() ) {
+            if ( !candidateOutput.openExisting( publishedIdentity ) ) {
                 return { false, CaptureOutputError::Open };
             }
         }
@@ -652,10 +658,15 @@ StreamingLogData::openDisplayOutputFile( const QString& outputPath, bool preserv
             stagedOutput.cancelWriting();
             return { false, replay.error };
         }
+        const auto publishedIdentity = klogg::platform::fileIdentity( stagedOutput );
+        if ( !publishedIdentity.has_value() ) {
+            stagedOutput.cancelWriting();
+            return { false, CaptureOutputError::Open };
+        }
         if ( !stagedOutput.commit() ) {
             return { false, CaptureOutputError::Flush };
         }
-        if ( !candidateOutput.openExisting() ) {
+        if ( !candidateOutput.openExisting( publishedIdentity ) ) {
             return { false, CaptureOutputError::Open };
         }
     }

--- a/src/utils/include/platform/platform_files.h
+++ b/src/utils/include/platform/platform_files.h
@@ -20,10 +20,23 @@
 #ifndef KLOGG_PLATFORM_FILES_H
 #define KLOGG_PLATFORM_FILES_H
 
+#include <cstdint>
+#include <optional>
+
 #include <QFile>
+#include <QFileDevice>
 #include <QString>
 
 namespace klogg::platform {
+
+struct FileIdentity {
+    std::uint64_t device = 0;
+    std::uint64_t file = 0;
+};
+
+bool operator==( const FileIdentity& left, const FileIdentity& right );
+bool operator!=( const FileIdentity& left, const FileIdentity& right );
+std::optional<FileIdentity> fileIdentity( const QFileDevice& file );
 
 // Whether the platform uses exclusive file locks (Windows). When true, the
 // "keep file closed" option is shown in preferences.

--- a/src/utils/src/platform_files.cpp
+++ b/src/utils/src/platform_files.cpp
@@ -1,6 +1,7 @@
 #include "platform/platform_files.h"
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 #include <QByteArray>
@@ -265,7 +266,11 @@ std::optional<FileIdentity> fileIdentity( const QFileDevice& file )
         return std::nullopt;
     }
 #if defined( Q_OS_WIN )
-    const auto nativeDescriptor = static_cast<int>( file.handle() );
+    const auto fileHandle = file.handle();
+    if ( fileHandle < 0 || fileHandle > std::numeric_limits<int>::max() ) {
+        return std::nullopt;
+    }
+    const auto nativeDescriptor = static_cast<int>( fileHandle );
     const auto nativeHandle = _get_osfhandle( nativeDescriptor );
     if ( nativeHandle == -1 ) {
         return std::nullopt;

--- a/src/utils/src/platform_files.cpp
+++ b/src/utils/src/platform_files.cpp
@@ -13,6 +13,7 @@
 #define NOMINMAX
 #endif
 #include <aclapi.h>
+#include <io.h>
 #include <windows.h>
 #else
 #include <cerrno>
@@ -247,6 +248,44 @@ bool securePosixObject( const QString& path, bool directory )
 #endif
 
 } // namespace
+
+bool operator==( const FileIdentity& left, const FileIdentity& right )
+{
+    return left.device == right.device && left.file == right.file;
+}
+
+bool operator!=( const FileIdentity& left, const FileIdentity& right )
+{
+    return !( left == right );
+}
+
+std::optional<FileIdentity> fileIdentity( const QFileDevice& file )
+{
+    if ( !file.isOpen() ) {
+        return std::nullopt;
+    }
+#if defined( Q_OS_WIN )
+    const auto nativeDescriptor = static_cast<int>( file.handle() );
+    const auto nativeHandle = _get_osfhandle( nativeDescriptor );
+    if ( nativeHandle == -1 ) {
+        return std::nullopt;
+    }
+    BY_HANDLE_FILE_INFORMATION info{};
+    if ( !GetFileInformationByHandle( reinterpret_cast<HANDLE>( nativeHandle ), &info ) ) {
+        return std::nullopt;
+    }
+    const auto fileIndex = ( static_cast<std::uint64_t>( info.nFileIndexHigh ) << 32u )
+                           | static_cast<std::uint64_t>( info.nFileIndexLow );
+    return FileIdentity{ info.dwVolumeSerialNumber, fileIndex };
+#else
+    struct stat info{};
+    if ( ::fstat( file.handle(), &info ) != 0 ) {
+        return std::nullopt;
+    }
+    return FileIdentity{ static_cast<std::uint64_t>( info.st_dev ),
+                         static_cast<std::uint64_t>( info.st_ino ) };
+#endif
+}
 
 bool ensureOwnerOnlyDirectory( const QString& path )
 {

--- a/tests/scripts/test_adb_helper_cycle8_release_contract.py
+++ b/tests/scripts/test_adb_helper_cycle8_release_contract.py
@@ -548,7 +548,8 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
                 self.assertIn("verify_adb_helper_envelope.py", job)
                 self.assertIn("gh attestation verify", job)
                 self.assertIn("prefetch_artifacts/adb-helper-archive", job)
-                self.assertIn("tar -xzf", job)
+                self.assertIn("python3 scripts/extract_verified_tar.py", job)
+                self.assertNotIn('tar -xzf "$archive"', job)
         self.assertIn(
             "-DKLOGG_ADB_HELPER_ARTIFACT_ROOT=/usr/local/prefetch_artifacts/adb-helper",
             linux_job,

--- a/tests/scripts/test_adb_helper_cycle8_release_contract.py
+++ b/tests/scripts/test_adb_helper_cycle8_release_contract.py
@@ -76,6 +76,35 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
         cls.superbuild = read_text(SUPERBUILD)
         cls.verify_script = read_text(VERIFY_SCRIPT)
 
+    def test_ci_reuses_only_the_exact_locked_adb_source_closure(self):
+        prefetch = section(
+            self.ci_build,
+            "  PrefetchAdbHelperSources:\n",
+            "  BuildAdbHelperLegalAssets:\n",
+        )
+        active = active_lines(prefetch)
+        exact_key = (
+            "adb-helper-sources-v1-${{ hashFiles("
+            "'packaging/adb/adb-helper.lock.json', "
+            "'scripts/prefetch_adb_helper_sources.py') }}"
+        )
+        self.assertIn("actions/cache/restore@", active)
+        self.assertIn("actions/cache/save@", active)
+        self.assertIn(exact_key, active)
+        self.assertNotIn("restore-keys:", active)
+        self.assertRegex(
+            active,
+            r"if:.*github\.event_name == 'push'.*cache-adb-sources\.outputs\.cache-hit != 'true'",
+        )
+        self.assertGreater(
+            active.index("python3 scripts/prefetch_adb_helper_sources.py"),
+            active.index("actions/cache/restore@"),
+        )
+        self.assertGreater(
+            active.index("actions/upload-artifact@"),
+            active.index("python3 scripts/prefetch_adb_helper_sources.py"),
+        )
+
     def test_fixture_distinguishes_buildability_from_native_device_qualification(self):
         classes = self.fixture.get("validation_classes")
         self.assertIsInstance(classes, dict)
@@ -351,7 +380,7 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
         mac_arm_entry = section(
             self.ci_build,
             "artifacts_id: macos-arm-qt6",
-            "# Sanitizer legs:",
+            "    runs-on:",
         )
 
         self.assertEqual(target.get("arch"), expected["architecture"])
@@ -429,11 +458,13 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
         self.assertEqual(failures, [], "\n".join(failures))
 
     def test_windows_x86_package_never_consumes_the_x64_helper(self):
-        windows_matrix = section(self.ci_build, "  Windows:\n", "  ci-gate:\n")
+        windows_matrix = section(
+            self.ci_build, "  WindowsX86:\n", "  WindowsAsan:\n"
+        )
         x86_entry = section(
             windows_matrix,
             "artifacts_id: windows-x86-qt5",
-            "# Sanitizer leg:",
+            "    runs-on:",
         )
         matching_helper = re.search(r"^\s*adb_target:\s*windows-x86\s*$", x86_entry, re.MULTILINE)
         fail_closed = re.search(r"^\s*package:\s*false\s*$", x86_entry, re.MULTILINE)
@@ -499,10 +530,10 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
         self.assertEqual(failures, [], "\n".join(failures))
 
     def test_cross_job_helper_consumers_verify_checksum_envelope_and_attestation(self):
-        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  Linux:\n")
-        linux_job = section(self.ci_build, "  Linux:\n", "  Mac:\n")
-        mac_job = section(self.ci_build, "  Mac:\n", "  Windows:\n")
-        windows_job = section(self.ci_build, "  Windows:\n", "  ci-gate:\n")
+        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  LinuxPackages:\n")
+        linux_job = section(self.ci_build, "  LinuxPackages:\n", "  PrefetchIosNativeSources:\n")
+        mac_job = section(self.ci_build, "  MacPackages:\n", "  MacSanitizers:\n")
+        windows_job = section(self.ci_build, "  WindowsPackages:\n", "  WindowsX86:\n")
 
         self.assertIn("actions/attest-build-provenance", helper_job)
         self.assertIn("adb-helper-${{ matrix.target }}.tar.gz", helper_job)
@@ -522,6 +553,19 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
             "-DKLOGG_ADB_HELPER_ARTIFACT_ROOT=/usr/local/prefetch_artifacts/adb-helper",
             linux_job,
         )
+
+    def test_windows_uses_shared_verified_tar_extractor_for_native_paths(self):
+        windows_job = section(self.ci_build, "  WindowsPackages:\n", "  WindowsX86:\n")
+        extract = section(
+            windows_job,
+            "      - name: Extract mode-preserving ADB helper artifact\n",
+            "      - uses: actions/download-artifact@",
+        )
+        active = active_lines(extract)
+        self.assertIn("python3 scripts/extract_verified_tar.py", active)
+        self.assertIn('--archive "$archive"', active)
+        self.assertIn('--destination "$artifact_root"', active)
+        self.assertNotIn('tar -xzf "$archive"', active)
 
     def test_windows_rejects_unbundled_mingw_runtime_dlls(self):
         target = self.lock.get("targets", {}).get("windows-x86_64", {})
@@ -561,7 +605,7 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
                     rf"^https://mirror\.msys2\.org/{repository}/.+\.pkg\.tar\.zst$",
                 )
                 self.assertIs(package.get("build_input"), False)
-        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  Linux:\n")
+        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  LinuxPackages:\n")
         windows_setup = section(
             helper_job,
             "Prepare pinned MinGW compiler for the MSYS2 source patch series",
@@ -580,10 +624,10 @@ class AdbHelperCycle8ReleaseContractTest(unittest.TestCase):
 
     def test_source_build_artifacts_are_disconnected_hashed_attested_and_target_bound(self):
         expected = self.fixture["artifact_envelope"]
-        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  Linux:\n")
-        linux_job = section(self.ci_build, "  Linux:\n", "  Mac:\n")
-        mac_job = section(self.ci_build, "  Mac:\n", "  Windows:\n")
-        windows_job = section(self.ci_build, "  Windows:\n", "  ci-gate:\n")
+        helper_job = section(self.ci_build, "  BuildAdbHelpers:\n", "  LinuxPackages:\n")
+        linux_job = section(self.ci_build, "  LinuxPackages:\n", "  PrefetchIosNativeSources:\n")
+        mac_job = section(self.ci_build, "  MacPackages:\n", "  MacSanitizers:\n")
+        windows_job = section(self.ci_build, "  WindowsPackages:\n", "  WindowsX86:\n")
         combined_build = "\n".join((helper_job, self.build_action, self.superbuild))
         failures = []
 

--- a/tests/scripts/test_adb_helper_hardening_contract.py
+++ b/tests/scripts/test_adb_helper_hardening_contract.py
@@ -84,6 +84,61 @@ class AdbHelperSourceHardeningContractTest(unittest.TestCase):
         path.write_text(json.dumps({"sources": [record], "dependencies": []}), encoding="utf-8")
         return path
 
+    def test_verified_extractor_accepts_tar_of_current_directory_contents(self):
+        artifact_root = self.root / "artifact"
+        nested = artifact_root / "bin"
+        nested.mkdir(parents=True)
+        executable = nested / "adb"
+        executable.write_bytes(b"adb helper\n")
+        executable.chmod(0o755)
+        (artifact_root / "SHA256SUMS").write_text("receipt\n", encoding="utf-8")
+        archive = self.root / "artifact.tar.gz"
+        subprocess.run(
+            ["tar", "-czf", str(archive), "-C", str(artifact_root), "."],
+            check=True,
+        )
+
+        extract_root = self.root / "extract-artifact"
+        load_prefetch_module().safe_extract(archive, extract_root)
+
+        extracted = extract_root / "bin" / "adb"
+        self.assertEqual(extracted.read_bytes(), b"adb helper\n")
+        self.assertEqual(extracted.stat().st_mode & 0o777, 0o755)
+
+    def test_verified_extractor_preserves_sole_directory_below_explicit_root(self):
+        archive = self.root / "explicit-root-directory.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            root = tarfile.TarInfo(".")
+            root.type = tarfile.DIRTYPE
+            root.mode = 0o755
+            tar.addfile(root)
+            directory = tarfile.TarInfo("./helpers")
+            directory.type = tarfile.DIRTYPE
+            directory.mode = 0o755
+            tar.addfile(directory)
+            add_bytes(tar, "./helpers/adb", b"adb helper\n")
+
+        extract_root = self.root / "extract-explicit-root-directory"
+        load_prefetch_module().safe_extract(archive, extract_root)
+
+        self.assertEqual(
+            (extract_root / "helpers" / "adb").read_bytes(), b"adb helper\n"
+        )
+        self.assertFalse((extract_root / "adb").exists())
+
+    def test_verified_extractor_rejects_root_only_archive(self):
+        archive = self.root / "empty-artifact.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            root = tarfile.TarInfo(".")
+            root.type = tarfile.DIRTYPE
+            root.mode = 0o755
+            tar.addfile(root)
+
+        with self.assertRaisesRegex(RuntimeError, "no real members"):
+            load_prefetch_module().safe_extract(
+                archive, self.root / "extract-empty-artifact"
+            )
+
     def run_prefetch(self, lock: pathlib.Path, download_root: pathlib.Path, extract_root=None):
         command = [
             sys.executable,
@@ -590,12 +645,14 @@ class AdbHelperSourceHardeningContractTest(unittest.TestCase):
             "not included in the installer",
             published_name,
             archive_hash,
-            f"/releases/download/v26.08.27/{published_name}",
+            "/releases",
             "shasum -a 256",
         ):
             self.assertIn(term, offer)
-        self.assertNotIn("/releases/download/continuous/", offer)
-        self.assertNotIn("rolling", offer)
+        self.assertNotIn(f"/releases/download/v26.08.27/{published_name}", offer)
+        self.assertIn("/releases/tag/continuous", offer)
+        self.assertNotIn(f"/releases/download/continuous/{published_name}", offer)
+        self.assertIn("rolling and mutable", offer)
 
 
 class AdbHelperBinaryInspectionContractTest(unittest.TestCase):

--- a/tests/scripts/test_adb_helper_hardening_contract.py
+++ b/tests/scripts/test_adb_helper_hardening_contract.py
@@ -103,7 +103,8 @@ class AdbHelperSourceHardeningContractTest(unittest.TestCase):
 
         extracted = extract_root / "bin" / "adb"
         self.assertEqual(extracted.read_bytes(), b"adb helper\n")
-        self.assertEqual(extracted.stat().st_mode & 0o777, 0o755)
+        if sys.platform != "win32":
+            self.assertEqual(extracted.stat().st_mode & 0o777, 0o755)
 
     def test_verified_extractor_preserves_sole_directory_below_explicit_root(self):
         archive = self.root / "explicit-root-directory.tar.gz"

--- a/tests/scripts/test_adb_helper_hardening_contract.py
+++ b/tests/scripts/test_adb_helper_hardening_contract.py
@@ -591,11 +591,11 @@ class AdbHelperSourceHardeningContractTest(unittest.TestCase):
             published_name,
             archive_hash,
             f"/releases/download/v26.08.27/{published_name}",
-            f"/releases/download/continuous/{published_name}",
-            "rolling",
             "shasum -a 256",
         ):
             self.assertIn(term, offer)
+        self.assertNotIn("/releases/download/continuous/", offer)
+        self.assertNotIn("rolling", offer)
 
 
 class AdbHelperBinaryInspectionContractTest(unittest.TestCase):

--- a/tests/scripts/test_adb_helper_release_contract.py
+++ b/tests/scripts/test_adb_helper_release_contract.py
@@ -549,7 +549,12 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
             APPIMAGE_SCRIPT,
             WIN_PREPARE,
         )
-        combined = "\n".join(self.required_text(path) for path in paths)
+        combined = "\n".join(
+            self.required_text(path).replace(
+                "github.ref == 'refs/heads/master'", "github.ref is trusted master"
+            )
+            for path in paths
+        )
         forbidden = {
             "Google platform-tools prebuilt": r"dl\.google\.com/[^\s'\"]*platform-tools|platform-tools-latest",
             "PATH adb lookup": r"(?:which|where|command\s+-v)\s+adb\b",

--- a/tests/scripts/test_adb_helper_release_contract.py
+++ b/tests/scripts/test_adb_helper_release_contract.py
@@ -463,6 +463,22 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
         self.assertNotRegex(adb_cmake, r"find_program\([^)]*\badb\b")
         self.assertNotRegex(adb_cmake, r"(?:find_package|pkg_check_modules|find_library)\([^)]*libusb")
 
+    def test_windows_installer_runs_makensis_directly_and_fail_closed(self):
+        action = self.required_text(WIN_PACKAGE)
+        installer = action.split("    - name: Win installer", 1)[1].split(
+            "    - name: Win package", 1
+        )[0]
+        self.assertNotIn("joncloud/makensis-action", installer)
+        for marker in (
+            "makensis.exe",
+            "/DVERSION=$env:KLOGG_VERSION",
+            "/DPLATFORM=$env:KLOGG_ARCH",
+            "/DQT_MAJOR=$env:KLOGG_QT",
+            "klogg.nsi",
+            "$LASTEXITCODE",
+        ):
+            self.assertIn(marker, installer)
+
     def test_package_definitions_stage_exact_resolver_paths_and_verify_first(self):
         files = {
             "linux-cpack": self.required_text(ROOT_CMAKE),

--- a/tests/scripts/test_adb_helper_release_contract.py
+++ b/tests/scripts/test_adb_helper_release_contract.py
@@ -479,6 +479,37 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
         ):
             self.assertIn(marker, installer)
 
+    def test_windows_runtime_staging_uses_package_architecture_and_fails_closed(self):
+        prepare = self.required_text(WIN_PREPARE)
+        runtime_section = prepare.split('echo "Copying vc runtime..."', 1)[1].split(
+            'echo "Copying ssl..."', 1
+        )[0]
+
+        self.assertIn(
+            r"%VCToolsRedistDir%%KLOGG_ARCH%\Microsoft.VC143.CRT",
+            runtime_section,
+        )
+        self.assertNotIn("%platform%", runtime_section)
+        for runtime in (
+            "msvcp140.dll",
+            "msvcp140_1.dll",
+            "msvcp140_2.dll",
+            "vcruntime140.dll",
+            "vcruntime140_1.dll",
+        ):
+            self.assertIn(runtime, runtime_section)
+        self.assertRegex(
+            runtime_section,
+            re.compile(
+                r"for\s+%%R\s+in\s*\([^)]*\)\s+do\s*\(.*?"
+                r'if\s+not\s+exist\s+"%KLOGG_VC_RUNTIME_DIR%\\%%R".*?'
+                r'xcopy\s+"%KLOGG_VC_RUNTIME_DIR%\\%%R".*?'
+                r"if\s+errorlevel\s+1.*?"
+                r'if\s+not\s+exist\s+"%KLOGG_WORKSPACE%\\release\\%%R"',
+                re.DOTALL | re.IGNORECASE,
+            ),
+        )
+
     def test_package_definitions_stage_exact_resolver_paths_and_verify_first(self):
         files = {
             "linux-cpack": self.required_text(ROOT_CMAKE),

--- a/tests/scripts/test_adb_helper_release_contract.py
+++ b/tests/scripts/test_adb_helper_release_contract.py
@@ -549,12 +549,20 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
             APPIMAGE_SCRIPT,
             WIN_PREPARE,
         )
-        combined = "\n".join(
-            self.required_text(path).replace(
-                "github.ref == 'refs/heads/master'", "github.ref is trusted master"
-            )
-            for path in paths
-        )
+        normalized_sources = []
+        for path in paths:
+            lines = []
+            for line in self.required_text(path).splitlines():
+                if (
+                    "GITHUB_REF" in line
+                    or "github.ref == 'refs/heads/master'" in line
+                    or "Stable releases must be dispatched from refs/heads/master" in line
+                    or "Signed release qualification must run from master" in line
+                ):
+                    line = line.replace("refs/heads/master", "trusted-master-ref")
+                lines.append(line)
+            normalized_sources.append("\n".join(lines))
+        combined = "\n".join(normalized_sources)
         forbidden = {
             "Google platform-tools prebuilt": r"dl\.google\.com/[^\s'\"]*platform-tools|platform-tools-latest",
             "PATH adb lookup": r"(?:which|where|command\s+-v)\s+adb\b",

--- a/tests/scripts/test_external_source_asset_package_contract.py
+++ b/tests/scripts/test_external_source_asset_package_contract.py
@@ -322,41 +322,49 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         self.assertGreater(post_upload, upload, "stable publication must verify after upload")
         self.assertRegex(workflow[upload:], r"gh\s+(?:api|release\s+download)")
 
-    def test_continuous_release_publishes_one_mutable_coherent_package_and_source_set(self):
-        workflow = required_text(CI_BUILD)
-        preparer = required_text(PUBLICATION_PREPARER)
-        manifest = self.contract["publication_manifest"]["file_name"]
-        publication = workflow[workflow.index("  CreatePreRelease:") :]
-        for name in (
-            self.adb["receipt_file"],
-            self.ios["receipt_file"],
-            manifest,
-            "prepare_source_publication.py",
-            "verify_source_publication_manifest.py",
-        ):
-            self.assertIn(name, publication)
-        self.assertRegex(publication, r"(?i)channel[^\n]*continuous")
-        self.assertRegex(publication, r"(?i)mutable[^\n]*(?:true|True)")
-        self.assertRegex(publication, r"(?i)rolling")
+    def test_release_qualification_has_an_explicit_signed_ci_caller(self):
+        build = required_text(CI_BUILD)
+        release = required_text(CI_RELEASE)
+        self.assertIn("qualification-mode:", build)
+        self.assertIn("- release", build)
         self.assertIn(
-            "published_source_name(version, component, archive_hash)",
-            preparer,
+            "qualification-mode: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && inputs.qualification-mode == 'release' && 'release' || 'validation' }}",
+            build,
         )
-        for component in ("adb-helper", "ios-native"):
-            self.assertIn(f'"{component}"', preparer)
-        create_release = publication.index("- name: Create continuous candidate draft")
-        verification = publication.find("verify_source_publication_manifest.py", create_release)
-        self.assertGreater(
-            verification,
-            create_release,
-            "continuous publication must verify the uploaded rolling package/source set",
-        )
+        for secret in (
+            "CODESIGN_BASE64",
+            "CODESIGN_PASSWORD",
+            "APPLE_DEVELOPER_ID_APPLICATION",
+            "NOTARIZATION_USERNAME",
+            "NOTARIZATION_TEAM",
+            "NOTARIZATION_PASSWORD",
+        ):
+            self.assertIn(f"secrets.{secret}", build)
+        self.assertIn("qualification-mode=release", release)
+        self.assertIn("required: true", release.split("ci-run-id:", 1)[1].split("jobs:", 1)[0])
+        self.assertIn("github.event_name == 'workflow_dispatch' && github.run_id || github.ref", build)
+        self.assertIn("inputs.qualification-mode == 'validation'", build)
+        self.assertIn("github.ref == 'refs/heads/master'", build)
+        self.assertIn("ReleaseQualificationPreflight:", build)
+        self.assertIn("SaveVersion:\n    needs: [ReleaseQualificationPreflight]", build)
+        self.assertIn("Missing release qualification secret", build)
+
+    def test_required_ci_does_not_publish_a_continuous_release(self):
+        workflow = required_text(CI_BUILD)
+        for marker in (
+            "CreatePreRelease:",
+            "Create continuous candidate draft",
+            "tag_name=continuous",
+            "softprops/action-gh-release",
+        ):
+            self.assertNotIn(marker, workflow)
+        self.assertIn("workflow_dispatch:", required_text(CI_RELEASE))
 
     def test_source_asset_producers_bind_release_version_and_flat_checksums(self):
         build = required_text(CI_BUILD)
         stable = required_text(CI_RELEASE)
         adb_producer = section(build, "  PrefetchAdbHelperSources:", "  BuildAdbHelpers:")
-        ios_producer = section(build, "  BuildIosNativeStacks:", "  Mac:")
+        ios_producer = section(build, "  BuildIosNativeStacks:", "  MacPackages:")
         for producer in (adb_producer, ios_producer):
             self.assertRegex(producer, r"needs:\s*\[[^\]]*SaveVersion")
             self.assertIn("--version", producer)
@@ -379,10 +387,9 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         ):
             self.assertIn(marker, preparer)
         stable = required_text(CI_RELEASE)
-        continuous = required_text(CI_BUILD)
-        for workflow in (stable, continuous):
-            self.assertIn("ios-native-dmg-package-verification.json", workflow)
-            self.assertIn("--ios-qualification-receipt", workflow)
+        self.assertIn("ios-native-dmg-package-verification.json", stable)
+        self.assertIn("--ios-qualification-receipt", stable)
+        self.assertNotIn("--ios-qualification-receipt", required_text(CI_BUILD))
 
     def test_stable_release_checks_out_selected_ci_commit_before_release_processing(self):
         workflow = required_text(CI_RELEASE)
@@ -392,7 +399,7 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             "- name: Download artifacts for selected CI workflow",
         )
         for marker in (
-            "actions/workflows/ci-build.yml/runs",
+            'run_id="${{ github.event.inputs.ci-run-id }}"',
             'run_path="$(gh api',
             'run_repository="$(gh api',
             'run_branch="$(gh api',
@@ -406,7 +413,8 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             '"success"',
         ):
             self.assertIn(marker, selection)
-        self.assertIn("push|workflow_dispatch", selection)
+        self.assertIn('test "$run_event" = "workflow_dispatch"', selection)
+        self.assertIn("qualification-mode=release", workflow)
         self.assertIn("run_id: ${{ env.KLOGG_CI_RUN_ID }}", workflow)
 
         metadata = workflow.index("klogg_commit.txt")
@@ -420,7 +428,7 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         changelog = section(workflow, "- name: Generate Changelog", "- name: Display structure")
         self.assertIn('--to-ref "${KLOGG_SOURCE_COMMIT}"', changelog)
 
-    def test_stable_and_continuous_retries_recreate_clean_draft_asset_sets(self):
+    def test_stable_retry_recreates_a_clean_draft_asset_set(self):
         stable = required_text(CI_RELEASE)
         stable_cleanup = stable.index("- name: Clean stale stable draft")
         stable_create = stable.index("- name: Create GitHub Release")
@@ -434,15 +442,7 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             cleanup,
             "stale stable tag deletion must fail closed",
         )
-
-        continuous = required_text(CI_BUILD)
-        publication = continuous[continuous.index("  CreatePreRelease:") :]
-        candidate_tag = "continuous-candidate-${{ github.run_id }}-${{ github.run_attempt }}"
-        self.assertIn(candidate_tag, publication)
-        candidate_cleanup = publication.index("- name: Clean stale continuous candidate draft")
-        candidate_create = publication.index("- name: Create continuous candidate draft")
-        self.assertLess(candidate_cleanup, candidate_create)
-        self.assertIn("gh api -X DELETE", publication[candidate_cleanup:candidate_create])
+        self.assertNotIn("Create continuous candidate draft", required_text(CI_BUILD))
 
     def test_stable_release_uses_selected_ci_commit_and_remains_draft_until_verified(self):
         workflow = required_text(CI_RELEASE)
@@ -463,52 +463,16 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         promotion = publication.find("draft=false", verify)
         self.assertGreater(promotion, verify, "stable release must publish only after verification")
 
-    def test_continuous_verifies_draft_candidate_before_replacing_public_release(self):
-        workflow = required_text(CI_BUILD)
-        publication = workflow[workflow.index("  CreatePreRelease:") :]
-        candidate = publication.index("- name: Create continuous candidate draft")
-        verification = publication.index("- name: Verify rolling source publication after upload")
-        parking = publication.index("- name: Park existing continuous release for rollback")
-        promotion = publication.index("- name: Promote verified continuous candidate")
-        self.assertLess(candidate, verification)
-        self.assertLess(verification, parking)
-        self.assertLess(parking, promotion)
-        self.assertIn("draft: true", publication[candidate:verification])
-        promoted = publication[promotion:]
-        self.assertIn("tag_name=continuous", promoted)
-        self.assertIn("draft=false", promoted)
-        self.assertIn("prerelease=true", promoted)
-        final_verification = publication.index("- name: Reverify promoted continuous release")
-        self.assertGreater(final_verification, promotion)
-        final_block = publication[final_verification:]
-        for marker in (
-            "tag_name",
-            "/git/ref/tags/continuous",
-            "KLOGG_SOURCE_COMMIT",
-            "continuous-candidate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
-            "verify_source_publication_manifest.py",
-            "--expected-tag continuous",
-            "- name: Roll back failed continuous promotion",
-            "KLOGG_PREVIOUS_CONTINUOUS_RELEASE_ID",
-            "KLOGG_PREVIOUS_CONTINUOUS_SHA",
-            "- name: Remove parked continuous release after promotion",
-        ):
-            self.assertIn(marker, final_block)
-
-        rollback = section(
-            publication,
-            "- name: Roll back failed continuous promotion",
-            "- name: Remove parked continuous release after promotion",
-        )
-        no_previous_guard = rollback.index('if [ -z "$previous_id" ]')
-        live_tag_delete = rollback.index(
-            'git/refs/tags/continuous" >/dev/null 2>&1 || true'
-        )
-        self.assertGreater(
-            live_tag_delete,
-            no_previous_guard,
-            "a failure before parking must leave the existing continuous tag untouched",
-        )
+    def test_release_publication_is_explicit_and_verifies_before_promotion(self):
+        self.assertNotIn("Create continuous candidate draft", required_text(CI_BUILD))
+        release = required_text(CI_RELEASE)
+        create = release.index("- name: Create GitHub Release")
+        verify = release.index("- name: Verify stable source publication after upload")
+        promote = release.index("- name: Publish verified stable release")
+        self.assertLess(create, verify)
+        self.assertLess(verify, promote)
+        self.assertIn("draft: true", release[create:verify])
+        self.assertIn("draft=false", release[promote:])
 
 
 class SourcePublicationManifestVerifierContractTest(unittest.TestCase):

--- a/tests/scripts/test_external_source_asset_package_contract.py
+++ b/tests/scripts/test_external_source_asset_package_contract.py
@@ -474,7 +474,6 @@ publish_component(
             'run_repository="$(gh api',
             'run_branch="$(gh api',
             'run_event="$(gh api',
-            'run_qualification="$(gh api',
             'run_conclusion="$(gh api',
             'KLOGG_CI_RUN_ID=',
             'KLOGG_CI_RUN_SHA=',
@@ -483,13 +482,12 @@ publish_component(
             '"master"',
             '"success"',
             "event=push",
-            'run_qualification" = release',
-            'KLOGG_EVIDENCE_LEVEL" = signed',
-            "validation|release",
             'KLOGG_EVIDENCE_LEVEL" = validation',
+            "workflow-run API does not expose workflow_dispatch inputs",
             "/branches/master",
         ):
             self.assertIn(marker, selection)
+        self.assertNotIn('.inputs["qualification-mode"]', selection)
         self.assertIn("run_id: ${{ env.KLOGG_CI_RUN_ID }}", workflow)
 
         metadata = workflow.index("klogg_commit.txt")
@@ -535,8 +533,13 @@ publish_component(
         self.assertIn("draft: true", publication[create:verify])
         self.assertIn("tag_name: v${{ env.KLOGG_VERSION }}-candidate", publication[create:verify])
         verification = publication[verify:]
-        self.assertIn('/git/ref/tags/v${KLOGG_VERSION}-candidate', verification)
-        self.assertIn('test "${ref_sha}" = "${KLOGG_SOURCE_COMMIT}"', verification)
+        draft_verification = verification[: verification.index("- name: Recheck master tip")]
+        self.assertIn(".target_commitish", draft_verification)
+        self.assertIn(
+            'test "${candidate_target}" = "${KLOGG_SOURCE_COMMIT}"',
+            draft_verification,
+        )
+        self.assertNotIn("/git/ref/tags/", draft_verification)
         promotion = publication.find("draft=false", verify)
         self.assertGreater(promotion, verify, "stable release must publish only after verification")
 

--- a/tests/scripts/test_external_source_asset_package_contract.py
+++ b/tests/scripts/test_external_source_asset_package_contract.py
@@ -23,7 +23,9 @@ WIN_PREPARE = ROOT / "packaging" / "windows" / "prepare_release.cmd"
 WIN_NSIS = ROOT / "packaging" / "windows" / "klogg.nsi"
 WIN_PORTABLE = ROOT / "packaging" / "windows" / "7z_klogg_listfile.txt"
 CI_BUILD = ROOT / ".github" / "workflows" / "ci-build.yml"
+CI_CONTINUOUS = ROOT / ".github" / "workflows" / "ci-continuous.yml"
 CI_RELEASE = ROOT / ".github" / "workflows" / "ci-release.yml"
+README = ROOT / "README.md"
 PUBLICATION_VERIFIER = ROOT / "scripts" / "verify_source_publication_manifest.py"
 PUBLICATION_PREPARER = ROOT / "scripts" / "prepare_source_publication.py"
 
@@ -107,6 +109,48 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         preparer = required_text(PUBLICATION_PREPARER)
         self.assertIn('validate_asset_file_name(record.get("name"))', preparer)
 
+    def test_publication_preparer_rejects_source_archive_path_escape(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = pathlib.Path(tempdir)
+            component_root = root / "component"
+            output = root / "output"
+            component_root.mkdir()
+            outside = root / "outside.tar.gz"
+            outside.write_bytes(b"outside source\n")
+            receipt = {
+                "receipt_kind": "component-source-set",
+                "component": "adb-helper",
+                "archive": {
+                    "file_name": "../outside.tar.gz",
+                    "sha256": sha256(outside),
+                },
+                "package_support_assets": [],
+            }
+            (component_root / "adb-helper-source-set-receipt.json").write_text(
+                json.dumps(receipt), encoding="utf-8"
+            )
+            code = """
+import pathlib, sys
+from prepare_source_publication import publish_component
+publish_component(
+    "adb-helper", pathlib.Path(sys.argv[1]),
+    "adb-helper-source-set-receipt.json", "26.08.30", "v26.08.30",
+    "https://github.com/ZEACENT/klogg", pathlib.Path(sys.argv[2]),
+)
+"""
+            output.mkdir()
+            result = subprocess.run(
+                [sys.executable, "-c", code, str(component_root), str(output)],
+                cwd=ROOT / "scripts",
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertRegex((result.stdout + result.stderr).lower(), r"unsafe|file name")
+            self.assertFalse(any(output.iterdir()))
+
     def test_publication_preparer_rejects_channel_tag_mismatches(self):
         for channel, tag in (("stable", "continuous"), ("continuous", "v26.08.28.1718")):
             with self.subTest(channel=channel, tag=tag):
@@ -116,6 +160,8 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
                         str(PUBLICATION_PREPARER),
                         "--channel",
                         channel,
+                        "--evidence-level",
+                        "validation",
                         "--tag",
                         tag,
                         "--version",
@@ -290,6 +336,10 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             "mounted_app",
             "verify_ios_native_stack.py",
             "--verify-package-receipt",
+            "mounted_helper",
+            "smoke_adb_helper.py",
+            "verify_adb_helper_artifact.py",
+            '--package-root "$mount_dir"',
             "Contents/Frameworks/ios-native",
             "Contents/SharedSupport/ios-native",
         ):
@@ -322,14 +372,20 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         self.assertGreater(post_upload, upload, "stable publication must verify after upload")
         self.assertRegex(workflow[upload:], r"gh\s+(?:api|release\s+download)")
 
-    def test_release_qualification_has_an_explicit_signed_ci_caller(self):
+    def test_stable_release_defaults_to_validation_and_keeps_signed_evidence_strict(self):
         build = required_text(CI_BUILD)
         release = required_text(CI_RELEASE)
         self.assertIn("qualification-mode:", build)
         self.assertIn("- release", build)
-        self.assertIn(
-            "qualification-mode: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && inputs.qualification-mode == 'release' && 'release' || 'validation' }}",
-            build,
+        self.assertIn("evidence-level:", release)
+        evidence_input = release.split("evidence-level:", 1)[1].split("jobs:", 1)[0]
+        self.assertIn("default: validation", evidence_input)
+        self.assertIn("- validation", evidence_input)
+        self.assertIn("- signed", evidence_input)
+        self.assertIn("--evidence-level \"${KLOGG_EVIDENCE_LEVEL}\"", release)
+        self.assertRegex(
+            release,
+            r"KLOGG_EVIDENCE_LEVEL.*signed[\s\S]+adb-helper-signing-receipt\.json[\s\S]+adb-helper-notarization-receipt\.json",
         )
         for secret in (
             "CODESIGN_BASE64",
@@ -339,26 +395,37 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             "NOTARIZATION_TEAM",
             "NOTARIZATION_PASSWORD",
         ):
-            self.assertIn(f"secrets.{secret}", build)
-        self.assertIn("qualification-mode=release", release)
-        self.assertIn("required: true", release.split("ci-run-id:", 1)[1].split("jobs:", 1)[0])
-        self.assertIn("github.event_name == 'workflow_dispatch' && github.run_id || github.ref", build)
-        self.assertIn("inputs.qualification-mode == 'validation'", build)
-        self.assertIn("github.ref == 'refs/heads/master'", build)
-        self.assertIn("ReleaseQualificationPreflight:", build)
-        self.assertIn("SaveVersion:\n    needs: [ReleaseQualificationPreflight]", build)
-        self.assertIn("Missing release qualification secret", build)
+            self.assertNotIn(f"secrets.{secret}", release)
 
-    def test_required_ci_does_not_publish_a_continuous_release(self):
-        workflow = required_text(CI_BUILD)
+    def test_required_ci_does_not_publish_and_workflow_run_publisher_is_trusted(self):
+        build = required_text(CI_BUILD)
         for marker in (
             "CreatePreRelease:",
             "Create continuous candidate draft",
             "tag_name=continuous",
             "softprops/action-gh-release",
         ):
-            self.assertNotIn(marker, workflow)
-        self.assertIn("workflow_dispatch:", required_text(CI_RELEASE))
+            self.assertNotIn(marker, build)
+
+        continuous = required_text(CI_CONTINUOUS)
+        self.assertIn("workflow_run:", continuous)
+        self.assertRegex(continuous, r"workflows:\s*\[\s*[\"']CI Build[\"']\s*\]")
+        self.assertIn("types: [completed]", continuous)
+        trusted = (
+            "github.event.workflow_run.conclusion == 'success'"
+            " && github.event.workflow_run.event == 'push'"
+            " && github.event.workflow_run.head_branch == 'master'"
+            " && github.event.workflow_run.head_repository.full_name == github.repository"
+        )
+        self.assertIn(trusted, " ".join(continuous.split()))
+        self.assertIn("actions: read", continuous)
+        self.assertIn("contents: write", continuous)
+        self.assertIn("cancel-in-progress: false", continuous)
+        self.assertIn("github.token", continuous)
+        self.assertNotRegex(continuous, r"secrets\.(?:CODESIGN|APPLE|NOTARIZATION)")
+        readme = required_text(README)
+        self.assertIn("continuous release", readme.lower())
+        self.assertRegex(readme, r"(?i)macOS[^\n]*unsigned")
 
     def test_source_asset_producers_bind_release_version_and_flat_checksums(self):
         build = required_text(CI_BUILD)
@@ -391,19 +458,23 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         self.assertIn("--ios-qualification-receipt", stable)
         self.assertNotIn("--ios-qualification-receipt", required_text(CI_BUILD))
 
-    def test_stable_release_checks_out_selected_ci_commit_before_release_processing(self):
+    def test_stable_release_selects_exact_trusted_ci_artifacts_without_expression_injection(self):
         workflow = required_text(CI_RELEASE)
+        self.assertIn('test "${GITHUB_REF}" = "refs/heads/master"', workflow)
+        self.assertIn("KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}", workflow)
         selection = section(
             workflow,
             "- name: Select trusted CI run",
             "- name: Download artifacts for selected CI workflow",
         )
+        self.assertNotIn("${{ github.event.inputs.ci-run-id }}", selection)
+        self.assertRegex(selection, r"\^\[0-9\]\+\$")
         for marker in (
-            'run_id="${{ github.event.inputs.ci-run-id }}"',
             'run_path="$(gh api',
             'run_repository="$(gh api',
             'run_branch="$(gh api',
             'run_event="$(gh api',
+            'run_qualification="$(gh api',
             'run_conclusion="$(gh api',
             'KLOGG_CI_RUN_ID=',
             'KLOGG_CI_RUN_SHA=',
@@ -411,10 +482,14 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
             '"${GITHUB_REPOSITORY}"',
             '"master"',
             '"success"',
+            "event=push",
+            'run_qualification" = release',
+            'KLOGG_EVIDENCE_LEVEL" = signed',
+            "validation|release",
+            'KLOGG_EVIDENCE_LEVEL" = validation',
+            "/branches/master",
         ):
             self.assertIn(marker, selection)
-        self.assertIn('test "$run_event" = "workflow_dispatch"', selection)
-        self.assertIn("qualification-mode=release", workflow)
         self.assertIn("run_id: ${{ env.KLOGG_CI_RUN_ID }}", workflow)
 
         metadata = workflow.index("klogg_commit.txt")
@@ -436,6 +511,7 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         cleanup = stable[stable_cleanup:stable_create]
         self.assertIn("draft", cleanup)
         self.assertIn("gh api -X DELETE", cleanup)
+        self.assertIn('candidate_tag="${final_tag}-candidate"', cleanup)
         self.assertIn("/git/ref/tags/${tag}", cleanup)
         self.assertNotIn(
             'git/refs/tags/${tag}" >/dev/null 2>&1 || true',
@@ -457,8 +533,9 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         verify = publication.index("- name: Verify stable source publication after upload")
         self.assertLess(create, verify)
         self.assertIn("draft: true", publication[create:verify])
+        self.assertIn("tag_name: v${{ env.KLOGG_VERSION }}-candidate", publication[create:verify])
         verification = publication[verify:]
-        self.assertIn('/git/ref/tags/v${KLOGG_VERSION}', verification)
+        self.assertIn('/git/ref/tags/v${KLOGG_VERSION}-candidate', verification)
         self.assertIn('test "${ref_sha}" = "${KLOGG_SOURCE_COMMIT}"', verification)
         promotion = publication.find("draft=false", verify)
         self.assertGreater(promotion, verify, "stable release must publish only after verification")
@@ -468,11 +545,80 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim"):
         release = required_text(CI_RELEASE)
         create = release.index("- name: Create GitHub Release")
         verify = release.index("- name: Verify stable source publication after upload")
+        stale = release.index("- name: Recheck master tip before stable promotion")
         promote = release.index("- name: Publish verified stable release")
         self.assertLess(create, verify)
-        self.assertLess(verify, promote)
+        self.assertLess(verify, stale)
+        self.assertLess(stale, promote)
         self.assertIn("draft: true", release[create:verify])
-        self.assertIn("draft=false", release[promote:])
+        promotion = release[promote:]
+        self.assertIn("draft=false", promotion)
+        self.assertGreaterEqual(promotion.count("/branches/master"), 2)
+        self.assertIn("Roll back failed stable promotion", promotion)
+        self.assertIn('releases/${RELEASE_ID}', promotion)
+        self.assertIn('delete_ref_if_present "$final_tag"', promotion)
+        before_create = release.index("- name: Recheck master tip before stable draft creation")
+        self.assertLess(before_create, create)
+        for position in (before_create, stale):
+            check = release[position : release.find("\n    - name:", position + 1)]
+            self.assertIn("/branches/master", check)
+            self.assertIn("KLOGG_SOURCE_COMMIT", check)
+
+    def test_continuous_publication_is_transactional_sha_bound_and_rollback_safe(self):
+        workflow = required_text(CI_CONTINUOUS)
+        ordered = [
+            "Create continuous candidate draft",
+            "Verify continuous candidate after upload",
+            "Recheck master tip before continuous promotion",
+            "Park existing continuous release for rollback",
+            "Promote verified continuous candidate",
+            "Reverify promoted continuous release",
+            "Roll back failed continuous promotion",
+        ]
+        positions = [workflow.index(marker) for marker in ordered]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("draft: true", workflow[positions[0] : positions[1]])
+        rollback = workflow[positions[-1] :]
+        self.assertIn("failure() || cancelled()", rollback)
+        recovery = workflow.index("Recover interrupted continuous transaction")
+        self.assertLess(recovery, positions[0])
+        reconciliation = workflow[recovery:positions[0]]
+        self.assertIn("continuous-rollback-", reconciliation)
+        self.assertIn("releases/tags/continuous", reconciliation)
+        self.assertIn("Restore parked continuous release", reconciliation)
+        self.assertIn("Remove stale parked continuous release", reconciliation)
+        self.assertIn("verify_source_publication_manifest.py", reconciliation)
+        self.assertIn("live continuous release is coherent", reconciliation)
+        self.assertIn('candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"', workflow)
+        self.assertIn('backup_tag="continuous-rollback-${KLOGG_CI_RUN_ID}"', workflow)
+        self.assertNotIn("continuous-candidate-${GITHUB_RUN_ID}", workflow)
+        self.assertNotIn("continuous-rollback-${GITHUB_RUN_ID}", workflow)
+        self.assertIn("run-id: ${{ github.event.workflow_run.id }}", workflow)
+        self.assertIn("github-token: ${{ github.token }}", workflow)
+        self.assertIn("github.event.workflow_run.head_sha", workflow)
+        self.assertIn('test "${KLOGG_SOURCE_COMMIT}" = "${KLOGG_CI_RUN_SHA}"', workflow)
+        reverify = section(
+            workflow,
+            "- name: Reverify promoted continuous release",
+            "- name: Roll back failed continuous promotion",
+        )
+        self.assertIn("/branches/master", reverify)
+        self.assertIn("KLOGG_SOURCE_COMMIT", reverify)
+        promotion = section(
+            workflow,
+            "- name: Promote verified continuous candidate",
+            "- name: Reverify promoted continuous release",
+        )
+        self.assertIn('candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"', promotion)
+        self.assertNotIn("2>&1 || true", promotion)
+        for marker in (
+            "continuous-candidate-",
+            "continuous-rollback-",
+            "tag_name=continuous",
+            "expected-channel continuous",
+            "expected-evidence-level validation",
+        ):
+            self.assertIn(marker, workflow)
 
 
 class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
@@ -488,7 +634,7 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
         path.write_bytes(content)
         return path
 
-    def make_manifest(self) -> tuple[pathlib.Path, dict]:
+    def make_manifest(self, evidence_level: str = "signed") -> tuple[pathlib.Path, dict]:
         version = "26.08.27"
         tag = f"v{version}"
         commit = "a" * 40
@@ -563,9 +709,42 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                 json.dumps(
                     {
                         "receipt_kind": "package-verification",
-                        "release_qualified": True,
+                        "target": "macos-arm64",
+                        "release_qualified": evidence_level == "signed",
                         "source_set_receipt_sha256": source_set_hashes["adb-helper"],
+                        "source_helper_sha256": "6" * 64,
+                        "helper_sha256": "7" * 64,
+                        "required_receipts": [
+                            "binary-build",
+                            "binary-smoke",
+                            "package-verification",
+                            "signing",
+                            "notarization",
+                        ],
+                        "verified_receipts": [
+                            "binary-build",
+                            "binary-smoke",
+                            "package-verification",
+                            *(["signing", "notarization"] if evidence_level == "signed" else []),
+                        ],
                         "packages": [{"name": package.name, "sha256": package_hash}],
+                    },
+                    sort_keys=True,
+                )
+                + "\n"
+            ).encode(),
+        )
+        ios_package_receipt = self.write_asset(
+            f"{package.name}.ios-package.json",
+            (
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "receipt_kind": "ios-native-package",
+                        "status": "passed",
+                        "source_set_receipt_sha256": source_set_hashes["ios-native"],
+                        "architecture": "arm64",
+                        "dylibs": [],
                     },
                     sort_keys=True,
                 )
@@ -578,9 +757,10 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                 json.dumps(
                     {
                         "receipt_kind": "ios-native-package-verification",
-                        "release_qualified": True,
+                        "qualification": evidence_level,
+                        "release_qualified": evidence_level == "signed",
                         "source_set_receipt_sha256": source_set_hashes["ios-native"],
-                        "ios_native_package_receipt_sha256": "5" * 64,
+                        "ios_native_package_receipt_sha256": sha256(ios_package_receipt),
                         "packages": [{"name": package.name, "sha256": package_hash}],
                     },
                     sort_keys=True,
@@ -588,6 +768,39 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                 + "\n"
             ).encode(),
         )
+        signed_evidence = {}
+        if evidence_level == "signed":
+            for kind in ("signing", "notarization"):
+                evidence = self.write_asset(
+                    f"adb-helper-{kind}-receipt.json",
+                    (
+                        json.dumps(
+                            {
+                                "receipt_kind": kind,
+                                "status": "passed",
+                                "target": "macos-arm64",
+                                **(
+                                    {"identity": "Developer ID Application: Klogg Test"}
+                                    if kind == "signing"
+                                    else {
+                                        "team_id": "TESTTEAM123",
+                                        "submission_id": "00000000-0000-0000-0000-000000000001",
+                                    }
+                                ),
+                                "package_sha256": package_hash,
+                                "source_helper_sha256": "6" * 64,
+                                "signed_helper_sha256": "7" * 64,
+                            },
+                            sort_keys=True,
+                        )
+                        + "\n"
+                    ).encode(),
+                )
+                signed_evidence[f"{kind}_receipt"] = {
+                    "file_name": evidence.name,
+                    "sha256": sha256(evidence),
+                }
+
         linux_package = self.write_asset("klogg-26.08.27-linux.deb", b"linux package\n")
         linux_hash = sha256(linux_package)
         linux_qualification = self.write_asset(
@@ -598,6 +811,16 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                         "receipt_kind": "package-verification",
                         "release_qualified": True,
                         "source_set_receipt_sha256": source_set_hashes["adb-helper"],
+                        "required_receipts": [
+                            "binary-build",
+                            "binary-smoke",
+                            "package-verification",
+                        ],
+                        "verified_receipts": [
+                            "binary-build",
+                            "binary-smoke",
+                            "package-verification",
+                        ],
                         "packages": [{"name": linux_package.name, "sha256": linux_hash}],
                     },
                     sort_keys=True,
@@ -609,6 +832,7 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
             "schema_version": 1,
             "manifest_kind": "klogg-source-publication",
             "channel": "stable",
+            "evidence_level": evidence_level,
             "release": {
                 "tag": tag,
                 "version": version,
@@ -628,6 +852,11 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                         "file_name": ios_qualification.name,
                         "sha256": sha256(ios_qualification),
                     },
+                    "ios_package_receipt": {
+                        "file_name": ios_package_receipt.name,
+                        "sha256": sha256(ios_package_receipt),
+                    },
+                    **signed_evidence,
                     "source_sets": source_set_hashes,
                 },
                 {
@@ -645,7 +874,7 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
         manifest.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         return manifest, document
 
-    def run_verifier(self, manifest: pathlib.Path):
+    def run_verifier(self, manifest: pathlib.Path, evidence_level: str = "signed"):
         self.assertTrue(
             PUBLICATION_VERIFIER.is_file(),
             f"missing publication manifest verifier: {PUBLICATION_VERIFIER}",
@@ -660,6 +889,8 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                 str(self.root),
                 "--expected-channel",
                 "stable",
+                "--expected-evidence-level",
+                evidence_level,
                 "--expected-tag",
                 "v26.08.27",
                 "--expected-version",
@@ -679,6 +910,32 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
         manifest, _ = self.make_manifest()
         result = self.run_verifier(manifest)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_validation_evidence_accepts_unsigned_macos_receipts_with_complete_bindings(self):
+        manifest, document = self.make_manifest("validation")
+        self.assertEqual(document["channel"], "stable")
+        self.assertEqual(document["evidence_level"], "validation")
+        result = self.run_verifier(manifest, "validation")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_signed_evidence_rejects_missing_or_failed_signing_and_notarization(self):
+        for mismatch in ("missing-signing", "failed-notarization"):
+            with self.subTest(mismatch=mismatch):
+                manifest, document = self.make_manifest("signed")
+                if mismatch == "missing-signing":
+                    document["packages"][0].pop("signing_receipt")
+                else:
+                    path = self.root / "adb-helper-notarization-receipt.json"
+                    receipt = json.loads(path.read_text(encoding="utf-8"))
+                    receipt["status"] = "failed"
+                    path.write_text(json.dumps(receipt, sort_keys=True) + "\n", encoding="utf-8")
+                    document["packages"][0]["notarization_receipt"]["sha256"] = sha256(path)
+                manifest.write_text(
+                    json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+                )
+                result = self.run_verifier(manifest, "signed")
+                self.assertNotEqual(result.returncode, 0)
+                self.assertRegex((result.stdout + result.stderr).lower(), r"sign|notari")
 
     def test_manifest_verifier_rejects_hash_tag_package_and_source_mismatches(self):
         mutations = {
@@ -788,6 +1045,26 @@ class SourcePublicationManifestVerifierContractTest(unittest.TestCase):
                 self.assertRegex(
                     (result.stdout + result.stderr).lower(), r"qualification|package"
                 )
+
+    def test_manifest_verifier_rejects_unbound_ios_package_receipt_hash(self):
+        manifest, document = self.make_manifest("signed")
+        qualification = self.root / "ios-native-dmg-package-verification.json"
+        receipt = json.loads(qualification.read_text(encoding="utf-8"))
+        receipt["ios_native_package_receipt_sha256"] = "5" * 64
+        qualification.write_text(
+            json.dumps(receipt, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        document["packages"][0]["ios_qualification_receipt"]["sha256"] = sha256(
+            qualification
+        )
+        manifest.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+        result = self.run_verifier(manifest, "signed")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertRegex((result.stdout + result.stderr).lower(), r"ios|package receipt")
 
     def test_manifest_verifier_requires_component_qualification_source_set_bindings(self):
         scenarios = ("adb-binding", "ios-missing", "ios-binding", "ios-package-receipt")

--- a/tests/scripts/test_ios_native_release_contract.py
+++ b/tests/scripts/test_ios_native_release_contract.py
@@ -596,6 +596,44 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
         self.assertIn("DYLD_FRAMEWORK_PATH=${KLOGG_SMOKE_QT_RPATH}", root_cmake)
         self.assertIn("DYLD_LIBRARY_PATH=${KLOGG_SMOKE_QT_RPATH}", root_cmake)
 
+    def test_ios_native_homebrew_bootstrap_cleans_aws_formula_and_tap_before_install(self):
+        workflow = required_text(CI_BUILD_WORKFLOW)
+        producer = workflow.split("  BuildIosNativeStacks:", 1)[1].split("\n  MacPackages:", 1)[0]
+        install_step = producer.split(
+            "      - name: Install iOS native source-build tools\n", 1
+        )[1].split("\n      - uses: actions/download-artifact@", 1)[0]
+        uninstall = "brew uninstall --ignore-dependencies aws-sam-cli"
+        untap = "brew untap aws/tap"
+        install = "brew install autoconf automake libtool pkg-config cmake ninja"
+        failures = []
+        for marker in (
+            "HOMEBREW_NO_AUTO_UPDATE=1",
+            "HOMEBREW_NO_INSTALL_CLEANUP=1",
+            uninstall,
+            untap,
+            install,
+        ):
+            if marker not in install_step:
+                failures.append(f"missing {marker}")
+        if not failures:
+            if not (
+                install_step.index(uninstall)
+                < install_step.index(untap)
+                < install_step.index(install)
+            ):
+                failures.append(
+                    "aws-sam-cli must be uninstalled before aws/tap is untapped "
+                    "and before project build tools are installed"
+                )
+            cleanup = install_step[
+                install_step.index(uninstall) : install_step.index(install)
+            ]
+            if "|| true" not in cleanup and "brew list --formula" not in cleanup:
+                failures.append(
+                    "shared AWS Homebrew cleanup must tolerate an absent formula and tap"
+                )
+        self.assertEqual(failures, [], "\n".join(failures))
+
     def test_ci_produces_both_thin_stacks_and_mac_consumes_the_bound_artifact(self):
         workflow = required_text(CI_BUILD_WORKFLOW)
         for token in (
@@ -616,13 +654,16 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
             "FETCHCONTENT_FULLY_DISCONNECTED=ON",
         ):
             self.assertIn(token, workflow)
-        self.assertRegex(workflow, r"Mac:\s+needs:\s*\[[^\]]*BuildIosNativeStacks")
+        self.assertRegex(
+            workflow,
+            r"MacPackages:\s+needs:\s*\[[^\]]*BuildIosNativeStacks",
+        )
         self.assertRegex(workflow, r"download-artifact@[^\r\n]+[\s\S]+name:\s+ios-native-\$\{\{")
         self.assertIn("${{ matrix.artifact }}.tar.gz", workflow)
         self.assertIn("tar -czf", workflow)
         self.assertIn("tar -xzf", workflow)
         self.assertIn("prefetch_artifacts/ios-native-archive", workflow)
-        producer = workflow.split("  BuildIosNativeStacks:", 1)[1].split("\n  Mac:", 1)[0]
+        producer = workflow.split("  BuildIosNativeStacks:", 1)[1].split("\n  MacPackages:", 1)[0]
         self.assertNotIn("continue-on-error: true", producer)
 
     def test_commit_archives_receive_locked_autotools_tarball_versions(self):
@@ -699,14 +740,15 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
             "--version",
             "--base-url",
             "not included in the installer",
-            'source_asset_url(base_url, "continuous"',
-            "rolling",
+            'source_asset_url(base_url, f"v{version}"',
             "shasum -a 256",
             "validated_relative_path(",
             'patch.get("path"), "locked patch"',
             'f"3rdparty/libimobiledevice/{patch_path}"',
         ):
             self.assertIn(token, legal)
+        self.assertNotIn('source_asset_url(base_url, "continuous"', legal)
+        self.assertNotIn("rolling and mutable", legal)
         self.assertNotIn(
             "The accompanying ios-native-corresponding-source.tar.gz",
             legal,
@@ -760,6 +802,19 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
         ):
             self.assertIn(token, verifier)
 
+    def test_unsigned_validation_receipts_do_not_require_code_signatures(self):
+        action = required_text(MAC_PACKAGE_ACTION)
+        validation = action.split("- name: Validate unsigned macOS disk image", 1)[1].split(
+            "- name: Sign and verify macOS disk image", 1
+        )[0]
+        self.assertIn("--unsigned-package-stage", validation)
+        verifier = required_text(VERIFY_SCRIPT)
+        self.assertIn("--unsigned-package-stage", verifier)
+        self.assertIn(
+            "args.verify_package_receipt is not None and not args.unsigned_package_stage",
+            verifier,
+        )
+
     def test_package_receipt_binds_legal_source_sbom_and_final_signed_closure(self):
         verifier = required_text(VERIFY_SCRIPT)
         for token in (
@@ -788,6 +843,21 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
         self.assertIn("--legal-receipt", signed_verification)
         self.assertIn("--sbom", signed_verification)
         self.assertIn("--verify-package-receipt", signed_verification)
+
+    def test_release_secrets_are_transported_through_step_environment(self):
+        action = required_text(MAC_PACKAGE_ACTION)
+        for unsafe in (
+            'require_input "p12-password" "${{ inputs.p12-password }}"',
+            '--password "${{ inputs.notarization-password }}"',
+            'echo "KLOGG_CODESIGN=${{ inputs.codesign-identity }}"',
+        ):
+            self.assertNotIn(unsafe, action)
+        for marker in (
+            "KLOGG_P12_PASSWORD: ${{ inputs.p12-password }}",
+            "KLOGG_NOTARIZATION_PASSWORD: ${{ inputs.notarization-password }}",
+            'printf \'KLOGG_CODESIGN=%s\\n\'',
+        ):
+            self.assertIn(marker, action)
 
     def test_release_consumption_is_disconnected_and_fails_closed(self):
         action = required_text(MAC_PACKAGE_ACTION)

--- a/tests/scripts/test_ios_native_release_contract.py
+++ b/tests/scripts/test_ios_native_release_contract.py
@@ -30,6 +30,7 @@ PREFETCH_CMAKE = ROOT / "cmake" / "prefetch_cpm" / "CMakeLists.txt"
 MAC_PACKAGE_ACTION = ROOT / ".github" / "actions" / "agent-package-mac" / "action.yml"
 APP_CMAKE = ROOT / "src" / "app" / "CMakeLists.txt"
 IOS_LIVE_SERVICES = ROOT / "src" / "ui" / "src" / "iosliveservices.cpp"
+IOS_NATIVE_STREAM = ROOT / "src" / "livecapture" / "src" / "iosnativestream.cpp"
 CI_BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "ci-build.yml"
 BUILD_SCRIPT = ROOT / "scripts" / "build_ios_native_stack.py"
 VERIFY_SCRIPT = ROOT / "scripts" / "verify_ios_native_stack.py"
@@ -182,6 +183,18 @@ class IosNativeReleaseContractTest(unittest.TestCase):
         self.assertIn("[ executor = catalogExecutor_ ]", source)
         self.assertNotIn("[ executor = catalogExecutor_.get() ]", source)
         self.assertIn("catalogExecutor_->shutdownAsync();", source)
+
+    def test_stop_acknowledgement_requires_cleanup_dispatch(self):
+        source = required_text(IOS_NATIVE_STREAM)
+        stop = re.search(
+            r"void IosNativeStreamWorker::stop\([^)]*\) noexcept\s*\{(.*?)\n\}",
+            source,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(stop)
+        body = stop.group(1)
+        self.assertIn("state->scheduleCleanup()", body)
+        self.assertNotIn("publishStopped", body)
 
     def test_legal_source_archive_rejects_traversal_member_names(self):
         code = """

--- a/tests/scripts/test_ios_native_release_contract.py
+++ b/tests/scripts/test_ios_native_release_contract.py
@@ -664,7 +664,14 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
         self.assertIn("tar -xzf", workflow)
         self.assertIn("prefetch_artifacts/ios-native-archive", workflow)
         producer = workflow.split("  BuildIosNativeStacks:", 1)[1].split("\n  MacPackages:", 1)[0]
-        self.assertNotIn("continue-on-error: true", producer)
+        for marker in (
+            "id: upload_ios_stack",
+            "continue-on-error: true",
+            "steps.upload_ios_stack.outcome == 'failure'",
+            "overwrite: true",
+        ):
+            self.assertIn(marker, producer)
+        self.assertEqual(producer.count("continue-on-error: true"), 1)
 
     def test_commit_archives_receive_locked_autotools_tarball_versions(self):
         build = required_text(BUILD_SCRIPT)

--- a/tests/scripts/test_ios_native_release_contract.py
+++ b/tests/scripts/test_ios_native_release_contract.py
@@ -740,15 +740,16 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
             "--version",
             "--base-url",
             "not included in the installer",
-            'source_asset_url(base_url, f"v{version}"',
+            'f"{base_url}/releases"',
             "shasum -a 256",
             "validated_relative_path(",
             'patch.get("path"), "locked patch"',
             'f"3rdparty/libimobiledevice/{patch_path}"',
         ):
             self.assertIn(token, legal)
+        self.assertIn('f"{base_url}/releases/tag/continuous"', legal)
         self.assertNotIn('source_asset_url(base_url, "continuous"', legal)
-        self.assertNotIn("rolling and mutable", legal)
+        self.assertIn("rolling and mutable", legal)
         self.assertNotIn(
             "The accompanying ios-native-corresponding-source.tar.gz",
             legal,

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -12,8 +12,35 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
 
 
-PINNED = "11d5960a326750d5838078e36cf38b85af677262"
-CODEQL_PINNED = "4187e74d05793876e9989daffde9c3e66b4acd07"
+PINNED = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+NODE20_CHECKOUT_PINNED = "11d5960a326750d5838078e36cf38b85af677262"
+CACHE_PINNED = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+UPLOAD_ARTIFACT_PINNED = "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+DOWNLOAD_ARTIFACT_PINNED = "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+CODEQL_PINNED = "cdf488f595d80d6e07e03d4674febd5ab45fa938"
+NODE20_CODEQL_PINNED = "4187e74d05793876e9989daffde9c3e66b4acd07"
+
+
+def secure_codeql_workflow() -> str:
+    return f"""\
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+jobs:
+  analyze:
+    timeout-minutes: 30
+    steps:
+      - uses: github/codeql-action/init@{CODEQL_PINNED}
+        with:
+          languages: c-cpp
+          build-mode: manual
+      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+      - run: cmake --build build -t klogg
+      - uses: github/codeql-action/analyze@{CODEQL_PINNED} # v4.37.9
+"""
 
 
 class CiQualityLintTest(unittest.TestCase):
@@ -98,6 +125,77 @@ class CiQualityLintTest(unittest.TestCase):
         )
         self.assertEqual(issues, [])
 
+    def test_all_remote_actions_require_reviewed_commit_shas(self):
+        path = pathlib.Path(".github/workflows/test.yml")
+        bad_refs = (
+            "actions/cache@v5",
+            "actions/cache@v5 # actions/cache@" + CACHE_PINNED,
+            ">-\n      actions/cache@v5",
+        )
+        for action_ref in bad_refs:
+            with self.subTest(action_ref=action_ref):
+                issues = MODULE.check_checkout_blocks(
+                    path,
+                    "steps:\n  - uses: " + action_ref + "\n",
+                )
+                self.assertTrue(
+                    any("remote actions must use a reviewed 40-char SHA" in issue for issue in issues),
+                    issues,
+                )
+
+    def test_sha_pinned_but_unreviewed_remote_action_is_rejected(self):
+        path = pathlib.Path(".github/workflows/test.yml")
+        issues = MODULE.check_checkout_blocks(
+            path,
+            f"steps:\n  - uses: actions/cache@{'a' * 40}\n",
+        )
+        self.assertTrue(
+            any("remote action SHA is not the reviewed revision" in issue for issue in issues),
+            issues,
+        )
+
+    def test_current_remote_action_sha_and_local_actions_are_accepted(self):
+        path = pathlib.Path(".github/workflows/test.yml")
+        text = (
+            "steps:\n"
+            f"  - uses: actions/cache@{CACHE_PINNED}\n"
+            f"  - uses: actions/upload-artifact@{UPLOAD_ARTIFACT_PINNED}\n"
+            f"  - uses: actions/download-artifact@{DOWNLOAD_ARTIFACT_PINNED}\n"
+            "  - uses: ./.github/actions/agent-setup\n"
+        )
+        self.assertEqual(MODULE.check_checkout_blocks(path, text), [])
+
+    def test_known_node20_action_generations_are_rejected_even_when_sha_pinned(self):
+        path = pathlib.Path(".github/workflows/test.yml")
+        node20_actions = (
+            (
+                f"actions/checkout@{NODE20_CHECKOUT_PINNED}",
+                "    with:\n      persist-credentials: false\n",
+            ),
+            (
+                "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
+                "",
+            ),
+            (
+                "actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093",
+                "",
+            ),
+            (
+                "ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756",
+                "",
+            ),
+        )
+        for action_ref, suffix in node20_actions:
+            with self.subTest(action_ref=action_ref):
+                issues = MODULE.check_checkout_blocks(
+                    path,
+                    f"steps:\n  - uses: {action_ref}\n{suffix}",
+                )
+                self.assertTrue(
+                    any("known Node20 action generation" in issue for issue in issues),
+                    issues,
+                )
+
     def test_workflow_job_needs_parses_inline_and_block_lists(self):
         workflow = """\
 jobs:
@@ -168,6 +266,155 @@ jobs:
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         self.assertEqual(MODULE.ci_build_workflow_issues(workflow), [])
 
+    def test_ci_build_splits_package_and_package_free_platform_jobs(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        needs = MODULE.workflow_job_needs(workflow)
+        expected_package_free = {
+            "LinuxSanitizers": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchCmakeInstaller",
+            },
+            "LinuxTsan": {"SaveVersion", "PrefetchCpmCache"},
+            "MacSanitizers": {"SaveVersion", "PrefetchCpmCache", "PrefetchBoost"},
+            "WindowsX86": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchBoost",
+                "PrefetchOpenSsl",
+                "PrefetchWindowsTools",
+            },
+            "WindowsAsan": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchBoost",
+                "PrefetchWindowsTools",
+            },
+        }
+        mobile_jobs = {
+            "BuildAdbHelpers",
+            "BuildAdbLinuxArm64",
+            "BuildAdbWindowsX64",
+            "BuildAdbMacX64",
+            "BuildAdbMacArm64",
+            "BuildIosNativeStacks",
+            "BuildIosNativeArm64",
+        }
+        for job, expected_needs in expected_package_free.items():
+            with self.subTest(job=job):
+                self.assertEqual(needs.get(job), expected_needs)
+                self.assertTrue(
+                    MODULE.workflow_job_ancestors(needs, job).isdisjoint(mobile_jobs)
+                )
+
+        expected_package_jobs = {
+            "LinuxPackages": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchLinuxDeployQt",
+                "PrefetchCmakeInstaller",
+                "BuildAdbHelpers",
+            },
+            "MacPackages": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchBoost",
+                "BuildAdbMacX64",
+                "BuildIosNativeStacks",
+            },
+            "MacArmPackages": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchBoost",
+                "BuildAdbMacArm64",
+                "BuildIosNativeArm64",
+            },
+            "WindowsPackages": {
+                "SaveVersion",
+                "PrefetchCpmCache",
+                "PrefetchBoost",
+                "PrefetchWindowsTools",
+                "BuildAdbWindowsX64",
+            },
+        }
+        for job, expected_needs in expected_package_jobs.items():
+            with self.subTest(job=job):
+                self.assertEqual(needs.get(job), expected_needs)
+                self.assertEqual(
+                    MODULE.workflow_job_ancestors(needs, job) & mobile_jobs,
+                    expected_needs & mobile_jobs,
+                )
+
+        self.assertEqual(
+            needs.get("ci-gate"),
+            mobile_jobs
+            | {
+                "LinuxPackages",
+                "LinuxSanitizers",
+                "LinuxTsan",
+                "MacPackages",
+                "MacArmPackages",
+                "MacSanitizers",
+                "WindowsPackages",
+                "WindowsX86",
+                "WindowsAsan",
+            },
+        )
+
+    def test_artifact_parser_resolves_anchored_platform_steps(self):
+        workflow = f"""\
+jobs:
+  Producer:
+    steps:
+      - uses: actions/upload-artifact@{UPLOAD_ARTIFACT_PINNED}
+        with:
+          name: locked-sources
+          path: sources
+  Package:
+    needs: Producer
+    steps: &platform_steps
+      - uses: actions/download-artifact@{DOWNLOAD_ARTIFACT_PINNED}
+        with:
+          name: locked-sources
+          path: sources
+  Sanitizer:
+    needs: Producer
+    steps: *platform_steps
+"""
+        self.assertEqual(
+            MODULE.workflow_artifact_actions(workflow),
+            {
+                "Producer": {"uploads": {"locked-sources"}, "downloads": set()},
+                "Package": {"uploads": set(), "downloads": {"locked-sources"}},
+                "Sanitizer": {"uploads": set(), "downloads": {"locked-sources"}},
+            },
+        )
+
+    def test_unknown_or_spoofed_steps_aliases_fail_closed(self):
+        unknown = """\
+jobs:
+  Consumer:
+    steps: *missing_steps
+"""
+        self.assertIn(
+            "workflow job Consumer uses unknown steps alias missing_steps",
+            MODULE.ci_build_workflow_issues(unknown),
+        )
+
+        comment_spoof = """\
+jobs:
+  Producer:
+    # steps: &missing_steps
+    steps:
+      - run: true
+  Consumer:
+    steps: *missing_steps
+"""
+        self.assertIn(
+            "workflow job Consumer uses unknown steps alias missing_steps",
+            MODULE.ci_build_workflow_issues(comment_spoof),
+        )
+
     def test_ci_build_rejects_a_restored_version_proxy_gate(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         mutated = workflow.replace(
@@ -178,7 +425,7 @@ jobs:
         self.assertNotEqual(mutated, workflow)
         self.assertTrue(
             any(
-                "SaveVersion must need exactly []" in issue
+                "SaveVersion must need exactly ['ReleaseQualificationPreflight']" in issue
                 for issue in MODULE.ci_build_workflow_issues(mutated)
             )
         )
@@ -186,18 +433,18 @@ jobs:
     def test_ci_build_rejects_a_missing_direct_artifact_dependency(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         mutated = workflow.replace(
-            "PrefetchOpenSsl, PrefetchWindowsTools, BuildAdbHelpers",
-            "PrefetchOpenSsl, BuildAdbHelpers",
+            "PrefetchBoost, PrefetchOpenSsl, PrefetchWindowsTools",
+            "PrefetchBoost, PrefetchOpenSsl",
             1,
         )
         self.assertNotEqual(mutated, workflow)
         issues = MODULE.ci_build_workflow_issues(mutated)
         self.assertTrue(
-            any("Windows must need exactly" in issue for issue in issues),
+            any("WindowsX86 must need exactly" in issue for issue in issues),
             issues,
         )
         self.assertIn(
-            "CI artifact msys2-tools producer PrefetchWindowsTools must be an ancestor of Windows",
+            "CI artifact msys2-tools producer PrefetchWindowsTools must be an ancestor of WindowsX86",
             issues,
         )
 
@@ -230,6 +477,28 @@ jobs:
             MODULE.ci_build_workflow_issues(mutated),
         )
 
+    def test_appimage_package_row_does_not_enable_cpack_or_dummy_install_checks(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        row = workflow.split("- os: ubuntu_appimage", 1)[1].split("\n\n    runs-on:", 1)[0]
+        self.assertIn("cpack_gen:\n", row)
+        self.assertIn("check_container:\n", row)
+        self.assertIn("check_command:\n", row)
+        self.assertNotIn("NONE", row)
+        self.assertNotIn("unused", row)
+
+    def test_ci_build_rejects_unmodeled_jobs_outside_ci_gate(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = workflow + """\
+  UnmodeledPlatform:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: exit 1
+"""
+        self.assertIn(
+            "CI build workflow contains unmodeled jobs outside the reviewed gate",
+            MODULE.ci_build_workflow_issues(mutated),
+        )
+
     def test_ci_build_gate_must_run_after_failures(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         mutated = workflow.replace("    if: always()\n", "    if: success()\n", 1)
@@ -242,31 +511,32 @@ jobs:
     def test_ci_build_platform_jobs_must_not_continue_on_error(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         mutated = workflow.replace(
-            "  Linux:\n",
-            "  Linux:\n    continue-on-error: true\n",
+            "  LinuxSanitizers:\n",
+            "  LinuxSanitizers:\n    continue-on-error: true\n",
             1,
         )
         self.assertNotEqual(mutated, workflow)
         self.assertIn(
-            "CI build job Linux must not continue on error",
+            "CI build job LinuxSanitizers must not continue on error",
             MODULE.ci_build_workflow_issues(mutated),
         )
 
-    def test_ci_build_requires_publication_source_artifact_downloads(self):
+    def test_ci_build_has_no_release_publication_job(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
-        marker = "      - name: Download architecture-independent iOS source assets\n"
-        start = workflow.index(marker)
-        suffix = workflow[start:]
-        mutated_suffix = suffix.replace(
-            "          name: ios-native-source-assets\n",
-            "          name: missing-ios-native-source-assets\n",
-            1,
+        self.assertNotIn(
+            "release publication must run outside the required CI workflow",
+            MODULE.ci_build_workflow_issues(workflow),
         )
-        self.assertNotEqual(mutated_suffix, suffix)
-        issues = MODULE.ci_build_workflow_issues(workflow[:start] + mutated_suffix)
+
+        mutated = workflow + """\
+  CreatePreRelease:
+    needs: [ci-gate]
+    steps:
+      - uses: softprops/action-gh-release@0123456789012345678901234567890123456789
+"""
         self.assertIn(
-            "CI job CreatePreRelease must download artifact ios-native-source-assets",
-            issues,
+            "release publication must run outside the required CI workflow",
+            MODULE.ci_build_workflow_issues(mutated),
         )
 
     def test_disabled_artifact_steps_do_not_satisfy_ownership(self):
@@ -315,12 +585,12 @@ jobs:
     def test_ci_build_rejects_artifact_conditions_outside_supported_triggers(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         old = (
-            "      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4\n"
+            "      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1\n"
             "        with:\n"
             "          name: cpm-cache\n"
         )
         new = (
-            "      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4\n"
+            "      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1\n"
             "        if: ${{ github.event_name == 'schedule' }}\n"
             "        with:\n"
             "          name: cpm-cache\n"
@@ -337,12 +607,248 @@ jobs:
     def test_explicit_false_continue_on_error_remains_fail_closed(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         mutated = workflow.replace(
-            "  Linux:\n",
-            "  Linux:\n    continue-on-error: false\n",
+            "  LinuxSanitizers:\n",
+            "  LinuxSanitizers:\n    continue-on-error: false\n",
             1,
         )
         self.assertNotEqual(mutated, workflow)
         self.assertEqual(MODULE.ci_build_workflow_issues(mutated), [])
+
+    def test_windows_package_preparation_and_artifact_upload_run_on_pull_requests(self):
+        message = "Windows package preparation and artifact upload must run on pull requests"
+        good = """\
+jobs:
+  WindowsPackages:
+    strategy:
+      matrix:
+        config:
+          - package: true
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        if: ${{ matrix.config.package != false }}
+        with:
+          name: adb-helper-${{ matrix.config.adb_target }}
+      - uses: ./.github/actions/agent-package-win
+        if: ${{ matrix.config.package != false }}
+      - name: Package tarball for upload
+        if: ${{ matrix.config.package != false }}
+        run: tar -czf packages-windows.tar.gz packages
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        if: ${{ matrix.config.package != false }}
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+
+        bad = good.replace(
+            "if: ${{ matrix.config.package != false }}",
+            "if: ${{ matrix.config.package != false && github.event_name != 'pull_request' }}",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+        spoofed = bad.replace(
+            "  WindowsPackages:\n",
+            "  WindowsPackages:\n    # Package preparation runs on pull_request\n",
+            1,
+        )
+        self.assertIn(message, MODULE.ci_build_workflow_issues(spoofed))
+
+        job_level = good.replace(
+            "  WindowsPackages:\n",
+            "  WindowsPackages:\n    if: ${{ github.event_name == 'push' }}\n",
+            1,
+        )
+        self.assertIn(message, MODULE.ci_build_workflow_issues(job_level))
+
+    def test_windows_package_composite_must_not_hide_validation_by_event(self):
+        message = "Windows package composite must remain event-neutral"
+        good = """\
+runs:
+  using: composite
+  steps:
+    - run: package-windows
+      shell: pwsh
+"""
+        self.assertEqual(MODULE.windows_package_action_issues(good), [])
+        bad = good.replace(
+            "    - run: package-windows\n",
+            "    - if: ${{ github.event_name == 'push' }}\n      run: package-windows\n",
+        )
+        self.assertIn(message, MODULE.windows_package_action_issues(bad))
+
+    def test_required_ci_validation_is_decoupled_from_signing_and_notarization(self):
+        message = "required CI validation must not require signing or notarization secrets"
+        good = """\
+jobs:
+  MacValidation:
+    steps:
+      - uses: ./.github/actions/agent-build
+      - uses: ./.github/actions/agent-run-tests
+  ci-gate:
+    needs: [MacValidation]
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+
+        bad = good.replace(
+            "      - uses: ./.github/actions/agent-run-tests\n",
+            "      - uses: ./.github/actions/agent-run-tests\n"
+            "      - uses: ./.github/actions/agent-package-mac\n"
+            "        with:\n"
+            "          codesign-identity: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}\n"
+            "          notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}\n",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+    def test_release_secrets_are_confined_to_explicit_dispatch_qualification(self):
+        message = "required CI validation must not require signing or notarization secrets"
+        good = """\
+on:
+  workflow_dispatch:
+    inputs:
+      qualification-mode:
+        type: choice
+        options:
+          - validation
+          - release
+jobs:
+  MacPackages:
+    steps:
+      - uses: ./.github/actions/agent-package-mac
+        with:
+          qualification-mode: ${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && inputs.qualification-mode == 'release' && 'release' || 'validation' }}
+          codesign-identity: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION }}
+          notarization-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+        bad = good.replace(
+            "${{ github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master' && inputs.qualification-mode == 'release' && 'release' || 'validation' }}",
+            "validation",
+            1,
+        )
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+    def test_publication_runs_outside_the_required_ci_workflow(self):
+        message = "release publication must run outside the required CI workflow"
+        good = """\
+jobs:
+  ci-gate:
+    steps:
+      - run: test validation-only = validation-only
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+
+        bad = good + """\
+  CreatePreRelease:
+    needs: [ci-gate]
+    steps:
+      - uses: softprops/action-gh-release@0123456789012345678901234567890123456789
+"""
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+    def test_package_free_sanitizer_aggregates_do_not_need_mobile_producers(self):
+        message = "package-free CI legs must not depend on mobile artifact producers"
+        good = """\
+jobs:
+  BuildAdbHelpers:
+    steps:
+      - run: build-mobile-helper
+  LinuxPackages:
+    needs: [BuildAdbHelpers]
+    strategy:
+      matrix:
+        config:
+          - package: true
+  LinuxSanitizers:
+    strategy:
+      matrix:
+        config:
+          - sanitizer: address
+            package: false
+  ci-gate:
+    needs: [LinuxPackages, LinuxSanitizers]
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+
+        bad = good.replace(
+            "  LinuxSanitizers:\n",
+            "  LinuxSanitizers:\n    needs: [BuildAdbHelpers]\n",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+        comment_spoof = bad.replace(
+            "    needs: [BuildAdbHelpers]\n",
+            "    # package-free legs do not need BuildAdbHelpers\n"
+            "    needs: [BuildAdbHelpers]\n",
+            1,
+        )
+        self.assertIn(message, MODULE.ci_build_workflow_issues(comment_spoof))
+
+    def test_ccache_keys_are_bounded_and_do_not_use_run_ids(self):
+        message = "ccache keys must be bounded and must not use github.run_id"
+        good = """\
+jobs:
+  Linux:
+    steps:
+      - uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: linux-ccache-v2-${{ hashFiles('CMakeLists.txt', '3rdparty/CMakeLists.txt') }}
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+
+        bad = good.replace(
+            "${{ hashFiles('CMakeLists.txt', '3rdparty/CMakeLists.txt') }}",
+            "${{ github.run_id }}",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
+
+        comment_spoof = bad.replace(
+            "          key:",
+            "          # bounded key: hashFiles('CMakeLists.txt')\n          key:",
+            1,
+        )
+        self.assertIn(message, MODULE.ci_build_workflow_issues(comment_spoof))
+
+    def test_ccache_refreshes_daily_without_unbounded_per_run_keys(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        self.assertEqual(workflow.count("current={today.isoformat()}"), 2)
+        self.assertEqual(workflow.count("days=1"), 2)
+        self.assertNotIn("isocalendar()", workflow)
+
+    def test_ccache_is_saved_only_after_tests_and_package_qualification(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        linux = workflow.split("  LinuxPackages:", 1)[1].split("\n  LinuxSanitizers:", 1)[0]
+        self.assertGreater(
+            linux.index("- name: Save ccache for the Linux build"),
+            linux.index("- uses: ./.github/actions/docker-run-tests"),
+        )
+        mac = workflow.split("  MacPackages:", 1)[1].split("\n  MacArmPackages:", 1)[0]
+        self.assertGreater(
+            mac.index("- name: Save ccache for the macOS build"),
+            mac.index("- uses: ./.github/actions/agent-package-mac"),
+        )
+
+    def test_ccache_entries_are_capped_to_the_repository_budget(self):
+        message = "ccache entries must be capped at 250M"
+        good = """\
+jobs:
+  Linux:
+    steps:
+      - run: ccache --max-size=250M && ccache --cleanup
+      - uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: linux-ccache-v2-week
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+        bad = good.replace("--max-size=250M", "--max-size=500M")
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
 
     def test_codeql_requires_pinned_matching_actions_and_timeout(self):
         insecure = """\
@@ -359,56 +865,80 @@ jobs:
         self.assertTrue(any("timeout-minutes" in issue for issue in issues))
 
     def test_codeql_rejects_mismatched_action_revisions(self):
-        text = f"""\
-jobs:
-  analyze:
-    timeout-minutes: 30
-    steps:
-      - uses: github/codeql-action/init@{CODEQL_PINNED}
-      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-      - uses: github/codeql-action/analyze@{'a' * 40}
-"""
+        text = secure_codeql_workflow().replace(
+            f"github/codeql-action/analyze@{CODEQL_PINNED}",
+            f"github/codeql-action/analyze@{'a' * 40}",
+            1,
+        )
         issues = MODULE.codeql_workflow_issues(text)
         self.assertEqual(len(issues), 1)
         self.assertIn("same reviewed SHA", issues[0])
 
     def test_codeql_rejects_continue_on_error(self):
-        text = f"""\
-jobs:
-  analyze:
-    timeout-minutes: 30
-    continue-on-error: true
-    steps:
-      - uses: github/codeql-action/init@{CODEQL_PINNED}
-      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-      - uses: github/codeql-action/analyze@{CODEQL_PINNED}
-"""
+        text = secure_codeql_workflow().replace(
+            "    timeout-minutes: 30\n",
+            "    timeout-minutes: 30\n    continue-on-error: true\n",
+            1,
+        )
         issues = MODULE.codeql_workflow_issues(text)
         self.assertEqual(len(issues), 1)
         self.assertIn("continue-on-error", issues[0])
 
     def test_secure_codeql_workflow_is_accepted(self):
-        text = f"""\
-jobs:
-  analyze:
-    timeout-minutes: 30
-    steps:
-      - uses: github/codeql-action/init@{CODEQL_PINNED}
-      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-      - uses: github/codeql-action/analyze@{CODEQL_PINNED}
-"""
-        self.assertEqual(MODULE.codeql_workflow_issues(text), [])
+        self.assertEqual(MODULE.codeql_workflow_issues(secure_codeql_workflow()), [])
+
+    def test_codeql_runs_on_master_pushes(self):
+        message = "CodeQL workflow must run on pushes to master"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        bad = good.replace("  push:\n    branches: [master]\n", "", 1)
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+        comment_spoof = bad.replace(
+            "on:\n",
+            "on:\n  # push:\n  #   branches: [master]\n",
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(comment_spoof))
+
+    def test_codeql_init_uses_explicit_manual_build_mode(self):
+        message = "CodeQL init must set build-mode: manual"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        bad = good.replace("          build-mode: manual\n", "", 1)
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+        misplaced = bad.replace(
+            f"      - uses: github/codeql-action/analyze@{CODEQL_PINNED}",
+            f"      - uses: github/codeql-action/analyze@{CODEQL_PINNED}\n"
+            "        with:\n"
+            "          build-mode: manual",
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(misplaced))
+
+    def test_codeql_uses_the_current_action_generation(self):
+        message = "CodeQL actions must use the current reviewed generation"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        bad = good.replace(CODEQL_PINNED, NODE20_CODEQL_PINNED)
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+        comment_spoof = bad.replace("# v4.37.9", "# current v4 generation")
+        self.assertIn(message, MODULE.codeql_workflow_issues(comment_spoof))
 
     def test_codeql_configure_requires_the_restored_cpm_source_cache(self):
-        text = f"""\
-jobs:
-  analyze:
-    timeout-minutes: 30
-    steps:
-      - uses: github/codeql-action/init@{CODEQL_PINNED}
-      - run: cmake -S "$GITHUB_WORKSPACE" -B build
-      - uses: github/codeql-action/analyze@{CODEQL_PINNED}
-"""
+        text = secure_codeql_workflow().replace(
+            ' -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache"',
+            "",
+            1,
+        )
         self.assertIn(
             "CodeQL configure must use the restored CPM source cache fully disconnected",
             MODULE.codeql_workflow_issues(text),
@@ -669,12 +1199,51 @@ steps:
         self.assertIn("libcurl4-openssl-dev", workflow)
         self.assertIn("ragel", workflow)
 
+    def test_static_analysis_full_audit_and_changed_events_do_not_cancel_each_other(self):
+        workflow = (ROOT / ".github" / "workflows" / "static-analysis.yml").read_text()
+        self.assertIn("group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}", workflow)
+        self.assertIn("cancel-in-progress: ${{ github.event_name != 'schedule' }}", workflow)
+
+    def test_static_analysis_dispatch_is_full_by_default_or_uses_an_explicit_base(self):
+        workflow = (ROOT / ".github" / "workflows" / "static-analysis.yml").read_text()
+        self.assertIn("analysis-mode:", workflow)
+        self.assertIn("default: full-report", workflow)
+        self.assertIn("MANUAL_BASE_SHA: ${{ inputs.base-sha }}", workflow)
+        self.assertNotIn('workflow_dispatch) base_sha="$(git rev-parse HEAD^)"', workflow)
+        self.assertIn('git fetch --no-tags origin "$base_sha"', workflow)
+
     def test_static_analysis_uses_reusable_changed_line_runner(self):
         workflow = (ROOT / ".github" / "workflows" / "static-analysis.yml").read_text()
         self.assertIn("python3 scripts/run_changed_clang_tidy.py", workflow)
-        self.assertIn("--base '${{ github.event.pull_request.base.sha }}'", workflow)
+        self.assertIn('--base "$KLOGG_ANALYSIS_BASE"', workflow)
+        self.assertIn("PUSH_BASE_SHA: ${{ github.event.before }}", workflow)
         self.assertIn('--build-dir "$KLOGG_BUILD_ROOT"', workflow)
         self.assertIn('--clang-tidy-diff "$CLANG_TIDY_DIFF"', workflow)
+
+    def test_static_analysis_is_equally_strict_on_pull_requests_and_master_pushes(self):
+        message = "clang-tidy findings must fail both pull requests and master pushes"
+        good = """\
+steps:
+  - name: Run clang-tidy
+    run: |
+      if [ "${{ github.event_name }}" = "pull_request" ]; then
+        python3 scripts/run_changed_clang_tidy.py --base '${{ github.event.pull_request.base.sha }}' --build-dir "$KLOGG_BUILD_ROOT" --clang-tidy-diff "$CLANG_TIDY_DIFF"
+      else
+        xargs -0 -n 1 bash -c 'clang-tidy --warnings-as-errors="*" -p "$KLOGG_BUILD_ROOT" "$1"' _ < tidy_files.nul
+      fi
+"""
+        self.assertNotIn(message, MODULE.static_analysis_workflow_issues(good))
+
+        bad = good.replace(' --warnings-as-errors="*"', "", 1)
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.static_analysis_workflow_issues(bad))
+
+        echo_spoof = bad.replace(
+            "      else\n",
+            "      else\n        echo 'clang-tidy --warnings-as-errors=\"*\"'\n",
+            1,
+        )
+        self.assertIn(message, MODULE.static_analysis_workflow_issues(echo_spoof))
 
     def test_static_analysis_rejects_masked_report_only_tool_failures(self):
         workflow = (
@@ -1006,19 +1575,9 @@ steps:
                     MODULE.static_analysis_workflow_issues(workflow),
                 )
 
-    def test_static_analysis_uses_a_sentry_specific_cpm_cache_key(self):
-        workflow = """\
-steps:
-  - run: |
-      cmake -S "$KLOGG_WORKSPACE" -B "$KLOGG_BUILD_ROOT" -DKLOGG_USE_SENTRY=ON -DKLOGG_USE_VECTORSCAN=ON
-      python3 scripts/first_party_compile_units.py "$KLOGG_BUILD_ROOT/compile_commands.json" "$KLOGG_WORKSPACE/src" --null > tidy_files.nul
-      xargs -0 -n 1 bash -c 'clang-tidy -p "$KLOGG_BUILD_ROOT" --line-filter="$TIDY_LINE_FILTER" "$1"' _ < tidy_files.nul
-      xargs -0 -n 1 bash -c 'clang-tidy -p "$KLOGG_BUILD_ROOT" "$1"' _ < tidy_files.nul
-"""
-        self.assertIn(
-            "static analysis must use a Sentry-and-Vectorscan-specific CPM cache key",
-            MODULE.static_analysis_workflow_issues(workflow),
-        )
+    def test_static_analysis_uses_the_shared_complete_cpm_cache_key(self):
+        workflow = (ROOT / ".github" / "workflows" / "static-analysis.yml").read_text()
+        self.assertNotIn("KLOGG_CPM_CACHE_KEY_SUFFIX", workflow)
 
     def test_cppcheck_baselines_require_path_and_line(self):
         self.assertEqual(

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -269,6 +269,23 @@ jobs:
             },
         )
 
+    def test_master_pushes_never_skip_ci_build_by_path(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        self.assertNotIn(
+            "master pushes must not skip CI Build by path",
+            MODULE.ci_build_workflow_issues(workflow),
+        )
+        mutated = workflow.replace(
+            "  push:\n    branches: [ master ]\n",
+            "  push:\n    branches: [ master ]\n    paths-ignore: [README.md]\n",
+            1,
+        )
+        self.assertNotEqual(mutated, workflow)
+        self.assertIn(
+            "master pushes must not skip CI Build by path",
+            MODULE.ci_build_workflow_issues(mutated),
+        )
+
     def test_ci_build_uses_the_optimized_prefetch_and_native_build_dag(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         self.assertEqual(MODULE.ci_build_workflow_issues(workflow), [])
@@ -449,6 +466,19 @@ jobs:
                 "CI root job SaveVersion must not have dependencies" in issue
                 for issue in MODULE.ci_build_workflow_issues(mutated)
             )
+        )
+
+    def test_ci_build_output_references_require_direct_needs(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = workflow.replace(
+            "  BuildIosNativeArm64:\n    needs: [SaveVersion, PrefetchIosNativeSources]",
+            "  BuildIosNativeArm64:\n    needs: [PrefetchIosNativeSources]",
+            1,
+        )
+        self.assertNotEqual(mutated, workflow)
+        self.assertIn(
+            "CI build job BuildIosNativeArm64 references outputs from SaveVersion without a direct need",
+            MODULE.ci_build_workflow_issues(mutated),
         )
 
     def test_ci_build_rejects_missing_dynamic_native_artifact_ancestry(self):
@@ -788,6 +818,22 @@ jobs:
         self.assertIn(
             "stable release dispatch must fail closed outside master",
             MODULE.stable_release_workflow_issues(bypassed),
+        )
+        run_api_inputs = workflow.replace(
+            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n',
+            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n'
+            '        run_qualification="$(gh api "$run_api" --jq \'.inputs["qualification-mode"] // empty\')"\n',
+            1,
+        )
+        self.assertNotEqual(run_api_inputs, workflow)
+        self.assertIn(
+            "stable release evidence must come from downloaded receipts, not run API inputs",
+            MODULE.stable_release_workflow_issues(run_api_inputs),
+        )
+        draft_tag_lookup = workflow.replace(".target_commitish", ".tag_name", 1)
+        self.assertIn(
+            "stable draft verification must not require an unpublished Git tag",
+            MODULE.stable_release_workflow_issues(draft_tag_lookup),
         )
         without_rollback = workflow.replace(
             "        trap rollback_stable_promotion ERR\n", "", 1

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -31,12 +31,19 @@ on:
   workflow_dispatch:
 jobs:
   analyze:
+    permissions:
+      contents: read
+      security-events: write
+    env:
+      CODEQL_ACTION_OVERLAY_ANALYSIS: "false"
+      CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"
     timeout-minutes: 30
     steps:
       - uses: github/codeql-action/init@{CODEQL_PINNED}
         with:
           languages: c-cpp
           build-mode: manual
+      - uses: ./.github/actions/agent-setup
       - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
       - run: cmake --build build -t klogg
       - uses: github/codeql-action/analyze@{CODEQL_PINNED} # v4.37.9
@@ -266,6 +273,18 @@ jobs:
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         self.assertEqual(MODULE.ci_build_workflow_issues(workflow), [])
 
+    def test_ci_build_native_artifact_consumers_use_verified_extraction(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        linux = workflow.split("  LinuxPackages:", 1)[1].split(
+            "\n  LinuxSanitizers:", 1
+        )[0]
+        mac = workflow.split("  MacPackages:", 1)[1].split(
+            "\n  MacArmPackages:", 1
+        )[0]
+        for block in (linux, mac):
+            self.assertIn("scripts/extract_verified_tar.py", block)
+            self.assertNotIn('tar -xzf "$archive"', block)
+
     def test_ci_build_splits_package_and_package_free_platform_jobs(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
         needs = MODULE.workflow_job_needs(workflow)
@@ -316,6 +335,7 @@ jobs:
                 "BuildAdbHelpers",
             },
             "MacPackages": {
+                "ReleaseQualificationPreflight",
                 "SaveVersion",
                 "PrefetchCpmCache",
                 "PrefetchBoost",
@@ -323,6 +343,7 @@ jobs:
                 "BuildIosNativeStacks",
             },
             "MacArmPackages": {
+                "ReleaseQualificationPreflight",
                 "SaveVersion",
                 "PrefetchCpmCache",
                 "PrefetchBoost",
@@ -347,8 +368,8 @@ jobs:
 
         self.assertEqual(
             needs.get("ci-gate"),
-            mobile_jobs
-            | {
+            {
+                "BuildAdbLinuxArm64",
                 "LinuxPackages",
                 "LinuxSanitizers",
                 "LinuxTsan",
@@ -425,9 +446,22 @@ jobs:
         self.assertNotEqual(mutated, workflow)
         self.assertTrue(
             any(
-                "SaveVersion must need exactly ['ReleaseQualificationPreflight']" in issue
+                "CI root job SaveVersion must not have dependencies" in issue
                 for issue in MODULE.ci_build_workflow_issues(mutated)
             )
+        )
+
+    def test_ci_build_rejects_missing_dynamic_native_artifact_ancestry(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = workflow.replace(
+            "PrefetchCmakeInstaller, BuildAdbHelpers",
+            "PrefetchCmakeInstaller, BuildAdbHelperLegalAssets",
+            1,
+        )
+        self.assertNotEqual(mutated, workflow)
+        self.assertIn(
+            "CI native artifact producer BuildAdbHelpers must be an ancestor of LinuxPackages",
+            MODULE.ci_build_workflow_issues(mutated),
         )
 
     def test_ci_build_rejects_a_missing_direct_artifact_dependency(self):
@@ -439,10 +473,6 @@ jobs:
         )
         self.assertNotEqual(mutated, workflow)
         issues = MODULE.ci_build_workflow_issues(mutated)
-        self.assertTrue(
-            any("WindowsX86 must need exactly" in issue for issue in issues),
-            issues,
-        )
         self.assertIn(
             "CI artifact msys2-tools producer PrefetchWindowsTools must be an ancestor of WindowsX86",
             issues,
@@ -494,9 +524,13 @@ jobs:
     steps:
       - run: exit 1
 """
-        self.assertIn(
-            "CI build workflow contains unmodeled jobs outside the reviewed gate",
-            MODULE.ci_build_workflow_issues(mutated),
+        self.assertTrue(
+            any(
+                issue.startswith(
+                    "CI build workflow contains unmodeled jobs outside the reviewed gate"
+                )
+                for issue in MODULE.ci_build_workflow_issues(mutated)
+            )
         )
 
     def test_ci_build_gate_must_run_after_failures(self):
@@ -729,6 +763,54 @@ jobs:
         )
         self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
 
+    def test_signed_ci_dispatch_master_guard_cannot_be_bypassed(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = workflow.replace(
+            '          test "$GITHUB_REF" = "refs/heads/master" || {',
+            '          true || test "$GITHUB_REF" = "refs/heads/master" || {',
+            1,
+        )
+        self.assertNotEqual(mutated, workflow)
+        self.assertIn(
+            "signed release qualification must reject non-master dispatches",
+            MODULE.ci_build_workflow_issues(mutated),
+        )
+
+    def test_stable_release_master_guard_and_promotion_are_fail_closed(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-release.yml").read_text()
+        self.assertEqual(MODULE.stable_release_workflow_issues(workflow), [])
+        bypassed = workflow.replace(
+            '        test "${GITHUB_REF}" = "refs/heads/master" || {',
+            '        true || test "${GITHUB_REF}" = "refs/heads/master" || {',
+            1,
+        )
+        self.assertNotEqual(bypassed, workflow)
+        self.assertIn(
+            "stable release dispatch must fail closed outside master",
+            MODULE.stable_release_workflow_issues(bypassed),
+        )
+        without_rollback = workflow.replace(
+            "        trap rollback_stable_promotion ERR\n", "", 1
+        )
+        self.assertIn(
+            "stable release promotion must roll back every post-publish failure",
+            MODULE.stable_release_workflow_issues(without_rollback),
+        )
+
+    def test_continuous_release_publish_requires_trusted_selection(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-continuous.yml").read_text()
+        self.assertEqual(MODULE.continuous_release_workflow_issues(workflow), [])
+        bypassed = workflow.replace(
+            "    if: ${{ needs.select.outputs.should-publish == 'true' }}",
+            "    if: always()",
+            1,
+        )
+        self.assertNotEqual(bypassed, workflow)
+        self.assertIn(
+            "continuous release publication must require the verified selection output",
+            MODULE.continuous_release_workflow_issues(bypassed),
+        )
+
     def test_publication_runs_outside_the_required_ci_workflow(self):
         message = "release publication must run outside the required CI workflow"
         good = """\
@@ -786,6 +868,44 @@ jobs:
             1,
         )
         self.assertIn(message, MODULE.ci_build_workflow_issues(comment_spoof))
+
+    def test_ci_build_requires_at_least_one_buildkit_cache_exporter(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = "\n".join(
+            line for line in workflow.splitlines() if "cache-to:" not in line
+        )
+        self.assertNotEqual(mutated, workflow)
+        self.assertIn(
+            "BuildKit cache exports must run only on default-branch pushes",
+            MODULE.ci_build_workflow_issues(mutated),
+        )
+
+    def test_buildkit_cache_export_condition_cannot_admit_pull_requests(self):
+        message = "BuildKit cache exports must run only on default-branch pushes"
+        good = """\
+jobs:
+  Linux:
+    steps:
+      - uses: docker/build-push-action@0123456789012345678901234567890123456789
+        with:
+          cache-to: ${{ github.event_name == 'push' && matrix.config.cache_write && 'type=gha,mode=min,scope=klogg-linux' || '' }}
+"""
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(good))
+        folded = good.replace(
+            "          cache-to: ${{ github.event_name == 'push' && matrix.config.cache_write && 'type=gha,mode=min,scope=klogg-linux' || '' }}",
+            "          cache-to: >-\n            ${{ github.event_name == 'push' && matrix.config.cache_write && 'type=gha,mode=min,scope=klogg-linux' || '' }}",
+            1,
+        )
+        self.assertNotEqual(folded, good)
+        self.assertNotIn(message, MODULE.ci_build_workflow_issues(folded))
+
+        bad = good.replace(
+            "github.event_name == 'push' && matrix.config.cache_write",
+            "(github.event_name == 'push' || github.event_name == 'pull_request') && matrix.config.cache_write",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.ci_build_workflow_issues(bad))
 
     def test_ccache_keys_are_bounded_and_do_not_use_run_ids(self):
         message = "ccache keys must be bounded and must not use github.run_id"
@@ -908,18 +1028,125 @@ jobs:
         good = secure_codeql_workflow()
         self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
 
-        bad = good.replace("          build-mode: manual\n", "", 1)
-        self.assertNotEqual(bad, good)
-        self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+        missing = good.replace("          build-mode: manual\n", "", 1)
+        self.assertNotEqual(missing, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(missing))
 
-        misplaced = bad.replace(
-            f"      - uses: github/codeql-action/analyze@{CODEQL_PINNED}",
-            f"      - uses: github/codeql-action/analyze@{CODEQL_PINNED}\n"
-            "        with:\n"
-            "          build-mode: manual",
+        no_build = good.replace("          build-mode: manual", "          build-mode: none", 1)
+        self.assertNotEqual(no_build, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(no_build))
+
+        comment_spoof = missing.replace(
+            "          languages: c-cpp\n",
+            "          languages: c-cpp\n          # build-mode: manual\n",
             1,
         )
-        self.assertIn(message, MODULE.codeql_workflow_issues(misplaced))
+        self.assertIn(message, MODULE.codeql_workflow_issues(comment_spoof))
+
+    def test_codeql_runs_on_pull_requests_and_manual_dispatch(self):
+        good = secure_codeql_workflow()
+        for trigger, marker in (
+            ("pull_request", "CodeQL workflow must run on pull requests to master"),
+            ("workflow_dispatch", "CodeQL workflow must support manual dispatch"),
+        ):
+            with self.subTest(trigger=trigger):
+                self.assertNotIn(marker, MODULE.codeql_workflow_issues(good))
+
+        without_pull_request = good.replace(
+            "  pull_request:\n    branches: [master]\n", "", 1
+        )
+        self.assertIn(
+            "CodeQL workflow must run on pull requests to master",
+            MODULE.codeql_workflow_issues(without_pull_request),
+        )
+
+        without_dispatch = good.replace("  workflow_dispatch:\n", "", 1)
+        self.assertIn(
+            "CodeQL workflow must support manual dispatch",
+            MODULE.codeql_workflow_issues(without_dispatch),
+        )
+
+    def test_codeql_security_permissions_are_fail_closed_and_job_scoped(self):
+        message = (
+            "CodeQL analyze job must grant only contents: read and "
+            "security-events: write permissions"
+        )
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        missing_security_events = good.replace("      security-events: write\n", "", 1)
+        self.assertIn(message, MODULE.codeql_workflow_issues(missing_security_events))
+
+        read_only_security_events = good.replace(
+            "      security-events: write", "      security-events: read", 1
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(read_only_security_events))
+
+        overprivileged = good.replace(
+            "      contents: read\n",
+            "      contents: read\n      actions: read\n",
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(overprivileged))
+
+        workflow_scoped = good.replace(
+            "jobs:\n  analyze:\n    permissions:\n"
+            "      contents: read\n"
+            "      security-events: write\n",
+            "permissions:\n"
+            "  contents: read\n"
+            "  security-events: write\n"
+            "jobs:\n"
+            "  analyze:\n",
+            1,
+        )
+        self.assertNotEqual(workflow_scoped, good)
+        self.assertIn(message, MODULE.codeql_workflow_issues(workflow_scoped))
+
+    def test_codeql_manual_build_disables_overlay_analysis(self):
+        message = "CodeQL traced build must explicitly disable overlay analysis"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+        for marker in (
+            '      CODEQL_ACTION_OVERLAY_ANALYSIS: "false"\n',
+            '      CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"\n',
+        ):
+            with self.subTest(marker=marker):
+                bad = good.replace(marker, "", 1)
+                self.assertNotEqual(bad, good)
+                self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+    def test_codeql_manual_build_restores_dependencies_and_builds_application(self):
+        good = secure_codeql_workflow()
+        mutations = (
+            (
+                "      - uses: ./.github/actions/agent-setup\n",
+                "CodeQL manual build must restore the shared dependency closure",
+            ),
+            (
+                "      - run: cmake --build build -t klogg\n",
+                "CodeQL manual build must trace the klogg application target",
+            ),
+        )
+        for marker, message in mutations:
+            with self.subTest(marker=marker):
+                bad = good.replace(marker, "", 1)
+                self.assertNotEqual(bad, good)
+                self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+    def test_codeql_build_cannot_be_spoofed_by_an_unrelated_job(self):
+        good = secure_codeql_workflow()
+        bad = good.replace(
+            "      - run: cmake --build build -t klogg\n", "", 1
+        ) + """\
+  Unrelated:
+    steps:
+      - run: cmake --build build -t klogg
+"""
+        self.assertIn(
+            "CodeQL manual build must trace the klogg application target",
+            MODULE.codeql_workflow_issues(bad),
+        )
 
     def test_codeql_uses_the_current_action_generation(self):
         message = "CodeQL actions must use the current reviewed generation"
@@ -933,15 +1160,21 @@ jobs:
         comment_spoof = bad.replace("# v4.37.9", "# current v4 generation")
         self.assertIn(message, MODULE.codeql_workflow_issues(comment_spoof))
 
-    def test_codeql_configure_requires_the_restored_cpm_source_cache(self):
-        text = secure_codeql_workflow().replace(
-            ' -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache"',
-            "",
+    def test_repository_codeql_workflow_uses_warning_free_traced_build(self):
+        workflow = (
+            ROOT / ".github" / "workflows" / "codeql-analysis.yml"
+        ).read_text()
+        self.assertEqual(MODULE.codeql_workflow_issues(workflow), [])
+
+        overlay_enabled = workflow.replace(
+            '      CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"',
+            '      CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "true"',
             1,
         )
+        self.assertNotEqual(overlay_enabled, workflow)
         self.assertIn(
-            "CodeQL configure must use the restored CPM source cache fully disconnected",
-            MODULE.codeql_workflow_issues(text),
+            "CodeQL traced build must explicitly disable overlay analysis",
+            MODULE.codeql_workflow_issues(overlay_enabled),
         )
 
     def test_agent_setup_self_populates_cold_cpm_caches(self):
@@ -1223,27 +1456,53 @@ steps:
     def test_static_analysis_is_equally_strict_on_pull_requests_and_master_pushes(self):
         message = "clang-tidy findings must fail both pull requests and master pushes"
         good = """\
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+env:
+  PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  PUSH_BASE_SHA: ${{ github.event.before }}
+  MANUAL_BASE_SHA: ${{ inputs.base-sha }}
 steps:
   - name: Run clang-tidy
     run: |
-      if [ "${{ github.event_name }}" = "pull_request" ]; then
-        python3 scripts/run_changed_clang_tidy.py --base '${{ github.event.pull_request.base.sha }}' --build-dir "$KLOGG_BUILD_ROOT" --clang-tidy-diff "$CLANG_TIDY_DIFF"
+      if [ "$KLOGG_ANALYSIS_MODE" = "full-report" ]; then
+        xargs -0 -n 1 bash -c 'clang-tidy -p "$KLOGG_BUILD_ROOT" "$1"' _ < tidy_files.nul
       else
-        xargs -0 -n 1 bash -c 'clang-tidy --warnings-as-errors="*" -p "$KLOGG_BUILD_ROOT" "$1"' _ < tidy_files.nul
+        case "$EVENT_NAME" in
+          pull_request) base_sha="$PR_BASE_SHA" ;;
+          push) base_sha="$PUSH_BASE_SHA" ;;
+          workflow_dispatch) base_sha="$MANUAL_BASE_SHA" ;;
+        esac
+        git fetch --no-tags origin "$base_sha"
+        python3 scripts/run_changed_clang_tidy.py --base "$KLOGG_ANALYSIS_BASE" --build-dir "$KLOGG_BUILD_ROOT" --clang-tidy-diff "$CLANG_TIDY_DIFF"
       fi
 """
-        self.assertNotIn(message, MODULE.static_analysis_workflow_issues(good))
+        issues = MODULE.static_analysis_workflow_issues(good)
+        self.assertNotIn(message, issues)
+        consumer_message = (
+            "clang-tidy TU scope must use NUL-delimited strict and report-only consumers"
+        )
+        self.assertNotIn(consumer_message, issues)
 
-        bad = good.replace(' --warnings-as-errors="*"', "", 1)
-        self.assertNotEqual(bad, good)
-        self.assertIn(message, MODULE.static_analysis_workflow_issues(bad))
-
-        echo_spoof = bad.replace(
-            "      else\n",
-            "      else\n        echo 'clang-tidy --warnings-as-errors=\"*\"'\n",
+        without_report_only_consumer = good.replace(
+            "        xargs -0 -n 1 bash -c 'clang-tidy -p \"$KLOGG_BUILD_ROOT\" \"$1\"' _ < tidy_files.nul\n",
+            "        true\n",
             1,
         )
-        self.assertIn(message, MODULE.static_analysis_workflow_issues(echo_spoof))
+        self.assertNotEqual(without_report_only_consumer, good)
+        self.assertIn(
+            consumer_message,
+            MODULE.static_analysis_workflow_issues(without_report_only_consumer),
+        )
+
+        bad = good.replace(
+            "  cancel-in-progress: ${{ github.event_name != 'schedule' }}",
+            "  cancel-in-progress: true",
+            1,
+        )
+        self.assertNotEqual(bad, good)
+        self.assertIn(message, MODULE.static_analysis_workflow_issues(bad))
 
     def test_static_analysis_rejects_masked_report_only_tool_failures(self):
         workflow = (
@@ -1336,6 +1595,23 @@ steps:
         )
         self.assertNotEqual(without_cache, workflow)
         self.assertIn(message, MODULE.static_analysis_workflow_issues(without_cache))
+
+    def test_static_analysis_cppcheck_scope_resolves_relative_compile_entries(self):
+        workflow = (
+            ROOT / ".github" / "workflows" / "static-analysis.yml"
+        ).read_text()
+        message = "cppcheck TU scope must resolve relative compile database entries"
+        self.assertNotIn(message, MODULE.static_analysis_workflow_issues(workflow))
+
+        without_filter = workflow.replace(
+            "          python3 scripts/filter_compile_database.py \\\n"
+            "            \"$KLOGG_BUILD_ROOT/compile_commands.json\" \"$KLOGG_WORKSPACE\" \\\n"
+            "            /tmp/cppcheck_files.nul /tmp/cc_src.json\n",
+            "          cp \"$KLOGG_BUILD_ROOT/compile_commands.json\" /tmp/cc_src.json\n",
+            1,
+        )
+        self.assertNotEqual(without_filter, workflow)
+        self.assertIn(message, MODULE.static_analysis_workflow_issues(without_filter))
 
     def test_static_analysis_changed_path_discovery_excludes_deleted_files(self):
         # A PR that deletes a src/ file must not feed the deleted path to

--- a/tests/scripts/test_python_baseline_contract.py
+++ b/tests/scripts/test_python_baseline_contract.py
@@ -7,6 +7,7 @@ import unittest
 
 ROOT = pathlib.Path(__file__).parents[2]
 LINT_WORKFLOW = ROOT / ".github" / "workflows" / "lint.yml"
+CI_QUALITY_RUNNER = ROOT / "scripts" / "run_ci_quality.py"
 PYTHON_BASELINE = "3.8"
 PEP585_BUILTINS = {"dict", "list", "set", "tuple"}
 UNSUPPORTED_STRING_METHODS = {"removeprefix", "removesuffix"}
@@ -42,9 +43,10 @@ class PythonBaselineContractTest(unittest.TestCase):
         workflow = LINT_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("actions/setup-python@", workflow)
         self.assertIn(f"python-version: '{PYTHON_BASELINE}'", workflow)
-        self.assertIn(
-            "python3 -m unittest discover -s tests/scripts -p 'test_*.py'", workflow
-        )
+        self.assertIn("python3 scripts/run_ci_quality.py", workflow)
+        runner = CI_QUALITY_RUNNER.read_text(encoding="utf-8")
+        for token in ("unittest", "discover", "tests/scripts", "test_*.py"):
+            self.assertIn(token, runner)
 
     def test_pep585_annotations_are_postponed_for_python_38(self):
         findings = []

--- a/tests/scripts/test_run_ci_quality.py
+++ b/tests/scripts/test_run_ci_quality.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+SCRIPT = ROOT / "scripts" / "run_ci_quality.py"
+SPEC = importlib.util.spec_from_file_location("run_ci_quality", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class Result:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class RunCiQualityTest(unittest.TestCase):
+    def test_commands_cover_every_fast_ci_quality_gate_in_order(self) -> None:
+        commands = MODULE.quality_commands(ROOT)
+        self.assertEqual(
+            commands,
+            [
+                [sys.executable, "scripts/lint_platform_fragile.py"],
+                [sys.executable, "scripts/lint_linux_package_runtime.py"],
+                [sys.executable, "scripts/lint_ci_quality.py"],
+                [sys.executable, "scripts/lint_translation_catalogs.py"],
+                [
+                    sys.executable,
+                    "-m",
+                    "unittest",
+                    "discover",
+                    "-s",
+                    "tests/scripts",
+                    "-p",
+                    "test_*.py",
+                ],
+            ],
+        )
+
+    def test_failure_is_fail_fast_and_propagated(self) -> None:
+        calls: list[list[str]] = []
+
+        def run(command: list[str], **_: object) -> Result:
+            calls.append(command)
+            return Result(returncode=7 if len(calls) == 2 else 0)
+
+        with mock.patch.object(MODULE.subprocess, "run", side_effect=run):
+            result = MODULE.run_quality_checks(ROOT)
+
+        self.assertEqual(result["returncode"], 7)
+        self.assertEqual(len(result["checks"]), 2)
+        self.assertEqual(calls, MODULE.quality_commands(ROOT)[:2])
+
+    def test_json_output_contains_repository_identity_and_durations(self) -> None:
+        completed = Result()
+        with mock.patch.object(
+            MODULE, "repository_identity", return_value=("a" * 40, True)
+        ), mock.patch.object(
+            MODULE.subprocess, "run", return_value=completed
+        ), mock.patch.object(
+            MODULE.time, "monotonic", side_effect=[1.0, 1.25] * 5
+        ), mock.patch.object(sys, "argv", [str(SCRIPT), "--json"]):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                returncode = MODULE.main()
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(returncode, 0)
+        self.assertEqual(payload["commit"], "a" * 40)
+        self.assertIs(payload["dirty"], True)
+        self.assertEqual(len(payload["checks"]), 5)
+        self.assertTrue(all(check["durationSeconds"] == 0.25 for check in payload["checks"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_sanitizer_configuration.py
+++ b/tests/scripts/test_sanitizer_configuration.py
@@ -1071,7 +1071,10 @@ class SanitizerConfigurationTest(unittest.TestCase):
             workflow,
         )
         self.assertIn("cache-from: type=gha,scope=klogg-qt5-tsan", workflow)
-        self.assertIn("cache-to: type=gha,mode=max,scope=klogg-qt5-tsan", workflow)
+        self.assertIn(
+            "cache-to: ${{ github.event_name == 'push' && matrix.config.cache_write && 'type=gha,mode=max,scope=klogg-qt5-tsan' || '' }}",
+            workflow,
+        )
 
     def test_linux_lsan_uses_complete_stacks_for_narrow_suppressions(self):
         workflow = CI_BUILD.read_text()

--- a/tests/scripts/test_setup_msvc_action.py
+++ b/tests/scripts/test_setup_msvc_action.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+CI_BUILD = ROOT / ".github" / "workflows" / "ci-build.yml"
+SETUP_MSVC = ROOT / ".github" / "actions" / "setup-msvc" / "action.yml"
+LINT = ROOT / "scripts" / "lint_ci_quality.py"
+LEGACY_ACTION = "ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756"
+
+
+class SetupMsvcActionContractTest(unittest.TestCase):
+    def test_ci_uses_the_local_node_free_msvc_setup(self) -> None:
+        workflow = CI_BUILD.read_text(encoding="utf-8")
+        self.assertNotIn(LEGACY_ACTION, workflow)
+        self.assertGreaterEqual(workflow.count("uses: ./.github/actions/setup-msvc"), 2)
+
+    def test_local_setup_exports_and_verifies_the_target_toolchain(self) -> None:
+        action = SETUP_MSVC.read_text(encoding="utf-8")
+        for marker in (
+            "vswhere.exe",
+            "Launch-VsDevShell.ps1",
+            '$developerShellArch = if ($target -eq "x64") { "amd64" }',
+            "GITHUB_ENV",
+            "/Bv /c",
+            "VSCMD_ARG_TGT_ARCH",
+        ):
+            self.assertIn(marker, action)
+
+    def test_lint_rejects_the_legacy_node20_action(self) -> None:
+        self.assertIn(LEGACY_ACTION, LINT.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_static_analysis_regressions.py
+++ b/tests/scripts/test_static_analysis_regressions.py
@@ -22,6 +22,7 @@ APP_MAIN = ROOT / "src" / "app" / "main.cpp"
 UNIT_TEST_MAIN = ROOT / "tests" / "unit" / "tests_main.cpp"
 UI_TEST_MAIN = ROOT / "tests" / "ui" / "qtests_main.cpp"
 ADB_TRACKER_MANAGER_TEST = ROOT / "tests" / "unit" / "adb_device_tracker_manager_test.cpp"
+PLATFORM_FILES_SOURCE = ROOT / "src" / "utils" / "src" / "platform_files.cpp"
 
 
 def function_body(source, signature):
@@ -52,6 +53,40 @@ def function_body(source, signature):
 
 
 class StaticAnalysisRegressionTest(unittest.TestCase):
+    def test_windows_file_identity_rejects_unrepresentable_qt_handles_before_narrowing(self):
+        source = PLATFORM_FILES_SOURCE.read_text()
+        file_identity = function_body(
+            source, "std::optional<FileIdentity> fileIdentity( const QFileDevice& file )"
+        )
+        windows_branch = file_identity.split("#if defined( Q_OS_WIN )", 1)[1].split(
+            "#else", 1
+        )[0]
+
+        handle_read = "const auto fileHandle = file.handle();"
+        invalid_guard = (
+            "if ( fileHandle < 0 || fileHandle > std::numeric_limits<int>::max() )"
+        )
+        descriptor_narrowing = "static_cast<int>( fileHandle )"
+        native_lookup = "_get_osfhandle( nativeDescriptor )"
+        for statement in (
+            handle_read,
+            invalid_guard,
+            descriptor_narrowing,
+            native_lookup,
+        ):
+            self.assertIn(statement, windows_branch)
+        self.assertLess(
+            windows_branch.index(handle_read), windows_branch.index(invalid_guard)
+        )
+        self.assertLess(
+            windows_branch.index(invalid_guard),
+            windows_branch.index(descriptor_narrowing),
+        )
+        self.assertLess(
+            windows_branch.index(descriptor_narrowing), windows_branch.index(native_lookup)
+        )
+        self.assertNotIn("static_cast<int>( file.handle() )", windows_branch)
+
     def test_reference_returning_adb_lookup_does_not_bind_a_temporary_string_key(self):
         source = ADB_TRACKER_MANAGER_TEST.read_text()
         lookup = function_body(source, "const DomainAdbDeviceInfo& deviceWithSerial(")

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -4062,30 +4062,37 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
     widget.selectResultRow( matchRowForFile( a ) );
     REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
     QTest::qWait( 200 );
+    auto* cachedAData = const_cast<AbstractLogData*>(
+        AbstractLogView::access_by<FolderViewTestAccess>::logData( widget.mainView() ) );
+    REQUIRE( cachedAData != nullptr );
 
     const LineNumber bRow = matchRowForFile( b );
     const LineNumber bLocalLine = widget.folderResults()->sourceForLine( bRow ).localLine;
     REQUIRE( bLocalLine.get() == static_cast<uint64_t>( bMatchLine ) );
 
     // Append to A on disk and IMMEDIATELY start B's open, then keep nudging A
-    // while B indexes, so at least one re-index of A completes inside B's
-    // pending window regardless of watcher latency (native watcher on
-    // Linux/macOS, 1s polling on Windows -- B's size keeps the window wide on
-    // native watchers; under 1s polling the clobber may not be exercised, but
-    // the healthy end state asserted below must hold either way).
+    // while B indexes. Deliver each change through the exact queued LogData slot
+    // used by FileWatcher so at least one A re-index completes inside B's pending
+    // window without depending on platform watcher latency.
     const auto appendLine = []( const QString& path ) {
         QFile f( path );
         REQUIRE( f.open( QIODevice::WriteOnly | QIODevice::Append ) );
         f.write( "nudge\n" );
         f.flush();
     };
+    const auto notifyChanged = []( AbstractLogData* data, const QString& path ) {
+        return QMetaObject::invokeMethod( data, "fileChangedOnDisk", Qt::QueuedConnection,
+                                          Q_ARG( QString, path ) );
+    };
     appendLine( a );
+    REQUIRE( notifyChanged( cachedAData, a ) );
     widget.selectResultRow( bRow );
     QElapsedTimer openBudget;
     openBudget.start();
     while ( widget.currentMainFilePath() != b && openBudget.elapsed() < 30000 ) {
         QTest::qWait( 100 );
         appendLine( a );
+        REQUIRE( notifyChanged( cachedAData, a ) );
     }
     REQUIRE( widget.currentMainFilePath() == b );
 
@@ -4114,9 +4121,8 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
 
     // B's follow data-flow must be bound (bindMainViewDataSignals at B's real
     // completion): enable follow through the same dispatch MainWindow uses,
-    // grow B on disk, and the view must track the tail -- mirrors the
-    // follow-tail test above (same FileWatcher seam, same 15s budget for the
-    // 1s polling watcher on Windows).
+    // grow B on disk, queue the same LogData slot FileWatcher calls, and require
+    // the view to track the new tail.
     static_cast<AbstractCrawlerWidget*>( &widget )->followSet( true );
     REQUIRE( waitFor( [ & ]() { return widget.mainView()->isFollowEnabled(); } ) );
     LineNumber topBefore = 0_lnum;
@@ -4135,6 +4141,10 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
         f.write( payload );
         f.flush();
     }
+    auto* mainData = const_cast<AbstractLogData*>(
+        AbstractLogView::access_by<FolderViewTestAccess>::logData( widget.mainView() ) );
+    REQUIRE( mainData != nullptr );
+    REQUIRE( notifyChanged( mainData, b ) );
     REQUIRE( waitFor( [ & ]() { return widget.mainView()->getTopLine() > topBefore; },
                       15000 ) );
 }

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include "capturestore.h"
+#include "platform/platform_files.h"
 #include "rollingfilemanager.h"
 
 class CaptureStoreTestAccess {
@@ -2463,6 +2464,33 @@ TEST_CASE( "CaptureStore removes a newly created Restore output after replay fai
     CHECK( QDir( rootPath )
                .entryList( { QStringLiteral( ".klogg-output-*" ) }, QDir::Files )
                .isEmpty() );
+}
+
+TEST_CASE( "RollingFileManager verifies a staged publication identity before binding",
+           "[rolling][identity]" )
+{
+    const auto rootPath = makeTestDir( "rolling_published_identity" );
+    const auto filePath = QDir( rootPath ).filePath( QStringLiteral( "output.log" ) );
+    QSaveFile staged( filePath );
+    REQUIRE( staged.open( QIODevice::WriteOnly ) );
+    REQUIRE( staged.write( QByteArrayLiteral( "published" ) ) > 0 );
+    const auto publishedIdentity = klogg::platform::fileIdentity( staged );
+    REQUIRE( publishedIdentity.has_value() );
+    REQUIRE( staged.commit() );
+
+    RollingFileManager exact( filePath, 0, 0 );
+    REQUIRE( exact.openExisting( publishedIdentity ) );
+    exact.close();
+
+    const auto movedPath = filePath + QStringLiteral( ".owned" );
+    REQUIRE( QFile::rename( filePath, movedPath ) );
+    QFile replacement( filePath );
+    REQUIRE( replacement.open( QIODevice::WriteOnly ) );
+    REQUIRE( replacement.write( QByteArrayLiteral( "replacement" ) ) > 0 );
+    replacement.close();
+
+    RollingFileManager replaced( filePath, 0, 0 );
+    CHECK_FALSE( replaced.openExisting( publishedIdentity ) );
 }
 
 TEST_CASE( "RollingFileManager resyncSize reads actual file size after direct writes" )


### PR DESCRIPTION
## Summary
- Preserve live-capture output identity across stop/cleanup and bind only the file that was actually published.
- Make PR, master, stable-release, and rolling continuous-release paths secret-neutral by default; unsigned macOS validation DMGs remain publishable without Apple credentials, while signed/notarized claims require complete evidence.
- Restore continuous prereleases as a trusted `workflow_run` publisher with candidate verification, rollback parking, cancellation recovery, stale-tip checks, and exact triggering-run artifact binding.
- Publish stable releases through a candidate tag and fail-closed promotion/rollback transaction, verify draft target commits without assuming a Git ref, and bind evidence level from downloaded receipts rather than unavailable dispatch metadata.
- Fix the PR #65 native tar round trip, preserve explicit-root archive layout, use fail-closed extraction for mobile artifacts, and bind published ADB/iOS source and package receipts.
- Stage Windows VC143 redistributables from the selected package architecture and fail before NSIS when any required runtime DLL cannot be copied.
- Simplify CI Build to immediate prerequisites and terminal gate jobs, run qualification for every master SHA, scope attestation permissions, stop PR BuildKit exports, designate bounded shared cache writers, and keep ccache generations bounded.
- Retain traced CodeQL C/C++ coverage while explicitly disabling the unsupported overlay experiment, and make cppcheck resolve relative compile-database entries through shared tooling.
- Expand local CI policy tests to cover event projections, DAG ancestry, cache writers, release master guards, publication transactions, archive safety, receipt identity, and Windows handle narrowing.

## Background
- Introduced by: The CI and live-capture changes leading into PR #65 exposed different PR/master event paths, removed the previous continuous publisher, and made the strict extractor reject normal `tar -C <root> .` root metadata.
- Use case: A PR must exercise the same secret-neutral validation that master and release workflows consume, while stable and continuous packages remain coherent and recoverable without Apple secrets.
- How to reproduce: Run the original PR #65 package jobs to hit `RuntimeError: archive member is empty: .`; inspect the successful CodeQL overlay annotation; or compare the removed rolling prerelease path and redundant CI dependency graph.
- Root cause: Required CI, publication channel, and signing evidence were coupled; direct `needs` mirrored transitive ancestry; cache writers used isolated PR refs; and producer/consumer contracts were tested as strings instead of real round trips.
- How to fix: Separate validation from optional signed qualification, move publication into transactional publishers, bind every artifact to run/SHA/source receipts, enforce safe extraction and semantic lint invariants, and keep CI dependencies/cache writers minimal.

## Tests
- `python3 scripts/run_ci_quality.py` — 602 script/lint contract tests passed.
- `actionlint -shellcheck= .github/workflows/*.yml` — all workflow YAML and expressions passed.
- `cmake --build build_root -j$(sysctl -n hw.ncpu)` — normal macOS build passed.
- `ctest --test-dir build_root --build-config RelWithDebInfo --output-on-failure` — 27/27 passed.
- Existing macOS ASan+UBSan CTest executables — 27/27 passed; the full sanitizer build still has an unrelated benchmark-only `PersistentInfo::ForcePortable` link failure.
- Fresh macOS TSan suite — all unit, UI, and Vectorscan tests passed.
- `python3 scripts/lint_header_self_contained.py --base origin/master --build-dir build_root` — passed.
- Changed-line clang-tidy against the current compile database — passed.
- Python 3.8 grammar checks and `git diff --check` — passed.
- Local clean-environment deployed `.app -v` smoke passed. A fully CI-equivalent mounted-DMG smoke remains unavailable with Homebrew's split Qt formula layout; package/publication contract surrogates pass.

The 30-minute CI Build target remains a measured objective. It should be evaluated from the first cold cache seed plus at least three warm master runs rather than claimed from this PR alone. No Actions cache, release, or tag was deleted during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation and release qualification modes for package builds.
  * Added unsigned package verification, shared MSVC setup, and consolidated CI quality reporting.
  * Added automated rolling continuous releases from successful master builds.

* **Bug Fixes**
  * Prevented opening replaced or unexpected log files.
  * Ensured iOS cleanup acknowledgements occur only after cleanup completes.

* **Release Process**
  * Added evidence-based signed release qualification and rollback protection.

* **Security & Reliability**
  * Updated and pinned build, analysis, and artifact tooling.
  * Strengthened archive validation, static analysis, caching, and credential checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

