### PR TITLE
Harden release publishing and live log reliability

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,8 +1,0 @@
-# CodeQL analyzes first-party code only. `cpm_cache/` is the CPM source cache
-# (CPM_SOURCE_CACHE in CI) holding vendored third-party checkouts materialized
-# at configure time; findings there belong to the upstream projects, not this
-# repository's alert backlog. Keep this exclusion in sync with
-# scripts/lint_ci_quality.py, which enforces that the CodeQL workflow
-# references this file.
-paths-ignore:
-  - cpm_cache

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,8 @@
+# CodeQL analyzes first-party code only. `cpm_cache/` is the CPM source cache
+# (CPM_SOURCE_CACHE in CI) holding vendored third-party checkouts materialized
+# at configure time; findings there belong to the upstream projects, not this
+# repository's alert backlog. Keep this exclusion in sync with
+# scripts/lint_ci_quality.py, which enforces that the CodeQL workflow
+# references this file.
+paths-ignore:
+  - cpm_cache

--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -62,6 +62,15 @@ jobs:
       KLOGG_CI_RUN_ID: ${{ github.event.workflow_run.id }}
       KLOGG_CI_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
       KLOGG_EVIDENCE_LEVEL: validation
+    # GitHub's workflow-persistence protection refuses to let the Actions app
+    # token (github.token) create or update a release whose target commit adds
+    # or changes .github/workflows/** files; such calls fail with
+    # "Resource not accessible by integration" (HTTP 403, run 33428615996).
+    # Continuous publications routinely target workflow-modifying commits, so
+    # every step that PATCHes a release (recover/park/promote/rollback) binds
+    # GITHUB_TOKEN to the KLOGG_GITHUB_TOKEN PAT provisioned with repo +
+    # workflow scopes. Read-only and draft-creation steps keep github.token:
+    # draft creation defers tag creation to promotion, which uses the PAT.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -181,8 +190,12 @@ jobs:
 
       - name: Recover interrupted continuous transaction
         shell: bash
+        env:
+          # Restores a parked release via PATCH: requires the PAT (see above)
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
           source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
 
@@ -375,8 +388,12 @@ jobs:
 
       - name: Park existing continuous release for rollback
         shell: bash
+        env:
+          # Renames the live release onto the backup tag via PATCH: requires the PAT (see above)
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
           source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
           backup_tag="continuous-rollback-${KLOGG_CI_RUN_ID}"
@@ -429,9 +446,12 @@ jobs:
       - name: Promote verified continuous candidate
         shell: bash
         env:
+          # Publishing the candidate creates the continuous tag via PATCH: requires the PAT (see above)
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
           RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
         run: |
           set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
           repo="$GITHUB_REPOSITORY"
           candidate_tag="continuous-candidate-${KLOGG_CI_RUN_ID}"
           test -n "$RELEASE_ID"
@@ -495,9 +515,12 @@ jobs:
         if: ${{ failure() || cancelled() }}
         shell: bash
         env:
+          # Restores the parked release via PATCH on the restore path: requires the PAT (see above)
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
           CANDIDATE_RELEASE_ID: ${{ steps.candidate_release.outputs.id }}
         run: |
           set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
           source scripts/github_api_helpers.sh
           repo="$GITHUB_REPOSITORY"
           candidate_id="${CANDIDATE_RELEASE_ID:-}"

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -612,10 +612,19 @@ jobs:
       if: env.GITHUB_TOKEN != ''
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        # Publishing the candidate creates the final tag via PATCH. GitHub's
+        # workflow-persistence protection requires workflow-modification
+        # authorization for release mutations whose target commit changes
+        # .github/workflows/** files — an authorization the Actions app token
+        # can never hold (HTTP 403 "Resource not accessible by integration").
+        # The draft creation above is safe with github.token because a draft
+        # defers tag creation to this step. KLOGG_GITHUB_TOKEN must carry
+        # repo + workflow scopes.
+        GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
         RELEASE_ID: ${{ steps.create_release.outputs.id }}
       run: |
         set -euo pipefail
+        test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
         repo="$GITHUB_REPOSITORY"
         final_tag="v${KLOGG_VERSION}"
         candidate_tag="${final_tag}-candidate"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,15 +39,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-        with:
-          languages: c-cpp
-          build-mode: manual
-          # Exclude vendored third-party sources fetched into cpm_cache/ at
-          # configure time; only first-party code produces repo alerts.
-          config-file: ./.github/codeql-config.yml
-
       - uses: ./.github/actions/agent-setup
 
       - name: Install Linux deps
@@ -72,6 +63,23 @@ jobs:
             -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" \
             -DFETCHCONTENT_FULLY_DISCONNECTED=ON \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+
+      - name: Prebuild vendored dependencies outside CodeQL tracing
+        run: cmake --build build -t klogg_codeql_thirdparty
+
+      - name: Verify traced build contains only first-party work
+        run: |
+          cmake --build build -t klogg -- -n > /tmp/codeql-traced-plan.txt
+          if grep -E 'cpm_cache|_deps|3rdparty/CMakeFiles' /tmp/codeql-traced-plan.txt; then
+            echo "::error::vendored compile work remains after CodeQL dependency prebuild"
+            exit 1
+          fi
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: c-cpp
+          build-mode: manual
 
       - name: Build traced application
         run: cmake --build build -t klogg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           languages: c-cpp
           build-mode: manual
+          # Exclude vendored third-party sources fetched into cpm_cache/ at
+          # configure time; only first-party code produces repo alerts.
+          config-file: ./.github/codeql-config.yml
 
       - uses: ./.github/actions/agent-setup
 

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -822,3 +822,32 @@ foreach(target ${klogg_cpm_targets})
     set_property(TARGET ${target} PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${${target}_include_dirs})
   endif()
 endforeach()
+
+# CodeQL's paths-ignore does not exclude C/C++ translation units observed by a
+# manual traced build. This target lets the workflow compile every vendored
+# library before extractor initialization; the subsequent klogg build then
+# traces only first-party application and generated Qt translation units.
+add_custom_target(klogg_codeql_thirdparty)
+set(
+  klogg_codeql_thirdparty_targets
+  simdutf
+  roaring
+  libuchardet
+  streamvbyte
+  klogg_karchive
+  kdsingleapp
+  xxhash
+  whereami
+  kdtoolbox
+  efsw
+  tbb
+  tbbmalloc
+  mimalloc-static
+  maddy
+  FastPFor
+)
+foreach(target IN LISTS klogg_codeql_thirdparty_targets)
+  if(TARGET ${target})
+    add_dependencies(klogg_codeql_thirdparty ${target})
+  endif()
+endforeach()

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -1519,6 +1519,11 @@ def codeql_workflow_issues(text: str) -> list[str]:
     if not has_application_build:
         issues.append("CodeQL manual build must trace the klogg application target")
 
+    if "config-file: ./.github/codeql-config.yml" not in text:
+        issues.append(
+            "codeql init must reference .github/codeql-config.yml so vendored"
+            " CPM sources under cpm_cache/ never produce repo alerts"
+        )
 
     return issues
 
@@ -2100,6 +2105,22 @@ def check_repo(root: Path) -> list[str]:
         f".github/workflows/codeql-analysis.yml: {issue}"
         for issue in codeql_workflow_issues(codeql_text)
     )
+    codeql_config_path = root / ".github" / "codeql-config.yml"
+    if codeql_config_path.is_file():
+        codeql_config_text = codeql_config_path.read_text()
+        if (
+            "paths-ignore:" not in codeql_config_text
+            or re.search(r"^\s*-\s+cpm_cache\s*$", codeql_config_text, re.MULTILINE)
+            is None
+        ):
+            issues.append(
+                ".github/codeql-config.yml: paths-ignore must exclude the"
+                " vendored CPM source cache (cpm_cache)"
+            )
+    else:
+        issues.append(
+            ".github/codeql-config.yml: CodeQL config file is missing"
+        )
 
     agent_setup_path = (
         root / ".github" / "actions" / "agent-setup" / "action.yml"

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -436,6 +436,55 @@ def workflow_step_blocks(job_block: list[str]) -> list[list[str]]:
     return result
 
 
+def workflow_step_fields(
+    step: list[str],
+) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    """Parse one workflow step's direct fields and simple child mappings."""
+    if not step:
+        return {}, {}
+    item = LIST_ITEM_RE.match(step[0])
+    if item is None:
+        return {}, {}
+    item_indent = len(item.group("indent"))
+    direct_indents = {item_indent, item_indent + 2}
+    fields: dict[str, str] = {}
+    field_offsets: dict[str, tuple[int, int]] = {}
+    for offset, line in enumerate(step):
+        entry = KEY_VALUE_RE.match(line)
+        if entry is None:
+            continue
+        indent = len(entry.group("indent"))
+        if indent not in direct_indents:
+            continue
+        key = entry.group("key")
+        value_indent = item_indent + 2 if indent == item_indent else indent
+        fields[key] = yaml_value(step, offset, entry.group("value"), value_indent)
+        field_offsets[key] = (offset, value_indent)
+
+    children: dict[str, dict[str, str]] = {}
+    for parent in ("env", "with"):
+        position = field_offsets.get(parent)
+        if position is None:
+            continue
+        parent_offset, parent_indent = position
+        values: dict[str, str] = {}
+        for offset in range(parent_offset + 1, len(step)):
+            line = step[offset]
+            active = strip_yaml_comment(line)
+            if not active:
+                continue
+            indent = len(line) - len(line.lstrip())
+            if indent <= parent_indent:
+                break
+            entry = KEY_VALUE_RE.match(line)
+            if entry is not None and indent == parent_indent + 2:
+                values[entry.group("key")] = yaml_value(
+                    step, offset, entry.group("value"), indent
+                )
+        children[parent] = values
+    return fields, children
+
+
 def workflow_job_matrix_values(block: list[str]) -> dict[str, set[str]]:
     if not block:
         return {}
@@ -1261,6 +1310,50 @@ def check_checkout_blocks(path: Path, text: str) -> list[str]:
     return issues
 
 
+CODEQL_THIRDPARTY_TARGETS = {
+    "simdutf",
+    "roaring",
+    "libuchardet",
+    "streamvbyte",
+    "klogg_karchive",
+    "kdsingleapp",
+    "xxhash",
+    "whereami",
+    "kdtoolbox",
+    "efsw",
+    "tbb",
+    "tbbmalloc",
+    "mimalloc-static",
+    "maddy",
+    "FastPFor",
+}
+
+
+def codeql_thirdparty_target_issues(text: str) -> list[str]:
+    """Keep CodeQL's pre-init dependency target complete and non-spoofable."""
+    active_lines = [line.partition("#")[0].strip() for line in text.splitlines()]
+    active_text = "\n".join(line for line in active_lines if line)
+    issues: list[str] = []
+    if "add_custom_target(klogg_codeql_thirdparty)" not in active_text:
+        issues.append("3rdparty must define the klogg_codeql_thirdparty target")
+
+    match = re.search(
+        r"set\(\s*klogg_codeql_thirdparty_targets\s+(?P<targets>.*?)\s*\)",
+        active_text,
+        re.DOTALL,
+    )
+    configured = set(match.group("targets").split()) if match is not None else set()
+    for target in sorted(CODEQL_THIRDPARTY_TARGETS - configured):
+        issues.append(
+            f"klogg_codeql_thirdparty must prebuild vendored target {target}"
+        )
+    if "add_dependencies(klogg_codeql_thirdparty ${target})" not in active_text:
+        issues.append(
+            "klogg_codeql_thirdparty must depend on every configured vendored target"
+        )
+    return issues
+
+
 def codeql_workflow_issues(text: str) -> list[str]:
     """Validate the fail-closed CodeQL job and its remote action revisions."""
     lines = text.splitlines()
@@ -1468,6 +1561,72 @@ def codeql_workflow_issues(text: str) -> list[str]:
     if init_build_modes != ["manual"]:
         issues.append("CodeQL init must set build-mode: manual")
 
+    configure_positions: list[int] = []
+    init_positions: list[int] = []
+    thirdparty_prebuild_positions: list[int] = []
+    traced_plan_positions: list[int] = []
+    application_build_positions: list[int] = []
+    for step_index, step in enumerate(workflow_step_blocks(job_block)):
+        fields, _ = workflow_step_fields(step)
+        if fields.get("uses", "").startswith("github/codeql-action/init@"):
+            init_positions.append(step_index)
+        active_step = "\n".join(
+            active
+            for line in "\n".join(step).splitlines()
+            if (active := strip_yaml_comment(line))
+        )
+        if (
+            "cmake --build build -t klogg -- -n > /tmp/codeql-traced-plan.txt"
+            in active_step
+            and "grep -E 'cpm_cache|_deps|3rdparty/CMakeFiles'"
+            in active_step
+        ):
+            traced_plan_positions.append(step_index)
+        for command in shell_commands("\n".join(step)):
+            tokens = shell_tokens(command)
+            if not tokens or tokens[0] != "cmake":
+                continue
+            if "--build" not in tokens and "-P" not in tokens:
+                configure_positions.append(step_index)
+                continue
+            if "--build" not in tokens:
+                continue
+            if "build" in tokens and "klogg_codeql_thirdparty" in tokens:
+                thirdparty_prebuild_positions.append(step_index)
+            if "build" in tokens and "klogg" in tokens and "-n" not in tokens:
+                application_build_positions.append(step_index)
+
+    prebuild_issue = "CodeQL must prebuild vendored targets before extractor initialization"
+    if (
+        len(configure_positions) != 1
+        or len(init_positions) != 1
+        or len(thirdparty_prebuild_positions) != 1
+        or not (
+            configure_positions[0]
+            < thirdparty_prebuild_positions[0]
+            < init_positions[0]
+        )
+    ):
+        issues.append(prebuild_issue)
+    traced_plan_issue = "CodeQL must verify that no vendored compile work remains"
+    if (
+        len(init_positions) != 1
+        or len(thirdparty_prebuild_positions) != 1
+        or len(traced_plan_positions) != 1
+        or not (
+            thirdparty_prebuild_positions[0]
+            < traced_plan_positions[0]
+            < init_positions[0]
+        )
+    ):
+        issues.append(traced_plan_issue)
+    if (
+        len(init_positions) == 1
+        and application_build_positions
+        and any(position <= init_positions[0] for position in application_build_positions)
+    ):
+        issues.append("CodeQL application build must run after extractor initialization")
+
     job_active = "\n".join(
         active for line in job_lines if (active := strip_yaml_comment(line))
     )
@@ -1491,7 +1650,7 @@ def codeql_workflow_issues(text: str) -> list[str]:
         if not tokens or tokens[0] != "cmake":
             continue
         if "--build" in tokens:
-            if "build" in tokens and "klogg" in tokens:
+            if "build" in tokens and "klogg" in tokens and "-n" not in tokens:
                 has_application_build = True
             continue
         if "-P" not in tokens:
@@ -1518,12 +1677,6 @@ def codeql_workflow_issues(text: str) -> list[str]:
         )
     if not has_application_build:
         issues.append("CodeQL manual build must trace the klogg application target")
-
-    if "config-file: ./.github/codeql-config.yml" not in text:
-        issues.append(
-            "codeql init must reference .github/codeql-config.yml so vendored"
-            " CPM sources under cpm_cache/ never produce repo alerts"
-        )
 
     return issues
 
@@ -1955,33 +2108,38 @@ def release_publisher_token_issues(text: str) -> list[str]:
     issues: list[str] = []
     for job_name, job_block in workflow_job_blocks(text).items():
         for step in workflow_step_blocks(job_block):
-            step_text = "\n".join(step)
-            step_name = "unnamed"
-            for line in step:
-                match = KEY_VALUE_RE.match(line)
-                if match is not None and match.group("key") == "name":
-                    step_name = match.group("value").strip("'\"") or "unnamed"
-                    break
-            uses_pat = RELEASE_PUBLISHER_TOKEN_DIRECTIVE in step_text
-            has_run = any(line.lstrip().startswith("run:") for line in step)
-            if RELEASE_PATCH_ENDPOINT_RE.search(step_text) and not uses_pat:
+            fields, children = workflow_step_fields(step)
+            step_name = fields.get("name", "unnamed").strip("'\"") or "unnamed"
+            run_text = fields.get("run", "")
+            active_run = "\n".join(
+                active
+                for line in run_text.splitlines()
+                if (active := strip_yaml_comment(line))
+            )
+            env_token = children.get("env", {}).get("GITHUB_TOKEN")
+            action_token = children.get("with", {}).get("token")
+            uses_pat = RELEASE_PUBLISHER_TOKEN_DIRECTIVE in {
+                env_token,
+                action_token,
+            }
+            if RELEASE_PATCH_ENDPOINT_RE.search(active_run) and not uses_pat:
                 issues.append(
                     f"job {job_name} step {step_name!r}: release mutation must"
                     f" bind GITHUB_TOKEN to {RELEASE_PUBLISHER_TOKEN_DIRECTIVE}"
                     " because github.token can never modify releases whose"
                     " target commit changes .github/workflows/** files"
                 )
-            softprops = "uses: softprops/action-gh-release@" in step_text
-            if softprops:
-                draft = re.search(r"^\s*draft:\s*(\S+)", step_text, re.MULTILINE)
-                if (draft is None or draft.group(1) != "true") and not uses_pat:
+            action = fields.get("uses", "")
+            if action.startswith("softprops/action-gh-release@"):
+                draft = children.get("with", {}).get("draft")
+                if draft != "true" and not uses_pat:
                     issues.append(
                         f"job {job_name} step {step_name!r}: published"
                         " softprops release creation must use"
                         f" {RELEASE_PUBLISHER_TOKEN_DIRECTIVE} (draft creation"
                         " may defer tag creation to promotion)"
                     )
-            if uses_pat and has_run and RELEASE_PUBLISHER_TOKEN_GUARD not in step_text:
+            if uses_pat and "run" in fields and RELEASE_PUBLISHER_TOKEN_GUARD not in active_run:
                 issues.append(
                     f"job {job_name} step {step_name!r}: KLOGG_GITHUB_TOKEN"
                     " step must fail fast when the secret is empty"
@@ -2105,23 +2263,11 @@ def check_repo(root: Path) -> list[str]:
         f".github/workflows/codeql-analysis.yml: {issue}"
         for issue in codeql_workflow_issues(codeql_text)
     )
-    codeql_config_path = root / ".github" / "codeql-config.yml"
-    if codeql_config_path.is_file():
-        codeql_config_text = codeql_config_path.read_text()
-        if (
-            "paths-ignore:" not in codeql_config_text
-            or re.search(r"^\s*-\s+cpm_cache\s*$", codeql_config_text, re.MULTILINE)
-            is None
-        ):
-            issues.append(
-                ".github/codeql-config.yml: paths-ignore must exclude the"
-                " vendored CPM source cache (cpm_cache)"
-            )
-    else:
-        issues.append(
-            ".github/codeql-config.yml: CodeQL config file is missing"
-        )
-
+    thirdparty_text = (root / "3rdparty" / "CMakeLists.txt").read_text()
+    issues.extend(
+        f"3rdparty/CMakeLists.txt: {issue}"
+        for issue in codeql_thirdparty_target_issues(thirdparty_text)
+    )
     agent_setup_path = (
         root / ".github" / "actions" / "agent-setup" / "action.yml"
     )

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -414,7 +414,11 @@ def workflow_step_blocks(job_block: list[str]) -> list[list[str]]:
         if not active:
             continue
         indent = len(line) - len(line.lstrip())
-        if indent <= steps_indent:
+        if indent < steps_indent:
+            region_end = index
+            break
+        if indent == steps_indent and LIST_ITEM_RE.match(line) is None:
+            # A sibling mapping key of steps: (e.g. outputs:) ends the region.
             region_end = index
             break
         item = LIST_ITEM_RE.match(line)
@@ -1515,6 +1519,7 @@ def codeql_workflow_issues(text: str) -> list[str]:
     if not has_application_build:
         issues.append("CodeQL manual build must trace the klogg application target")
 
+
     return issues
 
 
@@ -1922,6 +1927,63 @@ def workflow_display_name(text: str) -> str | None:
     return None
 
 
+RELEASE_PATCH_ENDPOINT_RE = re.compile(r'gh\s+api\s+-X\s+PATCH\s+"[^"]*/releases/')
+RELEASE_PUBLISHER_TOKEN_DIRECTIVE = "${{ secrets.KLOGG_GITHUB_TOKEN }}"
+RELEASE_PUBLISHER_TOKEN_GUARD = (
+    'test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret'
+    ' is missing or empty"; exit 1; }'
+)
+
+
+def release_publisher_token_issues(text: str) -> list[str]:
+    """Reject release-API mutations executed with the Actions app token.
+
+    GitHub's workflow-persistence protection requires workflow-modification
+    authorization to create or update a release whose target commit adds or
+    changes .github/workflows/** files, and the Actions app token can never
+    hold that authorization, so such calls fail with 403 "Resource not
+    accessible by integration" (continuous publisher run 33428615996, fixed
+    by binding the mutating steps to the KLOGG_GITHUB_TOKEN PAT). Draft-only
+    softprops uploads keep github.token because tag creation is deferred to
+    the promotion PATCH, which must use the PAT.
+    """
+    issues: list[str] = []
+    for job_name, job_block in workflow_job_blocks(text).items():
+        for step in workflow_step_blocks(job_block):
+            step_text = "\n".join(step)
+            step_name = "unnamed"
+            for line in step:
+                match = KEY_VALUE_RE.match(line)
+                if match is not None and match.group("key") == "name":
+                    step_name = match.group("value").strip("'\"") or "unnamed"
+                    break
+            uses_pat = RELEASE_PUBLISHER_TOKEN_DIRECTIVE in step_text
+            has_run = any(line.lstrip().startswith("run:") for line in step)
+            if RELEASE_PATCH_ENDPOINT_RE.search(step_text) and not uses_pat:
+                issues.append(
+                    f"job {job_name} step {step_name!r}: release mutation must"
+                    f" bind GITHUB_TOKEN to {RELEASE_PUBLISHER_TOKEN_DIRECTIVE}"
+                    " because github.token can never modify releases whose"
+                    " target commit changes .github/workflows/** files"
+                )
+            softprops = "uses: softprops/action-gh-release@" in step_text
+            if softprops:
+                draft = re.search(r"^\s*draft:\s*(\S+)", step_text, re.MULTILINE)
+                if (draft is None or draft.group(1) != "true") and not uses_pat:
+                    issues.append(
+                        f"job {job_name} step {step_name!r}: published"
+                        " softprops release creation must use"
+                        f" {RELEASE_PUBLISHER_TOKEN_DIRECTIVE} (draft creation"
+                        " may defer tag creation to promotion)"
+                    )
+            if uses_pat and has_run and RELEASE_PUBLISHER_TOKEN_GUARD not in step_text:
+                issues.append(
+                    f"job {job_name} step {step_name!r}: KLOGG_GITHUB_TOKEN"
+                    " step must fail fast when the secret is empty"
+                )
+    return issues
+
+
 def stable_release_workflow_issues(text: str) -> list[str]:
     issues: list[str] = []
     if workflow_display_name(text) != "Publish Release (Stable)":
@@ -1957,6 +2019,7 @@ def stable_release_workflow_issues(text: str) -> list[str]:
         or "trap rollback_stable_promotion ERR" not in text
     ):
         issues.append("stable release promotion must roll back every post-publish failure")
+    issues.extend(release_publisher_token_issues(text))
     return issues
 
 
@@ -1995,6 +2058,7 @@ def continuous_release_workflow_issues(text: str) -> list[str]:
         issues.append(
             "continuous rollback must reconcile a candidate created without an emitted id"
         )
+    issues.extend(release_publisher_token_issues(text))
     return issues
 
 

--- a/src/livecapture/CMakeLists.txt
+++ b/src/livecapture/CMakeLists.txt
@@ -1,4 +1,15 @@
 add_library(
+  klogg_ios_protocol STATIC
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosnativeerrors.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosostraceprotocol.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosnativeerrors.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosostraceprotocol.cpp
+)
+
+target_include_directories(klogg_ios_protocol PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(klogg_ios_protocol PUBLIC project_options project_warnings)
+
+add_library(
   klogg_livecapture STATIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include/adbprotocol.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/boundedserialexecutor.h
@@ -6,9 +17,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/iosdevicecatalog.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/iosnativeadapter.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/iosnativeapi.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosnativeerrors.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/iosnativestream.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/include/iosostraceprotocol.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/livedataqueue.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/livedatastatistics.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/livestate.h
@@ -16,16 +25,18 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/src/iosdevicecatalog.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/iosnativeadapter.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/iosnativeapi.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosnativeerrors.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/iosnativestream.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/src/iosostraceprotocol.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/livedataqueue.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/livedatastatistics.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/livestate.cpp
 )
 
 target_include_directories(klogg_livecapture PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(klogg_livecapture PUBLIC project_options project_warnings)
+target_link_libraries(
+  klogg_livecapture
+  PUBLIC klogg_ios_protocol project_options project_warnings
+  PRIVATE Qt${QT_VERSION_MAJOR}::Core
+)
 # iosnativeadapter resolves the verified private closure exclusively with dlopen.
 # KLOGG_ENABLE_IOS_NATIVE_STACK remains a configure-time fail-closed artifact
 # check in 3rdparty/CMakeLists.txt; linking the dylibs here would make macdeployqt

--- a/src/livecapture/include/adbprotocol.h
+++ b/src/livecapture/include/adbprotocol.h
@@ -129,7 +129,7 @@ private:
     std::optional<ProtocolError> error_;
 };
 
-enum class HostService : std::uint8_t { Version, Features, DevicesLong, TrackDevicesLong };
+enum class HostService : std::uint8_t { Version, ServerFeatures, DevicesLong, TrackDevicesLong };
 
 ProtocolResult<std::string> buildHostService( HostService service );
 
@@ -139,6 +139,10 @@ struct TransportSelection {
     TransportKind kind{ TransportKind::Any };
     std::string serial;
 };
+
+enum class TransportHostService : std::uint8_t { Features };
+
+ProtocolResult<std::string> buildTransportHostService( TransportHostService service );
 
 ProtocolResult<std::string> buildTransportService( const TransportSelection& selection );
 
@@ -158,6 +162,8 @@ struct LogcatCommandOptions {
     std::vector<LogcatFilter> filters;
 };
 
+std::vector<std::string> buildLogcatFormatArguments( bool ansiOutputEnabled );
+std::string normalizeLogcatStreamError( const std::string& diagnostic );
 ProtocolResult<std::string> buildLogcatService( const LogcatCommandOptions& options );
 std::string buildClearLogcatService();
 

--- a/src/livecapture/include/adbsmartsocketclient.h
+++ b/src/livecapture/include/adbsmartsocketclient.h
@@ -98,9 +98,11 @@ public:
     AdbSmartSocketClient& operator=( const AdbSmartSocketClient& ) = delete;
 
     void requestHostService( Generation generation, OperationId operationId, HostService service );
+    void requestTransportHostService( Generation generation, OperationId operationId,
+                                      const TransportSelection& transport,
+                                      TransportHostService service );
     void startShellService( Generation generation, OperationId operationId,
-                            const TransportSelection& transport,
-                            const std::string& service );
+                            const TransportSelection& transport, const std::string& service );
     void cancelGeneration( Generation generation );
 
 Q_SIGNALS:

--- a/src/livecapture/include/iosnativestream.h
+++ b/src/livecapture/include/iosnativestream.h
@@ -22,6 +22,7 @@
 #include "ioscatalogprovider.h"
 #include "iosnativeapi.h"
 #include "iosnativeerrors.h"
