### PR TITLE
Unify release publisher names and harden release transactions

### DIFF
--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -1,4 +1,4 @@
-name: "Publish Continuous Release"
+name: "Publish Release (Continuous)"
 
 on:
   workflow_run:

--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -530,6 +530,20 @@ jobs:
               1) ;;
               *) exit 1 ;;
             esac
+          else
+            # A cancelled create step can leave a draft candidate without an
+            # emitted id; reconcile it by the deterministic tag, drafts only.
+            orphan_status=0
+            gh_api_optional_scalar orphan_id "/repos/${repo}/releases/tags/${candidate_tag}" .id \
+              || orphan_status=$?
+            case "$orphan_status" in
+              0)
+                test "$(gh api "/repos/${repo}/releases/${orphan_id}" --jq '.draft')" = true
+                gh api -X DELETE "/repos/${repo}/releases/${orphan_id}" >/dev/null
+                ;;
+              1) ;;
+              *) exit 1 ;;
+            esac
           fi
           delete_ref_if_present "$candidate_tag"
           if [ "$published_tag" = continuous ]; then

--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -183,6 +183,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
 
           delete_ref_if_present() {
@@ -267,43 +268,44 @@ jobs:
           parked_sha="$(gh api "/repos/${repo}/git/ref/tags/${parked_tag}" --jq '.object.sha')"
           verify_release "$parked_id" "$parked_tag" true
 
-          lookup_error="$(mktemp)"
-          if live_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
-            if verify_release "$live_id" continuous false; then
-              echo "Remove stale parked continuous release ${parked_tag}; live continuous release is coherent"
-              gh api -X DELETE "/repos/${repo}/releases/${parked_id}" >/dev/null
-              delete_ref_if_present "$parked_tag"
-            else
-              restore_parked_release "$live_id"
-            fi
-          elif grep -Eq '404|Not Found' "$lookup_error"; then
-            restore_parked_release
-          else
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
+          lookup_status=0
+          gh_api_optional_scalar live_id "/repos/${repo}/releases/tags/continuous" .id \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0)
+              if verify_release "$live_id" continuous false; then
+                echo "Remove stale parked continuous release ${parked_tag}; live continuous release is coherent"
+                gh api -X DELETE "/repos/${repo}/releases/${parked_id}" >/dev/null
+                delete_ref_if_present "$parked_tag"
+              else
+                restore_parked_release "$live_id"
+              fi
+              ;;
+            1) restore_parked_release ;;
+            *) exit 1 ;;
+          esac
 
       - name: Clean stale continuous candidate draft
         shell: bash
         run: |
           set -euo pipefail
+          source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
           candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
           release_id=""
-          lookup_error="$(mktemp)"
-          if release_id="$(gh api "/repos/${repo}/releases/tags/${candidate_tag}" --jq '.id' 2>"$lookup_error")"; then
-            test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = true
-          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
+          lookup_status=0
+          gh_api_optional_scalar release_id "/repos/${repo}/releases/tags/${candidate_tag}" .id \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0) test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = true ;;
+            1) ;;
+            *) exit 1 ;;
+          esac
 
           lookup_error="$(mktemp)"
           if gh api "/repos/${repo}/git/ref/tags/${candidate_tag}" >/dev/null 2>"$lookup_error"; then
             gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null
-          elif [ -n "$release_id" ] || ! grep -Eq '404|Not Found' "$lookup_error"; then
+          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
             cat "$lookup_error"
             exit 1
           fi
@@ -375,20 +377,21 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
           backup_tag="continuous-rollback-${KLOGG_CI_RUN_ID}"
-          lookup_error="$(mktemp)"
-          if release_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
-            :
-          elif grep -Eq '404|Not Found' "$lookup_error"; then
-            echo "No existing continuous release to park"
-            rm -f "$lookup_error"
-            exit 0
-          else
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
+          release_id=""
+          lookup_status=0
+          gh_api_optional_scalar release_id "/repos/${repo}/releases/tags/continuous" .id \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0) ;;
+            1)
+              echo "No existing continuous release to park"
+              exit 0
+              ;;
+            *) exit 1 ;;
+          esac
           test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')" = false
           test "$(gh api "/repos/${repo}/releases/${release_id}" --jq '.prerelease')" = true
           old_sha="$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')"
@@ -495,6 +498,7 @@ jobs:
           CANDIDATE_RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
         run: |
           set -euo pipefail
+          source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
           candidate_id="${CANDIDATE_RELEASE_ID:-}"
           candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
@@ -518,14 +522,14 @@ jobs:
 
           published_tag=""
           if [ -n "$candidate_id" ]; then
-            lookup_error="$(mktemp)"
-            if published_tag="$(gh api "/repos/${repo}/releases/${candidate_id}" --jq '.tag_name' 2>"$lookup_error")"; then
-              gh api -X DELETE "/repos/${repo}/releases/${candidate_id}" >/dev/null
-            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-              cat "$lookup_error"
-              exit 1
-            fi
-            rm -f "$lookup_error"
+            lookup_status=0
+            gh_api_optional_scalar published_tag "/repos/${repo}/releases/${candidate_id}" .tag_name \
+              || lookup_status=$?
+            case "$lookup_status" in
+              0) gh api -X DELETE "/repos/${repo}/releases/${candidate_id}" >/dev/null ;;
+              1) ;;
+              *) exit 1 ;;
+            esac
           fi
           delete_ref_if_present "$candidate_tag"
           if [ "$published_tag" = continuous ]; then
@@ -538,19 +542,21 @@ jobs:
           test -n "$previous_sha" && test -n "$backup_tag"
 
           live_id=""
-          lookup_error="$(mktemp)"
-          if live_id="$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id' 2>"$lookup_error")"; then
-            if [ "$live_id" = "$previous_id" ]; then
-              test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$previous_sha"
-              delete_ref_if_present "$backup_tag"
-              exit 0
-            fi
-            gh api -X DELETE "/repos/${repo}/releases/${live_id}" >/dev/null
-          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
+          lookup_status=0
+          gh_api_optional_scalar live_id "/repos/${repo}/releases/tags/continuous" .id \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0)
+              if [ "$live_id" = "$previous_id" ]; then
+                test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$previous_sha"
+                delete_ref_if_present "$backup_tag"
+                exit 0
+              fi
+              gh api -X DELETE "/repos/${repo}/releases/${live_id}" >/dev/null
+              ;;
+            1) ;;
+            *) exit 1 ;;
+          esac
 
           delete_ref_if_present continuous
           test "$(gh api "/repos/${repo}/releases/${previous_id}" --jq '.tag_name')" = "$backup_tag"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,4 +1,4 @@
-name: "Make CI Release"
+name: "Publish Release (Stable)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -452,24 +452,27 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
+        source scripts/github_api_helpers.sh
         repo="${GITHUB_REPOSITORY}"
         final_tag="v${KLOGG_VERSION}"
         candidate_tag="${final_tag}-candidate"
         for tag in "$candidate_tag" "$final_tag"; do
           release_id=""
-          lookup_error="$(mktemp)"
-          if release_id="$(gh api "/repos/${repo}/releases/tags/${tag}" --jq '.id' 2>"$lookup_error")"; then
-            draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
-            test "$draft" = true || {
-              echo "::error::refusing to replace existing published release ${tag}"
-              exit 1
-            }
-            gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
-          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-            cat "$lookup_error"
-            exit 1
-          fi
-          rm -f "$lookup_error"
+          lookup_status=0
+          gh_api_optional_scalar release_id "/repos/${repo}/releases/tags/${tag}" .id \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0)
+              draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
+              test "$draft" = true || {
+                echo "::error::refusing to replace existing published release ${tag}"
+                exit 1
+              }
+              gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
+              ;;
+            1) ;;
+            *) exit 1 ;;
+          esac
 
           ref_error="$(mktemp)"
           if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$ref_error"; then