+#include "iosostraceprotocol.h"
 #include "livedataqueue.h"
 
 namespace klogg::livecapture::ios {
@@ -44,6 +45,9 @@ struct IosLogOptions {
 inline constexpr std::chrono::milliseconds DefaultIosNativeShutdownDeadline{ 750 };
 inline constexpr std::size_t DefaultIosNativeConcurrentSessionLimit{ 8u };
 
+using IosDeviceTimeZoneResolverFactory
+    = std::function<std::optional<OsTraceUtcOffsetResolver>( const std::string& )>;
+
 struct IosNativeStreamConfig {
     IosEndpointKey endpoint;
     Generation generation{ 0 };
@@ -52,6 +56,7 @@ struct IosNativeStreamConfig {
     std::size_t maximumSyslogRecordBytes{ std::size_t{ 1u } * 1024u * 1024u };
     IosNativeServicePolicy servicePolicy{ IosNativeServicePolicy::AutomaticByProductVersion };
     IosLogOptions logOptions;
+    IosDeviceTimeZoneResolverFactory timeZoneResolverFactory;
     std::chrono::milliseconds cleanupDeadline{ DefaultIosNativeShutdownDeadline };
 };
 

--- a/src/livecapture/include/iosostraceprotocol.h
+++ b/src/livecapture/include/iosostraceprotocol.h
@@ -169,10 +169,18 @@ private:
     std::optional<OsTraceRelayError> error_;
 };
 
+using OsTraceUtcOffsetResolver
+    = std::function<std::optional<std::int32_t>( std::uint64_t )>;
+
 struct OsTraceFormatOptions {
+    OsTraceFormatOptions() = default;
+    OsTraceFormatOptions( bool ansi, bool imageMetadata, bool labels,
+                          OsTraceUtcOffsetResolver utcOffsetResolver = {} );
+
     bool ansiColors{ false };
     bool includeImageMetadata{ true };
     bool includeLabels{ true };
+    OsTraceUtcOffsetResolver utcOffsetSecondsAt;
 };
 
 struct OsTraceFormatStatistics {
@@ -201,6 +209,21 @@ using OsTraceFormatStatisticsHook = std::function<void( const OsTraceFormatStati
 struct FormattedOsTraceRecord {
     std::string bytes;
     OsTraceFormatStatistics statistics;
+    bool utcOffsetResolved{ true };
+};
+
+class OsTraceRecordFormatter {
+public:
+    explicit OsTraceRecordFormatter( OsTraceFormatOptions options = {} );
+
+    FormattedOsTraceRecord format( const DecodedOsTraceRecord& record,
+                                   OsTraceFormatStatisticsHook statisticsHook = {} );
+
+private:
+    OsTraceFormatOptions options_;
+    std::optional<std::uint64_t> cachedEpochSecond_;
+    std::string cachedLocalSecond_;
+    std::string cachedUtcOffset_;
 };
 
 FormattedOsTraceRecord formatOsTraceRecord( const DecodedOsTraceRecord& record,

--- a/src/livecapture/src/adbprotocol.cpp
+++ b/src/livecapture/src/adbprotocol.cpp
@@ -20,6 +20,7 @@
 #include "adbprotocol.h"
 
 #include <algorithm>
+#include <cctype>
 #include <limits>
 #include <string_view>
 #include <utility>
@@ -256,6 +257,25 @@ std::optional<char> logPriorityLetter( LogPriority priority )
     }
 
     return std::nullopt;
+}
+
+bool lineRejectsOwnedLogcatFormat( std::string_view line )
+{
+    std::string normalized( line );
+    std::transform( normalized.begin(), normalized.end(), normalized.begin(), []( char value ) {
+        return static_cast<char>( std::tolower( static_cast<unsigned char>( value ) ) );
+    } );
+
+    if ( normalized.find( "invalid parameter" ) == std::string::npos
+         || normalized.find( "to -v" ) == std::string::npos ) {
+        return false;
+    }
+
+    constexpr std::array<std::string_view, 4> OwnedModifiers{ "year", "zone", "usec", "color" };
+    return std::any_of( OwnedModifiers.cbegin(), OwnedModifiers.cend(),
+                        [ &normalized ]( std::string_view modifier ) {
+                            return normalized.find( modifier ) != std::string::npos;
+                        } );
 }
 
 ProtocolResult<std::string> commandError( ProtocolErrorCode code, std::string message )
@@ -524,8 +544,8 @@ ProtocolResult<std::string> buildHostService( HostService service )
     switch ( service ) {
     case HostService::Version:
         return ProtocolResult<std::string>{ "host:version", std::nullopt };
-    case HostService::Features:
-        return ProtocolResult<std::string>{ "host:features", std::nullopt };
+    case HostService::ServerFeatures:
+        return ProtocolResult<std::string>{ "host:host-features", std::nullopt };
     case HostService::DevicesLong:
         return ProtocolResult<std::string>{ "host:devices-l", std::nullopt };
     case HostService::TrackDevicesLong:
@@ -534,6 +554,17 @@ ProtocolResult<std::string> buildHostService( HostService service )
 
     return commandError( ProtocolErrorCode::InvalidCommandOption,
                          "ADB host service contains an unknown service kind." );
+}
+
+ProtocolResult<std::string> buildTransportHostService( TransportHostService service )
+{
+    switch ( service ) {
+    case TransportHostService::Features:
+        return ProtocolResult<std::string>{ "host:features", std::nullopt };
+    }
+
+    return commandError( ProtocolErrorCode::InvalidCommandOption,
+                         "ADB transport-scoped host service contains an unknown service kind." );
 }
 
 ProtocolResult<std::string> buildTransportService( const TransportSelection& selection )
@@ -566,12 +597,46 @@ ProtocolResult<std::string> buildTransportService( const TransportSelection& sel
     return ProtocolResult<std::string>{ std::move( service ), std::nullopt };
 }
 
+std::vector<std::string> buildLogcatFormatArguments( bool ansiOutputEnabled )
+{
+    std::vector<std::string> arguments{
+        "-v", "threadtime", "-v", "year", "-v", "zone", "-v", "usec"
+    };
+    if ( ansiOutputEnabled ) {
+        arguments.emplace_back( "-v" );
+        arguments.emplace_back( "color" );
+    }
+    return arguments;
+}
+
+std::string normalizeLogcatStreamError( const std::string& diagnostic )
+{
+    std::string_view remaining( diagnostic );
+    while ( !remaining.empty() ) {
+        const auto end = remaining.find( '\n' );
+        const auto line = remaining.substr( 0u, end );
+        if ( lineRejectsOwnedLogcatFormat( line ) ) {
+            return "This ADB device cannot provide unambiguous source-device wall time because "
+                   "its logcat does not support the required year, zone, and microsecond format "
+                   "modifiers (Android 7.0 or compatible is required). Original error: "
+                   + diagnostic;
+        }
+        if ( end == std::string_view::npos ) {
+            break;
+        }
+        remaining.remove_prefix( end + 1u );
+    }
+    return diagnostic;
+}
+
 ProtocolResult<std::string> buildLogcatService( const LogcatCommandOptions& options )
 {
     std::string service{ "shell,v2,raw:logcat" };
-    if ( options.ansiOutputEnabled && !appendBounded( service, " -v color" ) ) {
-        return commandError( ProtocolErrorCode::PayloadTooLarge,
-                             "ADB logcat service exceeds the smart-socket payload limit." );
+    for ( const auto& argument : buildLogcatFormatArguments( options.ansiOutputEnabled ) ) {
+        if ( !appendBounded( service, " " ) || !appendBounded( service, argument ) ) {
+            return commandError( ProtocolErrorCode::PayloadTooLarge,
+                                 "ADB logcat service exceeds the smart-socket payload limit." );
+        }
     }
 
     for ( const auto buffer : options.buffers ) {

--- a/src/livecapture/src/adbprotocol.cpp
+++ b/src/livecapture/src/adbprotocol.cpp
@@ -632,7 +632,9 @@ std::string normalizeLogcatStreamError( const std::string& diagnostic )
 ProtocolResult<std::string> buildLogcatService( const LogcatCommandOptions& options )
 {
     std::string service{ "shell,v2,raw:logcat" };
+    // appendBounded mutates the command and must stop at the first overflow.
     for ( const auto& argument : buildLogcatFormatArguments( options.ansiOutputEnabled ) ) {
+        // cppcheck-suppress useStlAlgorithm
         if ( !appendBounded( service, " " ) || !appendBounded( service, argument ) ) {
             return commandError( ProtocolErrorCode::PayloadTooLarge,
                                  "ADB logcat service exceeds the smart-socket payload limit." );

--- a/src/livecapture/src/adbserveradapters.cpp
+++ b/src/livecapture/src/adbserveradapters.cpp
@@ -153,7 +153,8 @@ private:
             }
             version_ = static_cast<std::uint32_t>( value );
             phase_ = Phase::Features;
-            client_->requestHostService( activeToken_, featuresOperation, HostService::Features );
+            client_->requestHostService( activeToken_, featuresOperation,
+                                         HostService::ServerFeatures );
             return;
         }
 

--- a/src/livecapture/src/adbsmartsocketclient.cpp
+++ b/src/livecapture/src/adbsmartsocketclient.cpp
@@ -187,7 +187,110 @@ public:
 
     void requestHostService( Generation generation, OperationId operationId, HostService service )
     {
-        const auto builtService = buildHostService( service );
+        const auto kind = service == HostService::TrackDevicesLong ? OperationKind::StreamingHost
+                                                                   : OperationKind::OneShotHost;
+        startHostOperation( generation, operationId, buildHostService( service ), kind );
+    }
+
+    void requestTransportHostService( Generation generation, OperationId operationId,
+                                      const TransportSelection& transport,
+                                      TransportHostService service )
+    {
+        startTransportOperation( generation, operationId, transport,
+                                 buildTransportHostService( service ),
+                                 OperationKind::TransportHost );
+    }
+
+    void startShellService( Generation generation, OperationId operationId,
+                            const TransportSelection& transport, const std::string& service )
+    {
+        if ( service.rfind( "shell,v2,", 0u ) != 0u || service.find( '\0' ) != std::string::npos ) {
+            emitRequestError(
+                generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                QStringLiteral(
+                    "ADB shell operations require a shell-v2 service without NUL bytes." ) );
+            return;
+        }
+
+        startTransportOperation(
+            generation, operationId, transport,
+            ProtocolResult<std::string>{ service, std::nullopt }, OperationKind::Shell );
+    }
+
+    void cancelGeneration( Generation generation )
+    {
+        if ( phase_ == Phase::Idle || generation_ != generation ) {
+            return;
+        }
+        invalidateOperation();
+    }
+
+private:
+    enum class OperationKind : std::uint8_t { OneShotHost, StreamingHost, TransportHost, Shell };
+    enum class Phase : std::uint8_t {
+        Idle,
+        Connecting,
+        Writing,
+        HostStatus,
+        HostReply,
+        OneShotHostEof,
+        TransportStatus,
+        ShellStatus,
+        ShellFrames
+    };
+
+    void startTransportOperation( Generation generation, OperationId operationId,
+                                  const TransportSelection& transport,
+                                  ProtocolResult<std::string> builtService, OperationKind kind )
+    {
+        const auto transportService = buildTransportService( transport );
+        if ( transportService.error.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              protocolDiagnostic( *transportService.error ) );
+            return;
+        }
+        if ( builtService.error.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              protocolDiagnostic( *builtService.error ) );
+            return;
+        }
+        if ( !transportService.value.has_value() || !builtService.value.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              QStringLiteral( "ADB transport or service builder returned no request." ) );
+            return;
+        }
+
+        const auto encodedTransport
+            = encodeSmartSocketRequest( bytesFromString( *transportService.value ) );
+        const auto encodedService
+            = encodeSmartSocketRequest( bytesFromString( *builtService.value ) );
+        if ( encodedTransport.error.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              protocolDiagnostic( *encodedTransport.error ) );
+            return;
+        }
+        if ( encodedService.error.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              protocolDiagnostic( *encodedService.error ) );
+            return;
+        }
+        if ( !encodedTransport.value.has_value() || !encodedService.value.has_value() ) {
+            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
+                              QStringLiteral( "ADB request encoder returned no request." ) );
+            return;
+        }
+
+        if ( !beginOperation( generation, operationId, kind ) ) {
+            return;
+        }
+        firstRequest_ = byteArrayFromBytes( *encodedTransport.value );
+        serviceRequest_ = byteArrayFromBytes( *encodedService.value );
+        connectSocket();
+    }
+
+    void startHostOperation( Generation generation, OperationId operationId,
+                             ProtocolResult<std::string> builtService, OperationKind kind )
+    {
         if ( builtService.error.has_value() ) {
             emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
                               protocolDiagnostic( *builtService.error ) );
@@ -211,85 +314,12 @@ public:
             return;
         }
 
-        const auto kind = service == HostService::TrackDevicesLong ? OperationKind::StreamingHost
-                                                                   : OperationKind::OneShotHost;
         if ( !beginOperation( generation, operationId, kind ) ) {
             return;
         }
         firstRequest_ = byteArrayFromBytes( *encoded.value );
         connectSocket();
     }
-
-    void startShellService( Generation generation, OperationId operationId,
-                            const TransportSelection& transport, const std::string& service )
-    {
-        if ( service.rfind( "shell,v2,", 0u ) != 0u || service.find( '\0' ) != std::string::npos ) {
-            emitRequestError(
-                generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                QStringLiteral(
-                    "ADB shell operations require a shell-v2 service without NUL bytes." ) );
-            return;
-        }
-
-        const auto transportService = buildTransportService( transport );
-        if ( transportService.error.has_value() ) {
-            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                              protocolDiagnostic( *transportService.error ) );
-            return;
-        }
-        if ( !transportService.value.has_value() ) {
-            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                              QStringLiteral( "ADB transport builder returned no request." ) );
-            return;
-        }
-
-        const auto encodedTransport
-            = encodeSmartSocketRequest( bytesFromString( *transportService.value ) );
-        const auto encodedShell = encodeSmartSocketRequest( bytesFromString( service ) );
-        if ( encodedTransport.error.has_value() ) {
-            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                              protocolDiagnostic( *encodedTransport.error ) );
-            return;
-        }
-        if ( encodedShell.error.has_value() ) {
-            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                              protocolDiagnostic( *encodedShell.error ) );
-            return;
-        }
-        if ( !encodedTransport.value.has_value() || !encodedShell.value.has_value() ) {
-            emitRequestError( generation, operationId, AdbSmartSocketErrorCode::Protocol,
-                              QStringLiteral( "ADB request encoder returned no request." ) );
-            return;
-        }
-
-        if ( !beginOperation( generation, operationId, OperationKind::Shell ) ) {
-            return;
-        }
-        firstRequest_ = byteArrayFromBytes( *encodedTransport.value );
-        shellRequest_ = byteArrayFromBytes( *encodedShell.value );
-        connectSocket();
-    }
-
-    void cancelGeneration( Generation generation )
-    {
-        if ( phase_ == Phase::Idle || generation_ != generation ) {
-            return;
-        }
-        invalidateOperation();
-    }
-
-private:
-    enum class OperationKind : std::uint8_t { OneShotHost, StreamingHost, Shell };
-    enum class Phase : std::uint8_t {
-        Idle,
-        Connecting,
-        Writing,
-        HostStatus,
-        HostReply,
-        TransportStatus,
-        ShellStatus,
-        ShellFrames
-    };
 
     bool beginOperation( Generation generation, OperationId operationId, OperationKind kind )
     {
@@ -319,7 +349,8 @@ private:
         phase_ = Phase::Connecting;
         nextReadPhase_ = Phase::Idle;
         firstRequest_.clear();
-        shellRequest_.clear();
+        serviceRequest_.clear();
+        pendingHostReply_.clear();
         writeBuffer_.clear();
         writeOffset_ = 0;
         statusDecoder_ = SmartSocketStatusDecoder( config_.maxHostReplyBytes );
@@ -393,8 +424,9 @@ private:
             return;
         }
 
-        const auto readPhase
-            = operationKind_ == OperationKind::Shell ? Phase::TransportStatus : Phase::HostStatus;
+        const auto usesTransportSelection = operationKind_ == OperationKind::TransportHost
+                                            || operationKind_ == OperationKind::Shell;
+        const auto readPhase = usesTransportSelection ? Phase::TransportStatus : Phase::HostStatus;
         startWrite( firstRequest_, readPhase );
     }
 
@@ -450,6 +482,13 @@ private:
         }
     }
 
+    void armReadDeadline()
+    {
+        armDeadline( AdbSmartSocketDeadlineKind::Read, config_.readTimeoutMs,
+                     AdbSmartSocketErrorCode::ReadTimeout,
+                     QStringLiteral( "ADB smart-socket read timed out." ) );
+    }
+
     void enterReadPhase()
     {
         cancelDeadline();
@@ -458,9 +497,7 @@ private:
         phase_ = nextReadPhase_;
         nextReadPhase_ = Phase::Idle;
         statusDecoder_.reset();
-        armDeadline( AdbSmartSocketDeadlineKind::Read, config_.readTimeoutMs,
-                     AdbSmartSocketErrorCode::ReadTimeout,
-                     QStringLiteral( "ADB smart-socket read timed out." ) );
+        armReadDeadline();
     }
 
     void consumeAvailableBytes()
@@ -525,9 +562,7 @@ private:
                 if ( phase_ == Phase::HostStatus ) {
                     statusDecoder_.reset();
                     phase_ = Phase::HostReply;
-                    armDeadline( AdbSmartSocketDeadlineKind::Read, config_.readTimeoutMs,
-                                 AdbSmartSocketErrorCode::ReadTimeout,
-                                 QStringLiteral( "ADB smart-socket read timed out." ) );
+                    armReadDeadline();
                     continue;
                 }
                 if ( phase_ == Phase::TransportStatus ) {
@@ -538,7 +573,10 @@ private:
                         return;
                     }
                     statusDecoder_.reset();
-                    startWrite( shellRequest_, Phase::ShellStatus );
+                    const auto serviceStatus = operationKind_ == OperationKind::TransportHost
+                                                   ? Phase::HostStatus
+                                                   : Phase::ShellStatus;
+                    startWrite( serviceRequest_, serviceStatus );
                     return;
                 }
 
@@ -589,11 +627,15 @@ private:
                     return;
                 }
 
-                const auto reply = byteArrayFromBytes( result.frames.front() );
-                finishSuccess();
-                Q_EMIT client_.hostReplyReceived( generation, operationId, reply );
+                pendingHostReply_ = byteArrayFromBytes( result.frames.front() );
+                phase_ = Phase::OneShotHostEof;
+                armReadDeadline();
                 return;
             }
+            case Phase::OneShotHostEof:
+                fail( AdbSmartSocketErrorCode::Protocol,
+                      QStringLiteral( "ADB one-shot host service returned trailing data." ) );
+                return;
             case Phase::ShellFrames: {
                 auto result = shellDecoder_.feed( bytes );
                 const auto serial = operationSerial_;
@@ -681,6 +723,15 @@ private:
             return;
         }
 
+        if ( phase_ == Phase::OneShotHostEof ) {
+            const auto generation = generation_;
+            const auto operationId = operationId_;
+            const auto reply = std::move( pendingHostReply_ );
+            finishSuccess();
+            Q_EMIT client_.hostReplyReceived( generation, operationId, reply );
+            return;
+        }
+
         fail( AdbSmartSocketErrorCode::UnexpectedEof,
               QStringLiteral(
                   "ADB smart-socket closed before the current protocol frame completed." ) );
@@ -753,7 +804,8 @@ private:
         cancelDeadline();
         writeBuffer_.clear();
         firstRequest_.clear();
-        shellRequest_.clear();
+        serviceRequest_.clear();
+        pendingHostReply_.clear();
         statusDecoder_.reset();
         hostReplyDecoder_.reset();
         shellDecoder_.reset();
@@ -791,7 +843,8 @@ private:
     DeadlineToken deadlineToken_{ 0 };
 
     QByteArray firstRequest_;
-    QByteArray shellRequest_;
+    QByteArray serviceRequest_;
+    QByteArray pendingHostReply_;
     QByteArray writeBuffer_;
     qint64 writeOffset_{ 0 };
 
@@ -824,6 +877,14 @@ void AdbSmartSocketClient::requestHostService( Generation generation, OperationI
                                                HostService service )
 {
     impl_->requestHostService( generation, operationId, service );
+}
+
+void AdbSmartSocketClient::requestTransportHostService( Generation generation,
+                                                        OperationId operationId,
+                                                        const TransportSelection& transport,
+                                                        TransportHostService service )
+{
+    impl_->requestTransportHostService( generation, operationId, transport, service );
 }
 
 void AdbSmartSocketClient::startShellService( Generation generation, OperationId operationId,

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -97,6 +97,31 @@ bool usesOsTrace( const IosNativeStreamConfig& config, const std::string& produc
     }
 }
 
+std::optional<OsTraceUtcOffsetResolver>
+qtDeviceTimeZoneResolver( const std::string& deviceIanaId )
+{
+    QTimeZone sourceTimeZone( QByteArray::fromStdString( deviceIanaId ) );
+    if ( !sourceTimeZone.isValid() ) {
+        return std::nullopt;
+    }
+
+    return OsTraceUtcOffsetResolver{
+        [ sourceTimeZone = std::move( sourceTimeZone ) ]( std::uint64_t epochSeconds )
+            -> std::optional<std::int32_t> {
+            if ( epochSeconds
+                 > static_cast<std::uint64_t>( std::numeric_limits<qint64>::max() ) ) {
+                return std::nullopt;
+            }
+            const auto utc = QDateTime::fromSecsSinceEpoch(
+                static_cast<qint64>( epochSeconds ), QTimeZone::utc() );
+            if ( !utc.isValid() ) {
+                return std::nullopt;
+            }
+            return static_cast<std::int32_t>( sourceTimeZone.offsetFromUtc( utc ) );
+        }
+    };
+}
+
 } // namespace
 
 struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<State> {
@@ -652,13 +677,16 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
                 return;
             }
 
-            const bool timeZoneIdEmpty = rawTimeZone[ 0 ] == '\0';
-            const QTimeZone validatedTimeZone{ QByteArray( rawTimeZone ) };
+            const std::string timeZoneId( rawTimeZone );
+            const auto utcOffsetResolver
+                = config.timeZoneResolverFactory
+                      ? config.timeZoneResolverFactory( timeZoneId )
+                      : qtDeviceTimeZoneResolver( timeZoneId );
             openedTimeZone.reset();
             if ( cancelled() ) {
                 return;
             }
-            if ( timeZoneIdEmpty || !validatedTimeZone.isValid() ) {
+            if ( timeZoneId.empty() || !utcOffsetResolver ) {
                 publishFailure( localError(
                     ErrorCategory::Configuration, "ios-device-time-zone-invalid",
                     ErrorScope::Device, RetryPolicy::Never,
@@ -669,21 +697,8 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
                 return;
             }
 
-            osTraceFormatter.emplace( OsTraceFormatOptions{
-                config.ansiOutputEnabled, true, true,
-                [ sourceTimeZone = validatedTimeZone ]( std::uint64_t epochSeconds )
-                    -> std::optional<std::int32_t> {
-                    if ( epochSeconds
-                         > static_cast<std::uint64_t>( std::numeric_limits<qint64>::max() ) ) {
-                        return std::nullopt;
-                    }
-                    const auto utc = QDateTime::fromSecsSinceEpoch(
-                        static_cast<qint64>( epochSeconds ), QTimeZone::utc() );
-                    if ( !utc.isValid() ) {
-                        return std::nullopt;
-                    }
-                    return static_cast<std::int32_t>( sourceTimeZone.offsetFromUtc( utc ) );
-                } } );
+            osTraceFormatter.emplace( OsTraceFormatOptions{ config.ansiOutputEnabled, true, true,
+                                                             *utcOffsetResolver } );
             if ( cancelled() ) {
                 return;
             }

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -11,11 +11,16 @@
 
 #include "iosnativestream.h"
 
+#include <QByteArray>
+#include <QDateTime>
+#include <QTimeZone>
+
 #include <algorithm>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -369,9 +374,26 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
                                 "The iOS trace relay returned a malformed packet.", detail ) );
                 return;
             }
-            auto formatted = formatOsTraceRecord(
-                *decoded.record,
-                OsTraceFormatOptions{ state->config.ansiOutputEnabled, true, true } );
+            if ( !state->osTraceFormatter ) {
+                state->publishFailure( localError(
+                    ErrorCategory::Backend, "ios-ostrace-time-zone-unavailable", ErrorScope::Stream,
+                    RetryPolicy::Backoff, "The iOS trace time zone is unavailable.",
+                    "The validated device TimeZone formatter was not retained before callbacks "
+                    "started." ) );
+                return;
+            }
+            // The pinned libimobiledevice os_trace client invokes activity callbacks
+            // serially from its single receive worker, so the stateful per-second cache
+            // needs no callback-path mutex.
+            auto formatted = state->osTraceFormatter->format( *decoded.record );
+            if ( !formatted.utcOffsetResolved ) {
+                state->publishFailure( localError(
+                    ErrorCategory::Stream, "ios-ostrace-malformed-packet", ErrorScope::Stream,
+                    RetryPolicy::Backoff, "The iOS trace relay returned a malformed packet.",
+                    "The packet timestamp is outside the source device time zone's supported "
+                    "range." ) );
+                return;
+            }
             formatted.bytes.push_back( '\n' );
             state->enqueue(
                 std::vector<std::uint8_t>( formatted.bytes.begin(), formatted.bytes.end() ) );
@@ -606,6 +628,67 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             return;
         }
 
+        if ( osTrace ) {
+            char* rawTimeZone = nullptr;
+            const auto timeZoneCode
+                = api.lockdownGetStringValue( rawLockdown, nullptr, "TimeZone", &rawTimeZone );
+            NativeStringOwner openedTimeZone( api, rawTimeZone );
+            if ( cancelled() ) {
+                return;
+            }
+            if ( timeZoneCode != 0 ) {
+                publishFailure( classifyIosNativeError( IosNativeError{
+                    IosNativeErrorDomain::Lockdown, timeZoneCode,
+                    nativeDetail( "read TimeZone", timeZoneCode ) } ) );
+                return;
+            }
+            if ( rawTimeZone == nullptr ) {
+                publishFailure( localError(
+                    ErrorCategory::Configuration, "ios-device-time-zone-invalid",
+                    ErrorScope::Device, RetryPolicy::Never,
+                    "The iOS device time zone is missing or unrecognized.",
+                    "The global lockdownd TimeZone value is missing. Set a valid time zone in "
+                    "Settings > General > Date & Time on the iOS device, then reconnect it." ) );
+                return;
+            }
+
+            const bool timeZoneIdEmpty = rawTimeZone[ 0 ] == '\0';
+            const QTimeZone validatedTimeZone{ QByteArray( rawTimeZone ) };
+            openedTimeZone.reset();
+            if ( cancelled() ) {
+                return;
+            }
+            if ( timeZoneIdEmpty || !validatedTimeZone.isValid() ) {
+                publishFailure( localError(
+                    ErrorCategory::Configuration, "ios-device-time-zone-invalid",
+                    ErrorScope::Device, RetryPolicy::Never,
+                    "The iOS device time zone is missing or unrecognized.",
+                    "The global lockdownd TimeZone value is empty or unrecognized. Set a valid "
+                    "time zone in Settings > General > Date & Time on the iOS device, then "
+                    "reconnect it." ) );
+                return;
+            }
+
+            osTraceFormatter.emplace( OsTraceFormatOptions{
+                config.ansiOutputEnabled, true, true,
+                [ sourceTimeZone = validatedTimeZone ]( std::uint64_t epochSeconds )
+                    -> std::optional<std::int32_t> {
+                    if ( epochSeconds
+                         > static_cast<std::uint64_t>( std::numeric_limits<qint64>::max() ) ) {
+                        return std::nullopt;
+                    }
+                    const auto utc = QDateTime::fromSecsSinceEpoch(
+                        static_cast<qint64>( epochSeconds ), QTimeZone::utc() );
+                    if ( !utc.isValid() ) {
+                        return std::nullopt;
+                    }
+                    return static_cast<std::int32_t>( sourceTimeZone.offsetFromUtc( utc ) );
+                } } );
+            if ( cancelled() ) {
+                return;
+            }
+        }
+
         NativeServiceDescriptor rawService = nullptr;
         const auto serviceCode = api.lockdownStartService(
             rawLockdown, osTrace ? OsTraceService : SyslogService, &rawService );
@@ -785,6 +868,7 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
     std::condition_variable callbacksChanged;
     std::mutex syslogMutex;
     std::string syslogRecord;
+    std::optional<OsTraceRecordFormatter> osTraceFormatter;
     NativeDeviceOwner device;
     NativeLockdownOwner lockdown;
     NativeServiceOwner service;

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -686,7 +686,7 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             if ( cancelled() ) {
                 return;
             }