--- a/scripts/github_api_helpers.sh
+++ b/scripts/github_api_helpers.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Resolve an optional scalar without allowing a failed GitHub API response body
+# to become a valid value. Returns 0 when found, 1 when absent, and 2 for an
+# unexpected API failure. The destination is empty for both failure states.
+gh_api_optional_scalar() {
+  if [ "$#" -ne 3 ]; then
+    printf 'gh_api_optional_scalar requires: destination endpoint jq-filter\n' >&2
+    return 2
+  fi
+
+  local destination_name="$1"
+  local endpoint="$2"
+  local jq_filter="$3"
+  local lookup_error
+  local lookup_output=""
+  local lookup_status=0
+
+  if ! [[ "$destination_name" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    printf 'invalid gh_api_optional_scalar destination: %s\n' "$destination_name" >&2
+    return 2
+  fi
+  printf -v "$destination_name" '%s' ""
+
+  lookup_error="$(mktemp)"
+  lookup_output="$(gh api "$endpoint" --jq "$jq_filter" 2>"$lookup_error")" \
+    || lookup_status=$?
+  if [ "$lookup_status" -eq 0 ]; then
+    rm -f "$lookup_error"
+    printf -v "$destination_name" '%s' "$lookup_output"
+    return 0
+  fi
+  if grep -Eq '404|Not Found' "$lookup_error"; then
+    rm -f "$lookup_error"
+    return 1
+  fi
+
+  cat "$lookup_error" >&2
+  rm -f "$lookup_error"
+  return 2
+}

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -630,6 +630,8 @@ def ci_build_workflow_issues(text: str) -> list[str]:
         for line in push_section.splitlines()
     ):
         issues.append("master pushes must not skip CI Build by path")
+    if re.search(r"(?m)^\s*push:\s*\{[^}]*paths-ignore", trigger_prefix):
+        issues.append("master pushes must not skip CI Build by path")
     needs = workflow_job_needs(text)
     missing_jobs = CI_BUILD_REQUIRED_JOBS - set(needs)
     unexpected_jobs = set(needs) - CI_BUILD_REQUIRED_JOBS
@@ -1933,16 +1935,23 @@ def stable_release_workflow_issues(text: str) -> list[str]:
         or "[[ \"$requested_run_id\" =~ ^[0-9]+$ ]]" not in text
     ):
         issues.append("stable release run ID must use validated environment input")
-    if '.inputs["qualification-mode"]' in text:
+    if any(
+        re.search(r"\.inputs\b", jq_filter)
+        for jq_filter in re.findall(r"--jq\s+(?:'[^']*'|\"[^\"]*\")", text)
+    ):
         issues.append("stable release evidence must come from downloaded receipts, not run API inputs")
     draft_verification = text.partition(
         "- name: Verify stable source publication after upload"
     )[2].partition("- name: Recheck master tip before stable promotion")[0]
-    if (
-        ".target_commitish" not in draft_verification
-        or "/git/ref/tags/" in draft_verification
-    ):
+    if "/git/ref/tags/" in draft_verification:
         issues.append("stable draft verification must not require an unpublished Git tag")
+    draft_target_jq = re.search(r"--jq\s+'[^']*\.target_commitish", draft_verification)
+    draft_target_test = re.search(
+        r'test\s+"\$\{[A-Za-z_][A-Za-z0-9_]*\}"\s*=\s*"\$\{KLOGG_SOURCE_COMMIT\}"',
+        draft_verification,
+    )
+    if draft_target_jq is None or draft_target_test is None:
+        issues.append("stable draft verification must compare the candidate target commit")
     if (
         "rollback_stable_promotion" not in text
         or "trap rollback_stable_promotion ERR" not in text
@@ -1978,6 +1987,14 @@ def continuous_release_workflow_issues(text: str) -> list[str]:
         issues.append("continuous release transaction must not be canceled in progress")
     if "${{ failure() || cancelled() }}" not in text:
         issues.append("continuous release rollback must cover failure and cancellation")
+    rollback = text.partition("- name: Roll back failed continuous promotion")[2]
+    if (
+        "releases/tags/${candidate_tag}" not in rollback
+        or "--jq '.draft'" not in rollback
+    ):
+        issues.append(
+            "continuous rollback must reconcile a candidate created without an emitted id"
+        )
     return issues
 
 

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -1910,8 +1910,20 @@ def cppcheck_suppression_issues(text: str) -> list[str]:
     return issues
 
 
+def workflow_display_name(text: str) -> str | None:
+    lines = text.splitlines()
+    for offset, line in enumerate(lines):
+        entry = KEY_VALUE_RE.match(line)
+        if entry is None or entry.group("indent") or entry.group("key") != "name":
+            continue
+        return yaml_value(lines, offset, entry.group("value"), 0)
+    return None
+
+
 def stable_release_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
+    if workflow_display_name(text) != "Publish Release (Stable)":
+        issues.append('stable release workflow must be named "Publish Release (Stable)"')
     commands = shell_commands(text)
     master_guard = 'test "${GITHUB_REF}" = "refs/heads/master" || {'
     if commands.count(master_guard) != 1:
@@ -1941,6 +1953,10 @@ def stable_release_workflow_issues(text: str) -> list[str]:
 
 def continuous_release_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
+    if workflow_display_name(text) != "Publish Release (Continuous)":
+        issues.append(
+            'continuous release workflow must be named "Publish Release (Continuous)"'
+        )
     blocks = workflow_job_blocks(text)
     select = blocks.get("select")
     publish = blocks.get("publish")

--- a/tests/scripts/test_github_api_helpers.py
+++ b/tests/scripts/test_github_api_helpers.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+HELPERS = ROOT / "scripts" / "github_api_helpers.sh"
+CONTINUOUS_WORKFLOW = ROOT / ".github" / "workflows" / "ci-continuous.yml"
+STABLE_WORKFLOW = ROOT / ".github" / "workflows" / "ci-release.yml"
+
+
+def workflow_section(path: pathlib.Path, start: str, end: str) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.split(start, 1)[1].split(end, 1)[0]
+
+
+@unittest.skipUnless(shutil.which("bash"), "bash is required for GitHub API helper tests")
+class GitHubApiHelpersTest(unittest.TestCase):
+    def run_lookup(self, mode: str, initial: str = "sentinel") -> subprocess.CompletedProcess:
+        with tempfile.TemporaryDirectory() as directory:
+            bin_dir = pathlib.Path(directory)
+            fake_gh = bin_dir / "gh"
+            fake_gh.write_text(
+                """#!/usr/bin/env bash
+case "$FAKE_GH_MODE" in
+  success)
+    printf '12345\\n'
+    exit 0
+    ;;
+  missing)
+    printf '{"message":"Not Found","status":404}\\n'
+    printf 'gh: Not Found (HTTP 404)\\n' >&2
+    exit 1
+    ;;
+  error)
+    printf '{"message":"Server Error","status":500}\\n'
+    printf 'gh: Server Error (HTTP 500)\\n' >&2
+    exit 1
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = os.environ.copy()
+            env["FAKE_GH_MODE"] = mode
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            return subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        f'source "{HELPERS}"\n'
+                        f'value="{initial}"\n'
+                        "set +e\n"
+                        "gh_api_optional_scalar value /repos/example/releases/tags/test .id\n"
+                        "status=$?\n"
+                        "printf 'status=%s\\nvalue=<%s>\\n' \"$status\" \"$value\"\n"
+                    ),
+                ],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+    def test_success_assigns_the_requested_scalar(self):
+        result = self.run_lookup("success")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "status=0\nvalue=<12345>\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_not_found_discards_error_json_and_clears_destination(self):
+        result = self.run_lookup("missing")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "status=1\nvalue=<>\n")
+        self.assertEqual(result.stderr, "")
+
+    def test_non_404_failure_clears_destination_and_reports_error(self):
+        result = self.run_lookup("error")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "status=2\nvalue=<>\n")
+        self.assertIn("gh: Server Error (HTTP 500)", result.stderr)
+
+    def test_release_cleanup_uses_the_optional_scalar_lookup(self):
+        continuous = workflow_section(
+            CONTINUOUS_WORKFLOW,
+            "      - name: Clean stale continuous candidate draft",
+            "      - name: Create continuous candidate draft",
+        )
+        stable = workflow_section(
+            STABLE_WORKFLOW,
+            "    - name: Clean stale stable draft",
+            "    - name: Recheck master tip before stable draft creation",
+        )
+        for name, cleanup in (("continuous", continuous), ("stable", stable)):
+            with self.subTest(workflow=name):
+                self.assertIn("source scripts/github_api_helpers.sh", cleanup)
+                self.assertIn("gh_api_optional_scalar release_id", cleanup)
+                self.assertNotIn('release_id="$(gh api ', cleanup)
+
+        self.assertNotIn('elif [ -n "$release_id" ] ||', continuous)
+        self.assertIn(
+            'if [ "$tag" = "$final_tag" ] && [ -z "$release_id" ]',
+            stable,
+        )
+
+    def test_all_optional_release_scalar_lookups_use_the_shared_helper(self):
+        unsafe_lookup = re.compile(
+            r'if\s+[a-zA-Z_][a-zA-Z0-9_]*="\$\(gh api [^\n]+2>"\$[^"\n]+"\)"'
+        )
+        for path in (CONTINUOUS_WORKFLOW, STABLE_WORKFLOW):
+            with self.subTest(workflow=path.name):
+                workflow = path.read_text(encoding="utf-8")
+                self.assertNotRegex(workflow, unsafe_lookup)
+
+        continuous = CONTINUOUS_WORKFLOW.read_text(encoding="utf-8")
+        for destination in ("live_id", "release_id", "published_tag"):
+            self.assertIn(f"gh_api_optional_scalar {destination}", continuous)
+        self.assertGreaterEqual(
+            continuous.count("source scripts/github_api_helpers.sh"),
+            4,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -809,6 +809,16 @@ jobs:
     def test_stable_release_master_guard_and_promotion_are_fail_closed(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-release.yml").read_text()
         self.assertEqual(MODULE.stable_release_workflow_issues(workflow), [])
+        misnamed = workflow.replace(
+            'name: "Publish Release (Stable)"',
+            'name: "Make CI Release"',
+            1,
+        )
+        self.assertNotEqual(misnamed, workflow)
+        self.assertIn(
+            'stable release workflow must be named "Publish Release (Stable)"',
+            MODULE.stable_release_workflow_issues(misnamed),
+        )
         bypassed = workflow.replace(
             '        test "${GITHUB_REF}" = "refs/heads/master" || {',
             '        true || test "${GITHUB_REF}" = "refs/heads/master" || {',
@@ -846,6 +856,16 @@ jobs:
     def test_continuous_release_publish_requires_trusted_selection(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-continuous.yml").read_text()
         self.assertEqual(MODULE.continuous_release_workflow_issues(workflow), [])
+        misnamed = workflow.replace(
+            'name: "Publish Release (Continuous)"',
+            'name: "Publish Continuous Release"',
+            1,
+        )
+        self.assertNotEqual(misnamed, workflow)
+        self.assertIn(
+            'continuous release workflow must be named "Publish Release (Continuous)"',
+            MODULE.continuous_release_workflow_issues(misnamed),
+        )
         bypassed = workflow.replace(
             "    if: ${{ needs.select.outputs.should-publish == 'true' }}",
             "    if: always()",

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -285,6 +285,16 @@ jobs:
             "master pushes must not skip CI Build by path",
             MODULE.ci_build_workflow_issues(mutated),
         )
+        flow_mutated = workflow.replace(
+            "  push:\n    branches: [ master ]\n",
+            "  push: { branches: [ master ], paths-ignore: [README.md] }\n",
+            1,
+        )
+        self.assertNotEqual(flow_mutated, workflow)
+        self.assertIn(
+            "master pushes must not skip CI Build by path",
+            MODULE.ci_build_workflow_issues(flow_mutated),
+        )
 
     def test_ci_build_uses_the_optimized_prefetch_and_native_build_dag(self):
         workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
@@ -840,10 +850,35 @@ jobs:
             "stable release evidence must come from downloaded receipts, not run API inputs",
             MODULE.stable_release_workflow_issues(run_api_inputs),
         )
-        draft_tag_lookup = workflow.replace(".target_commitish", ".tag_name", 1)
+        run_api_inputs_alias = workflow.replace(
+            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n',
+            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n'
+            '        run_qualification="$(gh api "$run_api" --jq \'.inputs | .["qualification-mode"] // empty\')"\n',
+            1,
+        )
+        self.assertNotEqual(run_api_inputs_alias, workflow)
+        self.assertIn(
+            "stable release evidence must come from downloaded receipts, not run API inputs",
+            MODULE.stable_release_workflow_issues(run_api_inputs_alias),
+        )
+        draft_target_swap = workflow.replace(
+            "--jq '.target_commitish'", "--jq '.tag_name'", 1
+        )
+        self.assertNotEqual(draft_target_swap, workflow)
+        self.assertIn(
+            "stable draft verification must compare the candidate target commit",
+            MODULE.stable_release_workflow_issues(draft_target_swap),
+        )
+        draft_ref_lookup = workflow.replace(
+            '        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq \'.target_commitish\')"',
+            '        ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${KLOGG_VERSION}-candidate" --jq \'.object.sha\')"\n'
+            '        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq \'.target_commitish\')"',
+            1,
+        )
+        self.assertNotEqual(draft_ref_lookup, workflow)
         self.assertIn(
             "stable draft verification must not require an unpublished Git tag",
-            MODULE.stable_release_workflow_issues(draft_tag_lookup),
+            MODULE.stable_release_workflow_issues(draft_ref_lookup),
         )
         without_rollback = workflow.replace(
             "        trap rollback_stable_promotion ERR\n", "", 1
@@ -875,6 +910,26 @@ jobs:
         self.assertIn(
             "continuous release publication must require the verified selection output",
             MODULE.continuous_release_workflow_issues(bypassed),
+        )
+        unreconciled_candidate = workflow.replace(
+            'gh_api_optional_scalar orphan_id "/repos/${repo}/releases/tags/${candidate_tag}" .id',
+            'gh_api_optional_scalar orphan_id "/repos/${repo}/releases/${candidate_id}" .id',
+            1,
+        )
+        self.assertNotEqual(unreconciled_candidate, workflow)
+        self.assertIn(
+            "continuous rollback must reconcile a candidate created without an emitted id",
+            MODULE.continuous_release_workflow_issues(unreconciled_candidate),
+        )
+        unguarded_draft_deletion = workflow.replace(
+            '--jq \'.draft\')" = true\n                gh api -X DELETE "/repos/${repo}/releases/${orphan_id}"',
+            'gh api -X DELETE "/repos/${repo}/releases/${orphan_id}"',
+            1,
+        )
+        self.assertNotEqual(unguarded_draft_deletion, workflow)
+        self.assertIn(
+            "continuous rollback must reconcile a candidate created without an emitted id",
+            MODULE.continuous_release_workflow_issues(unguarded_draft_deletion),
         )
 
     def test_publication_runs_outside_the_required_ci_workflow(self):


### PR DESCRIPTION
## Summary
- Unify the two release publishers under one naming scheme: `Publish Release (Continuous)` and `Publish Release (Stable)`, so the Actions list presents them as two channels of the same operation.
- Fix the continuous-release publisher failure from run 33346658323: `gh api` exits nonzero on 404 but leaves the error JSON on stdout, so an optional release lookup polluted `release_id` and a perfectly absent candidate was treated as a corrupt transaction.
- Route all six optional release/tag lookups in both publishers through a shared `gh_api_optional_scalar` helper with tri-state semantics (found / absent / hard error), and eliminate the same latent defect in the stable workflow where leaked JSON would bypass the orphan-stable-tag guard and delete the tag.
- Reconcile a candidate created without an emitted id during continuous rollback: look it up by its deterministic tag and delete it only after confirming it is a draft.
- Harden three bypassable release policy lint checks: flow-style `push: { paths-ignore: ... }` triggers, any `gh api --jq` read of `.inputs` regardless of spelling, and semantic verification that the stable draft target commit is fetched and compared.

## Background
- Introduced by: PR #65's transactional publishers were the first code to run this lookup pattern against the live API; every earlier verification was static.
- Use case: Every master push runs the continuous publisher; the first post-merge run failed before creating its candidate because normal resource absence looked like corruption.
- How to reproduce: Run the continuous publisher for a master commit with no prior `continuous-candidate-*` release and observe `gh: Not Found (HTTP 404)` failing the cleanup step (run 33346658323).
- Root cause: Optional lookups assigned `gh api` stdout directly under `set -e`, so a 404 body became a valid-looking value; three lint checks matched single spellings or mere text presence and could be bypassed without failing policy.
- How to fix: Centralize optional lookups in `scripts/github_api_helpers.sh`, branch on the tri-state result, add the tag-based draft-only reconciliation fallback, and upgrade the lint checks to semantic detection with mutation tests for each bypass.

## Tests
- `python3 tests/scripts/test_github_api_helpers.py` — fake-`gh` coverage for success, 404 JSON stdout + 404 stderr, 500 hard error, helper adoption in both cleanup paths, retained orphan-stable-tag guard, and removal of the raw assignment pattern.
- `tests/scripts/test_lint_ci_quality.py` — new mutations for flow-style push triggers, jq-aliased `.inputs` reads, draft target swap, ref-lookup insertion in draft verification, orphan fallback removal, and unguarded draft deletion; positive workflow cases stay clean.
- `python3 scripts/run_ci_quality.py` — 607 tests passed.
- `actionlint -shellcheck=` on ci-continuous, ci-release, and ci-build — passed.
- `bash -n scripts/github_api_helpers.sh` — passed.
- Not run: a live continuous publication (requires a master push); the fake-`gh` behavioral tests stand in for the API interaction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved continuous and stable release publishing workflows with safer cleanup and rollback handling.
  * Orphaned draft releases are now reconciled or removed instead of causing unnecessary failures.
  * Release workflows now have clearer names for easier identification.

* **Quality Improvements**
  * Expanded validation to detect unsafe workflow configurations and enforce required release safeguards.
  * Added automated coverage for API lookups, cleanup behavior, rollback handling, and workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->