-            if ( timeZoneId.empty() || !utcOffsetResolver ) {
+            if ( timeZoneId.empty() || !utcOffsetResolver || !( *utcOffsetResolver ) ) {
                 publishFailure( localError(
                     ErrorCategory::Configuration, "ios-device-time-zone-invalid",
                     ErrorScope::Device, RetryPolicy::Never,

--- a/src/livecapture/src/iosostraceprotocol.cpp
+++ b/src/livecapture/src/iosostraceprotocol.cpp
@@ -401,32 +401,71 @@ std::string lowercaseHex( std::uint32_t value )
     return result;
 }
 
-std::string formatTimestamp( std::uint64_t seconds, std::uint32_t microseconds )
+std::int64_t floorDivide( std::int64_t value, std::int64_t divisor ) noexcept
 {
-    constexpr std::uint64_t SecondsPerDay = std::uint64_t{ 24u } * 60u * 60u;
-    const auto daysSinceEpoch = seconds / SecondsPerDay;
-    const auto secondsWithinDay = seconds % SecondsPerDay;
+    const auto quotient = value / divisor;
+    const auto remainder = value % divisor;
+    return remainder < 0 ? quotient - 1 : quotient;
+}
 
-    const auto shiftedDays = daysSinceEpoch + 719468u;
-    const auto era = shiftedDays / 146097u;
-    const auto dayOfEra = shiftedDays - era * 146097u;
+std::string formatLocalSecond( std::uint64_t seconds, std::int32_t utcOffsetSeconds )
+{
+    constexpr std::uint64_t UnsignedSecondsPerDay = std::uint64_t{ 24u } * 60u * 60u;
+    constexpr std::int64_t SecondsPerDay = std::int64_t{ 24 } * 60 * 60;
+
+    // Even UINT64_MAX seconds is only about 2.1e14 days, so the day count and
+    // all calendar intermediates fit comfortably in int64_t. Keeping the
+    // sub-day value signed lets historical negative offsets cross the epoch
+    // boundary without unsigned underflow.
+    auto daysSinceEpoch = static_cast<std::int64_t>( seconds / UnsignedSecondsPerDay );
+    const auto shiftedSeconds
+        = static_cast<std::int64_t>( seconds % UnsignedSecondsPerDay )
+          + static_cast<std::int64_t>( utcOffsetSeconds );
+    const auto dayAdjustment = floorDivide( shiftedSeconds, SecondsPerDay );
+    daysSinceEpoch += dayAdjustment;
+    const auto secondsWithinDay = shiftedSeconds - dayAdjustment * SecondsPerDay;
+
+    // Civil date conversion adapted from Howard Hinnant's public-domain
+    // days-from-civil inverse. It is purely arithmetic and works beyond the
+    // framework date-time ranges while preserving an exact signed UTC offset.
+    const auto shiftedDays = daysSinceEpoch + 719468;
+    const auto era = ( shiftedDays >= 0 ? shiftedDays : shiftedDays - 146096 ) / 146097;
+    const auto dayOfEra
+        = static_cast<std::uint64_t>( shiftedDays - era * 146097 );
     const auto yearOfEra
         = ( dayOfEra - dayOfEra / 1460u + dayOfEra / 36524u - dayOfEra / 146096u ) / 365u;
-    const auto year = yearOfEra + era * 400u;
+    const auto year = static_cast<std::int64_t>( yearOfEra ) + era * 400;
     const auto dayOfYear = dayOfEra - ( 365u * yearOfEra + yearOfEra / 4u - yearOfEra / 100u );
     const auto monthPrime = ( 5u * dayOfYear + 2u ) / 153u;
     const auto day = dayOfYear - ( 153u * monthPrime + 2u ) / 5u + 1u;
     const auto month = monthPrime < 10u ? monthPrime + 3u : monthPrime - 9u;
-    const auto calendarYear = year + ( month <= 2u ? 1u : 0u );
+    const auto calendarYear = year + ( month <= 2u ? 1 : 0 );
 
-    const auto hour = secondsWithinDay / 3600u;
-    const auto minute = ( secondsWithinDay % 3600u ) / 60u;
-    const auto second = secondsWithinDay % 60u;
+    const auto hour = static_cast<std::uint64_t>( secondsWithinDay / 3600 );
+    const auto minute = static_cast<std::uint64_t>( ( secondsWithinDay % 3600 ) / 60 );
+    const auto second = static_cast<std::uint64_t>( secondsWithinDay % 60 );
 
-    return paddedUnsigned( calendarYear, 4u ) + "-" + paddedUnsigned( month, 2u ) + "-"
-           + paddedUnsigned( day, 2u ) + " " + paddedUnsigned( hour, 2u ) + ":"
-           + paddedUnsigned( minute, 2u ) + ":" + paddedUnsigned( second, 2u ) + "."
-           + paddedUnsigned( microseconds, 6u );
+    return paddedUnsigned( static_cast<std::uint64_t>( calendarYear ), 4u ) + "-"
+           + paddedUnsigned( month, 2u ) + "-" + paddedUnsigned( day, 2u ) + " "
+           + paddedUnsigned( hour, 2u ) + ":" + paddedUnsigned( minute, 2u ) + ":"
+           + paddedUnsigned( second, 2u );
+}
+
+std::string normalizedUtcOffset( std::int32_t offsetSeconds )
+{
+    const auto signedOffset = static_cast<std::int64_t>( offsetSeconds );
+    const auto magnitude
+        = static_cast<std::uint64_t>( signedOffset < 0 ? -signedOffset : signedOffset );
+    const auto hours = magnitude / 3600u;
+    const auto minutes = ( magnitude % 3600u ) / 60u;
+    const auto seconds = magnitude % 60u;
+
+    auto result = std::string( 1u, signedOffset < 0 ? '-' : '+' )
+                  + paddedUnsigned( hours, 2u ) + ":" + paddedUnsigned( minutes, 2u );
+    if ( seconds != 0u ) {
+        result += ":" + paddedUnsigned( seconds, 2u );
+    }
+    return result;
 }
 
 class FormatBuilder {
@@ -711,20 +750,51 @@ void OsTraceRelayFrameDecoder::setError( OsTraceRelayErrorCode code ) noexcept
     payload_.clear();
 }
 
-FormattedOsTraceRecord formatOsTraceRecord( const DecodedOsTraceRecord& record,
-                                            const OsTraceFormatOptions& options,
-                                            OsTraceFormatStatisticsHook statisticsHook )
+OsTraceFormatOptions::OsTraceFormatOptions( bool ansi, bool imageMetadata, bool labels,
+                                            OsTraceUtcOffsetResolver utcOffsetResolver )
+    : ansiColors( ansi )
+    , includeImageMetadata( imageMetadata )
+    , includeLabels( labels )
+    , utcOffsetSecondsAt( std::move( utcOffsetResolver ) )
+{
+}
+
+OsTraceRecordFormatter::OsTraceRecordFormatter( OsTraceFormatOptions options )
+    : options_( std::move( options ) )
+{
+}
+
+FormattedOsTraceRecord
+OsTraceRecordFormatter::format( const DecodedOsTraceRecord& record,
+                                OsTraceFormatStatisticsHook statisticsHook )
 {
     constexpr const char* Green = "\x1b[32m";
     constexpr const char* Magenta = "\x1b[35m";
     constexpr const char* Cyan = "\x1b[36m";
 
-    FormatBuilder builder( options.ansiColors );
-    builder.appendStyled( formatTimestamp( record.seconds, record.microseconds ), Green );
+    if ( !cachedEpochSecond_ || *cachedEpochSecond_ != record.seconds ) {
+        const auto utcOffsetSeconds
+            = options_.utcOffsetSecondsAt
+                  ? options_.utcOffsetSecondsAt( record.seconds )
+                  : std::optional<std::int32_t>{ 0 };
+        if ( !utcOffsetSeconds ) {
+            FormattedOsTraceRecord result;
+            result.utcOffsetResolved = false;
+            return result;
+        }
+        cachedLocalSecond_ = formatLocalSecond( record.seconds, *utcOffsetSeconds );
+        cachedUtcOffset_ = normalizedUtcOffset( *utcOffsetSeconds );
+        cachedEpochSecond_ = record.seconds;
+    }
+    const auto timestamp = cachedLocalSecond_ + "." + paddedUnsigned( record.microseconds, 6u )
+                           + cachedUtcOffset_;
+
+    FormatBuilder builder( options_.ansiColors );
+    builder.appendStyled( timestamp, Green );
     builder.append( " " );
     builder.appendStyled( escapeDisplayText( baseName( record.processPath ) ), Magenta );
     builder.append( "{" );
-    if ( options.includeImageMetadata && record.imagePath ) {
+    if ( options_.includeImageMetadata && record.imagePath ) {
         constexpr const char* Blue = "\x1b[34m";
         builder.appendStyled( escapeDisplayText( baseName( record.imagePath ) ), Magenta );
         builder.appendStyled( "+0x" + lowercaseHex( record.imageOffset ), Blue );
@@ -737,7 +807,7 @@ FormattedOsTraceRecord formatOsTraceRecord( const DecodedOsTraceRecord& record,
     builder.appendStyled( escapeDisplayText( record.message.value_or( std::string{} ) ),
                           severityColor( record.level ) );
 
-    if ( options.includeLabels && ( record.subsystem || record.category ) ) {
+    if ( options_.includeLabels && ( record.subsystem || record.category ) ) {
         std::string labels;
         if ( record.subsystem ) {
             labels += "[" + escapeDisplayText( *record.subsystem ) + "]";
@@ -761,6 +831,14 @@ FormattedOsTraceRecord formatOsTraceRecord( const DecodedOsTraceRecord& record,
         statisticsHook( result.statistics );
     }
     return result;
+}
+
+FormattedOsTraceRecord formatOsTraceRecord( const DecodedOsTraceRecord& record,
+                                            const OsTraceFormatOptions& options,
+                                            OsTraceFormatStatisticsHook statisticsHook )
+{
+    OsTraceRecordFormatter formatter( options );
+    return formatter.format( record, std::move( statisticsHook ) );
 }
 
 BorrowedActivityCallbackBridge::BorrowedActivityCallbackBridge( OwnedBytesCallback callback,

--- a/src/ui/include/abstractlogview.h
+++ b/src/ui/include/abstractlogview.h
@@ -250,9 +250,13 @@ class AbstractLogView : public QAbstractScrollArea, public SearchableWidgetInter
     // route clicks to collapse/expand instead of selection.
     virtual LineKind lineKind( LineNumber lineNumber ) const;
 
-    // Line number to display for line at the given index
+    // Line number to display for line at the given index.
     virtual LineNumber displayLineNumber( LineNumber lineNumber ) const;
     virtual LineNumber lineIndex( LineNumber lineNumber ) const;
+    // Largest displayed label used only to size/render the line-number gutter.
+    // It is not the visible row count or a navigation bound; navigation must use
+    // logData_->getNbLine(), because filtered views can display source labels far
+    // larger than their compact row model.
     virtual LineNumber maxDisplayLineNumber() const;
 
     // Returns whether search range graying should be applied (true by default)

--- a/src/ui/include/adbprocesstransport.h
+++ b/src/ui/include/adbprocesstransport.h
@@ -29,6 +29,7 @@ class AdbProcessTransport : public ProcessLiveSourceTransport {
   protected:
     Command streamingCommand() const override;
     Command clearCommand() const override;
+    QString normalizeStreamingError( const QString& error ) const override;
 
   private:
     QString normalizedAdbExecutable() const;

--- a/src/ui/include/foldercrawlerwidget.h
+++ b/src/ui/include/foldercrawlerwidget.h
@@ -155,6 +155,13 @@ class FolderCrawlerWidget : public QWidget,
     // top-view-size shortcuts resize.
     QComboBox* visibilityCombo() const { return visibilityBox_; }
     QSplitter* viewsSplitter() const { return splitter_; }
+#ifdef KLOGG_TESTS
+    // Read-only seams for pending-open coalescing regressions. Returning the
+    // shared_ptr by const reference must not extend or otherwise change the
+    // ownership of the in-flight LogData.
+    const std::shared_ptr<LogData>& pendingMainDataForTest() const { return pendingMainData_; }
+    LineNumber pendingJumpLineForTest() const { return pendingJump_.line; }
+#endif
 
     // Restores the status label to the pre-search "Ready (N file(s))" text.
     void updateReadyStatus();
@@ -287,6 +294,10 @@ class FolderCrawlerWidget : public QWidget,
                              LinesCount nLines = LinesCount( 1 ),
                              LineColumn startCol = LineColumn( 0 ),
                              LineLength nSymbols = LineLength( 0 ) );
+    // Assign the complete pending selection payload in one place. Same-file
+    // pending opens update this payload without restarting the in-flight index.
+    void setPendingJumpPayload( LineNumber line, LinesCount nLines, LineColumn startCol,
+                                LineLength nSymbols );
     // (Re)bind the follow/refresh data-flow of the CURRENT currentMainData_ to
     // the main view: the per-file LogData self-registers with FileWatcher and
     // re-indexes on growth, but nothing else forwards those notifications to
@@ -489,12 +500,20 @@ class FolderCrawlerWidget : public QWidget,
     // pending jump, so the real completion early-returns and the new file's
     // jump/overview/encoding are never applied with the final index state.
     QMetaObject::Connection pendingMainDataConn_;
-    LineNumber pendingJumpLine_ = 0_lnum;
+    struct PendingJumpPayload {
+        LineNumber line = 0_lnum;
+        LinesCount lineCount = LinesCount( 1 );
+        LineColumn column = LineColumn( 0 );
+        LineLength length = LineLength( 0 );
+    };
     // Portion to mirror into the main view once the pending file is open
     // (plain row clicks use the defaults -> whole-line selection).
-    LinesCount pendingJumpNLines_ = LinesCount( 1 );
-    LineColumn pendingJumpCol_ = LineColumn( 0 );
-    LineLength pendingJumpLen_ = LineLength( 0 );
+    PendingJumpPayload pendingJump_;
+    // Every valid open request advances this revision. A pending load records
+    // the revision it started for, so a newer same-file click queued behind a
+    // failed completion can be retried once instead of being discarded.
+    std::uint64_t mainViewOpenRequestRevision_ = 0u;
+    std::uint64_t pendingLoadStartRevision_ = 0u;
 
     // Current search generation: streaming fileGroupReady/searchFinished signals
     // whose generation differs are dropped (superseded by a newer search).

--- a/src/ui/include/livesourcetransport.h
+++ b/src/ui/include/livesourcetransport.h
@@ -133,6 +133,7 @@ protected:
     virtual Command clearCommand() const = 0;
     virtual void prepareStreamingSession();
     virtual void filterReceivedBytes( QByteArray& data );
+    virtual QString normalizeStreamingError( const QString& error ) const;
     virtual void startProcessAsync( QProcess& process );
     virtual AsyncStartupTiming asyncStartupTiming() const;
 

--- a/src/ui/src/abstractlogview.cpp
+++ b/src/ui/src/abstractlogview.cpp
@@ -892,12 +892,20 @@ void AbstractLogView::doRegisterShortcuts()
         horizontalScrollBar()->triggerAction( QScrollBar::SliderPageStepAdd );
     } );
 
-    registerShortcut( ShortcutAction::LogViewJumpToTop,
-                      [ this ]() { selectAndDisplayLine( 0_lnum ); } );
+    registerShortcut( ShortcutAction::LogViewJumpToTop, [ this ]() {
+        if ( logData_->getNbLine() == 0_lcount ) {
+            return;
+        }
+        selectAndDisplayLine( 0_lnum );
+    } );
     registerShortcut( ShortcutAction::LogViewJumpToBottom, [ this ]() {
+        const auto totalRows = logData_->getNbLine();
+        if ( totalRows == 0_lcount ) {
+            return;
+        }
         const bool wasAtBottom = verticalScrollBar()->value() == verticalScrollBar()->maximum();
         if ( !wasAtBottom ) {
-            selectAndDisplayLine( maxDisplayLineNumber() - 1_lcount );
+            selectAndDisplayLine( LineNumber( totalRows.get() ) - 1_lcount );
             jumpToBottom();
         }
         else {
@@ -960,8 +968,12 @@ void AbstractLogView::doRegisterShortcuts()
     } );
 
     registerShortcut( ShortcutAction::LogViewSelectLinesDown, [ this ]() {
+        const auto totalRows = logData_->getNbLine();
+        if ( totalRows == 0_lcount ) {
+            return;
+        }
         auto newPosition = selectionCurrentEndPos_;
-        if ( newPosition.line() >= maxDisplayLineNumber() - 1_lcount ) {
+        if ( newPosition.line() >= LineNumber( totalRows.get() ) - 1_lcount ) {
             // Reached the end
             return;
         }
@@ -993,8 +1005,11 @@ std::optional<LineNumber> AbstractLogView::findMarkedLine( LineNumber from, bool
 {
     using LineTypeFlags = AbstractLogData::LineTypeFlags;
     if ( forward ) {
-        const auto total = maxDisplayLineNumber();
-        for ( auto i = from + 1_lcount; i < total; ++i ) {
+        const auto totalRows = logData_->getNbLine();
+        if ( totalRows == 0_lcount ) {
+            return {};
+        }
+        for ( auto i = from + 1_lcount; i < totalRows; ++i ) {
             if ( lineType( i ).testFlag( LineTypeFlags::Mark ) ) {
                 return i;
             }

--- a/src/ui/src/adbprocesstransport.cpp
+++ b/src/ui/src/adbprocesstransport.cpp
@@ -1,9 +1,64 @@
 #include "adbprocesstransport.h"
 #include "adbdevicelistprovider.h"
+#include "adbprotocol.h"
 #include "commandargumenttokenizer.h"
 #include "log.h"
 
 using ui::internal::splitCommandArguments;
+
+namespace adb = klogg::livecapture::adb;
+
+namespace {
+
+QStringList removeLogcatFormatArguments( const QStringList& arguments )
+{
+    const auto shortFormatOption = QStringLiteral( "-v" );
+    const auto longFormatOption = QStringLiteral( "--format" );
+    const auto longFormatAssignment = QStringLiteral( "--format=" );
+
+    QStringList filtered;
+    filtered.reserve( arguments.size() );
+
+    using ArgumentIndex = decltype( arguments.size() );
+    for ( ArgumentIndex index = 0; index < arguments.size(); ++index ) {
+        const auto& argument = arguments.at( index );
+        if ( argument == QStringLiteral( "--" ) ) {
+            filtered.append( arguments.mid( index ) );
+            break;
+        }
+
+        if ( argument == shortFormatOption || argument == longFormatOption ) {
+            const auto valueIndex = index + 1;
+            if ( valueIndex < arguments.size() ) {
+                const auto& value = arguments.at( valueIndex );
+                if ( !value.isEmpty() && !value.startsWith( QLatin1Char( '-' ) ) ) {
+                    index = valueIndex;
+                }
+            }
+            continue;
+        }
+
+        const auto isAttachedShortFormat
+            = argument.startsWith( shortFormatOption ) && argument.size() > shortFormatOption.size();
+        const auto isAssignedLongFormat = argument.startsWith( longFormatAssignment );
+        if ( isAttachedShortFormat || isAssignedLongFormat ) {
+            continue;
+        }
+
+        filtered.append( argument );
+    }
+
+    return filtered;
+}
+
+void appendLogcatFormatArguments( QStringList& arguments, bool ansiOutputEnabled )
+{
+    for ( const auto& argument : adb::buildLogcatFormatArguments( ansiOutputEnabled ) ) {
+        arguments.append( QString::fromStdString( argument ) );
+    }
+}
+
+} // namespace
 
 AdbProcessTransport::AdbProcessTransport( QString adbExecutable, QString deviceSerial,
                                           QString extraArgs, bool ansiOutputEnabled,
@@ -45,6 +100,11 @@ ProcessLiveSourceTransport::Command AdbProcessTransport::clearCommand() const
                       QStringLiteral( "-c" ) } };
 }
 
+QString AdbProcessTransport::normalizeStreamingError( const QString& error ) const
+{
+    return QString::fromStdString( adb::normalizeLogcatStreamError( error.toStdString() ) );
+}
+
 QString AdbProcessTransport::normalizedAdbExecutable() const
 {
     return AdbDeviceListProvider::normalizedExecutable( adbExecutable_ );
@@ -53,12 +113,12 @@ QString AdbProcessTransport::normalizedAdbExecutable() const
 QStringList AdbProcessTransport::logcatArguments() const
 {
     QStringList arguments{ QStringLiteral( "-s" ), deviceSerial_, QStringLiteral( "logcat" ) };
-    if ( ansiOutputEnabled_ ) {
-        arguments.append( { QStringLiteral( "-v" ), QStringLiteral( "color" ) } );
-    }
+    appendLogcatFormatArguments( arguments, ansiOutputEnabled_ );
+
     const auto trimmedExtraArgs = extraArgs_.trimmed();
     if ( !trimmedExtraArgs.isEmpty() ) {
-        arguments.append( splitCommandArguments( trimmedExtraArgs ) );
+        const auto extraArguments = splitCommandArguments( trimmedExtraArgs );
+        arguments.append( removeLogcatFormatArguments( extraArguments ) );
     }
     return arguments;
 }

--- a/src/ui/src/adbsmartsockettransport.cpp
+++ b/src/ui/src/adbsmartsockettransport.cpp
@@ -161,7 +161,8 @@ public:
         featureClient_ = createClient();
         auto* const client = featureClient_.data();
         connectFeatureClient( client, generation, operationId );
-        client->requestHostService( generation, operationId, HostService::Features );
+        client->requestTransportHostService( generation, operationId, transportSelection(),
+                                             TransportHostService::Features );
     }
 
     void stop( Generation generation )
@@ -190,7 +191,8 @@ public:
         operation.requestId = requestId;
         clearOperations_.emplace( operationId, std::move( operation ) );
         connectClearClient( client, generation, operationId );
-        client->requestHostService( generation, operationId, HostService::Features );
+        client->requestTransportHostService( generation, operationId, transportSelection(),
+                                             TransportHostService::Features );
     }
 
     QString lastError() const
@@ -264,8 +266,9 @@ private:
                 if ( !supportsShellV2( features ) ) {
                     failStream(
                         generation,
-                        QObject::tr( "ADB server does not advertise required shell_v2 support; "
-                                     "use a compatible ADB server." ) );
+                        QObject::tr(
+                            "Selected ADB device does not advertise required shell_v2 support; "
+                            "use a compatible ADB device." ) );
                     return;
                 }
                 startLogcat( generation );
@@ -279,9 +282,10 @@ private:
                      || featureClient_ != client || !isActive( generation ) ) {
                     return;
                 }
-                failStream( generation,
-                            contextualError( QObject::tr( "ADB server features negotiation" ), code,
-                                             diagnostic ) );
+                failStream(
+                    generation,
+                    contextualError( QObject::tr( "Selected ADB device features negotiation" ),
+                                     code, diagnostic ) );
             } );
     }
 
@@ -353,7 +357,8 @@ private:
                 auto error = QObject::tr( "ADB logcat exited with code %1." ).arg( exitCode );
                 if ( !diagnostic.isEmpty() ) {
                     error.append( QStringLiteral( " " ) );
-                    error.append( diagnostic );
+                    error.append( QString::fromStdString(
+                        normalizeLogcatStreamError( diagnostic.toStdString() ) ) );
                 }
                 failStream( generation, error );
             } );
@@ -396,8 +401,9 @@ private:
                 if ( !supportsShellV2( features ) ) {
                     completeClear(
                         operationId, false,
-                        QObject::tr( "ADB server does not advertise required shell_v2 support; "
-                                     "cannot clear logcat with this server." ) );
+                        QObject::tr(
+                            "Selected ADB device does not advertise required shell_v2 support; "
+                            "cannot clear logcat on this device." ) );
                     return;
                 }
 
@@ -450,9 +456,10 @@ private:
                     return;
                 }
 
-                const auto operation = found->second.phase == ClearPhase::Features
-                                           ? QObject::tr( "ADB logcat clear features negotiation" )
-                                           : QObject::tr( "ADB logcat clear" );
+                const auto operation
+                    = found->second.phase == ClearPhase::Features
+                          ? QObject::tr( "Selected ADB device logcat clear features negotiation" )
+                          : QObject::tr( "ADB logcat clear" );
                 auto error = contextualError( operation, code, diagnostic );
                 const auto stderrDiagnostic = trimmedDiagnostic( found->second.stderrBytes );
                 if ( !stderrDiagnostic.isEmpty() ) {

--- a/src/ui/src/foldercrawlerwidget.cpp
+++ b/src/ui/src/foldercrawlerwidget.cpp
@@ -1790,12 +1790,23 @@ void FolderCrawlerWidget::expandAll()
     }
 }
 
+void FolderCrawlerWidget::setPendingJumpPayload( LineNumber line, LinesCount nLines,
+                                                  LineColumn startCol, LineLength nSymbols )
+{
+    pendingJump_ = PendingJumpPayload{ line, nLines, startCol, nSymbols };
+}
+
 void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumber localLine,
                                               LinesCount nLines, LineColumn startCol,
                                               LineLength nSymbols )
 {
     if ( filePath.isEmpty() ) {
         return;
+    }
+
+    ++mainViewOpenRequestRevision_;
+    if ( mainViewOpenRequestRevision_ == 0u ) {
+        ++mainViewOpenRequestRevision_;
     }
 
     // Already showing this file -> just jump.
@@ -1857,6 +1868,16 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
         return;
     }
 
+    // A second synchronous selection in the same uncached file arrives while
+    // its LogData is still indexing. Keep that one in-flight open intact and
+    // only replace the selection it will consume on completion. Different-file,
+    // current-file, and cache-hit requests remain true supersession paths above
+    // or below this branch.
+    if ( pendingMainData_ != nullptr && filePath == pendingMainFilePath_ ) {
+        setPendingJumpPayload( localLine, nLines, startCol, nSymbols );
+        return;
+    }
+
     // Not loaded yet -> index the file asynchronously, then swap + jump.
     // Supersede any in-flight async open FIRST: disconnect its one-shot
     // loadingFinished connection so the abandoned LogData can never run the
@@ -1867,11 +1888,9 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
     // stale completion either.
     disconnect( pendingMainDataConn_ );
     pendingMainFilePath_ = filePath;
-    pendingJumpLine_ = localLine;
-    pendingJumpNLines_ = nLines;
-    pendingJumpCol_ = startCol;
-    pendingJumpLen_ = nSymbols;
+    setPendingJumpPayload( localLine, nLines, startCol, nSymbols );
     pendingMainData_ = std::make_shared<LogData>();
+    pendingLoadStartRevision_ = mainViewOpenRequestRevision_;
 
     // Store the connection so its lifetime is tied to the open it serves: the
     // lambda self-disconnects on completion, and the supersede paths above
@@ -1896,36 +1915,42 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
                        // installs below.
                        disconnect( pendingMainDataConn_ );
                        if ( status != LoadingStatus::Successful ) {
-                           // Defensive (no test: there is no deterministic way
-                           // to force an indexer exception). Unreadable or
-                           // deleted files still report Successful with 0 lines
-                           // -- the indexer treats them as empty
-                           // (logdataworker.cpp:616-637) -- so this guard only
-                           // covers the indexer-exception Interrupted path. Do
-                           // NOT promote the failed load: keep the previous
-                           // file displayed (a failed FIRST open leaves the
-                           // placeholder, a supported state), drop the pending
-                           // state, and skip caching/jumping/emitting.
                            LOG_WARNING << "FolderCrawlerWidget: open of "
                                        << pendingMainFilePath_ << " finished with status "
                                        << static_cast<int>( status ) << "; keeping the "
                                           "previously displayed file";
-                           // Defer the LogData destruction past the current
-                           // emission: this lambda runs inside
-                           // LogData::indexingFinished's Q_EMIT, and resetting
-                           // the last shared_ptr ref here would free the object
-                           // whose indexingFinished epilogue
-                           // (finishOperationAndStartNext, logdata.cpp:286) is
-                           // still on the stack.
+
+                           const auto retryLatestRequest
+                               = mainViewOpenRequestRevision_ != pendingLoadStartRevision_;
+                           const auto retryRevision = mainViewOpenRequestRevision_;
+                           const auto retryPath = pendingMainFilePath_;
+                           const auto retryJump = pendingJump_;
+
+                           // Defer destruction past LogData::indexingFinished's
+                           // signal stack. If a newer same-file click arrived
+                           // after this load became terminal, start one fresh
+                           // load for its latest jump. Any still-newer request
+                           // advances the revision and suppresses this retry.
                            auto abandonedData = std::move( pendingMainData_ );
                            pendingMainFilePath_.clear();
-                           QTimer::singleShot( 0, this,
-                                               [ abandonedData ]() mutable { abandonedData.reset(); } );
+                           QTimer::singleShot(
+                               0, this,
+                               [ this, abandonedData = std::move( abandonedData ),
+                                 retryLatestRequest, retryRevision, retryPath,
+                                 retryJump ]() mutable {
+                                   abandonedData.reset();
+                                   if ( retryLatestRequest && pendingMainData_ == nullptr
+                                        && mainViewOpenRequestRevision_ == retryRevision ) {
+                                       openFileInMainView( retryPath, retryJump.line,
+                                                           retryJump.lineCount, retryJump.column,
+                                                           retryJump.length );
+                                   }
+                               } );
                            return;
                        }
                        currentMainData_ = pendingMainData_;
                        currentMainFilePath_ = pendingMainFilePath_;
-                       lastMainViewLine_ = pendingJumpLine_;
+                       lastMainViewLine_ = pendingJump_.line;
                        cacheMainViewData( currentMainFilePath_, currentMainData_ );
 
                        // Sync the display codec to the indexer-detected encoding
@@ -1950,8 +1975,8 @@ void FolderCrawlerWidget::openFileInMainView( const QString& filePath, LineNumbe
                        // thread (loadingFinished is a queued signal), so threading is
                        // correct.
                        mainView_->setSearchPattern( currentSearchPattern_ );
-                       selectInMainView( pendingJumpLine_, pendingJumpNLines_,
-                                         pendingJumpCol_, pendingJumpLen_ );
+                       selectInMainView( pendingJump_.line, pendingJump_.lineCount,
+                                         pendingJump_.column, pendingJump_.length );
                        // getNbLine() is only valid now that indexing finished: the
                        // overview repoint MUST happen here, not at attachFile time.
                        refreshFileOverview( pendingMainFilePath_ );

--- a/src/ui/src/livesourcetransport.cpp
+++ b/src/ui/src/livesourcetransport.cpp
@@ -546,6 +546,7 @@ void ProcessLiveSourceTransport::failCurrentProcess( Generation generation,
     else if ( lastError_.isEmpty() ) {
         lastError_ = fallback;
     }
+    lastError_ = normalizeStreamingError( lastError_ );
 
     // Failure retires this run just as decisively as an intentional stop.
     // Invalidate before process teardown so any synchronous or queued callback
@@ -576,4 +577,9 @@ void ProcessLiveSourceTransport::prepareStreamingSession() {}
 void ProcessLiveSourceTransport::filterReceivedBytes( QByteArray& data )
 {
     Q_UNUSED( data );
+}
+
+QString ProcessLiveSourceTransport::normalizeStreamingError( const QString& error ) const
+{
+    return error;
 }

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -43,6 +43,7 @@ jobs:
         with:
           languages: c-cpp
           build-mode: manual
+          config-file: ./.github/codeql-config.yml
       - uses: ./.github/actions/agent-setup
       - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
       - run: cmake --build build -t klogg
@@ -1127,6 +1128,16 @@ jobs:
 
     def test_secure_codeql_workflow_is_accepted(self):
         self.assertEqual(MODULE.codeql_workflow_issues(secure_codeql_workflow()), [])
+
+    def test_codeql_requires_config_excluding_vendored_sources(self):
+        text = secure_codeql_workflow().replace(
+            "          config-file: ./.github/codeql-config.yml\n",
+            "",
+            1,
+        )
+        issues = MODULE.codeql_workflow_issues(text)
+        self.assertEqual(len(issues), 1)
+        self.assertIn("codeql-config.yml", issues[0])
 
     def test_release_mutation_requires_publishing_pat(self):
         message = "release mutation must bind GITHUB_TOKEN"

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -39,13 +39,14 @@ jobs:
       CODEQL_ACTION_OVERLAY_ANALYSIS_CODE_SCANNING_CPP: "false"
     timeout-minutes: 30
     steps:
+      - uses: ./.github/actions/agent-setup
+      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+      - run: cmake --build build -t klogg_codeql_thirdparty
+      - run: cmake --build build -t klogg -- -n > /tmp/codeql-traced-plan.txt && ! grep -E 'cpm_cache|_deps|3rdparty/CMakeFiles' /tmp/codeql-traced-plan.txt
       - uses: github/codeql-action/init@{CODEQL_PINNED}
         with:
           languages: c-cpp
           build-mode: manual
-          config-file: ./.github/codeql-config.yml
-      - uses: ./.github/actions/agent-setup
-      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON
       - run: cmake --build build -t klogg
       - uses: github/codeql-action/analyze@{CODEQL_PINNED} # v4.37.9
 """
@@ -1129,16 +1130,6 @@ jobs:
     def test_secure_codeql_workflow_is_accepted(self):
         self.assertEqual(MODULE.codeql_workflow_issues(secure_codeql_workflow()), [])
 
-    def test_codeql_requires_config_excluding_vendored_sources(self):
-        text = secure_codeql_workflow().replace(
-            "          config-file: ./.github/codeql-config.yml\n",
-            "",
-            1,
-        )
-        issues = MODULE.codeql_workflow_issues(text)
-        self.assertEqual(len(issues), 1)
-        self.assertIn("codeql-config.yml", issues[0])
-
     def test_release_mutation_requires_publishing_pat(self):
         message = "release mutation must bind GITHUB_TOKEN"
         good = """\
@@ -1162,6 +1153,71 @@ jobs:
         )
         self.assertTrue(
             any(message in issue for issue in MODULE.release_publisher_token_issues(bad))
+        )
+
+    def test_release_token_policy_rejects_comment_spoofs(self):
+        workflow = """\
+jobs:
+  publish:
+    steps:
+      - name: Spoofed release mutation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+          # test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" -F draft=false
+"""
+        issues = MODULE.release_publisher_token_issues(workflow)
+        self.assertTrue(any("release mutation must bind" in issue for issue in issues))
+
+        pat_without_guard = workflow.replace(
+            "GITHUB_TOKEN: ${{ github.token }}",
+            "GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}",
+            1,
+        )
+        issues = MODULE.release_publisher_token_issues(pat_without_guard)
+        self.assertTrue(any("must fail fast" in issue for issue in issues))
+
+    def test_release_token_policy_parses_inline_run_steps(self):
+        inline = """\
+jobs:
+  publish:
+    steps:
+      - run: |
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" -F draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+"""
+        self.assertEqual(MODULE.release_publisher_token_issues(inline), [])
+        unguarded = inline.replace(
+            '          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }\n',
+            "",
+            1,
+        ).replace(
+            "        env:\n",
+            "        env:\n"
+            "          SPOOF: 'test -n \"${GITHUB_TOKEN:-}\" || { echo \"::error::KLOGG_GITHUB_TOKEN secret is missing or empty\"; exit 1; }'\n",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "must fail fast" in issue
+                for issue in MODULE.release_publisher_token_issues(unguarded)
+            )
+        )
+
+        unsafe = inline.replace(
+            "GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}",
+            "GITHUB_TOKEN: ${{ github.token }}",
+            1,
+        )
+        self.assertTrue(
+            any(
+                "release mutation must bind" in issue
+                for issue in MODULE.release_publisher_token_issues(unsafe)
+            )
         )
 
     def test_release_pat_step_must_fail_fast_on_empty_secret(self):
@@ -1337,6 +1393,108 @@ jobs:
                 bad = good.replace(marker, "", 1)
                 self.assertNotEqual(bad, good)
                 self.assertIn(message, MODULE.codeql_workflow_issues(bad))
+
+    def test_codeql_prebuilds_vendored_targets_before_extractor_init(self):
+        message = "CodeQL must prebuild vendored targets before extractor initialization"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        missing = good.replace(
+            "      - run: cmake --build build -t klogg_codeql_thirdparty\n", "", 1
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(missing))
+
+        marker = "      - run: cmake --build build -t klogg_codeql_thirdparty\n"
+        after_init = good.replace(marker, "", 1).replace(
+            f"      - uses: github/codeql-action/init@{CODEQL_PINNED}\n",
+            f"      - uses: github/codeql-action/init@{CODEQL_PINNED}\n"
+            + marker,
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(after_init))
+
+        configure = '      - run: cmake -S "$GITHUB_WORKSPACE" -B build -DCPM_SOURCE_CACHE="$GITHUB_WORKSPACE/cpm_cache" -DFETCHCONTENT_FULLY_DISCONNECTED=ON\n'
+        prebuild = "      - run: cmake --build build -t klogg_codeql_thirdparty\n"
+        before_configure = good.replace(configure + prebuild, prebuild + configure, 1)
+        self.assertIn(message, MODULE.codeql_workflow_issues(before_configure))
+
+        comment_spoof = missing.replace(
+            "      - run: cmake --build build -t klogg\n",
+            "      # run: cmake --build build -t klogg_codeql_thirdparty\n"
+            "      - run: cmake --build build -t klogg\n",
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(comment_spoof))
+
+    def test_codeql_verifies_no_vendored_work_remains_after_prebuild(self):
+        message = "CodeQL must verify that no vendored compile work remains"
+        good = secure_codeql_workflow()
+        self.assertNotIn(message, MODULE.codeql_workflow_issues(good))
+
+        guard = "      - run: cmake --build build -t klogg -- -n > /tmp/codeql-traced-plan.txt && ! grep -E 'cpm_cache|_deps|3rdparty/CMakeFiles' /tmp/codeql-traced-plan.txt\n"
+        missing = good.replace(guard, "", 1)
+        self.assertIn(message, MODULE.codeql_workflow_issues(missing))
+
+        spoofed = missing.replace(
+            "      - uses: github/codeql-action/init@",
+            "      # " + guard.strip() + "\n      - uses: github/codeql-action/init@",
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(spoofed))
+
+        after_init = missing.replace(
+            "          build-mode: manual\n",
+            "          build-mode: manual\n" + guard,
+            1,
+        )
+        self.assertIn(message, MODULE.codeql_workflow_issues(after_init))
+
+    def test_codeql_thirdparty_target_covers_every_compiled_vendor(self):
+        good = """\
+add_custom_target(klogg_codeql_thirdparty)
+set(
+  klogg_codeql_thirdparty_targets
+  simdutf
+  roaring
+  libuchardet
+  streamvbyte
+  klogg_karchive
+  kdsingleapp
+  xxhash
+  whereami
+  kdtoolbox
+  efsw
+  tbb
+  tbbmalloc
+  mimalloc-static
+  maddy
+  FastPFor
+)
+foreach(target IN LISTS klogg_codeql_thirdparty_targets)
+  if(TARGET ${target})
+    add_dependencies(klogg_codeql_thirdparty ${target})
+  endif()
+endforeach()
+"""
+        self.assertEqual(MODULE.codeql_thirdparty_target_issues(good), [])
+
+        missing = good.replace("  maddy\n", "", 1)
+        self.assertTrue(
+            any(
+                "maddy" in issue
+                for issue in MODULE.codeql_thirdparty_target_issues(missing)
+            )
+        )
+
+        comment_spoof = missing.replace(
+            "  FastPFor\n", "  # maddy\n  FastPFor\n", 1
+        )
+        self.assertTrue(
+            any(
+                "maddy" in issue
+                for issue in MODULE.codeql_thirdparty_target_issues(comment_spoof)
+            )
+        )
 
     def test_codeql_build_cannot_be_spoofed_by_an_unrelated_job(self):
         good = secure_codeql_workflow()

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -1128,6 +1128,78 @@ jobs:
     def test_secure_codeql_workflow_is_accepted(self):
         self.assertEqual(MODULE.codeql_workflow_issues(secure_codeql_workflow()), [])
 
+    def test_release_mutation_requires_publishing_pat(self):
+        message = "release mutation must bind GITHUB_TOKEN"
+        good = """\
+jobs:
+  publish:
+    steps:
+      - name: Promote verified candidate
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" \\
+            -f tag_name=continuous -F draft=false >/dev/null
+"""
+        self.assertNotIn(message, MODULE.release_publisher_token_issues(good))
+        bad = good.replace(
+            "GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}",
+            "GITHUB_TOKEN: ${{ github.token }}",
+        )
+        self.assertTrue(
+            any(message in issue for issue in MODULE.release_publisher_token_issues(bad))
+        )
+
+    def test_release_pat_step_must_fail_fast_on_empty_secret(self):
+        message = "KLOGG_GITHUB_TOKEN step must fail fast when the secret is empty"
+        guarded = """\
+jobs:
+  publish:
+    steps:
+      - name: Park existing continuous release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          gh api -X DELETE "/repos/${repo}/git/refs/tags/continuous" >/dev/null
+"""
+        self.assertNotIn(message, MODULE.release_publisher_token_issues(guarded))
+        unguarded = guarded.replace(
+            '          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN'
+            ' secret is missing or empty"; exit 1; }\n',
+            "",
+            1,
+        )
+        self.assertTrue(
+            any(
+                message in issue
+                for issue in MODULE.release_publisher_token_issues(unguarded)
+            )
+        )
+
+    def test_draft_softprops_upload_may_keep_actions_token(self):
+        draft = """\
+jobs:
+  publish:
+    steps:
+      - name: Create continuous candidate draft
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64
+        with:
+          token: ${{ github.token }}
+          tag_name: continuous-candidate-1
+          draft: true
+"""
+        self.assertEqual(MODULE.release_publisher_token_issues(draft), [])
+        published = draft.replace("          draft: true\n", "", 1)
+        issues = MODULE.release_publisher_token_issues(published)
+        self.assertEqual(len(issues), 1)
+        self.assertIn("published softprops release creation", issues[0])
+
     def test_codeql_runs_on_master_pushes(self):
         message = "CodeQL workflow must run on pushes to master"
         good = secure_codeql_workflow()

--- a/tests/ui/CMakeLists.txt
+++ b/tests/ui/CMakeLists.txt
@@ -5,6 +5,7 @@ set(UI_TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/crawlerwidget_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/concatenatedlogdata_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/foldercrawler_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/foldercrawler_pending_failure_test.cpp
 )
 
 LIST(APPEND UI_TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/mainwindow_test.cpp)

--- a/tests/ui/foldercrawler_pending_failure_test.cpp
+++ b/tests/ui/foldercrawler_pending_failure_test.cpp
@@ -1,0 +1,78 @@
+#include <catch2/catch.hpp>
+
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QFile>
+#include <QMetaObject>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <functional>
+
+#include "foldercrawlerwidget.h"
+#include "loadingstatus.h"
+#include "logdata.h"
+
+namespace {
+
+QString makeFile( QTemporaryDir& dir, const char* name )
+{
+    const auto path = dir.filePath( QString::fromUtf8( name ) );
+    QFile file( path );
+    REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) );
+    for ( int line = 0; line < 12; ++line ) {
+        const auto text = line == 2 || line == 8 ? QByteArrayLiteral( "ERROR\n" )
+                                                : QByteArrayLiteral( "plain\n" );
+        REQUIRE( file.write( text ) == text.size() );
+    }
+    file.close();
+    return path;
+}
+
+bool waitFor( const std::function<bool()>& predicate, int timeoutMs = 5000 )
+{
+    QElapsedTimer timer;
+    timer.start();
+    while ( !predicate() && timer.elapsed() < timeoutMs ) {
+        QTest::qWait( 10 );
+    }
+    return predicate();
+}
+
+} // namespace
+
+TEST_CASE( "FolderCrawlerWidget retries a same-file selection queued behind a failed pending load",
+           "[folder][pending][regression]" )
+{
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const auto path = makeFile( dir, "a.log" );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ path } );
+    widget.searchFor( QStringLiteral( "ERROR" ) );
+    REQUIRE( waitFor( [ &widget ] { return !widget.isSearchActive(); } ) );
+    REQUIRE( widget.folderResults()->getNbLine() == 3_lcount );
+    const auto secondLine = widget.folderResults()->sourceForLine( 2_lnum ).localLine;
+    REQUIRE( secondLine == 8_lnum );
+
+    widget.selectResultRow( 1_lnum );
+    auto pending = widget.pendingMainDataForTest();
+    REQUIRE( pending != nullptr );
+    const std::weak_ptr<LogData> abandonedPending = pending;
+
+    // Queue failure before the second click, but do not process the event loop.
+    // The new click must survive cleanup of the terminal pending load.
+    REQUIRE( QMetaObject::invokeMethod(
+        pending.get(), "loadingFinished", Qt::QueuedConnection,
+        Q_ARG( LoadingStatus, LoadingStatus::Interrupted ) ) );
+    pending->interruptLoading();
+    widget.selectResultRow( 2_lnum );
+    pending.reset();
+
+    REQUIRE( waitFor( [ &widget, &path ] { return widget.currentMainFilePath() == path; } ) );
+    QTest::qWait( 200 );
+    REQUIRE( abandonedPending.expired() );
+    REQUIRE( widget.currentMainViewLine() == secondLine );
+}

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -196,10 +196,8 @@ struct FilterFavoritesGuard {
 // (two definitions of access_by<AbstractLogViewPrivate> would be an ODR clash).
 struct FolderViewTestAccess {
     // FolderCrawlerWidget's pending-open state is intentionally private. These
-    // wrappers keep the RED test coupled only to two narrow KLOGG_TESTS accessors
+    // wrappers keep the regression coupled only to two narrow KLOGG_TESTS accessors
     // instead of exposing the production members or using a private/public macro.
-    // The accessors do not exist yet; that compile failure is an acceptable RED
-    // until the production fix supplies the seam.
     static std::weak_ptr<LogData> pendingMainData( const FolderCrawlerWidget* widget )
     {
         return widget->pendingMainDataForTest();

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -51,6 +51,7 @@
 #include <atomic>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -194,6 +195,20 @@ struct FilterFavoritesGuard {
 // AbstractLogView::access_by MUST use a different tag in each translation unit
 // (two definitions of access_by<AbstractLogViewPrivate> would be an ODR clash).
 struct FolderViewTestAccess {
+    // FolderCrawlerWidget's pending-open state is intentionally private. These
+    // wrappers keep the RED test coupled only to two narrow KLOGG_TESTS accessors
+    // instead of exposing the production members or using a private/public macro.
+    // The accessors do not exist yet; that compile failure is an acceptable RED
+    // until the production fix supplies the seam.
+    static std::weak_ptr<LogData> pendingMainData( const FolderCrawlerWidget* widget )
+    {
+        return widget->pendingMainDataForTest();
+    }
+
+    static LineNumber pendingJumpLine( const FolderCrawlerWidget* widget )
+    {
+        return widget->pendingJumpLineForTest();
+    }
 };
 
 template <>
@@ -248,6 +263,32 @@ struct AbstractLogView::access_by<FolderViewTestAccess> {
     {
         return view->logData_;
     }
+
+    static void selectNextMark( AbstractLogView* view )
+    {
+        view->selectNextMark();
+    }
+};
+
+class NoProviderFolderMarkProbeView final : public FolderFilteredView {
+  public:
+    NoProviderFolderMarkProbeView( FolderSearchResults* results,
+                                   const QuickFindPattern* quickFindPattern )
+        : FolderFilteredView( results, quickFindPattern )
+    {
+    }
+
+    const std::vector<LineNumber>& probedLines() const { return probedLines_; }
+
+  protected:
+    AbstractLogData::LineType lineType( LineNumber lineNumber ) const override
+    {
+        probedLines_.push_back( lineNumber );
+        return {};
+    }
+
+  private:
+    mutable std::vector<LineNumber> probedLines_;
 };
 
 TEST_CASE( "FolderCrawlerWidget plain click on a result row repaints the selection highlight",
@@ -969,6 +1010,107 @@ TEST_CASE( "FolderCrawlerWidget exposes predefined filters and favorites in the 
     REQUIRE_FALSE( widget.searchToolbar()->keepSearchResultsButton()->isHidden() );
 }
 
+TEST_CASE( "FolderCrawlerWidget coalesces synchronous selections for one pending file",
+           "[folder][pending][regression]" )
+{
+    // A result click starts an asynchronous LogData index. A second click in the
+    // SAME uncached file can arrive synchronously before the event loop delivers
+    // loadingFinished. It must update only the pending jump -- not discard the
+    // in-flight LogData and start the same index again. A different file remains
+    // a true supersede and must replace the pending object.
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "a.log", 12, { 2, 8 } );
+    const QString b = makeFile( dir, "b.log", 12, { 5 } );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a, b } );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    const auto resultRowsForFile = [ & ]( const QString& path ) {
+        std::vector<LineNumber> rows;
+        const auto total = widget.folderResults()->getNbLine().get();
+        for ( uint64_t i = 0; i < total; ++i ) {
+            const LineNumber row{ i };
+            if ( widget.folderResults()->lineKind( row ) == LineKind::Data
+                 && widget.folderResults()->sourceForLine( row ).filePath == path ) {
+                rows.push_back( row );
+            }
+        }
+        return rows;
+    };
+
+    const auto aRows = resultRowsForFile( a );
+    const auto bRows = resultRowsForFile( b );
+    REQUIRE( aRows.size() == 2 );
+    REQUIRE( bRows.size() == 1 );
+    const auto firstALine = widget.folderResults()->sourceForLine( aRows[ 0 ] ).localLine;
+    const auto secondALine = widget.folderResults()->sourceForLine( aRows[ 1 ] ).localLine;
+    const auto bLine = widget.folderResults()->sourceForLine( bRows[ 0 ] ).localLine;
+    REQUIRE( firstALine == 2_lnum );
+    REQUIRE( secondALine == 8_lnum );
+    REQUIRE( bLine == 5_lnum );
+
+    using Access = FolderViewTestAccess;
+
+    SECTION( "same pending file keeps its LogData and completes once at the newest match" )
+    {
+        QSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+
+        // No event-loop turn between these calls: A is still uncached and pending
+        // for both selections.
+        widget.selectResultRow( aRows[ 0 ] );
+        const auto firstPending = Access::pendingMainData( &widget );
+        REQUIRE_FALSE( firstPending.expired() );
+        REQUIRE( Access::pendingJumpLine( &widget ) == firstALine );
+
+        widget.selectResultRow( aRows[ 1 ] );
+        const auto secondPending = Access::pendingMainData( &widget );
+        REQUIRE_FALSE( secondPending.expired() );
+        REQUIRE_FALSE( firstPending.owner_before( secondPending ) );
+        REQUIRE_FALSE( secondPending.owner_before( firstPending ) );
+        REQUIRE( Access::pendingJumpLine( &widget ) == secondALine );
+
+        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+        QTest::qWait( 200 ); // deterministic close-after-load settle
+
+        // One shared pending index completes once, and consumes the second jump.
+        REQUIRE( completionSpy.count() == 1 );
+        const auto selected
+            = AbstractLogView::access_by<FolderViewTestAccess>::selectedLines( widget.mainView() );
+        REQUIRE( selected.size() == 1 );
+        REQUIRE( selected.front() == secondALine );
+    }
+
+    SECTION( "a different pending file still replaces the in-flight LogData" )
+    {
+        QSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+
+        widget.selectResultRow( aRows[ 0 ] );
+        const auto pendingA = Access::pendingMainData( &widget );
+        REQUIRE_FALSE( pendingA.expired() );
+
+        // Still no event-loop turn: this is a genuine A-pending -> B-pending
+        // supersede, not a cache or current-file swap. Compare weak ownership so
+        // the assertion cannot be fooled by allocator address reuse and does not
+        // keep the abandoned A load alive.
+        widget.selectResultRow( bRows[ 0 ] );
+        const auto pendingB = Access::pendingMainData( &widget );
+        REQUIRE_FALSE( pendingB.expired() );
+        REQUIRE( ( pendingA.owner_before( pendingB ) || pendingB.owner_before( pendingA ) ) );
+        REQUIRE( Access::pendingJumpLine( &widget ) == bLine );
+
+        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+        QTest::qWait( 200 );
+        REQUIRE( completionSpy.count() == 1 );
+        const auto selected
+            = AbstractLogView::access_by<FolderViewTestAccess>::selectedLines( widget.mainView() );
+        REQUIRE( selected.size() == 1 );
+        REQUIRE( selected.front() == bLine );
+    }
+}
+
 TEST_CASE( "FolderCrawlerWidget reselecting the same file reuses it without reload churn",
            "[folder]" )
 {
@@ -983,6 +1125,7 @@ TEST_CASE( "FolderCrawlerWidget reselecting the same file reuses it without relo
 
     widget.selectResultRow( 1_lnum ); // first select -> async load + swap
     REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    QTest::qWait( 200 );
 
     // Selecting another row in the SAME file must keep the same file loaded.
     widget.selectResultRow( 2_lnum );
@@ -3591,6 +3734,121 @@ TEST_CASE( "Folder results view navigates marks with bracket shortcuts",
     pressConfiguredShortcut( view->viewport(), ShortcutAction::LogViewPrevMark );
     REQUIRE( selectionSpy.count() == spyCount + 1 );
     REQUIRE( selectionSpy.last().at( 0 ).value<LineNumber>() == 1_lnum );
+}
+
+TEST_CASE( "Folder results navigation is bounded by visible rows, not source line numbers",
+           "[folder][navigation][regression]" )
+{
+    // FolderFilteredView displays a compact row model (including its group header),
+    // while maxDisplayLineNumber() describes the largest SOURCE line number for
+    // gutter sizing. Navigation must never confuse those coordinate spaces.
+    constexpr int matchCount = 40;
+    constexpr int sourceStride = 100;
+    constexpr int totalSourceLines = matchCount * sourceStride;
+    std::vector<int> matchLines;
+    matchLines.reserve( matchCount );
+    for ( int i = 0; i < matchCount; ++i ) {
+        matchLines.push_back( i * sourceStride );
+    }
+
+    QTemporaryDir dir;
+    REQUIRE( dir.isValid() );
+    const QString a = makeFile( dir, "sparse.log", totalSourceLines, matchLines );
+
+    FolderCrawlerWidget widget;
+    widget.setFolder( dir.path(), QStringList{ a } );
+    widget.show();
+    widget.resize( 800, 600 );
+    QTest::qWait( 100 );
+    widget.searchFor( "ERROR" );
+    REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
+
+    auto* const view = widget.filteredView();
+    REQUIRE( view != nullptr );
+    const auto visibleRows = widget.folderResults()->getNbLine();
+    REQUIRE( visibleRows == LinesCount( matchCount + 1 ) ); // one header + matches
+    const LineNumber lastVisibleRow{ visibleRows.get() - 1 };
+    REQUIRE( widget.folderResults()->lineKind( 0_lnum ) == LineKind::Header );
+    REQUIRE( widget.folderResults()->lineKind( lastVisibleRow ) == LineKind::Data );
+    REQUIRE( widget.folderResults()->sourceForLine( lastVisibleRow ).localLine
+             == LineNumber( ( matchCount - 1 ) * sourceStride ) );
+    // Keep the header in the normal row model; only the upper navigation bound is
+    // under test (no header skipping or special-casing).
+
+    view->viewport()->setFocus();
+    REQUIRE( waitFor( [ & ]() { return view->verticalScrollBar()->maximum() > 0; } ) );
+    using Access = AbstractLogView::access_by<FolderViewTestAccess>;
+
+    SECTION( "JumpToBottom selects the final visible result row" )
+    {
+        view->selectAndDisplayLine( 1_lnum );
+        view->verticalScrollBar()->setValue( 0 );
+        REQUIRE( view->verticalScrollBar()->value() < view->verticalScrollBar()->maximum() );
+
+        QSignalSpy selectionSpy( view, &AbstractLogView::newSelection );
+        pressConfiguredShortcut( view->viewport(), ShortcutAction::LogViewJumpToBottom );
+
+        REQUIRE( selectionSpy.count() == 1 );
+        REQUIRE( selectionSpy.last().at( 0 ).value<LineNumber>() == lastVisibleRow );
+        const auto selected = Access::selectedLines( view );
+        REQUIRE( selected.size() == 1 );
+        REQUIRE( selected.front() == lastVisibleRow );
+    }
+
+    SECTION( "JumpToTop is a no-op for an empty result model" )
+    {
+        // No rows are marked, so the Marks projection is a real empty compact
+        // model. JumpToTop must not manufacture row 0 and route it through the
+        // results view's newSelection -> source-file jump connection.
+        widget.setResultsVisibility( FolderSearchResults::Visibility::Marks );
+        REQUIRE( widget.folderResults()->getNbLine() == 0_lcount );
+        REQUIRE( Access::selectedLines( view ).empty() );
+
+        QSignalSpy sourceJumpSpy( view, &AbstractLogView::newSelection );
+        pressConfiguredShortcut( view->viewport(), ShortcutAction::LogViewJumpToTop );
+
+        REQUIRE( sourceJumpSpy.count() == 0 );
+        REQUIRE( Access::selectedLines( view ).empty() );
+        REQUIRE( widget.currentMainFilePath().isEmpty() );
+    }
+
+    SECTION( "Shift+Down reaches the final visible row but cannot pass it" )
+    {
+        const LineNumber penultimateRow = lastVisibleRow - 1_lcount;
+        view->selectAndDisplayLine( penultimateRow );
+
+        // LogViewSelectLinesDown is the configured Shift+Down action. The first
+        // press extends onto the last row.
+        pressConfiguredShortcut( view->viewport(), ShortcutAction::LogViewSelectLinesDown );
+        const auto atBottom = Access::selectedLines( view );
+        REQUIRE( atBottom.size() == 2 );
+        REQUIRE( atBottom.front() == penultimateRow );
+        REQUIRE( atBottom.back() == lastVisibleRow );
+
+        // A second press at the boundary is a no-op, not a phantom row after the
+        // compact FolderSearchResults data set.
+        pressConfiguredShortcut( view->viewport(), ShortcutAction::LogViewSelectLinesDown );
+        REQUIRE( Access::selectedLines( view ) == atBottom );
+    }
+
+    SECTION( "forward mark fallback probes only visible result rows" )
+    {
+        // A standalone FolderFilteredView has no MarkProvider, forcing the base
+        // linear fallback. Override lineType only to record every row it probes;
+        // no row is marked, so a correct traversal visits rows 1..last exactly.
+        QuickFindPattern quickFindPattern;
+        NoProviderFolderMarkProbeView probeView( widget.folderResults(), &quickFindPattern );
+        probeView.selectAndDisplayLine( 0_lnum );
+        Access::selectNextMark( &probeView );
+
+        const auto& probed = probeView.probedLines();
+        REQUIRE( probed.size() == static_cast<size_t>( visibleRows.get() - 1 ) );
+        REQUIRE( probed.front() == 1_lnum );
+        REQUIRE( probed.back() == lastVisibleRow );
+        REQUIRE( std::all_of( probed.cbegin(), probed.cend(), [ visibleRows ]( LineNumber line ) {
+            return line < visibleRows;
+        } ) );
+    }
 }
 
 TEST_CASE( "FolderCrawlerWidget color labels apply to the selection in every view",

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(
   pure_catch_main.cpp
 )
 target_link_libraries(
-  klogg_ios_protocol_tests PRIVATE klogg_livecapture Catch2 project_options project_warnings
+  klogg_ios_protocol_tests PRIVATE klogg_ios_protocol Catch2 project_options project_warnings
 )
 klogg_configure_test_target(klogg_ios_protocol_tests)
 add_test(NAME klogg_ios_protocol_tests COMMAND klogg_ios_protocol_tests)
@@ -38,9 +38,9 @@ set_tests_properties(klogg_configuration_preapplication_tests PROPERTIES TIMEOUT
 find_package(Threads REQUIRED)
 
 # Native iOS discovery and stream-worker lifecycle are specified against an
-# injected C-ABI table. This target intentionally has no Qt or libimobiledevice
-# linkage: catalog snapshots, passive pairing, callbacks, ownership, event
-# races, queueing, and shutdown remain source-neutral and device-free.
+# injected C-ABI table. Tests include no Qt or libimobiledevice APIs directly:
+# catalog snapshots, passive pairing, callbacks, ownership, event races,
+# queueing, and shutdown remain source-neutral and device-free.
 add_executable(
   klogg_ios_native_contract_tests
   ios_device_catalog_test.cpp

--- a/tests/unit/adb_protocol_test.cpp
+++ b/tests/unit/adb_protocol_test.cpp
@@ -523,15 +523,15 @@ TEST_CASE( "ADB host and transport service builders produce exact smart-socket t
            "[livecapture][adb][protocol][command]" )
 {
     const auto version = buildHostService( HostService::Version );
-    const auto features = buildHostService( HostService::Features );
+    const auto serverFeatures = buildHostService( HostService::ServerFeatures );
     const auto devices = buildHostService( HostService::DevicesLong );
     const auto trackDevices = buildHostService( HostService::TrackDevicesLong );
     REQUIRE( version.value.has_value() );
-    REQUIRE( features.value.has_value() );
+    REQUIRE( serverFeatures.value.has_value() );
     REQUIRE( devices.value.has_value() );
     REQUIRE( trackDevices.value.has_value() );
     CHECK( *version.value == "host:version" );
-    CHECK( *features.value == "host:features" );
+    CHECK( *serverFeatures.value == "host:host-features" );
     CHECK( *devices.value == "host:devices-l" );
     CHECK( *trackDevices.value == "host:track-devices-l" );
 
@@ -540,20 +540,35 @@ TEST_CASE( "ADB host and transport service builders produce exact smart-socket t
     REQUIRE( invalidHost.error.has_value() );
     CHECK( invalidHost.error->code == ProtocolErrorCode::InvalidCommandOption );
 
+    const auto transportFeatures = buildTransportHostService( TransportHostService::Features );
+    REQUIRE( transportFeatures.value.has_value() );
+    REQUIRE_FALSE( transportFeatures.error.has_value() );
+    CHECK( *transportFeatures.value == "host:features" );
+
+    const auto invalidTransportService
+        = buildTransportHostService( static_cast<TransportHostService>( 0xffu ) );
+    REQUIRE_FALSE( invalidTransportService.value.has_value() );
+    REQUIRE( invalidTransportService.error.has_value() );
+    CHECK( invalidTransportService.error->code == ProtocolErrorCode::InvalidCommandOption );
+
     const auto any = buildTransportService( TransportSelection{ TransportKind::Any, {} } );
     const auto usb = buildTransportService( TransportSelection{ TransportKind::Usb, {} } );
     const auto local = buildTransportService( TransportSelection{ TransportKind::Local, {} } );
     const auto serial
         = buildTransportService( TransportSelection{ TransportKind::Serial, "emulator-5554" } );
+    const auto colonSerial
+        = buildTransportService( TransportSelection{ TransportKind::Serial, "foo:bar" } );
 
     REQUIRE( any.value.has_value() );
     REQUIRE( usb.value.has_value() );
     REQUIRE( local.value.has_value() );
     REQUIRE( serial.value.has_value() );
+    REQUIRE( colonSerial.value.has_value() );
     CHECK( *any.value == "host:transport-any" );
     CHECK( *usb.value == "host:transport-usb" );
     CHECK( *local.value == "host:transport-local" );
     CHECK( *serial.value == "host:transport:emulator-5554" );
+    CHECK( *colonSerial.value == "host:transport:foo:bar" );
 
     const auto missingSerial
         = buildTransportService( TransportSelection{ TransportKind::Serial, {} } );
@@ -588,13 +603,14 @@ TEST_CASE( "ADB host and transport service builders produce exact smart-socket t
     CHECK( oversized.error->code == ProtocolErrorCode::PayloadTooLarge );
 }
 
-TEST_CASE( "typed ADB logcat command builder emits exact streaming and clear services",
-           "[livecapture][adb][protocol][command]" )
+TEST_CASE( "typed ADB logcat command builder owns ordered source-device wall-time modifiers",
+           "[livecapture][adb][protocol][command][wall-time]" )
 {
     const auto defaults = buildLogcatService( LogcatCommandOptions{} );
     REQUIRE( defaults.value.has_value() );
     REQUIRE_FALSE( defaults.error.has_value() );
-    CHECK( *defaults.value == "shell,v2,raw:logcat" );
+    CHECK( *defaults.value
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec" );
 
     LogcatCommandOptions options;
     options.ansiOutputEnabled = true;
@@ -609,10 +625,25 @@ TEST_CASE( "typed ADB logcat command builder emits exact streaming and clear ser
     REQUIRE( structured.value.has_value() );
     REQUIRE_FALSE( structured.error.has_value() );
     CHECK( *structured.value
-           == "shell,v2,raw:logcat -v color -b main -b system -b crash -T 25 "
-              "--pid 4242 'ActivityManager:I' '*:S'" );
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec -v color -b main "
+              "-b system -b crash -T 25 --pid 4242 'ActivityManager:I' '*:S'" );
 
     CHECK( buildClearLogcatService() == "shell,v2,raw:logcat -c" );
+}
+
+TEST_CASE( "ADB logcat diagnostics classify only rejected owned format modifiers",
+           "[livecapture][adb][protocol][command][wall-time][diagnostic]" )
+{
+    const std::string unsupported{ "Invalid parameter year to -v\n" };
+    const auto normalized = normalizeLogcatStreamError( unsupported );
+    CHECK( normalized.find( "Android 7.0" ) != std::string::npos );
+    CHECK( normalized.find( "source-device wall time" ) != std::string::npos );
+    CHECK( normalized.find( unsupported ) != std::string::npos );
+
+    const std::string unrelated{
+        "Invalid parameter nope to -r\nusage: logcat [options]\n  -v <format>\n"
+    };
+    CHECK( normalizeLogcatStreamError( unrelated ) == unrelated );
 }
 
 TEST_CASE( "ADB logcat command builder shell-quotes filter values without interpolation",
@@ -629,8 +660,8 @@ TEST_CASE( "ADB logcat command builder shell-quotes filter values without interp
     REQUIRE( command.value.has_value() );
     REQUIRE_FALSE( command.error.has_value() );
     CHECK( *command.value
-           == "shell,v2,raw:logcat -v color --pid 4294967295 "
-              "'Activity Manager'\"'\"'$(reboot):I'" );
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec -v color "
+              "--pid 4294967295 'Activity Manager'\"'\"'$(reboot):I'" );
 }
 
 TEST_CASE( "ADB logcat command builder rejects options that cannot be represented safely",

--- a/tests/unit/adb_smart_socket_client_test.cpp
+++ b/tests/unit/adb_smart_socket_client_test.cpp
@@ -416,12 +416,61 @@ public:
         } );
     }
 
+    std::size_t armCount( AdbSmartSocketDeadlineKind kind ) const
+    {
+        return static_cast<std::size_t>(
+            std::count_if( entries_.cbegin(), entries_.cend(), [ kind ]( const Entry& entry ) {
+                return entry.kind == kind;
+            } ) );
+    }
+
+    DeadlineToken activeToken( AdbSmartSocketDeadlineKind kind ) const
+    {
+        const auto found
+            = std::find_if( entries_.cbegin(), entries_.cend(), [ kind ]( const Entry& entry ) {
+                  return entry.active && entry.kind == kind && !entry.context.isNull();
+              } );
+        REQUIRE( found != entries_.cend() );
+        return found->token;
+    }
+
+    bool isActive( DeadlineToken token ) const
+    {
+        const auto found = std::find_if(
+            entries_.cbegin(), entries_.cend(),
+            [ token ]( const Entry& entry ) { return entry.token == token; } );
+        REQUIRE( found != entries_.cend() );
+        return found->active && !found->context.isNull();
+    }
+
+    int timeoutMs( DeadlineToken token ) const
+    {
+        const auto found = std::find_if(
+            entries_.cbegin(), entries_.cend(),
+            [ token ]( const Entry& entry ) { return entry.token == token; } );
+        REQUIRE( found != entries_.cend() );
+        return found->timeoutMs;
+    }
+
     void fire( AdbSmartSocketDeadlineKind kind )
     {
         auto found
             = std::find_if( entries_.begin(), entries_.end(), [ kind ]( const Entry& entry ) {
                   return entry.active && entry.kind == kind && !entry.context.isNull();
               } );
+        REQUIRE( found != entries_.end() );
+        found->active = false;
+        const auto callback = found->callback;
+        callback();
+    }
+
+    void fire( DeadlineToken token )
+    {
+        auto found = std::find_if( entries_.begin(), entries_.end(),
+                                  [ token ]( const Entry& entry ) {
+                                      return entry.token == token && entry.active
+                                             && !entry.context.isNull();
+                                  } );
         REQUIRE( found != entries_.end() );
         found->active = false;
         const auto callback = found->callback;
@@ -619,7 +668,7 @@ void requireHostUnexpectedEof( const QByteArray& responsePrefix )
 
     constexpr Generation generation = 501;
     constexpr AdbSmartSocketClient::OperationId operationId = 601;
-    client.requestHostService( generation, operationId, HostService::Features );
+    client.requestHostService( generation, operationId, HostService::ServerFeatures );
 
     REQUIRE(
         pumpEventsUntil( [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
@@ -684,8 +733,9 @@ TEST_CASE( "ADB smart-socket host requests are loopback-only nonblocking bounded
 {
     const QByteArray features = QByteArrayLiteral( "shell_v2,cmd,stat_v2,apex" );
     FakeAdbServer server( [ features ]( QTcpSocket& socket, int, int, const QByteArray& request ) {
-        REQUIRE( request == QByteArrayLiteral( "host:features" ) );
-        FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( features ) );
+        REQUIRE( request == QByteArrayLiteral( "host:host-features" ) );
+        FakeAdbServer::sendThenClose( socket,
+                                      QByteArrayLiteral( "OKAY" ) + hostReplyFrame( features ) );
     } );
     InspectableSocketFactory socketFactory( InspectableTcpSocket::WriteMode::Partial, 2 );
     ManualDeadlineScheduler deadlines;
@@ -697,7 +747,7 @@ TEST_CASE( "ADB smart-socket host requests are loopback-only nonblocking bounded
 
     constexpr Generation generation = 41;
     constexpr AdbSmartSocketClient::OperationId operationId = 7001;
-    client.requestHostService( generation, operationId, HostService::Features );
+    client.requestHostService( generation, operationId, HostService::ServerFeatures );
 
     // Starting the operation must only schedule connectToHost; it must not spin or block
     // until the local server accepts the connection.
@@ -708,7 +758,7 @@ TEST_CASE( "ADB smart-socket host requests are loopback-only nonblocking bounded
         [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 1; } ) );
     REQUIRE( server.connectionCount() == 1 );
     REQUIRE( server.requestCount() == 1 );
-    CHECK( server.requests().front() == QByteArrayLiteral( "host:features" ) );
+    CHECK( server.requests().front() == QByteArrayLiteral( "host:host-features" ) );
     CHECK( server.peerWasLoopbackAtAccept( 0 ) );
 
     REQUIRE( probe.count( ClientCallback::Kind::Connected ) == 1 );
@@ -749,7 +799,7 @@ TEST_CASE( "ADB smart-socket client sends exact features and devices-l host tran
         AdbSmartSocketClient::OperationId operationId;
     };
     const std::vector<Scenario> scenarios{
-        { HostService::Features, QByteArrayLiteral( "host:features" ),
+        { HostService::ServerFeatures, QByteArrayLiteral( "host:host-features" ),
           QByteArrayLiteral( "shell_v2,cmd" ), 1001 },
         { HostService::DevicesLong, QByteArrayLiteral( "host:devices-l" ),
           QByteArrayLiteral( "emulator-5554\tdevice transport_id:1\n" ), 1002 },
@@ -761,8 +811,8 @@ TEST_CASE( "ADB smart-socket client sends exact features and devices-l host tran
             FakeAdbServer server(
                 [ &scenario ]( QTcpSocket& socket, int, int, const QByteArray& request ) {
                     REQUIRE( request == scenario.request );
-                    FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" )
-                                                     + hostReplyFrame( scenario.reply ) );
+                    FakeAdbServer::sendThenClose(
+                        socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( scenario.reply ) );
                 } );
             InspectableSocketFactory socketFactory;
             ManualDeadlineScheduler deadlines;
@@ -779,6 +829,319 @@ TEST_CASE( "ADB smart-socket client sends exact features and devices-l host tran
             CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
         }
     }
+}
+
+TEST_CASE( "ADB smart-socket selected-device features use a transport-scoped host transaction",
+           "[livecapture][adb][network][client][host][transport]" )
+{
+    constexpr Generation generation = 82;
+    constexpr AdbSmartSocketClient::OperationId operationId = 1003;
+    const TransportSelection transport{ TransportKind::Serial, "foo:bar" };
+    const QByteArray features = QByteArrayLiteral( "shell_v2,cmd,stat_v2" );
+
+    FakeAdbServer server( [ features ]( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                        const QByteArray& request ) {
+        REQUIRE( connectionIndex == 0 );
+        if ( requestIndex == 0 ) {
+            REQUIRE( request == QByteArrayLiteral( "host:transport:foo:bar" ) );
+            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+            return;
+        }
+
+        REQUIRE( requestIndex == 1 );
+        REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+        FakeAdbServer::sendThenClose( socket,
+                                      QByteArrayLiteral( "OKAY" ) + hostReplyFrame( features ) );
+    } );
+    InspectableSocketFactory socketFactory;
+    ManualDeadlineScheduler deadlines;
+    AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+    ClientProbe probe( client );
+
+    client.requestTransportHostService( generation, operationId, transport,
+                                        TransportHostService::Features );
+
+    REQUIRE( pumpEventsUntil(
+        [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 1; } ) );
+    REQUIRE( server.connectionCount() == 1 );
+    REQUIRE( socketFactory.socketCount() == 1 );
+    REQUIRE( server.requestCount() == 2 );
+    REQUIRE( server.requestConnections().size() == 2 );
+    CHECK( server.requests().at( 0 ) == QByteArrayLiteral( "host:transport:foo:bar" ) );
+    CHECK( server.requests().at( 1 ) == QByteArrayLiteral( "host:features" ) );
+    CHECK( server.requestConnections().at( 0 ) == 0 );
+    CHECK( server.requestConnections().at( 1 ) == 0 );
+    CHECK( probe.first( ClientCallback::Kind::HostReply ).bytes == features );
+    CHECK( probe.count( ClientCallback::Kind::HostReply ) == 1 );
+    CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
+    CHECK( probe.allCallbacksMatch( generation, operationId ) );
+}
+
+TEST_CASE( "ADB smart-socket selected-device feature query preserves transport and feature FAIL diagnostics",
+           "[livecapture][adb][network][client][host][transport][error]" )
+{
+    constexpr Generation generation = 83;
+    const TransportSelection transport{ TransportKind::Serial, "emulator-5554" };
+
+    SECTION( "transport FAIL" )
+    {
+        constexpr AdbSmartSocketClient::OperationId operationId = 1004;
+        const QByteArray diagnostic = QByteArrayLiteral( "device 'emulator-5554' not found" );
+        FakeAdbServer server(
+            [ diagnostic ]( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                            const QByteArray& request ) {
+                REQUIRE( connectionIndex == 0 );
+                REQUIRE( requestIndex == 0 );
+                REQUIRE( request == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                FakeAdbServer::send(
+                    socket, QByteArrayLiteral( "FAIL" ) + hostReplyFrame( diagnostic ) );
+            } );
+        InspectableSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+        ClientProbe probe( client );
+
+        client.requestTransportHostService( generation, operationId, transport,
+                                            TransportHostService::Features );
+
+        REQUIRE( pumpEventsUntil(
+            [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
+        REQUIRE( server.connectionCount() == 1 );
+        REQUIRE( server.requestCount() == 1 );
+        const auto& error = probe.first( ClientCallback::Kind::Error );
+        CHECK( error.errorCode == AdbSmartSocketErrorCode::RemoteFailure );
+        CHECK( error.diagnostic.contains( QString::fromUtf8( diagnostic ) ) );
+        CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+        CHECK( probe.allCallbacksMatch( generation, operationId ) );
+    }
+
+    SECTION( "features FAIL" )
+    {
+        constexpr AdbSmartSocketClient::OperationId operationId = 1005;
+        const QByteArray diagnostic = QByteArrayLiteral( "selected device rejected host:features" );
+        FakeAdbServer server(
+            [ diagnostic ]( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                            const QByteArray& request ) {
+                REQUIRE( connectionIndex == 0 );
+                if ( requestIndex == 0 ) {
+                    REQUIRE( request == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                    FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                    return;
+                }
+
+                REQUIRE( requestIndex == 1 );
+                REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+                FakeAdbServer::send(
+                    socket, QByteArrayLiteral( "FAIL" ) + hostReplyFrame( diagnostic ) );
+            } );
+        InspectableSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+        ClientProbe probe( client );
+
+        client.requestTransportHostService( generation, operationId, transport,
+                                            TransportHostService::Features );
+
+        REQUIRE( pumpEventsUntil(
+            [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
+        REQUIRE( server.connectionCount() == 1 );
+        REQUIRE( server.requestCount() == 2 );
+        const auto& error = probe.first( ClientCallback::Kind::Error );
+        CHECK( error.errorCode == AdbSmartSocketErrorCode::RemoteFailure );
+        CHECK( error.diagnostic.contains( QString::fromUtf8( diagnostic ) ) );
+        CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+        CHECK( probe.allCallbacksMatch( generation, operationId ) );
+    }
+}
+
+TEST_CASE( "ADB smart-socket selected-device feature replies reject malformed framing and trailing "
+           "bytes",
+           "[livecapture][adb][network][client][host][transport][protocol]" )
+{
+    struct Scenario {
+        QByteArray response;
+        AdbSmartSocketClient::OperationId operationId;
+    };
+    const std::vector<Scenario> scenarios{
+        { QByteArrayLiteral( "OKAY00Z1" ), 1005 },
+        { QByteArrayLiteral( "OKAY" ) + hostReplyFrame( QByteArrayLiteral( "one" ) )
+              + hostReplyFrame( QByteArrayLiteral( "two" ) ),
+          1006 },
+        { QByteArrayLiteral( "OKAY" ) + hostReplyFrame( QByteArrayLiteral( "one" ) )
+              + QByteArrayLiteral( "00" ),
+          1007 },
+    };
+
+    for ( const auto& scenario : scenarios ) {
+        DYNAMIC_SECTION( "response size " << scenario.response.size() )
+        {
+            FakeAdbServer server(
+                [ &scenario ]( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                               const QByteArray& request ) {
+                    REQUIRE( connectionIndex == 0 );
+                    if ( requestIndex == 0 ) {
+                        REQUIRE( request
+                                 == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                        FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                        return;
+                    }
+                    REQUIRE( requestIndex == 1 );
+                    REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+                    FakeAdbServer::send( socket, scenario.response );
+                } );
+            InspectableSocketFactory socketFactory;
+            ManualDeadlineScheduler deadlines;
+            AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+            ClientProbe probe( client );
+
+            constexpr Generation generation = 84;
+            client.requestTransportHostService(
+                generation, scenario.operationId,
+                TransportSelection{ TransportKind::Serial, "emulator-5554" },
+                TransportHostService::Features );
+
+            REQUIRE( pumpEventsUntil(
+                [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
+            CHECK( server.connectionCount() == 1 );
+            CHECK( server.requestCount() == 2 );
+            CHECK( probe.first( ClientCallback::Kind::Error ).errorCode
+                   == AdbSmartSocketErrorCode::Protocol );
+            CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+            CHECK( probe.allCallbacksMatch( generation, scenario.operationId ) );
+        }
+    }
+}
+
+TEST_CASE( "ADB smart-socket selected-device feature transaction preserves cancellation and "
+           "timeout correlation",
+           "[livecapture][adb][network][client][host][transport][cancel][deadline]" )
+{
+    const TransportSelection transport{ TransportKind::Serial, "emulator-5554" };
+
+    SECTION( "cancellation while awaiting the one-shot host reply is silent" )
+    {
+        FakeAdbServer server( []( QTcpSocket& socket, int, int requestIndex,
+                                  const QByteArray& request ) {
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+        } );
+        InspectableSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+        ClientProbe probe( client );
+
+        constexpr Generation generation = 85;
+        constexpr AdbSmartSocketClient::OperationId operationId = 1008;
+        client.requestTransportHostService( generation, operationId, transport,
+                                            TransportHostService::Features );
+        REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
+            return server.requestCount() == 2
+                   && deadlines.hasActive( AdbSmartSocketDeadlineKind::Read );
+        } ) );
+
+        client.cancelGeneration( generation );
+        deadlines.fireLastEvenIfCancelled();
+        QCoreApplication::processEvents( QEventLoop::AllEvents );
+
+        CHECK( server.connectionCount() == 1 );
+        CHECK( server.requestCount() == 2 );
+        CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
+        CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+    }
+
+    SECTION( "one-shot host reply read timeout keeps operation correlation" )
+    {
+        FakeAdbServer server( []( QTcpSocket& socket, int, int requestIndex,
+                                  const QByteArray& request ) {
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+        } );
+        InspectableSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+        ClientProbe probe( client );
+
+        constexpr Generation generation = 86;
+        constexpr AdbSmartSocketClient::OperationId operationId = 1009;
+        client.requestTransportHostService( generation, operationId, transport,
+                                            TransportHostService::Features );
+        REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
+            return server.requestCount() == 2
+                   && deadlines.hasActive( AdbSmartSocketDeadlineKind::Read );
+        } ) );
+
+        deadlines.fire( AdbSmartSocketDeadlineKind::Read );
+
+        REQUIRE( probe.count( ClientCallback::Kind::Error ) == 1 );
+        CHECK( server.connectionCount() == 1 );
+        CHECK( server.requestCount() == 2 );
+        CHECK( probe.first( ClientCallback::Kind::Error ).errorCode
+               == AdbSmartSocketErrorCode::ReadTimeout );
+        CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+        CHECK( probe.allCallbacksMatch( generation, operationId ) );
+    }
+}
+
+TEST_CASE( "ADB one-shot host reply rearms a full EOF deadline while the socket stays open",
+           "[livecapture][adb][network][client][host][eof][deadline]" )
+{
+    FakeAdbServer server( []( QTcpSocket& socket, int, int, const QByteArray& request ) {
+        REQUIRE( request == QByteArrayLiteral( "host:host-features" ) );
+        FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+    } );
+    InspectableSocketFactory socketFactory;
+    ManualDeadlineScheduler deadlines;
+    const auto config = clientConfig( server.port() );
+    AdbSmartSocketClient client( config, socketFactory, deadlines );
+    ClientProbe probe( client );
+
+    constexpr Generation generation = 87;
+    constexpr AdbSmartSocketClient::OperationId operationId = 1010;
+    client.requestHostService( generation, operationId, HostService::ServerFeatures );
+    REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
+        return server.requestCount() == 1
+               && deadlines.armCount( AdbSmartSocketDeadlineKind::Read ) >= 2u
+               && deadlines.hasActive( AdbSmartSocketDeadlineKind::Read );
+    } ) );
+
+    const auto payloadReadDeadline
+        = deadlines.activeToken( AdbSmartSocketDeadlineKind::Read );
+    REQUIRE( deadlines.timeoutMs( payloadReadDeadline ) == config.readTimeoutMs );
+    const auto readsBeforeReply = socketFactory.requestedReadSizes().size();
+    FakeAdbServer::send( *server.socketAt( 0 ),
+                         hostReplyFrame( QByteArrayLiteral( "shell_v2,cmd" ) ) );
+    REQUIRE( pumpEventsUntil( [ &socketFactory, readsBeforeReply ] {
+        return socketFactory.requestedReadSizes().size() > readsBeforeReply;
+    } ) );
+
+    CHECK( server.socketAt( 0 )->state() == QAbstractSocket::ConnectedState );
+    CHECK_FALSE( deadlines.isActive( payloadReadDeadline ) );
+    CHECK( deadlines.armCount( AdbSmartSocketDeadlineKind::Read ) == 3u );
+    REQUIRE( deadlines.hasActive( AdbSmartSocketDeadlineKind::Read ) );
+    const auto eofDeadline = deadlines.activeToken( AdbSmartSocketDeadlineKind::Read );
+    CHECK( eofDeadline != payloadReadDeadline );
+    CHECK( deadlines.timeoutMs( eofDeadline ) == config.readTimeoutMs );
+    CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+    CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
+
+    deadlines.fire( eofDeadline );
+
+    REQUIRE( probe.count( ClientCallback::Kind::Error ) == 1 );
+    const auto& error = probe.first( ClientCallback::Kind::Error );
+    CHECK( error.errorCode == AdbSmartSocketErrorCode::ReadTimeout );
+    CHECK( error.generation == generation );
+    CHECK( error.operationId == operationId );
+    CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
 }
 
 TEST_CASE( "ADB smart-socket shell operation sequences transport and service on one socket",
@@ -953,7 +1316,7 @@ TEST_CASE( "ADB smart-socket FAIL replies preserve remote diagnostics",
         AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
         ClientProbe probe( client );
 
-        client.requestHostService( 101, 3001, HostService::Features );
+        client.requestHostService( 101, 3001, HostService::ServerFeatures );
         REQUIRE( pumpEventsUntil(
             [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
         const auto& error = probe.first( ClientCallback::Kind::Error );
@@ -1044,7 +1407,7 @@ TEST_CASE( "ADB smart-socket deadlines are deterministic for connect write and r
                                      deadlines );
         ClientProbe probe( client );
 
-        client.requestHostService( 201, 4001, HostService::Features );
+        client.requestHostService( 201, 4001, HostService::ServerFeatures );
         REQUIRE( deadlines.hasActive( AdbSmartSocketDeadlineKind::Connect ) );
         deadlines.fire( AdbSmartSocketDeadlineKind::Connect );
 
@@ -1063,7 +1426,7 @@ TEST_CASE( "ADB smart-socket deadlines are deterministic for connect write and r
         AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
         ClientProbe probe( client );
 
-        client.requestHostService( 202, 4002, HostService::Features );
+        client.requestHostService( 202, 4002, HostService::ServerFeatures );
         REQUIRE( pumpEventsUntil(
             [ &deadlines ] { return deadlines.hasActive( AdbSmartSocketDeadlineKind::Write ); } ) );
         deadlines.fire( AdbSmartSocketDeadlineKind::Write );
@@ -1109,7 +1472,7 @@ TEST_CASE( "ADB smart-socket cancels a deadline token returned after a synchrono
     AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 251, 4501, HostService::Features );
+    client.requestHostService( 251, 4501, HostService::ServerFeatures );
 
     REQUIRE(
         pumpEventsUntil( [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
@@ -1133,7 +1496,7 @@ TEST_CASE( "ADB smart-socket cancel invalidates generation and closes without an
     ClientProbe probe( client );
 
     constexpr Generation generation = 301;
-    client.requestHostService( generation, 5001, HostService::Features );
+    client.requestHostService( generation, 5001, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
         return server.requestCount() == 1
                && deadlines.hasActive( AdbSmartSocketDeadlineKind::Read );
@@ -1164,18 +1527,19 @@ TEST_CASE( "ADB smart-socket reconnect reconstructs sockets and resets partial d
             FakeAdbServer::send( socket, QByteArrayLiteral( "OKA" ) );
             return;
         }
-        FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( secondReply ) );
+        FakeAdbServer::sendThenClose(
+            socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( secondReply ) );
     } );
     InspectableSocketFactory socketFactory;
     ManualDeadlineScheduler deadlines;
     AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 401, 6001, HostService::Features );
+    client.requestHostService( 401, 6001, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil( [ &server ] { return server.requestCount() == 1; } ) );
     client.cancelGeneration( 401 );
 
-    client.requestHostService( 402, 6002, HostService::Features );
+    client.requestHostService( 402, 6002, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil(
         [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 1; } ) );
 
@@ -1205,7 +1569,7 @@ TEST_CASE(
         AdbSmartSocketClient client( config, socketFactory, deadlines );
         ClientProbe probe( client );
 
-        client.requestHostService( 601, 7001, HostService::Features );
+        client.requestHostService( 601, 7001, HostService::ServerFeatures );
         REQUIRE( pumpEventsUntil(
             [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
         const auto& error = probe.first( ClientCallback::Kind::Error );
@@ -1288,7 +1652,8 @@ TEST_CASE( "ADB smart-socket terminal callbacks may synchronously start successo
                                   const QByteArray& ) {
             const auto reply = connectionIndex == 0 ? QByteArrayLiteral( "first" )
                                                     : QByteArrayLiteral( "second" );
-            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( reply ) );
+            FakeAdbServer::sendThenClose( socket,
+                                          QByteArrayLiteral( "OKAY" ) + hostReplyFrame( reply ) );
         } );
         InspectableSocketFactory socketFactory;
         ManualDeadlineScheduler deadlines;
@@ -1302,11 +1667,60 @@ TEST_CASE( "ADB smart-socket terminal callbacks may synchronously start successo
                               }
                           } );
 
-        client.requestHostService( 711, 8101, HostService::Features );
+        client.requestHostService( 711, 8101, HostService::ServerFeatures );
         REQUIRE( pumpEventsUntil(
             [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 2; } ) );
         CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
         CHECK( server.connectionCount() == 2 );
+    }
+
+    SECTION( "selected-device host reply starts another host request" )
+    {
+        FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                  const QByteArray& request ) {
+            if ( connectionIndex == 0 ) {
+                if ( requestIndex == 0 ) {
+                    REQUIRE( request
+                             == QByteArrayLiteral( "host:transport:emulator-5554" ) );
+                    FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                    return;
+                }
+
+                REQUIRE( requestIndex == 1 );
+                REQUIRE( request == QByteArrayLiteral( "host:features" ) );
+                FakeAdbServer::sendThenClose(
+                    socket, QByteArrayLiteral( "OKAY" )
+                                + hostReplyFrame( QByteArrayLiteral( "selected" ) ) );
+                return;
+            }
+
+            REQUIRE( connectionIndex == 1 );
+            REQUIRE( requestIndex == 0 );
+            REQUIRE( request == QByteArrayLiteral( "host:version" ) );
+            FakeAdbServer::sendThenClose(
+                socket, QByteArrayLiteral( "OKAY" )
+                            + hostReplyFrame( QByteArrayLiteral( "0029" ) ) );
+        } );
+        InspectableSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
+        ClientProbe probe( client );
+        QObject::connect( &client, &AdbSmartSocketClient::hostReplyReceived, &client,
+                          [ &client ]( Generation, AdbSmartSocketClient::OperationId operationId,
+                                       const QByteArray& ) {
+                              if ( operationId == 8151 ) {
+                                  client.requestHostService( 711, 8152, HostService::Version );
+                              }
+                          } );
+
+        client.requestTransportHostService(
+            711, 8151, TransportSelection{ TransportKind::Serial, "emulator-5554" },
+            TransportHostService::Features );
+        REQUIRE( pumpEventsUntil(
+            [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 2; } ) );
+        CHECK( probe.count( ClientCallback::Kind::Error ) == 0 );
+        CHECK( server.connectionCount() == 2 );
+        CHECK( server.requestCount() == 3 );
     }
 
     SECTION( "shell exit starts a host request" )
@@ -1321,9 +1735,9 @@ TEST_CASE( "ADB smart-socket terminal callbacks may synchronously start successo
                                                      + shellV2Frame( 3u, QByteArray( 1, '\0' ) ) );
                 }
                 else {
-                    FakeAdbServer::send( socket,
-                                         QByteArrayLiteral( "OKAY" )
-                                             + hostReplyFrame( QByteArrayLiteral( "features" ) ) );
+                    FakeAdbServer::sendThenClose(
+                        socket, QByteArrayLiteral( "OKAY" )
+                                    + hostReplyFrame( QByteArrayLiteral( "features" ) ) );
                 }
             } );
         InspectableSocketFactory socketFactory;
@@ -1333,7 +1747,7 @@ TEST_CASE( "ADB smart-socket terminal callbacks may synchronously start successo
         QObject::connect(
             &client, &AdbSmartSocketClient::shellExited, &client,
             [ &client ]( Generation, AdbSmartSocketClient::OperationId, std::uint8_t ) {
-                client.requestHostService( 712, 8202, HostService::Features );
+                client.requestHostService( 712, 8202, HostService::ServerFeatures );
             } );
 
         client.startShellService( 712, 8201, TransportSelection{ TransportKind::Any, {} },
@@ -1351,7 +1765,7 @@ TEST_CASE( "ADB smart-socket retires completed sockets without child accumulatio
            "[livecapture][adb][network][client][ownership]" )
 {
     FakeAdbServer server( []( QTcpSocket& socket, int, int, const QByteArray& ) {
-        FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY0000" ) );
+        FakeAdbServer::sendThenClose( socket, QByteArrayLiteral( "OKAY0000" ) );
     } );
     InspectableSocketFactory socketFactory;
     ManualDeadlineScheduler deadlines;
@@ -1360,7 +1774,7 @@ TEST_CASE( "ADB smart-socket retires completed sockets without child accumulatio
 
     for ( AdbSmartSocketClient::OperationId operationId = 8301; operationId < 8311;
           ++operationId ) {
-        client.requestHostService( 713, operationId, HostService::Features );
+        client.requestHostService( 713, operationId, HostService::ServerFeatures );
         REQUIRE( pumpEventsUntil( [ &probe, operationId ] {
             return probe.count( ClientCallback::Kind::HostReply )
                    == static_cast<int>( operationId - 8300 );
@@ -1380,7 +1794,7 @@ TEST_CASE( "ADB smart-socket write deadline covers accepted bytes until socket d
     AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 714, 8401, HostService::Features );
+    client.requestHostService( 714, 8401, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil(
         [ &deadlines ] { return deadlines.hasActive( AdbSmartSocketDeadlineKind::Write ); } ) );
     CHECK_FALSE( deadlines.hasActive( AdbSmartSocketDeadlineKind::Read ) );
@@ -1400,14 +1814,14 @@ TEST_CASE( "ADB smart-socket response after full write acceptance advances despi
     AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 715, 8501, HostService::Features );
+    client.requestHostService( 715, 8501, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
         return server.connectionCount() == 1
                && deadlines.hasActive( AdbSmartSocketDeadlineKind::Write );
     } ) );
-    FakeAdbServer::send( *server.socketAt( 0 ),
-                         QByteArrayLiteral( "OKAY" )
-                             + hostReplyFrame( QByteArrayLiteral( "shell_v2" ) ) );
+    FakeAdbServer::sendThenClose(
+        *server.socketAt( 0 ),
+        QByteArrayLiteral( "OKAY" ) + hostReplyFrame( QByteArrayLiteral( "shell_v2" ) ) );
 
     REQUIRE( pumpEventsUntil(
         [ &probe ] { return probe.count( ClientCallback::Kind::HostReply ) == 1; } ) );
@@ -1426,7 +1840,7 @@ TEST_CASE( "ADB smart-socket rejects unsolicited input before request acceptance
     AdbSmartSocketClient client( config, socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 716, 8601, HostService::Features );
+    client.requestHostService( 716, 8601, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil( [ &server, &deadlines ] {
         return server.connectionCount() == 1
                && deadlines.hasActive( AdbSmartSocketDeadlineKind::Write );
@@ -1471,9 +1885,50 @@ TEST_CASE( "ADB smart-socket rejects invalid configuration and non-v2 shell serv
         config.maxShellFrameBytes = 0;
         AdbSmartSocketClient client( config, socketFactory, deadlines );
         ClientProbe probe( client );
-        client.requestHostService( 718, 8801, HostService::Features );
+        client.requestHostService( 718, 8801, HostService::ServerFeatures );
         REQUIRE( probe.count( ClientCallback::Kind::Error ) == 1 );
         CHECK( socketFactory.socketCount() == 0 );
+    }
+
+    SECTION( "invalid selected-device feature inputs are rejected before connecting" )
+    {
+        struct Scenario {
+            const char* name;
+            TransportSelection transport;
+            TransportHostService service;
+            AdbSmartSocketClient::OperationId operationId;
+        };
+        const std::vector<Scenario> scenarios{
+            { "invalid service", { TransportKind::Serial, "emulator-5554" },
+              static_cast<TransportHostService>( 0xffu ), 8802 },
+            { "invalid transport kind",
+              { static_cast<TransportKind>( 0xffu ), "emulator-5554" },
+              TransportHostService::Features, 8803 },
+            { "missing serial", { TransportKind::Serial, {} },
+              TransportHostService::Features, 8804 },
+            { "NUL serial",
+              { TransportKind::Serial, std::string( "serial\0hidden", 13u ) },
+              TransportHostService::Features, 8805 },
+        };
+
+        for ( const auto& scenario : scenarios ) {
+            DYNAMIC_SECTION( scenario.name )
+            {
+                InspectableSocketFactory socketFactory;
+                ManualDeadlineScheduler deadlines;
+                AdbSmartSocketClient client( clientConfig( 5037 ), socketFactory, deadlines );
+                ClientProbe probe( client );
+
+                client.requestTransportHostService( 718, scenario.operationId,
+                                                            scenario.transport, scenario.service );
+
+                REQUIRE( probe.count( ClientCallback::Kind::Error ) == 1 );
+                CHECK( probe.first( ClientCallback::Kind::Error ).errorCode
+                       == AdbSmartSocketErrorCode::Protocol );
+                CHECK( probe.allCallbacksMatch( 718, scenario.operationId ) );
+                CHECK( socketFactory.socketCount() == 0 );
+            }
+        }
     }
 
     for ( const auto& service : std::vector<std::string>{
@@ -1517,7 +1972,7 @@ TEST_CASE( "ADB smart-socket queued callbacks preserve correlation and custom er
         },
         Qt::QueuedConnection );
 
-    client.requestHostService( 719, 8901, HostService::Features );
+    client.requestHostService( 719, 8901, HostService::ServerFeatures );
     REQUIRE( pumpEventsUntil( [ &queuedErrors ] { return queuedErrors == 1; } ) );
 }
 
@@ -1538,7 +1993,7 @@ TEST_CASE( "ADB smart-socket rejects extra or partial trailing one-shot host fra
             ManualDeadlineScheduler deadlines;
             AdbSmartSocketClient client( clientConfig( server.port() ), socketFactory, deadlines );
             ClientProbe probe( client );
-            client.requestHostService( 720, 9001, HostService::Features );
+            client.requestHostService( 720, 9001, HostService::ServerFeatures );
 
             REQUIRE( pumpEventsUntil(
                 [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
@@ -1549,6 +2004,32 @@ TEST_CASE( "ADB smart-socket rejects extra or partial trailing one-shot host fra
     }
 }
 
+TEST_CASE( "ADB smart-socket rejects a trailing one-shot host frame split at the read boundary",
+           "[livecapture][adb][network][client][host][protocol]" )
+{
+    const auto firstReply = hostReplyFrame( QByteArrayLiteral( "one" ) );
+    const auto trailingReply = hostReplyFrame( QByteArrayLiteral( "two" ) );
+    FakeAdbServer server(
+        [ firstReply, trailingReply ]( QTcpSocket& socket, int, int, const QByteArray& ) {
+            FakeAdbServer::sendThenClose( socket, QByteArrayLiteral( "OKAY" ) + firstReply
+                                                     + trailingReply );
+        } );
+    InspectableSocketFactory socketFactory;
+    ManualDeadlineScheduler deadlines;
+    auto config = clientConfig( server.port() );
+    config.maxReadChunkBytes = QByteArrayLiteral( "OKAY" ).size() + firstReply.size();
+    AdbSmartSocketClient client( config, socketFactory, deadlines );
+    ClientProbe probe( client );
+
+    client.requestHostService( 721, 9101, HostService::ServerFeatures );
+
+    REQUIRE(
+        pumpEventsUntil( [ &probe ] { return probe.count( ClientCallback::Kind::Error ) == 1; } ) );
+    CHECK( probe.first( ClientCallback::Kind::Error ).errorCode
+           == AdbSmartSocketErrorCode::Protocol );
+    CHECK( probe.count( ClientCallback::Kind::HostReply ) == 0 );
+}
+
 TEST_CASE( "ADB smart-socket survives synchronous connect deadline expiry",
            "[livecapture][adb][network][client][deadline][reentrant]" )
 {
@@ -1557,7 +2038,7 @@ TEST_CASE( "ADB smart-socket survives synchronous connect deadline expiry",
     AdbSmartSocketClient client( clientConfig( unusedLoopbackPort() ), socketFactory, deadlines );
     ClientProbe probe( client );
 
-    client.requestHostService( 721, 9101, HostService::Features );
+    client.requestHostService( 721, 9101, HostService::ServerFeatures );
 
     REQUIRE( probe.count( ClientCallback::Kind::Error ) == 1 );
     CHECK( probe.first( ClientCallback::Kind::Error ).errorCode

--- a/tests/unit/adb_smart_socket_transport_test.cpp
+++ b/tests/unit/adb_smart_socket_transport_test.cpp
@@ -42,6 +42,7 @@
 
 #include "adblogcatsource.h"
 #include "adbprotocol.h"
+#include "adbserversupervisor.h"
 #include "adbsmartsocketclient.h"
 #include "adbsmartsockettransport.h"
 #include "livedataqueue.h"
@@ -55,9 +56,12 @@ using namespace klogg::livecapture::adb;
 constexpr int EventPumpTimeoutMs = 1500;
 constexpr Generation StreamGeneration = 101u;
 constexpr auto StreamSerial = "SERIAL-42";
-constexpr auto FeaturesRequest = "host:features";
+constexpr auto VersionRequest = "host:version";
+constexpr auto HostFeaturesRequest = "host:host-features";
+constexpr auto UnscopedFeaturesRequest = "host:features";
 constexpr auto TransportRequest = "host:transport:SERIAL-42";
-constexpr auto LogcatRequest = "shell,v2,raw:logcat";
+constexpr auto LogcatRequest
+    = "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec";
 constexpr auto ClearRequest = "shell,v2,raw:logcat -c";
 
 static_assert( std::is_base_of<LiveSourceTransport, AdbSmartSocketTransport>::value,
@@ -443,26 +447,27 @@ public:
 void sendFeaturesOkay( QTcpSocket& socket,
                        const QByteArray& features = QByteArrayLiteral( "cmd,shell_v2,stat_v2" ) )
 {
-    FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) + hostReplyFrame( features ) );
+    FakeAdbServer::sendThenClose( socket,
+                                  QByteArrayLiteral( "OKAY" ) + hostReplyFrame( features ) );
 }
 
-void handleSuccessfulStartupRequest( QTcpSocket& socket, int, int requestIndex,
+void handleSuccessfulStartupRequest( QTcpSocket& socket, int connectionIndex, int requestIndex,
                                      const QByteArray& request, bool sendServiceOkay = true )
 {
-    if ( request == QByteArray( FeaturesRequest ) ) {
-        REQUIRE( requestIndex == 0 );
-        sendFeaturesOkay( socket );
-        return;
-    }
-
-    if ( request == QByteArray( TransportRequest ) ) {
-        REQUIRE( requestIndex == 0 );
+    if ( requestIndex == 0 ) {
+        REQUIRE( request == QByteArray( TransportRequest ) );
         FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
         return;
     }
 
-    REQUIRE( request == QByteArray( LogcatRequest ) );
     REQUIRE( requestIndex == 1 );
+    if ( connectionIndex % 2 == 0 ) {
+        REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
+        sendFeaturesOkay( socket );
+        return;
+    }
+
+    REQUIRE( request == QByteArray( LogcatRequest ) );
     if ( sendServiceOkay ) {
         FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
     }
@@ -483,6 +488,54 @@ void requireSingleTerminalError( const AdbSmartSocketTransport& transport,
 }
 
 } // namespace
+
+TEST_CASE( "ADB smart-socket server probe requests server-scoped features with multiple devices",
+           "[livecapture][adb][server][probe][features]" )
+{
+    FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                              const QByteArray& request ) {
+        REQUIRE( requestIndex == 0 );
+        if ( request == QByteArray( VersionRequest ) ) {
+            REQUIRE( connectionIndex == 0 );
+            FakeAdbServer::sendThenClose(
+                socket,
+                QByteArrayLiteral( "OKAY" ) + hostReplyFrame( QByteArrayLiteral( "0029" ) ) );
+            return;
+        }
+        if ( request == QByteArray( HostFeaturesRequest ) ) {
+            REQUIRE( connectionIndex == 1 );
+            sendFeaturesOkay( socket );
+            return;
+        }
+
+        REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
+        FakeAdbServer::send(
+            socket, QByteArrayLiteral( "FAIL" )
+                        + hostReplyFrame( QByteArrayLiteral( "more than one device/emulator" ) ) );
+    } );
+    AdbSmartSocketServerProbe probe;
+    std::optional<AdbServerProbeResult> result;
+    AdbServerEndpoint endpoint;
+    endpoint.port = server.port();
+
+    probe.probe( endpoint, [ &result ]( AdbServerProbeResult completed ) {
+        result = std::move( completed );
+    } );
+
+    REQUIRE( pumpEventsUntil( [ &result ] { return result.has_value(); } ) );
+    REQUIRE( result.has_value() );
+    CHECK( result->state == AdbServerProbeState::Ready );
+    CHECK( result->protocolVersion == 0x29u );
+    CHECK( result->features
+           == std::vector<std::string>{ "cmd", "shell_v2", "stat_v2" } );
+    CHECK( result->diagnostic.empty() );
+    REQUIRE( server.connectionCount() == 2 );
+    REQUIRE( server.requests().size() == 2 );
+    CHECK( server.requests().at( 0 ) == QByteArray( VersionRequest ) );
+    CHECK( server.requests().at( 1 ) == QByteArray( HostFeaturesRequest ) );
+    CHECK( server.requestConnections().at( 0 ) == 0 );
+    CHECK( server.requestConnections().at( 1 ) == 1 );
+}
 
 TEST_CASE( "ADB smart-socket transport starts nonblocking and reaches Connected only after shell "
            "service readiness",
@@ -506,15 +559,17 @@ TEST_CASE( "ADB smart-socket transport starts nonblocking and reaches Connected 
     CHECK( server.connectionCount() == 0 );
     CHECK( probe.received.empty() );
 
-    REQUIRE( pumpEventsUntil( [ &server ] { return server.requestCount() == 3; } ) );
+    REQUIRE( pumpEventsUntil( [ &server ] { return server.requestCount() == 4; } ) );
     REQUIRE( server.connectionCount() == 2 );
-    REQUIRE( server.requests().size() == 3 );
-    CHECK( server.requests().at( 0 ) == QByteArray( FeaturesRequest ) );
-    CHECK( server.requests().at( 1 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 2 ) == QByteArray( LogcatRequest ) );
+    REQUIRE( server.requests().size() == 4 );
+    CHECK( server.requests().at( 0 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 1 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 2 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 3 ) == QByteArray( LogcatRequest ) );
     CHECK( server.requestConnections().at( 0 ) == 0 );
-    CHECK( server.requestConnections().at( 1 ) == 1 );
+    CHECK( server.requestConnections().at( 1 ) == 0 );
     CHECK( server.requestConnections().at( 2 ) == 1 );
+    CHECK( server.requestConnections().at( 3 ) == 1 );
     CHECK( server.peerWasLoopbackAtAccept( 0 ) );
     CHECK( server.peerWasLoopbackAtAccept( 1 ) );
     CHECK( probe.stateCount( LiveSourceTransport::State::Connected ) == 0 );
@@ -584,46 +639,67 @@ TEST_CASE( "ADB smart-socket stdout crosses the bounded queue byte-for-byte with
 TEST_CASE( "ADB smart-socket stderr remains diagnostic while shell exit fails the stream once",
            "[livecapture][adb][transport][stderr][exit][error]" )
 {
-    FakeAdbServer server(
-        []( QTcpSocket& socket, int connectionIndex, int requestIndex, const QByteArray& request ) {
+    struct FailureCase {
+        QByteArray diagnostic;
+        QStringList expectedFragments;
+    };
+    const std::array cases{
+        FailureCase{ QByteArrayLiteral( "logcat: permission denied\n" ),
+                     { QStringLiteral( "permission denied" ), QStringLiteral( "17" ) } },
+        FailureCase{ QByteArrayLiteral( "Invalid parameter year to -v\n" ),
+                     { QStringLiteral( "Android 7.0" ),
+                       QStringLiteral( "source-device wall time" ),
+                       QStringLiteral( "Invalid parameter year to -v" ),
+                       QStringLiteral( "17" ) } },
+    };
+
+    for ( const auto& value : cases ) {
+        INFO( value.diagnostic.constData() );
+        FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                  const QByteArray& request ) {
             handleSuccessfulStartupRequest( socket, connectionIndex, requestIndex, request );
         } );
-    TrackingSocketFactory socketFactory;
-    ManualDeadlineScheduler deadlines;
-    AdbSmartSocketTransport transport( transportConfig( server.port() ), socketFactory, deadlines );
-    TransportProbe probe( transport );
+        TrackingSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketTransport transport( transportConfig( server.port() ), socketFactory,
+                                           deadlines );
+        TransportProbe probe( transport );
 
-    transport.start( StreamGeneration );
-    REQUIRE( pumpEventsUntil(
-        [ &probe ] { return probe.stateCount( LiveSourceTransport::State::Connected ) == 1; } ) );
+        transport.start( StreamGeneration );
+        REQUIRE( pumpEventsUntil(
+            [ &probe ] { return probe.stateCount( LiveSourceTransport::State::Connected ) == 1; } ) );
 
-    const auto diagnostic = QByteArrayLiteral( "logcat: permission denied\n" );
-    const auto stdoutBytes = QByteArrayLiteral( "captured stdout\n" );
-    FakeAdbServer::send( *server.socketAt( 1 ),
-                         shellV2Frame( 2u, diagnostic ) + shellV2Frame( 1u, stdoutBytes ) );
-    REQUIRE( pumpEventsUntil(
-        [ &probe, &stdoutBytes ] { return probe.receivedBytes() == stdoutBytes; } ) );
-    CHECK_FALSE( probe.receivedBytes().contains( diagnostic ) );
-    CHECK( transport.lastError().isEmpty() );
+        const auto stdoutBytes = QByteArrayLiteral( "captured stdout\n" );
+        FakeAdbServer::send( *server.socketAt( 1 ),
+                             shellV2Frame( 2u, value.diagnostic )
+                                 + shellV2Frame( 1u, stdoutBytes ) );
+        REQUIRE( pumpEventsUntil(
+            [ &probe, &stdoutBytes ] { return probe.receivedBytes() == stdoutBytes; } ) );
+        CHECK_FALSE( probe.receivedBytes().contains( value.diagnostic ) );
+        CHECK( transport.lastError().isEmpty() );
 
-    FakeAdbServer::send( *server.socketAt( 1 ),
-                         shellV2Frame( 3u, QByteArray( 1, static_cast<char>( 17 ) ) ) );
-    REQUIRE( pumpEventsUntil( [ &probe ] { return probe.errors.size() == 1u; } ) );
+        FakeAdbServer::send( *server.socketAt( 1 ),
+                             shellV2Frame( 3u, QByteArray( 1, static_cast<char>( 17 ) ) ) );
+        REQUIRE( pumpEventsUntil( [ &probe ] { return probe.errors.size() == 1u; } ) );
 
-    requireSingleTerminalError( transport, probe, StreamGeneration,
-                                { QStringLiteral( "permission denied" ), QStringLiteral( "17" ) } );
+        requireSingleTerminalError( transport, probe, StreamGeneration, value.expectedFragments );
+    }
 }
 
 TEST_CASE( "ADB smart-socket FAIL EOF and timeout failures map to one terminal transport error",
            "[livecapture][adb][transport][error]" )
 {
-    SECTION( "host features FAIL" )
+    SECTION( "selected-device transport FAIL" )
     {
-        FakeAdbServer server( []( QTcpSocket& socket, int, int, const QByteArray& request ) {
-            REQUIRE( request == QByteArray( FeaturesRequest ) );
-            FakeAdbServer::send( socket, QByteArrayLiteral( "FAIL" )
-                                             + hostReplyFrame( QByteArrayLiteral(
-                                                 "ADB server rejected host:features" ) ) );
+        FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                  const QByteArray& request ) {
+            REQUIRE( connectionIndex == 0 );
+            REQUIRE( requestIndex == 0 );
+            REQUIRE( request == QByteArray( TransportRequest ) );
+            FakeAdbServer::send(
+                socket, QByteArrayLiteral( "FAIL" )
+                            + hostReplyFrame( QByteArrayLiteral(
+                                "ADB server rejected host:transport:SERIAL-42" ) ) );
         } );
         TrackingSocketFactory socketFactory;
         ManualDeadlineScheduler deadlines;
@@ -635,28 +711,67 @@ TEST_CASE( "ADB smart-socket FAIL EOF and timeout failures map to one terminal t
         REQUIRE( pumpEventsUntil( [ &probe ] { return probe.errors.size() == 1u; } ) );
         requireSingleTerminalError(
             transport, probe, StreamGeneration,
-            { QStringLiteral( "features" ), QStringLiteral( "rejected" ) } );
+            { QStringLiteral( "selected ADB device" ), QStringLiteral( "features" ),
+              QStringLiteral( "rejected" ) } );
+        CHECK( server.connectionCount() == 1 );
         CHECK( server.requestCount() == 1 );
+    }
+
+    SECTION( "selected-device features FAIL" )
+    {
+        FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                  const QByteArray& request ) {
+            REQUIRE( connectionIndex == 0 );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
+            FakeAdbServer::send(
+                socket, QByteArrayLiteral( "FAIL" )
+                            + hostReplyFrame( QByteArrayLiteral(
+                                "ADB server rejected host:features for selected transport" ) ) );
+        } );
+        TrackingSocketFactory socketFactory;
+        ManualDeadlineScheduler deadlines;
+        AdbSmartSocketTransport transport( transportConfig( server.port() ), socketFactory,
+                                           deadlines );
+        TransportProbe probe( transport );
+
+        transport.start( StreamGeneration );
+        REQUIRE( pumpEventsUntil( [ &probe ] { return probe.errors.size() == 1u; } ) );
+        requireSingleTerminalError(
+            transport, probe, StreamGeneration,
+            { QStringLiteral( "selected ADB device" ), QStringLiteral( "features" ),
+              QStringLiteral( "rejected" ) } );
+        CHECK( server.connectionCount() == 1 );
+        CHECK( server.requestCount() == 2 );
     }
 
     SECTION( "device logcat service FAIL" )
     {
         FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
                                   const QByteArray& request ) {
-            if ( request == QByteArray( FeaturesRequest ) ) {
-                sendFeaturesOkay( socket );
+            if ( connectionIndex == 0 ) {
+                handleSuccessfulStartupRequest( socket, connectionIndex, requestIndex, request );
+                return;
             }
-            else if ( request == QByteArray( TransportRequest ) ) {
+
+            REQUIRE( connectionIndex == 1 );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
                 FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
             }
-            else {
-                REQUIRE( connectionIndex == 1 );
-                REQUIRE( requestIndex == 1 );
-                REQUIRE( request == QByteArray( LogcatRequest ) );
-                FakeAdbServer::send( socket, QByteArrayLiteral( "FAIL" )
-                                                 + hostReplyFrame( QByteArrayLiteral(
-                                                     "device unauthorized for logcat" ) ) );
-            }
+
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( LogcatRequest ) );
+            FakeAdbServer::send( socket, QByteArrayLiteral( "FAIL" )
+                                             + hostReplyFrame( QByteArrayLiteral(
+                                                 "device unauthorized for logcat" ) ) );
         } );
         TrackingSocketFactory socketFactory;
         ManualDeadlineScheduler deadlines;
@@ -696,8 +811,16 @@ TEST_CASE( "ADB smart-socket FAIL EOF and timeout failures map to one terminal t
 
     SECTION( "features read timeout" )
     {
-        FakeAdbServer server( []( QTcpSocket&, int, int, const QByteArray& request ) {
-            REQUIRE( request == QByteArray( FeaturesRequest ) );
+        FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                                  const QByteArray& request ) {
+            REQUIRE( connectionIndex == 0 );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
         } );
         TrackingSocketFactory socketFactory;
         ManualDeadlineScheduler deadlines;
@@ -707,7 +830,7 @@ TEST_CASE( "ADB smart-socket FAIL EOF and timeout failures map to one terminal t
 
         transport.start( StreamGeneration );
         REQUIRE( pumpEventsUntil( [ & ] {
-            return server.requestCount() == 1
+            return server.requestCount() == 2
                    && deadlines.hasActive( AdbSmartSocketDeadlineKind::Read );
         } ) );
         deadlines.fire( AdbSmartSocketDeadlineKind::Read );
@@ -715,7 +838,8 @@ TEST_CASE( "ADB smart-socket FAIL EOF and timeout failures map to one terminal t
         REQUIRE( probe.errors.size() == 1u );
         requireSingleTerminalError(
             transport, probe, StreamGeneration,
-            { QStringLiteral( "features" ), QStringLiteral( "timed out" ) } );
+            { QStringLiteral( "selected ADB device" ), QStringLiteral( "features" ),
+              QStringLiteral( "timed out" ) } );
     }
 }
 
@@ -725,8 +849,13 @@ TEST_CASE( "ADB smart-socket fails safely when the server is replaced after feat
     FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
                               const QByteArray& request ) {
         if ( connectionIndex == 0 ) {
-            REQUIRE( requestIndex == 0 );
-            REQUIRE( request == QByteArray( FeaturesRequest ) );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
             sendFeaturesOkay( socket );
             return;
         }
@@ -753,19 +882,27 @@ TEST_CASE( "ADB smart-socket fails safely when the server is replaced after feat
     CHECK( probe.stateCount( LiveSourceTransport::State::Connected ) == 0 );
     CHECK( probe.received.empty() );
     CHECK( server.connectionCount() == 2 );
-    CHECK( server.requestCount() == 2 );
+    CHECK( server.requestCount() == 3 );
     processDeferredDeletes();
     CHECK( socketFactory.allSocketsRetired() );
 }
 
-TEST_CASE( "ADB smart-socket transport rejects servers without shell_v2 actionably and without "
-           "modifying the environment",
+TEST_CASE( "ADB smart-socket transport rejects selected devices without shell_v2 actionably and "
+           "without modifying the environment",
            "[livecapture][adb][transport][features][compatibility]" )
 {
     const auto originalPath = qgetenv( "PATH" );
     const auto originalServerSocket = qgetenv( "ADB_SERVER_SOCKET" );
-    FakeAdbServer server( []( QTcpSocket& socket, int, int, const QByteArray& request ) {
-        REQUIRE( request == QByteArray( FeaturesRequest ) );
+    FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
+                              const QByteArray& request ) {
+        REQUIRE( connectionIndex == 0 );
+        if ( requestIndex == 0 ) {
+            REQUIRE( request == QByteArray( TransportRequest ) );
+            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+            return;
+        }
+        REQUIRE( requestIndex == 1 );
+        REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
         sendFeaturesOkay( socket, QByteArrayLiteral( "cmd,shell_v2x,stat_v2,apex" ) );
     } );
     TrackingSocketFactory socketFactory;
@@ -776,10 +913,11 @@ TEST_CASE( "ADB smart-socket transport rejects servers without shell_v2 actionab
     transport.start( StreamGeneration );
     REQUIRE( pumpEventsUntil( [ &probe ] { return probe.errors.size() == 1u; } ) );
 
-    requireSingleTerminalError( transport, probe, StreamGeneration,
-                                { QStringLiteral( "shell_v2" ), QStringLiteral( "ADB server" ) } );
+    requireSingleTerminalError(
+        transport, probe, StreamGeneration,
+        { QStringLiteral( "shell_v2" ), QStringLiteral( "selected ADB device" ) } );
     CHECK( server.connectionCount() == 1 );
-    CHECK( server.requestCount() == 1 );
+    CHECK( server.requestCount() == 2 );
     CHECK( transport.findChildren<QProcess*>().empty() );
     CHECK( qgetenv( "PATH" ) == originalPath );
     CHECK( qgetenv( "ADB_SERVER_SOCKET" ) == originalServerSocket );
@@ -880,20 +1018,24 @@ TEST_CASE( "ADB smart-socket clear negotiates independently without an active st
 {
     FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
                               const QByteArray& request ) {
-        if ( request == QByteArray( FeaturesRequest ) ) {
-            REQUIRE( connectionIndex == 0 );
-            REQUIRE( requestIndex == 0 );
+        if ( connectionIndex == 0 ) {
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
             sendFeaturesOkay( socket );
-            return;
-        }
-        if ( request == QByteArray( TransportRequest ) ) {
-            REQUIRE( connectionIndex == 1 );
-            REQUIRE( requestIndex == 0 );
-            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
             return;
         }
 
         REQUIRE( connectionIndex == 1 );
+        if ( requestIndex == 0 ) {
+            REQUIRE( request == QByteArray( TransportRequest ) );
+            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+            return;
+        }
         REQUIRE( requestIndex == 1 );
         REQUIRE( request == QByteArray( ClearRequest ) );
         FakeAdbServer::send( socket,
@@ -919,10 +1061,15 @@ TEST_CASE( "ADB smart-socket clear negotiates independently without an active st
     CHECK( probe.states.empty() );
     CHECK( probe.errors.empty() );
     CHECK( transport.lastError().isEmpty() );
-    REQUIRE( server.requests().size() == 3 );
-    CHECK( server.requests().at( 0 ) == QByteArray( FeaturesRequest ) );
-    CHECK( server.requests().at( 1 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 2 ) == QByteArray( ClearRequest ) );
+    REQUIRE( server.requests().size() == 4 );
+    CHECK( server.requests().at( 0 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 1 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 2 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 3 ) == QByteArray( ClearRequest ) );
+    CHECK( server.requestConnections().at( 0 ) == 0 );
+    CHECK( server.requestConnections().at( 1 ) == 0 );
+    CHECK( server.requestConnections().at( 2 ) == 1 );
+    CHECK( server.requestConnections().at( 3 ) == 1 );
 }
 
 TEST_CASE( "ADB smart-socket clear uses an independent correlated operation without pausing stream",
@@ -930,20 +1077,23 @@ TEST_CASE( "ADB smart-socket clear uses an independent correlated operation with
 {
     FakeAdbServer server(
         []( QTcpSocket& socket, int connectionIndex, int requestIndex, const QByteArray& request ) {
-            if ( request == QByteArray( FeaturesRequest ) ) {
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+
+            REQUIRE( requestIndex == 1 );
+            if ( connectionIndex % 2 == 0 ) {
+                REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
                 sendFeaturesOkay( socket );
             }
-            else if ( request == QByteArray( TransportRequest ) ) {
-                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
-            }
-            else if ( request == QByteArray( LogcatRequest ) ) {
-                REQUIRE( connectionIndex == 1 );
-                REQUIRE( requestIndex == 1 );
+            else if ( connectionIndex == 1 ) {
+                REQUIRE( request == QByteArray( LogcatRequest ) );
                 FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
             }
             else {
                 REQUIRE( connectionIndex == 3 );
-                REQUIRE( requestIndex == 1 );
                 REQUIRE( request == QByteArray( ClearRequest ) );
                 FakeAdbServer::send(
                     socket, QByteArrayLiteral( "OKAY" )
@@ -974,13 +1124,17 @@ TEST_CASE( "ADB smart-socket clear uses an independent correlated operation with
     CHECK( probe.stateCount( LiveSourceTransport::State::Error ) == 0 );
     CHECK( probe.errors.empty() );
     CHECK( transport.lastError().isEmpty() );
-    REQUIRE( server.requests().size() == 6 );
-    CHECK( server.requests().at( 3 ) == QByteArray( FeaturesRequest ) );
+    REQUIRE( server.requests().size() == 8 );
+    CHECK( server.requests().at( 0 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 1 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 2 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 3 ) == QByteArray( LogcatRequest ) );
     CHECK( server.requests().at( 4 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 5 ) == QByteArray( ClearRequest ) );
-    CHECK( server.requestConnections().at( 3 ) == 2 );
-    CHECK( server.requestConnections().at( 4 ) == 3 );
-    CHECK( server.requestConnections().at( 5 ) == 3 );
+    CHECK( server.requests().at( 5 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 6 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 7 ) == QByteArray( ClearRequest ) );
+    CHECK( server.requestConnections()
+           == QVector<int>{ 0, 0, 1, 1, 2, 2, 3, 3 } );
 
     const auto afterClear = QByteArrayLiteral( "stream-still-running\n" );
     FakeAdbServer::send( *server.socketAt( 1 ), shellV2Frame( 1u, afterClear ) );
@@ -996,15 +1150,19 @@ TEST_CASE( "ADB smart-socket clear failure remains request-local and leaves stre
     const auto clearDiagnostic = QByteArrayLiteral( "logcat clear denied" );
     FakeAdbServer server( [ clearDiagnostic ]( QTcpSocket& socket, int connectionIndex,
                                                int requestIndex, const QByteArray& request ) {
-        if ( request == QByteArray( FeaturesRequest ) ) {
+        if ( requestIndex == 0 ) {
+            REQUIRE( request == QByteArray( TransportRequest ) );
+            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+            return;
+        }
+
+        REQUIRE( requestIndex == 1 );
+        if ( connectionIndex % 2 == 0 ) {
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
             sendFeaturesOkay( socket );
         }
-        else if ( request == QByteArray( TransportRequest ) ) {
-            FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
-        }
-        else if ( request == QByteArray( LogcatRequest ) ) {
-            REQUIRE( connectionIndex == 1 );
-            REQUIRE( requestIndex == 1 );
+        else if ( connectionIndex == 1 ) {
+            REQUIRE( request == QByteArray( LogcatRequest ) );
             FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
         }
         else {
@@ -1131,19 +1289,20 @@ TEST_CASE( "ADB smart-socket delivers queued stdout before a coalesced terminal 
 TEST_CASE( "AdbLogcatSource stop-then-clear workflow restarts through the smart-socket adapter",
            "[livecapture][adb][transport][source][clear][restart]" )
 {
-    FakeAdbServer server( []( QTcpSocket& socket, int, int requestIndex,
+    FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
                               const QByteArray& request ) {
-        if ( request == QByteArray( FeaturesRequest ) ) {
-            REQUIRE( requestIndex == 0 );
-            sendFeaturesOkay( socket );
-            return;
-        }
-        if ( request == QByteArray( TransportRequest ) ) {
-            REQUIRE( requestIndex == 0 );
+        if ( requestIndex == 0 ) {
+            REQUIRE( request == QByteArray( TransportRequest ) );
             FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
             return;
         }
+
         REQUIRE( requestIndex == 1 );
+        if ( connectionIndex % 2 == 0 ) {
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
+            sendFeaturesOkay( socket );
+            return;
+        }
         if ( request == QByteArray( LogcatRequest ) ) {
             FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
             return;
@@ -1167,19 +1326,24 @@ TEST_CASE( "AdbLogcatSource stop-then-clear workflow restarts through the smart-
         [ &source ] { return source.state() == AdbLogcatSource::State::Connected; } ) );
     REQUIRE( source.clearAndRestart() );
     REQUIRE( pumpEventsUntil( [ & ] {
-        return source.state() == AdbLogcatSource::State::Connected && server.requestCount() == 9;
+        return source.state() == AdbLogcatSource::State::Connected && server.requestCount() == 12;
     } ) );
 
-    REQUIRE( server.requests().size() == 9 );
-    CHECK( server.requests().at( 0 ) == QByteArray( FeaturesRequest ) );
-    CHECK( server.requests().at( 1 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 2 ) == QByteArray( LogcatRequest ) );
-    CHECK( server.requests().at( 3 ) == QByteArray( FeaturesRequest ) );
+    REQUIRE( server.requests().size() == 12 );
+    CHECK( server.requests().at( 0 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 1 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 2 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 3 ) == QByteArray( LogcatRequest ) );
     CHECK( server.requests().at( 4 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 5 ) == QByteArray( ClearRequest ) );
-    CHECK( server.requests().at( 6 ) == QByteArray( FeaturesRequest ) );
-    CHECK( server.requests().at( 7 ) == QByteArray( TransportRequest ) );
-    CHECK( server.requests().at( 8 ) == QByteArray( LogcatRequest ) );
+    CHECK( server.requests().at( 5 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 6 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 7 ) == QByteArray( ClearRequest ) );
+    CHECK( server.requests().at( 8 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 9 ) == QByteArray( UnscopedFeaturesRequest ) );
+    CHECK( server.requests().at( 10 ) == QByteArray( TransportRequest ) );
+    CHECK( server.requests().at( 11 ) == QByteArray( LogcatRequest ) );
+    CHECK( server.requestConnections()
+           == QVector<int>{ 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5 } );
     CHECK( source.lastError().isEmpty() );
 
     source.disconnectSource();
@@ -1196,13 +1360,20 @@ TEST_CASE( "ADB smart-socket clear is independent from stream generation lifecyc
                 handleSuccessfulStartupRequest( socket, connectionIndex, requestIndex, request );
                 return;
             }
-            if ( request == QByteArray( FeaturesRequest ) ) {
-                REQUIRE( requestIndex == 0 );
+            if ( connectionIndex == 2 ) {
+                if ( requestIndex == 0 ) {
+                    REQUIRE( request == QByteArray( TransportRequest ) );
+                    FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                    return;
+                }
+                REQUIRE( requestIndex == 1 );
+                REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
                 sendFeaturesOkay( socket );
                 return;
             }
-            if ( request == QByteArray( TransportRequest ) ) {
-                REQUIRE( requestIndex == 0 );
+            REQUIRE( connectionIndex == 3 );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
                 FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
                 return;
             }
@@ -1233,7 +1404,7 @@ TEST_CASE( "ADB smart-socket clear is independent from stream generation lifecyc
         CHECK( probe.clears.front().generation == clearGeneration );
         CHECK( probe.clears.front().requestId == requestId );
         CHECK( probe.clears.front().succeeded );
-        CHECK( server.requestCount() == 6 );
+        CHECK( server.requestCount() == 8 );
         CHECK( probe.errors.empty() );
     }
 
@@ -1261,7 +1432,7 @@ TEST_CASE( "ADB smart-socket clear is independent from stream generation lifecyc
         } ) );
         constexpr LiveSourceTransport::ClearRequestId requestId = 7202u;
         transport.clearRemoteAsync( StreamGeneration, requestId );
-        REQUIRE( pumpEventsUntil( [ &server ] { return server.requestCount() == 6; } ) );
+        REQUIRE( pumpEventsUntil( [ &server ] { return server.requestCount() == 8; } ) );
 
         transport.stop( StreamGeneration );
         REQUIRE( socketFactory.connectedSocketCount() == 1 );
@@ -1282,7 +1453,13 @@ TEST_CASE( "ADB smart-socket preserves a failed generation diagnostic across ree
     FakeAdbServer server( []( QTcpSocket& socket, int connectionIndex, int requestIndex,
                               const QByteArray& request ) {
         if ( connectionIndex == 0 ) {
-            REQUIRE( request == QByteArray( FeaturesRequest ) );
+            if ( requestIndex == 0 ) {
+                REQUIRE( request == QByteArray( TransportRequest ) );
+                FakeAdbServer::send( socket, QByteArrayLiteral( "OKAY" ) );
+                return;
+            }
+            REQUIRE( requestIndex == 1 );
+            REQUIRE( request == QByteArray( UnscopedFeaturesRequest ) );
             FakeAdbServer::send(
                 socket, QByteArrayLiteral( "FAIL" )
                             + hostReplyFrame( QByteArrayLiteral( "first generation rejected" ) ) );

--- a/tests/unit/adb_ui_transport_test.cpp
+++ b/tests/unit/adb_ui_transport_test.cpp
@@ -257,6 +257,32 @@ protected:
     }
 };
 
+class LegacyLogcatFormatFailureTransport
+    : public GenerationDrivenProcessTransport<AdbProcessTransport> {
+public:
+    LegacyLogcatFormatFailureTransport()
+        : GenerationDrivenProcessTransport<AdbProcessTransport>(
+              QString{}, QStringLiteral( "serial-123" ), {} )
+    {
+    }
+
+protected:
+    Command streamingCommand() const override
+    {
+#ifdef Q_OS_WIN
+        return Command{ QStringLiteral( "cmd" ),
+                        { QStringLiteral( "/c" ),
+                          QStringLiteral( "echo Invalid parameter year to -v 1>&2 & exit /b 1" ) } };
+#else
+        return Command{
+            QStringLiteral( "/bin/sh" ),
+            { QStringLiteral( "-c" ),
+              QStringLiteral( "echo 'Invalid parameter year to -v' >&2; exit 1" ) }
+        };
+#endif
+    }
+};
+
 class ReentrantReconnectAdbProcessTransport final : public ImmediateFailureAdbProcessTransport {
 public:
     QString stderrFilePathForTest() const
@@ -464,7 +490,7 @@ TEST_CASE( "Default live-source factory selects the explicit ADB backend" )
     CHECK( dynamic_cast<IosLogProcessTransport*>( iosTransport.get() ) != nullptr );
 }
 
-TEST_CASE( "AdbProcessTransport builds normalized streaming and clear commands" )
+TEST_CASE( "AdbProcessTransport owns ordered wall-time modifiers and unchanged clear" )
 {
     TestAdbProcessTransport transport(
         QString{}, QStringLiteral( "emulator-5554" ),
@@ -489,18 +515,22 @@ TEST_CASE( "AdbProcessTransport builds normalized streaming and clear commands" 
                         && ( leaf == QStringLiteral( "adb" )
                              || leaf == QStringLiteral( "adb.exe" ) ) ) ) );
     }
-    REQUIRE( streaming.arguments
-             == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "emulator-5554" ),
-                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
-                             QStringLiteral( "threadtime" ), QStringLiteral( "-T" ),
-                             QStringLiteral( "2026-03-15 12:34:56.000" ),
-                             QStringLiteral( "*:I" ) } );
 
     const auto clear = transport.clearCommandForTest();
     REQUIRE( clear.program == streaming.program );
     REQUIRE( clear.arguments
              == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "emulator-5554" ),
                              QStringLiteral( "logcat" ), QStringLiteral( "-c" ) } );
+
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "emulator-5554" ),
+                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "usec" ), QStringLiteral( "-T" ),
+                             QStringLiteral( "2026-03-15 12:34:56.000" ),
+                             QStringLiteral( "*:I" ) } );
 }
 
 TEST_CASE( "AdbProcessTransport preserves literal backslashes in extra args" )
@@ -512,7 +542,11 @@ TEST_CASE( "AdbProcessTransport preserves literal backslashes in extra args" )
     const auto streaming = transport.streamingCommandForTest();
     REQUIRE( streaming.arguments
              == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
-                             QStringLiteral( "logcat" ), QStringLiteral( "--path" ),
+                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "usec" ), QStringLiteral( "--path" ),
                              QStringLiteral( "C:\\temp\\log.txt" ), QStringLiteral( "--pattern" ),
                              QStringLiteral( "regex\\d+" ), QStringLiteral( "--title" ),
                              QStringLiteral( "hello world" ) } );
@@ -526,11 +560,15 @@ TEST_CASE( "AdbProcessTransport preserves empty quoted extra args" )
     const auto streaming = transport.streamingCommandForTest();
     REQUIRE( streaming.arguments
              == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
-                             QStringLiteral( "logcat" ), QStringLiteral( "--empty" ), QString{},
+                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "usec" ), QStringLiteral( "--empty" ), QString{},
                              QStringLiteral( "--quoted" ), QString{} } );
 }
 
-TEST_CASE( "AdbProcessTransport adds logcat color modifier when ANSI output is enabled" )
+TEST_CASE( "AdbProcessTransport appends a repeated color modifier for ANSI" )
 {
     TestAdbProcessTransport transport( QString{}, QStringLiteral( "serial-123" ),
                                        QStringLiteral( "-v threadtime *:I" ), true );
@@ -539,8 +577,94 @@ TEST_CASE( "AdbProcessTransport adds logcat color modifier when ANSI output is e
     REQUIRE( streaming.arguments
              == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
                              QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
-                             QStringLiteral( "color" ), QStringLiteral( "-v" ),
-                             QStringLiteral( "threadtime" ), QStringLiteral( "*:I" ) } );
+                             QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "usec" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "color" ), QStringLiteral( "*:I" ) } );
+}
+
+TEST_CASE( "AdbProcessTransport removes valid format args without reordering other tokens" )
+{
+    TestAdbProcessTransport transport(
+        QString{}, QStringLiteral( "serial-123" ),
+        QStringLiteral( "--pid 42 -v raw -b main -vraw -T 10 -v zone ActivityManager:I "
+                        "--format epoch *:D --format=epoch" ) );
+
+    const auto streaming = transport.streamingCommandForTest();
+    REQUIRE( streaming.arguments
+             == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                             QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                             QStringLiteral( "usec" ), QStringLiteral( "--pid" ),
+                             QStringLiteral( "42" ), QStringLiteral( "-b" ),
+                             QStringLiteral( "main" ), QStringLiteral( "-T" ),
+                             QStringLiteral( "10" ), QStringLiteral( "ActivityManager:I" ),
+                             QStringLiteral( "*:D" ) } );
+}
+
+TEST_CASE( "AdbProcessTransport format sanitizer preserves option boundaries and end-of-options" )
+{
+    SECTION( "bare format options do not consume a following option" )
+    {
+        TestAdbProcessTransport transport(
+            QString{}, QStringLiteral( "serial-123" ),
+            QStringLiteral( "-v --pid 42 --format -b main ActivityManager:I" ) );
+
+        const auto streaming = transport.streamingCommandForTest();
+        REQUIRE( streaming.arguments
+                 == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                                 QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "usec" ), QStringLiteral( "--pid" ),
+                                 QStringLiteral( "42" ), QStringLiteral( "-b" ),
+                                 QStringLiteral( "main" ),
+                                 QStringLiteral( "ActivityManager:I" ) } );
+    }
+
+    SECTION( "end-of-options preserves every following token" )
+    {
+        TestAdbProcessTransport transport(
+            QString{}, QStringLiteral( "serial-123" ),
+            QStringLiteral(
+                "--pid 42 -- -v raw --format epoch -v:I --format=epoch ActivityManager:D" ) );
+
+        const auto streaming = transport.streamingCommandForTest();
+        REQUIRE( streaming.arguments
+                 == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                                 QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "usec" ), QStringLiteral( "--pid" ),
+                                 QStringLiteral( "42" ), QStringLiteral( "--" ),
+                                 QStringLiteral( "-v" ), QStringLiteral( "raw" ),
+                                 QStringLiteral( "--format" ), QStringLiteral( "epoch" ),
+                                 QStringLiteral( "-v:I" ), QStringLiteral( "--format=epoch" ),
+                                 QStringLiteral( "ActivityManager:D" ) } );
+    }
+
+    SECTION( "empty assigned format is removed without consuming a following option" )
+    {
+        TestAdbProcessTransport transport(
+            QString{}, QStringLiteral( "serial-123" ),
+            QStringLiteral( "--format= --pid 42 ActivityManager:I" ) );
+
+        const auto streaming = transport.streamingCommandForTest();
+        REQUIRE( streaming.arguments
+                 == QStringList{ QStringLiteral( "-s" ), QStringLiteral( "serial-123" ),
+                                 QStringLiteral( "logcat" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "threadtime" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "year" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "zone" ), QStringLiteral( "-v" ),
+                                 QStringLiteral( "usec" ), QStringLiteral( "--pid" ),
+                                 QStringLiteral( "42" ),
+                                 QStringLiteral( "ActivityManager:I" ) } );
+    }
 }
 
 TEST_CASE( "IosLogProcessTransport builds normalized streaming commands" )
@@ -1092,6 +1216,16 @@ TEST_CASE( "AdbProcessTransport surfaces immediate post-start failures as transp
     REQUIRE( errorSpy.safeWait() );
     REQUIRE( stateSpy.count() >= 1 );
     REQUIRE_FALSE( transport.lastError().isEmpty() );
+}
+
+TEST_CASE( "AdbProcessTransport explains legacy logcat wall-time format rejection" )
+{
+    LegacyLogcatFormatFailureTransport transport;
+
+    REQUIRE_FALSE( transport.startAndWait() );
+    CHECK( transport.lastError().contains( QStringLiteral( "Android 7.0" ) ) );
+    CHECK( transport.lastError().contains( QStringLiteral( "source-device wall time" ) ) );
+    CHECK( transport.lastError().contains( QStringLiteral( "Invalid parameter year to -v" ) ) );
 }
 
 TEST_CASE( "OptionsDialog exposes no legacy live-source executable or raw-argument controls" )

--- a/tests/unit/ios_native_stream_worker_test.cpp
+++ b/tests/unit/ios_native_stream_worker_test.cpp
@@ -4,8 +4,8 @@
  * This file is part of klogg.
  *
  * RED contract for the passive native iOS stream worker. Every native call is
- * injected; the tests use no vendor headers, daemon, framework, device, Qt,
- * timer, subprocess, Python, or real device content.
+ * injected; the tests use no vendor headers, daemon, framework, device, timer,
+ * subprocess, Python, or real device content.
  */
 
 #include <catch2/catch.hpp>
@@ -48,12 +48,14 @@ struct FakeNative {
     std::int32_t deviceResult{ 0 };
     std::int32_t handshakeResult{ 0 };
     std::int32_t productVersionResult{ 0 };
+    std::int32_t timeZoneResult{ 0 };
     std::int32_t startServiceResult{ 0 };
     std::int32_t osTraceNewResult{ 0 };
     std::int32_t osTraceStartResult{ 0 };
     std::int32_t syslogNewResult{ 0 };
     std::int32_t syslogStartResult{ 0 };
     std::string productVersion{ "17.6.1" };
+    std::string timeZone{ "America/New_York" };
     bool allocateDeviceOnError{ false };
     bool allocateLockdownOnError{ false };
     bool allocateServiceOnError{ false };
@@ -62,6 +64,7 @@ struct FakeNative {
     bool nullDeviceOnSuccess{ false };
     bool nullLockdownOnSuccess{ false };
     bool nullServiceOnSuccess{ false };
+    bool nullTimeZoneOnSuccess{ false };
     bool nullOsTraceOnSuccess{ false };
     bool nullSyslogOnSuccess{ false };
     bool emitOsTraceErrorDuringStart{ false };
@@ -98,10 +101,16 @@ struct FakeNative {
     bool handshakeReleased{ false };
     std::mutex handshakeMutex;
     std::condition_variable handshakeChanged;
+    bool blockTimeZone{ false };
+    bool timeZoneEntered{ false };
+    bool timeZoneReleased{ false };
+    std::mutex timeZoneMutex;
+    std::condition_variable timeZoneChanged;
 
     ~FakeNative()
     {
         releaseHandshake();
+        releaseTimeZone();
         interruptBlockedReceive();
     }
 
@@ -163,6 +172,32 @@ struct FakeNative {
         std::lock_guard<std::mutex> lock( handshakeMutex );
         handshakeReleased = true;
         handshakeChanged.notify_all();
+    }
+
+    void waitAtTimeZone()
+    {
+        if ( !blockTimeZone ) {
+            return;
+        }
+        std::unique_lock<std::mutex> lock( timeZoneMutex );
+        timeZoneEntered = true;
+        timeZoneChanged.notify_all();
+        if ( !timeZoneChanged.wait_for( lock, 2s, [ this ] { return timeZoneReleased; } ) ) {
+            abiViolation = true;
+        }
+    }
+
+    bool waitUntilTimeZoneEntered()
+    {
+        std::unique_lock<std::mutex> lock( timeZoneMutex );
+        return timeZoneChanged.wait_for( lock, 2s, [ this ] { return timeZoneEntered; } );
+    }
+
+    void releaseTimeZone()
+    {
+        std::lock_guard<std::mutex> lock( timeZoneMutex );
+        timeZoneReleased = true;
+        timeZoneChanged.notify_all();
     }
 
     void beginCallback()
@@ -360,16 +395,37 @@ std::int32_t freeLockdown( NativeLockdownClient client )
 std::int32_t getString( NativeLockdownClient client, const char* domain, const char* key,
                         char** value )
 {
-    if ( client != LockdownHandle || domain != nullptr || key == nullptr
-         || std::string{ key } != "ProductVersion" ) {
+    if ( client != LockdownHandle || domain != nullptr || key == nullptr ) {
         fake->abiViolation = true;
+        return -1;
     }
-    fake->record( "get:ProductVersion" );
-    if ( fake->productVersionResult != 0 ) {
-        return fake->productVersionResult;
+
+    const std::string requestedKey{ key };
+    fake->record( "get:" + requestedKey );
+    const std::string* returnedValue = nullptr;
+    std::int32_t result = 0;
+    if ( requestedKey == "ProductVersion" ) {
+        returnedValue = &fake->productVersion;
+        result = fake->productVersionResult;
     }
-    auto bytes = std::make_unique<char[]>( fake->productVersion.size() + 1u );
-    std::memcpy( bytes.get(), fake->productVersion.c_str(), fake->productVersion.size() + 1u );
+    else if ( requestedKey == "TimeZone" ) {
+        fake->waitAtTimeZone();
+        returnedValue = &fake->timeZone;
+        result = fake->timeZoneResult;
+    }
+    else {
+        fake->abiViolation = true;
+        return -1;
+    }
+
+    if ( result != 0 ) {
+        return result;
+    }
+    if ( requestedKey == "TimeZone" && fake->nullTimeZoneOnSuccess ) {
+        return 0;
+    }
+    auto bytes = std::make_unique<char[]>( returnedValue->size() + 1u );
+    std::memcpy( bytes.get(), returnedValue->c_str(), returnedValue->size() + 1u );
     *value = bytes.release();
     return 0;
 }
@@ -675,6 +731,8 @@ TEST_CASE( "native iOS worker preflights an existing pair record before passive 
                                                    "lockdown-existing-pair",
                                                    "get:ProductVersion",
                                                    "string-free",
+                                                   "get:TimeZone",
+                                                   "string-free",
                                                    "service-start:com.apple.os_trace_relay",
                                                    "ostrace-new",
                                                    "ostrace-start" };
@@ -754,11 +812,12 @@ TEST_CASE( "native iOS worker selects os_trace for iOS 9 and newer and syslog on
         const char* version;
         const char* service;
         const char* client;
+        bool queriesTimeZone;
     };
     const std::vector<VersionCase> cases{
-        { "8.4.1", "service-start:com.apple.syslog_relay", "syslog-new" },
-        { "9.0", "service-start:com.apple.os_trace_relay", "ostrace-new" },
-        { "17.6.1", "service-start:com.apple.os_trace_relay", "ostrace-new" },
+        { "8.4.1", "service-start:com.apple.syslog_relay", "syslog-new", false },
+        { "9.0", "service-start:com.apple.os_trace_relay", "ostrace-new", true },
+        { "17.6.1", "service-start:com.apple.os_trace_relay", "ostrace-new", true },
     };
 
     for ( const auto& value : cases ) {
@@ -775,10 +834,165 @@ TEST_CASE( "native iOS worker selects os_trace for iOS 9 and newer and syslog on
                != state.calls.cend() );
         CHECK( std::find( state.calls.cbegin(), state.calls.cend(), value.client )
                != state.calls.cend() );
+        if ( value.queriesTimeZone ) {
+            CHECK( indexOf( state.calls, "get:ProductVersion" )
+                   < indexOf( state.calls, "get:TimeZone" ) );
+            CHECK( indexOf( state.calls, "get:TimeZone" ) < indexOf( state.calls, value.service ) );
+        }
+        else {
+            CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "get:TimeZone" )
+                   == state.calls.cend() );
+        }
         CHECK( observed.ready == std::vector<Generation>{ 20u } );
         worker.stop( 20u );
         executor.runAllOnWorker();
     }
+}
+
+TEST_CASE( "TimeZone native errors retain the existing Lockdown classification",
+           "[ios][native][stream][startup][timezone][error][mapping]" )
+{
+    FakeNative state;
+    fake = &state;
+    state.timeZoneResult = -8;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), config( 201u ),
+                                  observed.callbacks() );
+
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+
+    CHECK( observed.ready.empty() );
+    REQUIRE( observed.errors.size() == 1u );
+    const auto& classified = observed.errors.front().second;
+    CHECK( classified.error.code == "ios-device-disconnected" );
+    CHECK( classified.error.category == ErrorCategory::Device );
+    CHECK( classified.error.scope == ErrorScope::Device );
+    CHECK( classified.error.retryPolicy == RetryPolicy::WaitForDevice );
+    CHECK( classified.error.code != "ios-device-time-zone-invalid" );
+    CHECK( classified.error.nativeDetail.find( "read TimeZone" ) != std::string::npos );
+    CHECK( classified.error.nativeDetail.find( "-8" ) != std::string::npos );
+    CHECK_FALSE( classified.awaitingUserReason.has_value() );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(),
+                      "service-start:com.apple.os_trace_relay" )
+           == state.calls.cend() );
+    CHECK_FALSE( state.abiViolation );
+}
+
+TEST_CASE( "os_trace startup rejects null empty or unrecognized device time zones before readiness",
+           "[ios][native][stream][startup][timezone][configuration]" )
+{
+    struct TimeZoneCase {
+        const char* name;
+        std::function<void( FakeNative& )> arrange;
+        const char* diagnostic;
+    };
+    const std::vector<TimeZoneCase> cases{
+        { "missing null TimeZone", []( FakeNative& value ) { value.nullTimeZoneOnSuccess = true; },
+          "missing" },
+        { "empty TimeZone", []( FakeNative& value ) { value.timeZone.clear(); }, "unrecognized" },
+        { "unrecognized TimeZone",
+          []( FakeNative& value ) { value.timeZone = "Mars/Olympus_Mons"; }, "unrecognized" },
+    };
+
+    Generation generation = 210u;
+    for ( const auto& value : cases ) {
+        INFO( value.name );
+        FakeNative state;
+        fake = &state;
+        value.arrange( state );
+        ManualExecutor executor;
+        ObservedCallbacks observed;
+        IosNativeStreamWorker worker( makeApi(), executor.executor(), config( ++generation ),
+                                      observed.callbacks() );
+
+        REQUIRE( worker.start() );
+        executor.runAllOnWorker();
+
+        CHECK( observed.ready.empty() );
+        REQUIRE( observed.errors.size() == 1u );
+        const auto& error = observed.errors.front().second.error;
+        CHECK( error.code == "ios-device-time-zone-invalid" );
+        CHECK( error.category == ErrorCategory::Configuration );
+        CHECK( error.scope == ErrorScope::Device );
+        CHECK( error.retryPolicy == RetryPolicy::Never );
+        CHECK( error.message.find( "time zone" ) != std::string::npos );
+        CHECK( error.nativeDetail.find( "TimeZone" ) != std::string::npos );
+        CHECK( error.nativeDetail.find( value.diagnostic ) != std::string::npos );
+        CHECK( indexOf( state.calls, "get:ProductVersion" )
+               < indexOf( state.calls, "get:TimeZone" ) );
+        CHECK( std::find( state.calls.cbegin(), state.calls.cend(),
+                          "service-start:com.apple.os_trace_relay" )
+               == state.calls.cend() );
+        CHECK_FALSE( state.abiViolation );
+    }
+}
+
+TEST_CASE( "stop during a blocked TimeZone query prevents all startup publication and service work",
+           "[ios][native][stream][startup][timezone][stop][barrier]" )
+{
+    FakeNative state;
+    fake = &state;
+    state.blockTimeZone = true;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), config( 220u ),
+                                  observed.callbacks() );
+    REQUIRE( worker.start() );
+    auto startup = executor.startNextOnWorker();
+    if ( !state.waitUntilTimeZoneEntered() ) {
+        state.releaseTimeZone();
+        startup.join();
+        FAIL( "native startup did not reach the TimeZone query barrier" );
+    }
+
+    worker.stop( 220u );
+    REQUIRE( executor.pending() == 1u );
+    state.releaseTimeZone();
+    startup.join();
+    executor.runAllOnWorker();
+
+    CHECK( observed.ready.empty() );
+    CHECK( observed.bytesAvailable.empty() );
+    CHECK( observed.errors.empty() );
+    CHECK( observed.stopped == std::vector<Generation>{ 220u } );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(),
+                      "service-start:com.apple.os_trace_relay" )
+           == state.calls.cend() );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "ostrace-new" )
+           == state.calls.cend() );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "ostrace-start" )
+           == state.calls.cend() );
+    CHECK( std::count( state.calls.cbegin(), state.calls.cend(), "lockdown-free" ) == 1 );
+    CHECK( std::count( state.calls.cbegin(), state.calls.cend(), "device-free" ) == 1 );
+    CHECK_FALSE( state.abiViolation );
+}
+
+TEST_CASE( "native iOS startup validates the selected stream ABI before device metadata I/O",
+           "[ios][native][stream][startup][abi][ordering]" )
+{
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto api = makeApi();
+    api.osTraceStart = nullptr;
+    IosNativeStreamWorker worker( std::move( api ), executor.executor(), config( 221u ),
+                                  observed.callbacks() );
+
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-native-abi-incomplete" );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "get:ProductVersion" )
+           != state.calls.cend() );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "get:TimeZone" )
+           == state.calls.cend() );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(),
+                      "service-start:com.apple.os_trace_relay" )
+           == state.calls.cend() );
 }
 
 TEST_CASE( "native iOS readiness requires service descriptor stream handle and armed read",
@@ -970,6 +1184,63 @@ TEST_CASE( "startup owns partial native handles and rejects success with null ha
     }
 }
 
+TEST_CASE( "os_trace packets are emitted in the fake source device time zone",
+           "[ios][native][stream][callback][format][timezone]" )
+{
+    FakeNative state;
+    fake = &state;
+    state.timeZone = "Asia/Kolkata";
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), config( 401u ),
+                                  observed.callbacks() );
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+    REQUIRE( observed.ready == std::vector<Generation>{ 401u } );
+
+    state.emitOsTrace( osTracePacket() );
+
+    REQUIRE( observed.bytesAvailable == std::vector<Generation>{ 401u } );
+    const auto drained = worker.drain();
+    REQUIRE( drained.has_value() );
+    const std::string output( drained->bytes.begin(), drained->bytes.end() );
+    CHECK( output
+           == "2023-11-15 03:43:20.123456+05:30 Test{}[42] <ERROR>: native log\n" );
+    CHECK( output.find( "2023-11-14 22:13:20" ) == std::string::npos );
+    CHECK_FALSE( state.abiViolation );
+
+    worker.stop( 401u );
+    executor.runAllOnWorker();
+}
+
+TEST_CASE( "os_trace rejects epochs the device time zone cannot represent",
+           "[ios][native][stream][callback][format][timezone][malformed]" )
+{
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), config( 402u ),
+                                  observed.callbacks() );
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+    REQUIRE( observed.ready == std::vector<Generation>{ 402u } );
+
+    auto packet = osTracePacket();
+    putLe64( packet, 55u, std::numeric_limits<std::uint64_t>::max() );
+    state.emitOsTrace( packet );
+
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-ostrace-malformed-packet" );
+    CHECK( observed.errors.front().second.error.nativeDetail.find( "timestamp" )
+           != std::string::npos );
+    CHECK_FALSE( worker.drain().has_value() );
+    CHECK_FALSE( state.abiViolation );
+
+    worker.stop( 402u );
+    executor.runAllOnWorker();
+}
+
 TEST_CASE( "os_trace callback copies decodes formats and queues bytes without unwinding into C",
            "[ios][native][stream][callback][ownership][format]" )
 {
@@ -1125,6 +1396,8 @@ TEST_CASE(
 {
     FakeNative state;
     fake = &state;
+    state.timeZoneResult = -8;
+    state.timeZone = "Not/A_TimeZone";
     ManualExecutor executor;
     ObservedCallbacks observed;
     auto options = config( 51u, "8.4" );
@@ -1132,6 +1405,9 @@ TEST_CASE(
     IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
     REQUIRE( worker.start() );
     executor.runAllOnWorker();
+    CHECK( observed.ready == std::vector<Generation>{ 51u } );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(), "get:TimeZone" )
+           == state.calls.cend() );
 
     CHECK_NOTHROW( state.emitSyslog( "alp" ) );
     CHECK( observed.bytesAvailable.empty() );

--- a/tests/unit/ios_native_stream_worker_test.cpp
+++ b/tests/unit/ios_native_stream_worker_test.cpp
@@ -653,6 +653,29 @@ IosNativeStreamConfig config( Generation generation, std::string version = "17.6
     result.ansiOutputEnabled = false;
     result.queueLimits = LiveDataQueueLimits{ 64u * 1024u, 32u };
     result.servicePolicy = IosNativeServicePolicy::AutomaticByProductVersion;
+    result.timeZoneResolverFactory
+        = []( const std::string& timeZoneId ) -> std::optional<OsTraceUtcOffsetResolver> {
+        std::optional<std::int32_t> fixedOffset;
+        if ( timeZoneId == "America/New_York" ) {
+            fixedOffset = -5 * 60 * 60;
+        }
+        else if ( timeZoneId == "Asia/Kolkata" ) {
+            fixedOffset = 5 * 60 * 60 + 30 * 60;
+        }
+        if ( !fixedOffset ) {
+            return std::nullopt;
+        }
+        return OsTraceUtcOffsetResolver{
+            [ offset = *fixedOffset ]( std::uint64_t epochSeconds )
+                -> std::optional<std::int32_t> {
+                if ( epochSeconds
+                     > static_cast<std::uint64_t>( std::numeric_limits<std::int64_t>::max() ) ) {
+                    return std::nullopt;
+                }
+                return offset;
+            }
+        };
+    };
     result.cleanupDeadline = 75ms;
     return result;
 }

--- a/tests/unit/ios_native_stream_worker_test.cpp
+++ b/tests/unit/ios_native_stream_worker_test.cpp
@@ -952,6 +952,32 @@ TEST_CASE( "os_trace startup rejects null empty or unrecognized device time zone
     }
 }
 
+TEST_CASE( "os_trace startup rejects an empty device time-zone resolver",
+           "[ios][native][stream][startup][timezone][configuration]" )
+{
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 219u );
+    options.timeZoneResolverFactory
+        = []( const std::string& ) -> std::optional<OsTraceUtcOffsetResolver> {
+        return OsTraceUtcOffsetResolver{};
+    };
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), std::move( options ),
+                                  observed.callbacks() );
+
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+
+    CHECK( observed.ready.empty() );
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-device-time-zone-invalid" );
+    CHECK( std::find( state.calls.cbegin(), state.calls.cend(),
+                      "service-start:com.apple.os_trace_relay" )
+           == state.calls.cend() );
+}
+
 TEST_CASE( "stop during a blocked TimeZone query prevents all startup publication and service work",
            "[ios][native][stream][startup][timezone][stop][barrier]" )
 {

--- a/tests/unit/ios_ostrace_protocol_test.cpp
+++ b/tests/unit/ios_ostrace_protocol_test.cpp
@@ -23,17 +23,28 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include "iosostraceprotocol.h"
 
+#ifdef QTIMEZONE_H
+#error "iosostraceprotocol.h must remain source-neutral and must not expose QTimeZone"
+#endif
+
 namespace {
 using namespace klogg::livecapture::ios;
+
+static_assert(
+    std::is_same<OsTraceUtcOffsetResolver,
+                 std::function<std::optional<std::int32_t>( std::uint64_t )>>::value,
+    "the protocol boundary accepts only an epoch-second to optional UTC-offset resolver" );
 
 constexpr std::size_t HeaderSize = 0x81u;
 constexpr std::size_t MarkerOffset = 0u;
@@ -778,18 +789,20 @@ TEST_CASE( "iOS formatter covers the supported unsigned timestamp range determin
     auto record = formattingRecord();
     record.seconds = 0u;
     record.microseconds = 0u;
-    CHECK( formatOsTraceRecord( record ).bytes.find( "1970-01-01 00:00:00.000000" ) == 0u );
+    CHECK( formatOsTraceRecord( record ).bytes.find( "1970-01-01 00:00:00.000000+00:00" )
+           == 0u );
 
     record.seconds = 253402300799ull;
     record.microseconds = 999999u;
-    CHECK( formatOsTraceRecord( record ).bytes.find( "9999-12-31 23:59:59.999999" ) == 0u );
+    CHECK( formatOsTraceRecord( record ).bytes.find( "9999-12-31 23:59:59.999999+00:00" )
+           == 0u );
 
     record.seconds = std::numeric_limits<std::uint64_t>::max();
     const auto first = formatOsTraceRecord( record );
     const auto second = formatOsTraceRecord( record );
     CHECK( first.bytes == second.bytes );
     CHECK( first.statistics == second.statistics );
-    CHECK( first.bytes.find( ".999999 " ) != std::string::npos );
+    CHECK( first.bytes.find( ".999999+00:00 " ) != std::string::npos );
 }
 
 TEST_CASE(
@@ -798,10 +811,10 @@ TEST_CASE(
 {
     const auto record = formattingRecord();
     const std::string expectedPlain
-        = "2023-11-14 22:13:20.123456 Runner{Framework+0x1234}[4242] <ERROR>: "
+        = "2023-11-14 22:13:20.123456+00:00 Runner{Framework+0x1234}[4242] <ERROR>: "
           "bad \xef\xbf\xbd payload [com.example][network]";
     const std::string expectedAnsi
-        = "\x1b[32m2023-11-14 22:13:20.123456\x1b[0m "
+        = "\x1b[32m2023-11-14 22:13:20.123456+00:00\x1b[0m "
           "\x1b[35mRunner\x1b[0m{\x1b[35mFramework\x1b[0m\x1b[34m+0x1234\x1b[0m}"
           "[\x1b[36m4242\x1b[0m] <\x1b[31mERROR\x1b[0m>: "
           "\x1b[31mbad \xef\xbf\xbd payload\x1b[0m "
@@ -830,6 +843,109 @@ TEST_CASE(
     CHECK( ansi.statistics.ansiExpansionByteCount == expectedAnsi.size() - expectedPlain.size() );
     REQUIRE( ansiHook.has_value() );
     CHECK( ansiHook.value() == ansi.statistics );
+}
+
+TEST_CASE( "iOS formatter applies source-neutral per-epoch UTC offsets exactly",
+           "[livecapture][ios][ostrace][format][timezone]" )
+{
+    struct WallTimeCase {
+        const char* name;
+        std::uint64_t seconds;
+        std::int32_t utcOffsetSeconds;
+        const char* timestamp;
+    };
+    const std::array cases{
+        WallTimeCase{ "New York winter", 1700000000ull, -5 * 60 * 60,
+                      "2023-11-14 17:13:20.123456-05:00" },
+        WallTimeCase{ "New York summer", 1689372800ull, -4 * 60 * 60,
+                      "2023-07-14 18:13:20.123456-04:00" },
+        WallTimeCase{ "New York immediately before spring DST", 1710053999ull, -5 * 60 * 60,
+                      "2024-03-10 01:59:59.123456-05:00" },
+        WallTimeCase{ "New York immediately after spring DST", 1710054000ull, -4 * 60 * 60,
+                      "2024-03-10 03:00:00.123456-04:00" },
+        WallTimeCase{ "Kolkata half-hour offset", 1700000000ull, 5 * 60 * 60 + 30 * 60,
+                      "2023-11-15 03:43:20.123456+05:30" },
+        WallTimeCase{ "historical Liberia seconds offset", 0ull, -( 44 * 60 + 30 ),
+                      "1969-12-31 23:15:30.123456-00:44:30" },
+    };
+    const std::string plainSuffix
+        = " Runner{Framework+0x1234}[4242] <ERROR>: bad \xef\xbf\xbd payload "
+          "[com.example][network]";
+    const std::string ansiSuffix
+        = "\x1b[0m \x1b[35mRunner\x1b[0m{\x1b[35mFramework\x1b[0m"
+          "\x1b[34m+0x1234\x1b[0m}[\x1b[36m4242\x1b[0m] "
+          "<\x1b[31mERROR\x1b[0m>: \x1b[31mbad \xef\xbf\xbd payload\x1b[0m "
+          "\x1b[36m[com.example][network]\x1b[0m";
+
+    for ( const auto& value : cases ) {
+        INFO( value.name );
+        auto record = formattingRecord();
+        record.seconds = value.seconds;
+        const OsTraceUtcOffsetResolver resolver
+            = [ expectedSeconds = value.seconds,
+                offset = value.utcOffsetSeconds ]( std::uint64_t epochSeconds ) {
+                  CHECK( epochSeconds == expectedSeconds );
+                  return offset;
+              };
+        const auto plain
+            = formatOsTraceRecord( record, OsTraceFormatOptions{ false, true, true, resolver } );
+        const auto ansi
+            = formatOsTraceRecord( record, OsTraceFormatOptions{ true, true, true, resolver } );
+        const auto expectedPlain = std::string{ value.timestamp } + plainSuffix;
+        const auto expectedAnsi = std::string{ "\x1b[32m" } + value.timestamp + ansiSuffix;
+
+        CHECK( plain.bytes == expectedPlain );
+        CHECK( ansi.bytes == expectedAnsi );
+        CHECK( plain.statistics.plainByteCount == expectedPlain.size() );
+        CHECK( plain.statistics.outputByteCount == expectedPlain.size() );
+        CHECK( ansi.statistics.plainByteCount == expectedPlain.size() );
+        CHECK( ansi.statistics.outputByteCount == expectedAnsi.size() );
+        CHECK( stripGeneratedAnsi( ansi.bytes ) == plain.bytes );
+    }
+}
+
+TEST_CASE( "iOS formatter reports an unavailable source time-zone offset without inventing UTC",
+           "[livecapture][ios][ostrace][format][timezone][range]" )
+{
+    OsTraceFormatOptions options;
+    options.utcOffsetSecondsAt = []( std::uint64_t ) -> std::optional<std::int32_t> {
+        return std::nullopt;
+    };
+
+    const auto formatted = formatOsTraceRecord( formattingRecord(), options );
+
+    CHECK_FALSE( formatted.utcOffsetResolved );
+    CHECK( formatted.bytes.empty() );
+    CHECK( formatted.statistics == OsTraceFormatStatistics{} );
+}
+
+TEST_CASE( "stateful iOS formatter resolves and formats each epoch second only once",
+           "[livecapture][ios][ostrace][format][timezone][cache]" )
+{
+    std::vector<std::uint64_t> resolvedSeconds;
+    OsTraceFormatOptions options;
+    options.utcOffsetSecondsAt = [ &resolvedSeconds ]( std::uint64_t seconds ) {
+        resolvedSeconds.push_back( seconds );
+        return std::int32_t{ 5 * 60 * 60 + 45 * 60 };
+    };
+    OsTraceRecordFormatter formatter( std::move( options ) );
+
+    auto firstRecord = formattingRecord();
+    firstRecord.microseconds = 1u;
+    auto secondRecord = firstRecord;
+    secondRecord.microseconds = 999999u;
+
+    const auto first = formatter.format( firstRecord );
+    const auto second = formatter.format( secondRecord );
+
+    CHECK( first.bytes.find( "2023-11-15 03:58:20.000001+05:45" ) == 0u );
+    CHECK( second.bytes.find( "2023-11-15 03:58:20.999999+05:45" ) == 0u );
+    CHECK( resolvedSeconds == std::vector<std::uint64_t>{ 1700000000ull } );
+
+    secondRecord.seconds += 1u;
+    CHECK( formatter.format( secondRecord ).bytes.find( "2023-11-15 03:58:21.999999+05:45" )
+           == 0u );
+    CHECK( resolvedSeconds == std::vector<std::uint64_t>{ 1700000000ull, 1700000001ull } );
 }
 
 TEST_CASE( "iOS formatter keeps plain and ANSI output semantically identical across a corpus",
@@ -929,12 +1045,12 @@ TEST_CASE( "iOS formatter keeps labels and image metadata optional without punct
 
     const auto formatted = formatOsTraceRecord( record, OsTraceFormatOptions{ false, true, true } );
     CHECK( formatted.bytes
-           == "2023-11-14 22:13:20.123456 Runner{}[4242] <ERROR>: bad \xef\xbf\xbd payload" );
+           == "2023-11-14 22:13:20.123456+00:00 Runner{}[4242] <ERROR>: bad \xef\xbf\xbd payload" );
 
     record.processPath.reset();
     record.message.reset();
     const auto missing = formatOsTraceRecord( record, OsTraceFormatOptions{ false, true, true } );
-    CHECK( missing.bytes == "2023-11-14 22:13:20.123456 {}[4242] <ERROR>: " );
+    CHECK( missing.bytes == "2023-11-14 22:13:20.123456+00:00 {}[4242] <ERROR>: " );
 }
 
 TEST_CASE(

--- a/tests/unit/livelog_controller_test.cpp
+++ b/tests/unit/livelog_controller_test.cpp
@@ -706,8 +706,8 @@ TEST_CASE( "Typed Android options reach transport config and command on every ge
     const auto service = adb::buildLogcatService( backend->logcatOptions );
     REQUIRE( service.value.has_value() );
     CHECK( *service.value
-           == "shell,v2,raw:logcat -v color -b main -b system -b crash --pid 4242 "
-              "'ActivityManager:I' '*:D'" );
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec -v color -b main "
+              "-b system -b crash --pid 4242 'ActivityManager:I' '*:D'" );
 
     clock.set( at( 100 ) );
     controller.reconnectRequested();
@@ -927,7 +927,8 @@ TEST_CASE( "A scheduler that completes inline cannot leave a stale retry token",
     CHECK_FALSE( controller.presentation().retryCountdownVisible );
 }
 
-TEST_CASE( "Android ANSI output controls the logcat formatter", "[livelog-controller][red][ansi]" )
+TEST_CASE( "Android streams own ordered wall-time modifiers with optional ANSI color",
+           "[livelog-controller][red][ansi][wall-time]" )
 {
     LiveSourceTransportConfig config;
     config.sourceType = LiveLogSourceType::AdbLogcat;
@@ -938,12 +939,14 @@ TEST_CASE( "Android ANSI output controls the logcat formatter", "[livelog-contro
     REQUIRE( plain.has_value() );
     const auto plainService = adb::buildLogcatService( plain->logcatOptions );
     REQUIRE( plainService.value.has_value() );
-    CHECK( *plainService.value == "shell,v2,raw:logcat" );
+    CHECK( *plainService.value
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec" );
 
     config.ansiOutputEnabled = true;
     const auto colored = livelog::makeAdbSmartSocketTransportConfig( config );
     REQUIRE( colored.has_value() );
     const auto coloredService = adb::buildLogcatService( colored->logcatOptions );
     REQUIRE( coloredService.value.has_value() );
-    CHECK( *coloredService.value == "shell,v2,raw:logcat -v color" );
+    CHECK( *coloredService.value
+           == "shell,v2,raw:logcat -v threadtime -v year -v zone -v usec -v color" );
 }


### PR DESCRIPTION
## Summary
- require the authorized `KLOGG_GITHUB_TOKEN` PAT for workflow-bearing release mutations, parse real YAML step fields so comments/inline syntax cannot spoof the gate, and exclude vendored C++ from CodeQL by prebuilding it before initialization and guarding the remaining traced plan
- fix multi-device ADB startup by separating server-wide and selected-transport feature requests, and make one-shot smart-socket replies deterministic across packetization and trailing data
- keep folder-result navigation responsive by using visible-row bounds, coalescing same-file pending jumps, and preserving newer selections across failed asynchronous loads
- render Android and native iOS live logs in the source device's local wall time with explicit numeric UTC offsets, use host-independent injected timezone resolvers in native-worker contracts, and fail closed for missing, invalid, empty, or out-of-range timezone resolution

## Background
- **Introduced by:** the release publisher workflow needed a PAT authorized for workflow changes; integrated mobile capture and folder-result navigation retained assumptions from server-wide ADB probing, ordinary single-file row numbering, and UTC-oriented timestamp formatting.
- **Use case:** publish a release containing workflow files, open ADB logcat with multiple devices, browse a large multi-file folder search, or save Android/iOS live logs for later correlation.
- **How to reproduce:** update a workflow-bearing release with `github.token`; probe ADB while multiple devices are attached; click multiple uncached-file results or navigate sparse folder results; compare captured timestamps with the source device's local clock.
- **Root cause:** release PATCH requests used a token GitHub rejects for workflow changes; ADB mixed server and selected-device feature scopes and lacked a packetization-independent one-shot completion boundary; folder code mixed source labels with visible rows and discarded newer pending intent; modern live-log paths did not own source-device timezone semantics.
- **How to fix:** gate release mutation on the authorized PAT using parsed YAML step fields, prebuild and dry-run-check vendored CodeQL targets before tracing, use `host:host-features` for server probes and transport-scoped `host:features` for selected devices, validate one-shot replies through orderly EOF, revision-protect folder pending loads, force Android year/zone/usec output, and resolve native iOS epochs through the validated lockdown `TimeZone` with explicit startup/range failures.

## Tests
- `cmake --build build_root --target ci_build -j$(sysctl -n hw.ncpu)`
- `ctest --test-dir build_root --build-config RelWithDebInfo --output-on-failure` — 27/27 passed
- affected macOS ASan targets and CTest — 4/4 passed (`klogg_tests`, `klogg_itests`, `klogg_ios_protocol_tests`, `klogg_ios_native_contract_tests`)
- `python3 scripts/run_ci_quality.py` — 615 script tests passed
- changed-header standalone compilation — 8/8 passed
- fast and full upstream `run_changed_clang_tidy.py` — clean
- focused ADB protocol/client/transport/process, iOS protocol/native worker, and folder pending/navigation regressions
- host-independent native iOS timezone resolver contracts, including rejection of an engaged optional containing an empty resolver
- fresh CodeQL-style configure/prebuild/dry-run: 177 remaining first-party/generated operations and no `cpm_cache`, `_deps`, or `3rdparty/CMakeFiles` work
- final medium code review plus focused verification — no actionable findings remain

A full ASan `ci_build` was not used because the unrelated `live_capture_process_integrated_benchmark` currently fails to link `PersistentInfo::ForcePortable`; every ASan target affected by this PR was rebuilt and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - iOS trace timestamps now reflect the connected device’s local time zone, including daylight-saving and UTC offsets.
  - Android device feature negotiation is now scoped to the selected device.

- **Bug Fixes**
  - Improved compatibility with Android versions that reject certain logcat formatting options, with clearer diagnostic guidance.
  - Fixed folder search navigation and same-file selection after interrupted or failed loads.
  - Prevented empty log views from performing invalid navigation actions.
  - Improved handling of one-shot ADB responses and streaming errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
