### PR TITLE
Promote verified Continuous releases and improve live capture responsiveness

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2329,3 +2329,38 @@ jobs:
             fi
           done
           echo "CI passed: $results"
+
+  DispatchContinuous:
+    needs: [ci-gate]
+    if: >-
+      ${{
+        success()
+        && needs.ci-gate.result == 'success'
+        && github.event_name == 'push'
+        && github.ref == 'refs/heads/master'
+        && github.event.repository.full_name == github.repository
+      }}
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch Continuous publisher for current master
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          KLOGG_CI_RUN_ID: ${{ github.run_id }}
+          KLOGG_CI_RUN_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+          if [ "$master_sha" != "$KLOGG_CI_RUN_SHA" ]; then
+            echo "::notice::Skipping stale Continuous dispatch: ${KLOGG_CI_RUN_SHA} != ${master_sha}"
+            exit 0
+          fi
+          gh workflow run ci-continuous.yml \
+            --repo "$repo" \
+            --ref master \
+            -f ci-run-id="$KLOGG_CI_RUN_ID" \
+            -f ci-run-sha="$KLOGG_CI_RUN_SHA"

--- a/.github/workflows/ci-continuous.yml
+++ b/.github/workflows/ci-continuous.yml
@@ -1,54 +1,156 @@
 name: "Publish Release (Continuous)"
 
 on:
-  workflow_run:
-    workflows: ["CI Build"]
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      ci-run-id:
+        description: "Successful trusted master CI Build run ID"
+        required: true
+        type: string
+      ci-run-sha:
+        description: "Commit SHA produced by the trusted master CI Build"
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: continuous-release-publisher
+  group: release-publisher
+  queue: max
   cancel-in-progress: false
 
 jobs:
   select:
-    if: >-
-      github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.event == 'push'
-      && github.event.workflow_run.head_branch == 'master'
-      && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      KLOGG_CI_RUN_ID: ${{ github.event.workflow_run.id }}
-      KLOGG_CI_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+      KLOGG_REQUESTED_CI_RUN_ID: ${{ inputs.ci-run-id }}
+      KLOGG_REQUESTED_CI_RUN_SHA: ${{ inputs.ci-run-sha }}
+      KLOGG_DISPATCH_SHA: ${{ github.sha }}
+      KLOGG_CI_POLL_ATTEMPTS: 24
+      KLOGG_CI_POLL_INTERVAL_SECONDS: 5
+      KLOGG_GH_API_RETRY_ATTEMPTS: 4
+      KLOGG_GH_API_RETRY_DELAY_SECONDS: 2
     outputs:
       should-publish: ${{ steps.selection.outputs.should-publish }}
+      ci-run-id: ${{ steps.selection.outputs.ci-run-id }}
+      ci-run-sha: ${{ steps.selection.outputs.ci-run-sha }}
     steps:
-      - name: Verify triggering CI run and current master tip
+      - name: Verify dispatched CI run and current master tip
         id: selection
         shell: bash
         run: |
           set -euo pipefail
           repo="${GITHUB_REPOSITORY}"
-          run_api="/repos/${repo}/actions/runs/${KLOGG_CI_RUN_ID}"
-          test "$(gh api "$run_api" --jq '.path')" = ".github/workflows/ci-build.yml"
-          test "$(gh api "$run_api" --jq '.head_repository.full_name // empty')" = "$repo"
-          test "$(gh api "$run_api" --jq '.head_branch')" = "master"
-          test "$(gh api "$run_api" --jq '.event')" = "push"
-          test "$(gh api "$run_api" --jq '.conclusion')" = "success"
-          test "$(gh api "$run_api" --jq '.head_sha')" = "$KLOGG_CI_RUN_SHA"
-          master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
-          if [ "$master_sha" != "$KLOGG_CI_RUN_SHA" ]; then
-            echo "::notice::Skipping stale continuous run ${KLOGG_CI_RUN_ID}: ${KLOGG_CI_RUN_SHA} != ${master_sha}"
+          run_id="${KLOGG_REQUESTED_CI_RUN_ID}"
+          run_sha="${KLOGG_REQUESTED_CI_RUN_SHA}"
+          [[ "$run_id" =~ ^[0-9]+$ ]] || {
+            echo "::error::ci-run-id must contain digits only"
+            exit 1
+          }
+          [[ "$run_sha" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "::error::ci-run-sha must be a lowercase 40-character commit SHA"
+            exit 1
+          }
+          test "$run_sha" = "$KLOGG_DISPATCH_SHA" || {
+            echo "::error::Dispatched CI SHA ${run_sha} does not match workflow revision ${KLOGG_DISPATCH_SHA}"
+            exit 1
+          }
+
+          gh_api_retry() {
+            local attempt=1
+            while true; do
+              if gh api "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -ge "$KLOGG_GH_API_RETRY_ATTEMPTS" ]; then
+                echo "::error::GitHub API request failed after ${attempt} attempts" >&2
+                return 1
+              fi
+              if [ "$KLOGG_GH_API_RETRY_DELAY_SECONDS" != 0 ]; then
+                sleep "$KLOGG_GH_API_RETRY_DELAY_SECONDS"
+              fi
+              attempt=$((attempt + 1))
+            done
+          }
+
+          run_api="/repos/${repo}/actions/runs/${run_id}"
+          verify_run_identity() {
+            identity="$(gh_api_retry "$run_api" --jq '
+              [.path, (.head_repository.full_name // ""), (.head_branch // ""), .event, .head_sha]
+              | @tsv
+            ')"
+            IFS=$'\t' read -r run_path run_repository run_branch run_event api_run_sha <<< "$identity"
+            test "$run_path" = ".github/workflows/ci-build.yml"
+            test "$run_repository" = "$repo"
+            test "$run_branch" = "master"
+            test "$run_event" = "push"
+            test "$api_run_sha" = "$run_sha"
+          }
+          verify_run_identity
+
+          run_attempt="$(gh_api_retry "$run_api" --jq '.run_attempt')"
+          [[ "$run_attempt" =~ ^[0-9]+$ ]]
+          gate_record=""
+          for gate_attempt in $(seq "$run_attempt" -1 1); do
+            gate_record="$(gh_api_retry --paginate --slurp \
+              "${run_api}/attempts/${gate_attempt}/jobs?per_page=100" --jq '
+                [.[].jobs[] | select(.name == "ci-gate")]
+                | if length == 0 then empty
+                  elif length == 1 then .[0] | [.status, .conclusion] | @tsv
+                  else error("expected at most one ci-gate job per attempt") end
+              ')"
+            if [ -n "$gate_record" ]; then
+              break
+            fi
+          done
+          test -n "$gate_record" || { echo "::error::Source CI has no ci-gate job"; exit 1; }
+          IFS=$'\t' read -r gate_status gate_conclusion <<< "$gate_record"
+          test "$gate_status" = "completed" && test "$gate_conclusion" = "success" || {
+            echo "::error::Source CI gate is ${gate_status}/${gate_conclusion}"
+            exit 1
+          }
+
+          completed=false
+          for _ in $(seq 1 "$KLOGG_CI_POLL_ATTEMPTS"); do
+            run_state="$(gh_api_retry "$run_api" --jq '[.status, (.conclusion // "")] | @tsv')"
+            IFS=$'\t' read -r run_status run_conclusion <<< "$run_state"
+            if [ "$run_status" = "completed" ]; then
+              test "$run_conclusion" = "success" || {
+                echo "::error::Source CI completed with ${run_conclusion:-no conclusion}"
+                exit 1
+              }
+              completed=true
+              break
+            fi
+            case "$run_status" in
+              queued|in_progress|pending|waiting|requested) ;;
+              *) echo "::error::Unexpected source CI status ${run_status}"; exit 1 ;;
+            esac
+            if [ "$KLOGG_CI_POLL_INTERVAL_SECONDS" != 0 ]; then
+              sleep "$KLOGG_CI_POLL_INTERVAL_SECONDS"
+            fi
+          done
+          test "$completed" = true || {
+            echo "::error::Timed out waiting for source CI run ${run_id} to complete"
+            exit 1
+          }
+          verify_run_identity
+
+          master_sha="$(gh_api_retry "/repos/${repo}/branches/master" --jq '.commit.sha')"
+          if [ "$master_sha" != "$run_sha" ]; then
+            echo "::notice::Skipping stale continuous run ${run_id}: ${run_sha} != ${master_sha}"
             echo "should-publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "ci-run-id=${run_id}"
+            echo "ci-run-sha=${run_sha}"
+            echo "should-publish=true"
+          } >> "$GITHUB_OUTPUT"
 
   publish:
     needs: select
@@ -59,8 +161,8 @@ jobs:
       contents: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      KLOGG_CI_RUN_ID: ${{ github.event.workflow_run.id }}
-      KLOGG_CI_RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+      KLOGG_CI_RUN_ID: ${{ needs.select.outputs.ci-run-id }}
+      KLOGG_CI_RUN_SHA: ${{ needs.select.outputs.ci-run-sha }}
       KLOGG_EVIDENCE_LEVEL: validation
     # GitHub's workflow-persistence protection refuses to let the Actions app
     # token (github.token) create or update a release whose target commit adds
@@ -81,7 +183,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.KLOGG_CI_RUN_ID }}
           pattern: packages-*
           path: packages-all
 
@@ -89,7 +191,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.KLOGG_CI_RUN_ID }}
           name: klogg_version
           path: klogg_version
 
@@ -97,7 +199,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.KLOGG_CI_RUN_ID }}
           name: adb-helper-legal-assets
           path: adb-helper-legal-assets
 
@@ -105,7 +207,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ env.KLOGG_CI_RUN_ID }}
           name: ios-native-source-assets
           path: ios-native-source-assets
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -2,627 +2,524 @@ name: "Publish Release (Stable)"
 
 on:
   workflow_dispatch:
-    inputs:
-      ci-run-id:
-        description: "Optional successful trusted master CI Build run ID; defaults to latest successful master push"
-        required: false
-        type: string
-      evidence-level:
-        description: "Publish secret-neutral validation artifacts, or require signed/notarized macOS evidence"
-        required: true
-        default: validation
-        type: choice
-        options:
-          - validation
-          - signed
 
 permissions: {}
 
 concurrency:
-  group: stable-release-publisher
+  group: release-publisher
+  queue: max
   cancel-in-progress: false
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
-      actions: read
       contents: write
     env:
-      KLOGG_HAS_SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN != '' && 'true' || 'false' }}
       KLOGG_HAS_DISCORD_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK != '' && 'true' || 'false' }}
       GITHUB_TOKEN: ${{ github.token }}
-      KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}
-      KLOGG_EVIDENCE_LEVEL: ${{ github.event.inputs.evidence-level }}
     steps:
-    - name: Reject non-master stable dispatch
-      shell: bash
-      run: |
-        set -euo pipefail
-        test "${GITHUB_REF}" = "refs/heads/master" || {
-          echo "::error::Stable releases must be dispatched from refs/heads/master"
-          exit 1
-        }
-
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-
-    - name: Select trusted CI run
-      shell: bash
-      run: |
-        set -euo pipefail
-        repo="${GITHUB_REPOSITORY}"
-        requested_run_id="${KLOGG_REQUESTED_CI_RUN_ID}"
-        if [ -n "$requested_run_id" ]; then
-          [[ "$requested_run_id" =~ ^[0-9]+$ ]] || {
-            echo "::error::ci-run-id must contain digits only"
+      - name: Reject non-master stable dispatch
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/master" || {
+            echo "::error::Stable releases must be dispatched from refs/heads/master"
             exit 1
           }
-          run_id="$requested_run_id"
-        else
-          run_id="$(gh api "/repos/${repo}/actions/workflows/ci-build.yml/runs?branch=master&event=push&status=success&per_page=1" --jq '.workflow_runs[0].id // empty')"
-        fi
-        test -n "$run_id" || { echo "::error::No successful trusted master CI Build run found"; exit 1; }
-        run_api="/repos/${repo}/actions/runs/${run_id}"
-        run_path="$(gh api "$run_api" --jq '.path')"
-        run_repository="$(gh api "$run_api" --jq '.head_repository.full_name // empty')"
-        run_branch="$(gh api "$run_api" --jq '.head_branch // empty')"
-        run_event="$(gh api "$run_api" --jq '.event')"
-        run_conclusion="$(gh api "$run_api" --jq '.conclusion')"
-        run_sha="$(gh api "$run_api" --jq '.head_sha')"
-        test "$run_path" = ".github/workflows/ci-build.yml" || { echo "::error::Selected run uses ${run_path}"; exit 1; }
-        test "$run_repository" = "${GITHUB_REPOSITORY}" || { echo "::error::Selected run is from ${run_repository}"; exit 1; }
-        test "$run_branch" = "master" || { echo "::error::Selected run branch is ${run_branch}"; exit 1; }
-        case "$run_event" in
-          push)
-            test "$KLOGG_EVIDENCE_LEVEL" = validation || {
-              echo "::error::Push CI runs contain validation evidence, not signed evidence"
-              exit 1
-            }
-            ;;
-          workflow_dispatch)
-            # The workflow-run API does not expose workflow_dispatch inputs.
-            # Bind the requested evidence level after download from the SHA-bound
-            # package, iOS, signing, and notarization receipts instead.
-            ;;
-          *) echo "::error::Selected run event is ${run_event}"; exit 1 ;;
-        esac
-        test "$run_conclusion" = "success" || { echo "::error::Selected run conclusion is ${run_conclusion}"; exit 1; }
-        test "$run_sha" != "null" && test -n "$run_sha"
-        master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
-        test "$run_sha" = "$master_sha" || {
-          echo "::error::Selected CI run is stale: ${run_sha} != current master ${master_sha}"
-          exit 1
-        }
-        {
-          echo "KLOGG_CI_RUN_ID=${run_id}"
-          echo "KLOGG_CI_RUN_SHA=${run_sha}"
-        } >> "$GITHUB_ENV"
 
-    - name: Download artifacts for selected CI workflow
-      uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
-      with:
-        workflow: ci-build.yml
-        run_id: ${{ env.KLOGG_CI_RUN_ID }}
-        github_token: ${{ github.token }}
-        # Download only the artifacts the release consumes. Without a filter,
-        # dawidd6 downloads ALL run artifacts, including the
-        # "<owner>~<repo>~<id>.dockerbuild" build records that
-        # docker/build-push-action uploads alongside the docker `type=gha`
-        # cache (added in 1ddee61d). Those are gzipped OCI tarballs, not
-        # zips, so dawidd6's unzip step fails the release with "Invalid or
-        # unsupported zip format. No END header found" (run 31241902650).
-        name: '^(packages-.*|klogg_version|adb-helper-legal-assets|ios-native-source-assets)$'
-        name_is_regexp: true
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
-    - name: Initialize selected CI metadata and checkout
-      shell: bash
-      run: |
-        set -euo pipefail
-        KLOGG_VERSION=$(cat klogg_version/klogg_version.txt)
-        KLOGG_SOURCE_COMMIT=$(cat klogg_version/klogg_commit.txt)
-        test "${KLOGG_SOURCE_COMMIT}" = "${KLOGG_CI_RUN_SHA}" || {
-          echo "::error::Artifact commit ${KLOGG_SOURCE_COMMIT} does not match selected run ${KLOGG_CI_RUN_SHA}"
-          exit 1
-        }
-        git fetch --no-tags origin master
-        git merge-base --is-ancestor "${KLOGG_SOURCE_COMMIT}" origin/master || {
-          echo "::error::Selected CI commit is not in trusted master history"
-          exit 1
-        }
-        echo "KLOGG_VERSION=${KLOGG_VERSION}" >> "$GITHUB_ENV"
-        echo "KLOGG_SOURCE_COMMIT=${KLOGG_SOURCE_COMMIT}" >> "$GITHUB_ENV"
-        git checkout --detach "${KLOGG_SOURCE_COMMIT}"
-        test "$(git rev-parse HEAD)" = "${KLOGG_SOURCE_COMMIT}"
+      - name: Select live Continuous release snapshot
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          release_api="/repos/${repo}/releases/tags/continuous"
+          release_id="$(gh api "$release_api" --jq '.id')"
+          release_tag="$(gh api "$release_api" --jq '.tag_name')"
+          release_draft="$(gh api "$release_api" --jq '.draft')"
+          release_prerelease="$(gh api "$release_api" --jq '.prerelease')"
+          [[ "$release_id" =~ ^[0-9]+$ ]] && [ "$release_id" -gt 0 ] || {
+            echo "::error::Live Continuous release ID is invalid"
+            exit 1
+          }
+          test "$release_tag" = continuous || { echo "::error::Live Continuous release tag is ${release_tag}"; exit 1; }
+          test "$release_draft" = false || { echo "::error::Live Continuous release is still a draft"; exit 1; }
+          test "$release_prerelease" = true || { echo "::error::Live Continuous release is not a pre-release"; exit 1; }
+          source_tag_sha="$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')"
+          [[ "$source_tag_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::Continuous tag SHA is invalid"; exit 1; }
+          master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
+          test "$source_tag_sha" = "$master_sha" || {
+            echo "::error::Continuous release is not the latest master revision: ${source_tag_sha} != ${master_sha}"
+            exit 1
+          }
+          {
+            echo "KLOGG_SOURCE_RELEASE_ID=${release_id}"
+            echo "KLOGG_SOURCE_COMMIT=${source_tag_sha}"
+          } >> "$GITHUB_ENV"
 
-    # Package artifacts are uploaded as single-file tarballs (not raw
-    # multi-file directories) to avoid GitHub's artifact backend intermittently
-    # corrupting multi-file zip64 archives ("No END header found" on extract).
-    # Restore the ./packages-*/ directory layout the steps below expect.
-    - name: Extract package tarballs
-      shell: bash
-      run: |
-        set -euo pipefail
-        while IFS= read -r -d '' t; do
-          echo "Extracting: $t"
-          staging=$(mktemp -d)
-          python3 scripts/extract_verified_tar.py --archive "$t" --destination "$staging"
-          cp -a "$staging"/. "$(dirname "$t")"/
-          rm -rf "$staging" "$t"
-        done < <(find . -maxdepth 2 -name 'packages-*.tar.gz' -type f -print0)
+      - name: Download immutable Continuous release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          source_root="continuous-publication"
+          assets_json="continuous-release-assets.json"
+          mkdir -p "$source_root"
+          gh api "/repos/${repo}/releases/${KLOGG_SOURCE_RELEASE_ID}/assets?per_page=100" > "$assets_json"
+          python3 - "$assets_json" <<'PY' > continuous-release-download-plan.jsonl
+          import json
+          import pathlib
+          import sys
 
-    - name: Validate package evidence before publication
-      shell: bash
-      run: |
-        set -eu
-        required="
-          packages-jammy-vs-gen/adb-helper-deb-package-verification.json
-          packages-noble-vs-gen/adb-helper-deb-package-verification.json
-          packages-resolute-vs-gen/adb-helper-deb-package-verification.json
-          packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
-          packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
-          packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
-          packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
-          packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
-          packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
-        "
-        if [ "$KLOGG_EVIDENCE_LEVEL" = signed ]; then
-          required="$required
-            packages-macos-intel-qt6-vs-gen/adb-helper-signing-receipt.json
-            packages-macos-intel-qt6-vs-gen/adb-helper-notarization-receipt.json
-            packages-macos-arm-qt6-vs-arm64/adb-helper-signing-receipt.json
-            packages-macos-arm-qt6-vs-arm64/adb-helper-notarization-receipt.json
-          "
-        fi
-        for receipt in $required; do
-          test -f "$receipt" || { echo "Missing release qualification receipt: $receipt"; exit 1; }
-        done
-        python3 - <<'PY'
-        import hashlib, json, os, pathlib
-        evidence_level = os.environ["KLOGG_EVIDENCE_LEVEL"]
-        package_receipts = [
-            pathlib.Path("packages-jammy-vs-gen/adb-helper-deb-package-verification.json"),
-            pathlib.Path("packages-noble-vs-gen/adb-helper-deb-package-verification.json"),
-            pathlib.Path("packages-resolute-vs-gen/adb-helper-deb-package-verification.json"),
-            pathlib.Path("packages-appimage-vs-gen/adb-helper-appimage-package-verification.json"),
-            pathlib.Path("packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json"),
-            pathlib.Path("packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json"),
-            pathlib.Path("packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json"),
-        ]
-        for path in package_receipts:
-            receipt = json.loads(path.read_text(encoding="utf-8"))
-            if receipt.get("receipt_kind") != "package-verification":
-                raise SystemExit(f"invalid package qualification receipt kind: {path}")
-            if not isinstance(receipt.get("release_qualified"), bool):
-                raise SystemExit(f"package has an invalid release claim: {path}")
-            required = set(receipt.get("required_receipts", []))
-            verified = set(receipt.get("verified_receipts", []))
-            mandatory = {"binary-build", "binary-smoke", "package-verification"}
-            if not mandatory.issubset(required) or not mandatory.issubset(verified):
-                raise SystemExit(f"package validation receipt is incomplete: {path}")
-            if not verified.issubset(required):
-                raise SystemExit(f"package receipt verifies evidence outside policy: {path}")
-            if evidence_level == "signed" and (
-                receipt.get("release_qualified") is not True
-                or not required.issubset(verified)
-            ):
-                raise SystemExit(f"package is not signed/release-qualified: {path}")
-            packages = receipt.get("packages")
-            if not isinstance(packages, list) or not packages:
-                raise SystemExit(f"package qualification receipt has no final package hashes: {path}")
-            for package in packages:
-                name = package.get("name") if isinstance(package, dict) else None
-                if not isinstance(name, str) or pathlib.PurePath(name).name != name:
-                    raise SystemExit(f"unsafe qualified package name in {path}: {name}")
-                published = path.parent / name
-                if not published.is_file():
-                    raise SystemExit(f"qualified package is missing: {published}")
-                actual = hashlib.sha256(published.read_bytes()).hexdigest()
-                if package.get("sha256") != actual:
-                    raise SystemExit(f"qualified package hash mismatch: {published}")
-        for package_dir in ("packages-macos-intel-qt6-vs-gen", "packages-macos-arm-qt6-vs-arm64"):
-            directory = pathlib.Path(package_dir)
-            dmgs = list(directory.glob("*.dmg"))
-            if len(dmgs) != 1:
-                raise SystemExit(f"expected one qualified DMG in {directory}, got {len(dmgs)}")
-            dmg_hash = hashlib.sha256(dmgs[0].read_bytes()).hexdigest()
-            qualification_path = directory / "adb-helper-dmg-package-verification.json"
-            qualification = json.loads(qualification_path.read_text(encoding="utf-8"))
-            if qualification.get("package_sha256") != dmg_hash:
-                raise SystemExit(f"macOS qualification receipt is not bound to published DMG: {qualification_path}")
-            ios_path = directory / "ios-native-dmg-package-verification.json"
-            ios_qualification = json.loads(ios_path.read_text(encoding="utf-8"))
-            if (
-                ios_qualification.get("qualification") != evidence_level
-                or ios_qualification.get("release_qualified") != (evidence_level == "signed")
-            ):
-                raise SystemExit(f"iOS qualification evidence level mismatch: {ios_path}")
-            if evidence_level != "signed":
-                continue
-            for name in ("signing", "notarization"):
-                path = directory / f"adb-helper-{name}-receipt.json"
-                receipt = json.loads(path.read_text(encoding="utf-8"))
-                if receipt.get("receipt_kind") != name or receipt.get("status") != "passed":
-                    raise SystemExit(f"invalid macOS {name} receipt: {path}")
-                if receipt.get("package_sha256", receipt.get("dmg_sha256")) != dmg_hash:
-                    raise SystemExit(f"macOS {name} receipt is not bound to published DMG: {path}")
-                if receipt.get("signed_helper_sha256") != qualification.get("helper_sha256"):
-                    raise SystemExit(f"macOS {name} receipt is not bound to qualified helper: {path}")
-                if receipt.get("source_helper_sha256") != qualification.get("source_helper_sha256"):
-                    raise SystemExit(f"macOS {name} receipt is not bound to source-built helper: {path}")
-        PY
+          records = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          if not isinstance(records, list) or len(records) != 23:
+              raise SystemExit("live Continuous release must contain exactly 23 assets")
+          ids = set()
+          names = set()
+          normalized = []
+          for record in records:
+              if not isinstance(record, dict):
+                  raise SystemExit("malformed Continuous release asset record")
+              asset_id = record.get("id")
+              name = record.get("name")
+              if type(asset_id) is not int or asset_id <= 0 or asset_id in ids:
+                  raise SystemExit("invalid or duplicate Continuous release asset ID")
+              if (
+                  not isinstance(name, str)
+                  or not name
+                  or pathlib.PurePosixPath(name).name != name
+                  or "\\" in name
+                  or any(ord(char) < 32 or ord(char) == 127 for char in name)
+                  or name in names
+              ):
+                  raise SystemExit("invalid or duplicate Continuous release asset name")
+              ids.add(asset_id)
+              names.add(name)
+              normalized.append([asset_id, name])
+          for record in sorted(normalized, key=lambda item: item[1]):
+              print(json.dumps(record, separators=(",", ":")))
+          PY
+          while IFS= read -r record; do
+            asset_id="$(jq -r '.[0]' <<< "$record")"
+            asset_name="$(jq -r '.[1]' <<< "$record")"
+            gh api -H "Accept: application/octet-stream" \
+              "/repos/${repo}/releases/assets/${asset_id}" > "$source_root/$asset_name"
+          done < continuous-release-download-plan.jsonl
+          python3 - "$assets_json" "$source_root" "$KLOGG_SOURCE_RELEASE_ID" "$KLOGG_SOURCE_COMMIT" <<'PY'
+          import hashlib
+          import json
+          import pathlib
+          import sys
 
-    - name: Generate Changelog
-      shell: bash
-      run: |
-        set -euo pipefail
-        python3 scripts/gen_changelog.py \
-          --mode release \
-          --current-tag "v${KLOGG_VERSION}" \
-          --to-ref "${KLOGG_SOURCE_COMMIT}" \
-          --print-range > release-changelog.txt
+          assets_path = pathlib.Path(sys.argv[1])
+          assets_root = pathlib.Path(sys.argv[2])
+          release_id = int(sys.argv[3])
+          tag_sha = sys.argv[4]
+          records = json.loads(assets_path.read_text(encoding="utf-8"))
+          source_assets = []
+          for record in records:
+              path = assets_root / record["name"]
+              if path.is_symlink() or not path.is_file():
+                  raise SystemExit(f"missing regular Continuous asset: {record['name']}")
+              digest = hashlib.sha256()
+              with path.open("rb") as stream:
+                  for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                      digest.update(chunk)
+              source_assets.append(
+                  {
+                      "id": record["id"],
+                      "name": record["name"],
+                      "sha256": digest.hexdigest(),
+                  }
+              )
+          metadata = {
+              "schema_version": 1,
+              "metadata_kind": "klogg-continuous-publication-source",
+              "source_release_id": release_id,
+              "source_tag_sha": tag_sha,
+              "source_assets": sorted(source_assets, key=lambda item: item["name"]),
+          }
+          pathlib.Path("continuous-source-metadata.json").write_text(
+              json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
 
-    - name: Display structure of downloaded files
-      run: ls -R ./packages-*
+      - name: Verify Continuous source publication and checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          readarray -t identity < <(python3 - <<'PY'
+          import json
+          import pathlib
+          import re
 
-    - name: Decompress debug symbols
-      shell: sh
-      run: |
-        if [ -f ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug.xz ]; then
-          xz -d ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug.xz
-        else
-          echo "Warning: ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug.xz not found, skipping"
-        fi
-        if [ -f ./packages-noble-vs-gen/klogg_noble_vs-gen.debug.xz ]; then
-          xz -d ./packages-noble-vs-gen/klogg_noble_vs-gen.debug.xz
-        else
-          echo "Warning: ./packages-noble-vs-gen/klogg_noble_vs-gen.debug.xz not found, skipping"
-        fi
-        if [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz ]; then
-          xz -d ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz
-        else
-          echo "Warning: ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug.xz not found, skipping"
-        fi
-        if [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug.xz ]; then
-          xz -d ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug.xz
-        else
-          echo "Warning: ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug.xz not found, skipping"
-        fi
+          manifest = json.loads(
+              pathlib.Path("continuous-publication/klogg-source-publication-manifest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          release = manifest.get("release")
+          if not isinstance(release, dict):
+              raise SystemExit("Continuous publication release identity is malformed")
+          version = release.get("version")
+          commit = release.get("commit")
+          if not isinstance(version, str) or re.fullmatch(r"[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]+", version) is None:
+              raise SystemExit("Continuous publication version is malformed")
+          if not isinstance(commit, str) or re.fullmatch(r"[0-9a-f]{40}", commit) is None:
+              raise SystemExit("Continuous publication commit is malformed")
+          print(version)
+          print(commit)
+          PY
+          )
+          KLOGG_VERSION="${identity[0]}"
+          manifest_commit="${identity[1]}"
+          test "$manifest_commit" = "$KLOGG_SOURCE_COMMIT" || {
+            echo "::error::Continuous manifest commit ${manifest_commit} != tag ${KLOGG_SOURCE_COMMIT}"
+            exit 1
+          }
+          python3 scripts/verify_source_publication_manifest.py \
+            --manifest continuous-publication/klogg-source-publication-manifest.json \
+            --assets-root continuous-publication \
+            --expected-channel continuous \
+            --expected-evidence-level validation \
+            --expected-tag continuous \
+            --expected-version "$KLOGG_VERSION" \
+            --expected-commit "$KLOGG_SOURCE_COMMIT" \
+            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
+          git fetch --no-tags origin master
+          git merge-base --is-ancestor "$KLOGG_SOURCE_COMMIT" origin/master || {
+            echo "::error::Continuous commit is not in trusted master history"
+            exit 1
+          }
+          git checkout --detach "$KLOGG_SOURCE_COMMIT"
+          test "$(git rev-parse HEAD)" = "$KLOGG_SOURCE_COMMIT"
+          echo "KLOGG_VERSION=${KLOGG_VERSION}" >> "$GITHUB_ENV"
 
-    - name: Setup Sentry CLI
-      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
-      uses: mathrix-education/setup-sentry-cli@ff4fff773f5e628fa214ebd19e46fb7289454ee2 # v3.0.0
-      with:
-        token: ${{ secrets.SENTRY_TOKEN }}
-        organization: anton-filimonov
-        project: klogg
+      - name: Recheck Continuous snapshot after download
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$KLOGG_SOURCE_RELEASE_ID"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.prerelease')" = true
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          test "$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" = "$KLOGG_SOURCE_COMMIT"
 
-    - name: Create Sentry release
-      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
-      shell: sh
-      run: |
-        sentry-cli releases new $KLOGG_VERSION
-        sentry-cli releases set-commits --auto $KLOGG_VERSION
+      - name: Generate Changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/gen_changelog.py \
+            --mode release \
+            --current-tag "v${KLOGG_VERSION}" \
+            --to-ref "${KLOGG_SOURCE_COMMIT}" \
+            --print-range > release-changelog.txt
 
-    - name: Upload symbols linux
-      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
-      shell: sh
-      run: |
-        if [ -f ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug ] && [ -f ./packages-jammy-vs-gen/klogg_jammy_vs-gen ]; then
-          sentry-cli upload-dif ./packages-jammy-vs-gen/klogg_jammy_vs-gen.debug ./packages-jammy-vs-gen/klogg_jammy_vs-gen
-        else
-          echo "Warning: ./packages-jammy-vs-gen debug files not found, skipping"
-        fi
-        if [ -f ./packages-noble-vs-gen/klogg_noble_vs-gen.debug ] && [ -f ./packages-noble-vs-gen/klogg_noble_vs-gen ]; then
-          sentry-cli upload-dif ./packages-noble-vs-gen/klogg_noble_vs-gen.debug  ./packages-noble-vs-gen/klogg_noble_vs-gen
-        else
-          echo "Warning: ./packages-noble-vs-gen debug files not found, skipping"
-        fi
-        if [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug ] && [ -f ./packages-resolute-vs-gen/klogg_resolute_vs-gen ]; then
-          sentry-cli upload-dif ./packages-resolute-vs-gen/klogg_resolute_vs-gen.debug  ./packages-resolute-vs-gen/klogg_resolute_vs-gen
-        else
-          echo "Warning: ./packages-resolute-vs-gen debug files not found, skipping"
-        fi
-        if [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug ] && [ -f ./packages-appimage-vs-gen/klogg_appimage_vs-gen ]; then
-          sentry-cli upload-dif ./packages-appimage-vs-gen/klogg_appimage_vs-gen.debug  ./packages-appimage-vs-gen/klogg_appimage_vs-gen
-        else
-          echo "Warning: ./packages-appimage-vs-gen debug files not found, skipping"
-        fi
+      - name: Promote verified Continuous publication to Stable
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/promote_release_publication.py \
+            --source-manifest continuous-publication/klogg-source-publication-manifest.json \
+            --source-assets-root continuous-publication \
+            --source-metadata continuous-source-metadata.json \
+            --output packages-publication
 
-    - name: Upload symbols mac
-      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
-      shell: sh
-      run: |
-        if [ -d ./packages-macos-intel-qt6-vs-gen ] && [ -f ./packages-macos-intel-qt6-vs-gen/klogg-x64.app/Contents/MacOS/klogg ]; then
-          sentry-cli upload-dif ./packages-macos-intel-qt6-vs-gen/klogg-x64.app/Contents/MacOS/klogg ./packages-macos-intel-qt6-vs-gen/klogg-x64.dSym
-        else
-          echo "Skipping macOS Intel symbols upload - artifacts not found"
-        fi
-        if [ -d ./packages-macos-arm-qt6-vs-arm64 ] && [ -f ./packages-macos-arm-qt6-vs-arm64/klogg-arm64.app/Contents/MacOS/klogg ]; then
-          sentry-cli upload-dif ./packages-macos-arm-qt6-vs-arm64/klogg-arm64.app/Contents/MacOS/klogg ./packages-macos-arm-qt6-vs-arm64/klogg-arm64.dSym
-        else
-          echo "Skipping macOS ARM symbols upload - artifacts not found"
-        fi
+      - name: Verify manifest and render release downloads
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(jq -r '.schema_version' packages-publication/klogg-source-publication-manifest.json)" = 3
+          python3 scripts/verify_source_publication_manifest.py \
+            --manifest packages-publication/klogg-source-publication-manifest.json \
+            --assets-root packages-publication \
+            --expected-channel stable \
+            --expected-evidence-level validation \
+            --expected-tag "v${KLOGG_VERSION}" \
+            --expected-version "${KLOGG_VERSION}" \
+            --expected-commit "${KLOGG_SOURCE_COMMIT}" \
+            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
+          asset_count="$(find packages-publication -maxdepth 1 -type f | wc -l)"
+          test "$asset_count" -eq 23
+          python3 scripts/render_release_downloads.py \
+            --manifest packages-publication/klogg-source-publication-manifest.json \
+            --assets-root packages-publication \
+            --base-url "https://github.com/${GITHUB_REPOSITORY}" \
+            --tag "v${KLOGG_VERSION}" \
+            --channel stable \
+            --version "${KLOGG_VERSION}" \
+            --evidence-description "These disk images are unsigned validation artifacts promoted byte-for-byte from the verified Continuous release." \
+            --changelog-file release-changelog.txt \
+            --output release-body.md
 
-    - name: Upload symbols win
-      if: env.KLOGG_HAS_SENTRY_TOKEN == 'true'
-      shell: sh
-      run: |
-        sentry-cli upload-dif ./packages-windows-x64-qt6-vs-avx2/klogg-$KLOGG_VERSION-x64-Qt6-vs-avx2-pdb.zip
-
-    - name: Prepare coherent stable package and source publication
-      shell: bash
-      run: |
-        set -euo pipefail
-        qualification_args=(
-          --qualification-receipt packages-jammy-vs-gen/adb-helper-deb-package-verification.json
-          --qualification-receipt packages-noble-vs-gen/adb-helper-deb-package-verification.json
-          --qualification-receipt packages-resolute-vs-gen/adb-helper-deb-package-verification.json
-          --qualification-receipt packages-appimage-vs-gen/adb-helper-appimage-package-verification.json
-          --qualification-receipt packages-windows-x64-qt6-vs-avx2/adb-helper-windows-package-verification.json
-          --qualification-receipt packages-macos-intel-qt6-vs-gen/adb-helper-dmg-package-verification.json
-          --qualification-receipt packages-macos-arm-qt6-vs-arm64/adb-helper-dmg-package-verification.json
-          --ios-qualification-receipt packages-macos-intel-qt6-vs-gen/ios-native-dmg-package-verification.json
-          --ios-qualification-receipt packages-macos-arm-qt6-vs-arm64/ios-native-dmg-package-verification.json
-        )
-        python3 scripts/prepare_source_publication.py \
-          --channel stable \
-          --evidence-level "${KLOGG_EVIDENCE_LEVEL}" \
-          --tag "v${KLOGG_VERSION}" \
-          --version "${KLOGG_VERSION}" \
-          --commit "${KLOGG_SOURCE_COMMIT}" \
-          --base-url "https://github.com/${GITHUB_REPOSITORY}" \
-          --adb-source-root ./adb-helper-legal-assets \
-          --ios-source-root ./ios-native-source-assets \
-          "${qualification_args[@]}" \
-          --output ./packages-publication
-
-    - name: Verify manifest and render release downloads
-      shell: bash
-      run: |
-        set -euo pipefail
-        python3 scripts/verify_source_publication_manifest.py \
-          --manifest packages-publication/klogg-source-publication-manifest.json \
-          --assets-root packages-publication \
-          --expected-channel stable \
-          --expected-evidence-level "${KLOGG_EVIDENCE_LEVEL}" \
-          --expected-tag "v${KLOGG_VERSION}" \
-          --expected-version "${KLOGG_VERSION}" \
-          --expected-commit "${KLOGG_SOURCE_COMMIT}" \
-          --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
-        asset_count="$(find packages-publication -maxdepth 1 -type f | wc -l)"
-        test "$asset_count" -eq 23
-        test -f packages-publication/klogg-release-evidence.tar
-        test -f packages-publication/SHA256SUMS
-        test -f packages-publication/adb-helper-source-set-receipt.json
-        test -f packages-publication/ios-native-source-set-receipt.json
-        if [ "${KLOGG_EVIDENCE_LEVEL}" = signed ]; then
-          evidence_description="Signed evidence includes signing and notarization receipts."
-        else
-          evidence_description="These disk images are unsigned validation artifacts, not signed or notarized releases."
-        fi
-        python3 scripts/render_release_downloads.py \
-          --manifest packages-publication/klogg-source-publication-manifest.json \
-          --assets-root packages-publication \
-          --base-url "https://github.com/${GITHUB_REPOSITORY}" \
-          --tag "v${KLOGG_VERSION}" \
-          --channel stable \
-          --version "${KLOGG_VERSION}" \
-          --evidence-description "$evidence_description" \
-          --changelog-file release-changelog.txt \
-          --output release-body.md
-
-    - name: Clean stale stable draft
-      if: env.GITHUB_TOKEN != ''
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        source scripts/github_api_helpers.sh
-        repo="${GITHUB_REPOSITORY}"
-        final_tag="v${KLOGG_VERSION}"
-        candidate_tag="${final_tag}-candidate"
-        for tag in "$candidate_tag" "$final_tag"; do
-          release_id=""
-          lookup_status=0
-          gh_api_optional_scalar release_id "/repos/${repo}/releases/tags/${tag}" .id \
-            || lookup_status=$?
-          case "$lookup_status" in
-            0)
-              draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
-              test "$draft" = true || {
-                echo "::error::refusing to replace existing published release ${tag}"
+      - name: Clean stale stable draft
+        if: env.GITHUB_TOKEN != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          source scripts/github_api_helpers.sh
+          repo="${GITHUB_REPOSITORY}"
+          final_tag="v${KLOGG_VERSION}"
+          candidate_tag="${final_tag}-candidate"
+          for tag in "$candidate_tag" "$final_tag"; do
+            release_id=""
+            lookup_status=0
+            gh_api_optional_scalar release_id "/repos/${repo}/releases/tags/${tag}" .id \
+              || lookup_status=$?
+            case "$lookup_status" in
+              0)
+                draft="$(gh api "/repos/${repo}/releases/${release_id}" --jq '.draft')"
+                test "$draft" = true || {
+                  echo "::error::refusing to replace existing published release ${tag}"
+                  exit 1
+                }
+                gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
+                ;;
+              1) ;;
+              *) exit 1 ;;
+            esac
+            ref_error="$(mktemp)"
+            if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$ref_error"; then
+              if [ "$tag" = "$final_tag" ] && [ -z "$release_id" ]; then
+                echo "::error::refusing to remove orphan stable tag ${tag}"
                 exit 1
-              }
-              gh api -X DELETE "/repos/${repo}/releases/${release_id}" >/dev/null
-              ;;
-            1) ;;
-            *) exit 1 ;;
-          esac
-
-          ref_error="$(mktemp)"
-          if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$ref_error"; then
-            if [ "$tag" = "$final_tag" ] && [ -z "$release_id" ]; then
-              echo "::error::refusing to remove orphan stable tag ${tag}"
+              fi
+              gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$ref_error"; then
+              cat "$ref_error"
               exit 1
             fi
-            gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
-          elif ! grep -Eq '404|Not Found' "$ref_error"; then
-            cat "$ref_error"
+            rm -f "$ref_error"
+          done
+
+      - name: Recheck Continuous snapshot before stable draft creation
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$KLOGG_SOURCE_RELEASE_ID"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.prerelease')" = true
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          test "$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" = "$KLOGG_SOURCE_COMMIT"
+
+      - name: Create GitHub Release
+        id: create_release
+        if: env.GITHUB_TOKEN != ''
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
+        with:
+          token: ${{ github.token }}
+          tag_name: v${{ env.KLOGG_VERSION }}-candidate
+          target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}
+          name: Release v${{ env.KLOGG_VERSION }}
+          body_path: release-body.md
+          prerelease: false
+          draft: true
+          files: |
+            ./packages-publication/*
+
+      - name: Verify stable source publication after upload
+        if: env.GITHUB_TOKEN != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.create_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
+          release_tag="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')"
+          test "${release_tag}" = "v${KLOGG_VERSION}-candidate" || { echo "::error::Stable candidate tag mismatch"; exit 1; }
+          candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.target_commitish')"
+          test "${candidate_target}" = "${KLOGG_SOURCE_COMMIT}" || {
+            echo "::error::Stable candidate target ${candidate_target} != source commit ${KLOGG_SOURCE_COMMIT}"
             exit 1
-          fi
-          rm -f "$ref_error"
-        done
+          }
+          verification_root="$(mktemp -d)"
+          while IFS=$'\t' read -r asset_id asset_name; do
+            gh api -H "Accept: application/octet-stream" \
+              "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "$verification_root/$asset_name"
+          done < <(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?per_page=100" \
+            --jq '.[] | [.id, .name] | @tsv')
+          test "$(jq -r '.schema_version' "$verification_root/klogg-source-publication-manifest.json")" = 3
+          python3 scripts/verify_source_publication_manifest.py \
+            --manifest "$verification_root/klogg-source-publication-manifest.json" \
+            --assets-root "$verification_root" \
+            --expected-channel stable \
+            --expected-evidence-level validation \
+            --expected-tag "v${KLOGG_VERSION}" \
+            --expected-version "${KLOGG_VERSION}" \
+            --expected-commit "${KLOGG_SOURCE_COMMIT}" \
+            --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
 
-    - name: Recheck master tip before stable draft creation
-      shell: bash
-      run: |
-        set -euo pipefail
-        master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
-        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
-          echo "::error::Master advanced before stable draft creation: ${master_sha}"
-          exit 1
-        }
+      - name: Recheck Continuous snapshot before stable promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$KLOGG_SOURCE_RELEASE_ID"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.prerelease')" = true
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          test "$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" = "$KLOGG_SOURCE_COMMIT"
 
-    - name: Create GitHub Release
-      id: create_release
-      if: env.GITHUB_TOKEN != ''
-      uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
-      with:
-        token: ${{ github.token }}
-        tag_name: v${{ env.KLOGG_VERSION }}-candidate
-        target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}
-        name: Release v${{ env.KLOGG_VERSION }}
-        body_path: release-body.md
-        prerelease: false
-        draft: true
-        files: |
-          ./packages-publication/*
-
-    - name: Verify stable source publication after upload
-      if: env.GITHUB_TOKEN != ''
-      shell: bash
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-        RELEASE_ID: ${{ steps.create_release.outputs.id }}
-      run: |
-        set -euo pipefail
-        test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
-        release_tag="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.tag_name')"
-        test "${release_tag}" = "v${KLOGG_VERSION}-candidate" || { echo "::error::Stable candidate tag mismatch"; exit 1; }
-        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.target_commitish')"
-        test "${candidate_target}" = "${KLOGG_SOURCE_COMMIT}" || {
-          echo "::error::Stable candidate target ${candidate_target} != source commit ${KLOGG_SOURCE_COMMIT}"
-          exit 1
-        }
-        verification_root=$(mktemp -d)
-        while IFS=$'\t' read -r asset_id asset_name; do
-          gh api -H "Accept: application/octet-stream" \
-            "/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "$verification_root/$asset_name"
-        done < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets" \
-          --jq '.[] | [.id, .name] | @tsv')
-        python3 scripts/verify_source_publication_manifest.py \
-          --manifest "$verification_root/klogg-source-publication-manifest.json" \
-          --assets-root "$verification_root" \
-          --expected-channel stable \
-          --expected-evidence-level "${KLOGG_EVIDENCE_LEVEL}" \
-          --expected-tag "v${KLOGG_VERSION}" \
-          --expected-version "${KLOGG_VERSION}" \
-          --expected-commit "${KLOGG_SOURCE_COMMIT}" \
-          --expected-base-url "https://github.com/${GITHUB_REPOSITORY}"
-
-    - name: Recheck master tip before stable promotion
-      shell: bash
-      run: |
-        set -euo pipefail
-        master_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/branches/master" --jq '.commit.sha')"
-        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
-          echo "::error::Master advanced before stable promotion: ${master_sha}"
-          exit 1
-        }
-
-    - name: Publish verified stable release
-      if: env.GITHUB_TOKEN != ''
-      shell: bash
-      env:
-        # Publishing the candidate creates the final tag via PATCH. GitHub's
-        # workflow-persistence protection requires workflow-modification
-        # authorization for release mutations whose target commit changes
-        # .github/workflows/** files — an authorization the Actions app token
-        # can never hold (HTTP 403 "Resource not accessible by integration").
-        # The draft creation above is safe with github.token because a draft
-        # defers tag creation to this step. KLOGG_GITHUB_TOKEN must carry
-        # repo + workflow scopes.
-        GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
-        RELEASE_ID: ${{ steps.create_release.outputs.id }}
-      run: |
-        set -euo pipefail
-        test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
-        repo="$GITHUB_REPOSITORY"
-        final_tag="v${KLOGG_VERSION}"
-        candidate_tag="${final_tag}-candidate"
-        promoted=false
-        delete_ref_if_present() {
-          local tag="$1"
-          local lookup_error
-          lookup_error="$(mktemp)"
-          if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
-            gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
-          elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-            cat "$lookup_error"
+      - name: Publish verified stable release
+        if: env.GITHUB_TOKEN != ''
+        shell: bash
+        env:
+          # The final PATCH creates a tag at a commit that can modify workflow
+          # files, so GitHub requires a PAT carrying repo + workflow scopes.
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.create_release.outputs.id }}
+        run: |
+          set -euo pipefail
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          repo="$GITHUB_REPOSITORY"
+          source scripts/github_api_helpers.sh
+          final_tag="v${KLOGG_VERSION}"
+          candidate_tag="${final_tag}-candidate"
+          final_ref_owned=false
+          delete_ref_if_present() {
+            local tag="$1"
+            local lookup_error
+            lookup_error="$(mktemp)"
+            if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
+              gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+              cat "$lookup_error"
+              rm -f "$lookup_error"
+              return 1
+            fi
             rm -f "$lookup_error"
-            return 1
-          fi
-          rm -f "$lookup_error"
-        }
-        rollback_stable_promotion() {
-          local original_status=$?
-          trap - ERR
-          if [ "$promoted" = true ]; then
-            echo "Roll back failed stable promotion ${final_tag}"
+          }
+          rollback_stable_promotion() {
+            local original_status=$?
+            local cleanup_status=0
+            local owned_tag=""
+            local lookup_status=0
+            trap - ERR
             set +e
-            cleanup_status=0
-            gh api -X DELETE "/repos/${repo}/releases/${RELEASE_ID}" >/dev/null \
-              || cleanup_status=1
-            delete_ref_if_present "$final_tag" || cleanup_status=1
+            echo "Roll back failed stable promotion ${final_tag}"
+            gh_api_optional_scalar owned_tag "/repos/${repo}/releases/${RELEASE_ID}" .tag_name \
+              || lookup_status=$?
+            case "$lookup_status" in
+              0)
+                if [ "$owned_tag" != "$candidate_tag" ] && [ "$owned_tag" != "$final_tag" ]; then
+                  echo "::error::Stable candidate changed to unexpected tag ${owned_tag}"
+                  cleanup_status=1
+                else
+                  gh api -X DELETE "/repos/${repo}/releases/${RELEASE_ID}" >/dev/null || cleanup_status=1
+                fi
+                ;;
+              1) ;;
+              *) cleanup_status=1 ;;
+            esac
+            if [ "$final_ref_owned" = true ]; then
+              delete_ref_if_present "$final_tag" || cleanup_status=1
+            fi
             delete_ref_if_present "$candidate_tag" || cleanup_status=1
             if [ "$cleanup_status" -ne 0 ]; then
               echo "::error::Stable promotion rollback was incomplete"
             fi
+            exit "$original_status"
+          }
+          trap rollback_stable_promotion ERR
+
+          test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$KLOGG_SOURCE_RELEASE_ID"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.prerelease')" = true
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          test "$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" = "$KLOGG_SOURCE_COMMIT"
+          lookup_error="$(mktemp)"
+          if gh api "/repos/${repo}/git/ref/tags/${final_tag}" >/dev/null 2>"$lookup_error" \
+            || ! grep -Eq '404|Not Found' "$lookup_error"; then
+            cat "$lookup_error"
+            echo "::error::Stable tag already exists: ${final_tag}"
             exit 1
           fi
-          exit "$original_status"
-        }
-        trap rollback_stable_promotion ERR
+          rm -f "$lookup_error"
+          gh api -X POST "/repos/${repo}/git/refs" \
+            -f ref="refs/tags/${final_tag}" -f sha="$KLOGG_SOURCE_COMMIT" >/dev/null
+          final_ref_owned=true
+          echo "KLOGG_STABLE_FINAL_REF_OWNED=true" >> "$GITHUB_ENV"
+          test "$(gh api "/repos/${repo}/git/ref/tags/${final_tag}" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" \
+            -f tag_name="$final_tag" -F draft=false -F prerelease=false >/dev/null
+          test "$(gh api "/repos/${repo}/releases/tags/${final_tag}" --jq '.id')" = "$RELEASE_ID"
+          test "$(gh api "/repos/${repo}/git/ref/tags/${final_tag}" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          delete_ref_if_present "$candidate_tag"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.id')" = "$KLOGG_SOURCE_RELEASE_ID"
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.draft')" = false
+          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq '.prerelease')" = true
+          test "$(gh api "/repos/${repo}/git/ref/tags/continuous" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
+          test "$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" = "$KLOGG_SOURCE_COMMIT"
+          trap - ERR
 
-        test -n "${RELEASE_ID}" || { echo "::error::Missing draft release ID"; exit 1; }
-        master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')"
-        test "${master_sha}" = "${KLOGG_SOURCE_COMMIT}" || {
-          echo "::error::Master advanced inside stable promotion: ${master_sha}"
-          exit 1
-        }
-        lookup_error="$(mktemp)"
-        if gh api "/repos/${repo}/git/ref/tags/${final_tag}" >/dev/null 2>"$lookup_error" \
-          || ! grep -Eq '404|Not Found' "$lookup_error"; then
-          cat "$lookup_error"
-          echo "::error::Stable tag already exists: ${final_tag}"
-          exit 1
-        fi
-        rm -f "$lookup_error"
-        gh api -X PATCH "/repos/${repo}/releases/${RELEASE_ID}" \
-          -f tag_name="$final_tag" -F draft=false -F prerelease=false >/dev/null
-        promoted=true
-        test "$(gh api "/repos/${repo}/releases/tags/${final_tag}" --jq '.id')" = "$RELEASE_ID"
-        test "$(gh api "/repos/${repo}/git/ref/tags/${final_tag}" --jq '.object.sha')" = "$KLOGG_SOURCE_COMMIT"
-        lookup_error="$(mktemp)"
-        if gh api "/repos/${repo}/git/ref/tags/${candidate_tag}" >/dev/null 2>"$lookup_error"; then
-          gh api -X DELETE "/repos/${repo}/git/refs/tags/${candidate_tag}" >/dev/null
-        elif ! grep -Eq '404|Not Found' "$lookup_error"; then
-          cat "$lookup_error"
-          exit 1
-        fi
-        rm -f "$lookup_error"
-        if ! master_sha="$(gh api "/repos/${repo}/branches/master" --jq '.commit.sha')" \
-          || [ "${master_sha}" != "${KLOGG_SOURCE_COMMIT}" ]; then
-          echo "::error::Master advanced while stable release was being published: ${master_sha:-unknown}"
-          false
-        fi
-        promoted=false
-        trap - ERR
+      - name: Roll back failed or cancelled stable promotion
+        if: ${{ failure() || cancelled() }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.create_release.outputs.id }}
+          FINAL_REF_OWNED: ${{ env.KLOGG_STABLE_FINAL_REF_OWNED }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_ID:-}" ]; then
+            echo "No Stable candidate was created; no release rollback is required"
+            exit 0
+          fi
+          test -n "${GITHUB_TOKEN:-}" || { echo "::error::KLOGG_GITHUB_TOKEN secret is missing or empty"; exit 1; }
+          source scripts/github_api_helpers.sh
+          repo="$GITHUB_REPOSITORY"
+          final_tag="v${KLOGG_VERSION}"
+          candidate_tag="${final_tag}-candidate"
+          delete_ref_if_present() {
+            local tag="$1"
+            local lookup_error
+            lookup_error="$(mktemp)"
+            if gh api "/repos/${repo}/git/ref/tags/${tag}" >/dev/null 2>"$lookup_error"; then
+              gh api -X DELETE "/repos/${repo}/git/refs/tags/${tag}" >/dev/null
+            elif ! grep -Eq '404|Not Found' "$lookup_error"; then
+              cat "$lookup_error"
+              rm -f "$lookup_error"
+              return 1
+            fi
+            rm -f "$lookup_error"
+          }
+          owned_tag=""
+          lookup_status=0
+          gh_api_optional_scalar owned_tag "/repos/${repo}/releases/${RELEASE_ID}" .tag_name \
+            || lookup_status=$?
+          case "$lookup_status" in
+            0)
+              test "$owned_tag" = "$candidate_tag" || test "$owned_tag" = "$final_tag" || {
+                echo "::error::Stable candidate changed to unexpected tag ${owned_tag}"
+                exit 1
+              }
+              gh api -X DELETE "/repos/${repo}/releases/${RELEASE_ID}" >/dev/null
+              ;;
+            1) ;;
+            *) exit 1 ;;
+          esac
+          if [ "${FINAL_REF_OWNED:-false}" = true ]; then
+            delete_ref_if_present "$final_tag"
+          fi
+          delete_ref_if_present "$candidate_tag"
 
-    - name: Discord notification
-      if: env.KLOGG_HAS_DISCORD_WEBHOOK == 'true'
-      env:
-        DISCORD_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
-        DISCORD_EMBEDS: '[{"title": "Release v${{ env.KLOGG_VERSION }}", "url": "https://github.com/ZEACENT/klogg/releases/tag/v${{ env.KLOGG_VERSION }}"}]'
-      uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
-      with:
-        args: 'New release v${{ env.KLOGG_VERSION }} has been published!'
-
-
-
-
-   
+      - name: Discord notification
+        if: success() && env.KLOGG_HAS_DISCORD_WEBHOOK == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_NEW_VERSIONS_WEBHOOK }}
+          DISCORD_EMBEDS: '[{"title": "Release v${{ env.KLOGG_VERSION }}", "url": "https://github.com/ZEACENT/klogg/releases/tag/v${{ env.KLOGG_VERSION }}"}]'
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
+        with:
+          args: 'New release v${{ env.KLOGG_VERSION }} has been published!'

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Binaries for all platforms are available from [GitHub Releases](https://github.c
 
 Automated rolling builds are available from the [continuous release](https://github.com/ZEACENT/klogg/releases/tag/continuous). Windows and Linux packages are CI-validated; macOS disk images are unsigned CI validation artifacts and may require local Gatekeeper approval.
 
-Stable releases default to the same secret-neutral validation evidence. A stable release explicitly published with signed evidence requires both macOS signing and notarization receipts; unsigned macOS artifacts are never described as signed or notarized.
+Stable releases are created manually by promoting the current manifest-verified Continuous release. The package, source, support, and evidence payloads are reused byte-for-byte; only immutable Stable release metadata and checksums are regenerated. Stable macOS disk images therefore remain unsigned validation artifacts and are never described as signed or notarized.
 
 ## Building
 

--- a/benchmarks/live_capture_benchmark_core.cpp
+++ b/benchmarks/live_capture_benchmark_core.cpp
@@ -249,6 +249,10 @@ public:
     {
         statistics_.generation = generation_;
         for ( const auto& fragment : fragments_ ) {
+            if ( fragment.size()
+                 > std::numeric_limits<std::size_t>::max() - statistics_.receivedBytes ) {
+                throw std::length_error( "synthetic native fixture byte count exceeds size limits" );
+            }
             statistics_.receivedBytes += fragment.size();
             ++statistics_.receivedChunks;
             statistics_.queuedBytes += fragment.size();
@@ -283,16 +287,25 @@ public:
 
     std::optional<::klogg::livecapture::LiveDataBatch> drain() override
     {
-        if ( nextFragment_ == fragments_.size() ) {
+        if ( fragments_.empty() ) {
             return std::nullopt;
         }
-        auto bytes = std::move( fragments_.at( nextFragment_ ) );
-        ++nextFragment_;
-        statistics_.queuedBytes -= bytes.size();
-        --statistics_.queuedChunks;
+
+        // Match the production queue's whole-pending-batch contract. Build the
+        // aggregate before consuming fragments so allocation failure preserves
+        // both the pending data and its accounting.
+        Bytes bytes;
+        bytes.reserve( statistics_.queuedBytes );
+        for ( const auto& fragment : fragments_ ) {
+            bytes.insert( bytes.end(), fragment.cbegin(), fragment.cend() );
+        }
+        const auto sourceChunks = fragments_.size();
+        fragments_.clear();
+        statistics_.queuedBytes = 0u;
+        statistics_.queuedChunks = 0u;
         statistics_.deliveredBytes += bytes.size();
-        ++statistics_.deliveredChunks;
-        return ::klogg::livecapture::LiveDataBatch{ generation_, std::move( bytes ), 1u };
+        statistics_.deliveredChunks += sourceChunks;
+        return ::klogg::livecapture::LiveDataBatch{ generation_, std::move( bytes ), sourceChunks };
     }
 
     ::klogg::livecapture::LiveDataStatistics statistics() const override
@@ -316,7 +329,6 @@ private:
     ::klogg::livecapture::ios::IosNativeStreamCallbacks callbacks_;
     std::shared_ptr<SyntheticQueueTotals> totals_;
     ::klogg::livecapture::LiveDataStatistics statistics_;
-    std::size_t nextFragment_{ 0u };
     bool published_{ false };
 };
 
@@ -762,6 +774,16 @@ std::vector<std::size_t> cumulativeSegmentRecordCounts( const FramedFixture& fix
 }
 
 } // namespace
+
+std::unique_ptr<::klogg::livecapture::ios::IosNativeStreamSession>
+SyntheticNativeSessionTestAccess::create(
+    std::uint64_t generation, std::vector<Bytes> fragments,
+    ::klogg::livecapture::ios::IosNativeStreamCallbacks callbacks )
+{
+    return std::make_unique<FixtureNativeSession>(
+        generation, std::move( fragments ), std::move( callbacks ),
+        std::make_shared<SyntheticQueueTotals>() );
+}
 
 ArmObservation runSyntheticArm( const SyntheticArmPlan& plan )
 {

--- a/benchmarks/live_capture_benchmark_core.h
+++ b/benchmarks/live_capture_benchmark_core.h
@@ -19,9 +19,22 @@
 #include <string>
 #include <vector>
 
+namespace klogg::livecapture::ios {
+class IosNativeStreamSession;
+struct IosNativeStreamCallbacks;
+} // namespace klogg::livecapture::ios
+
 namespace klogg::benchmarks::livecapture {
 
 using Bytes = std::vector<std::uint8_t>;
+
+// Benchmark-only access to the actual integrated fixture session. Forward
+// declarations keep native/Qt dependencies out of the pure fixture protocol.
+struct SyntheticNativeSessionTestAccess {
+    static std::unique_ptr<::klogg::livecapture::ios::IosNativeStreamSession>
+    create( std::uint64_t generation, std::vector<Bytes> fragments,
+            ::klogg::livecapture::ios::IosNativeStreamCallbacks callbacks );
+};
 
 constexpr std::uint16_t FramedRecordVersion = 1u;
 constexpr std::size_t FramedRecordHeaderBytes = 44u;

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -95,7 +95,10 @@ CI_BUILD_REQUIRED_JOBS = {
     "WindowsX86",
     "WindowsAsan",
     "ci-gate",
+    "DispatchContinuous",
 }
+
+CI_BUILD_POST_GATE_JOBS = {"DispatchContinuous"}
 
 CI_BUILD_ROOT_JOBS = {
     "SaveVersion",
@@ -741,24 +744,30 @@ def ci_build_workflow_issues(text: str) -> list[str]:
                 )
 
     gate = "ci-gate"
+    validation_jobs = set(needs) - {gate} - CI_BUILD_POST_GATE_JOBS
     if gate in needs:
         consumed_before_gate = {
             dependency
             for job, dependencies in needs.items()
-            if job != gate
+            if job in validation_jobs
             for dependency in dependencies
         }
-        terminal_jobs = (set(needs) - {gate}) - consumed_before_gate
+        terminal_jobs = validation_jobs - consumed_before_gate
         if needs[gate] != terminal_jobs:
             issues.append(
                 "CI gate must directly need exactly terminal validation jobs, got "
                 f"{sorted(needs[gate])}, expected {sorted(terminal_jobs)}"
             )
-        missing_from_gate = (set(needs) - {gate}) - ancestors[gate]
+        missing_from_gate = validation_jobs - ancestors[gate]
         if missing_from_gate:
             issues.append(
                 "CI gate does not cover jobs: " + ", ".join(sorted(missing_from_gate))
             )
+    for job in CI_BUILD_POST_GATE_JOBS & set(needs):
+        if needs[job] != {gate}:
+            issues.append(f"CI post-gate job {job} must directly need only {gate}")
+        if validation_jobs - ancestors[job]:
+            issues.append(f"CI post-gate job {job} must run after the complete CI gate")
 
     try:
         artifact_records = workflow_artifact_records(text)
@@ -981,6 +990,53 @@ def ci_build_workflow_issues(text: str) -> list[str]:
         or shell_commands(text).count(release_master_guard) != 1
     ):
         issues.append("signed release qualification must reject non-master dispatches")
+
+    dispatch = job_blocks.get("DispatchContinuous")
+    dispatch_message = (
+        "CI Continuous dispatch must be an exact successful trusted master post-gate job"
+    )
+    if dispatch is not None:
+        expected_condition = (
+            "${{ success() && needs.ci-gate.result == 'success' "
+            "&& github.event_name == 'push' && github.ref == 'refs/heads/master' "
+            "&& github.event.repository.full_name == github.repository }}"
+        )
+        permissions = workflow_mapping_block(dispatch, "permissions", 4)
+        parsed_steps = [
+            workflow_step_fields(step) for step in workflow_step_blocks(dispatch)
+        ]
+        valid_step = len(parsed_steps) == 1
+        if valid_step:
+            fields, children = parsed_steps[0]
+            run_text = fields.get("run", "")
+            active_run = "\n".join(
+                active
+                for line in run_text.splitlines()
+                if (active := strip_yaml_comment(line))
+            )
+            env = children.get("env", {})
+            valid_step = (
+                fields.get("name") == "Dispatch Continuous publisher for current master"
+                and fields.get("shell") == "bash"
+                and env.get("GH_TOKEN") == "${{ github.token }}"
+                and env.get("KLOGG_CI_RUN_ID") == "${{ github.run_id }}"
+                and env.get("KLOGG_CI_RUN_SHA") == "${{ github.sha }}"
+                and 'master_sha="$(gh api "/repos/${repo}/branches/master" --jq ".commit.sha")"'
+                in active_run.replace("'", '"')
+                and "gh workflow run ci-continuous.yml" in active_run
+                and '--repo "$repo"' in active_run
+                and "--ref master" in active_run
+                and '-f ci-run-id="$KLOGG_CI_RUN_ID"' in active_run
+                and '-f ci-run-sha="$KLOGG_CI_RUN_SHA"' in active_run
+            )
+        if (
+            workflow_job_direct_value(dispatch, "if") != expected_condition
+            or permissions is None
+            or {key: value for key, (value, _) in permissions.items()}
+            != {"actions": "write", "contents": "read"}
+            or not valid_step
+        ):
+            issues.append(dispatch_message)
 
     if "CreatePreRelease" in job_blocks or "softprops/action-gh-release@" in active_text:
         issues.append("release publication must run outside the required CI workflow")
@@ -2250,10 +2306,10 @@ STABLE_TRIGGER_MESSAGE = (
     "stable release workflow must support only workflow_dispatch publication"
 )
 CONTINUOUS_TRIGGER_MESSAGE = (
-    "continuous release workflow must use only completed CI Build workflow_run events"
+    "continuous release workflow must use only reviewed CI dispatch receipts"
 )
 STABLE_RUN_PROJECTION_MESSAGE = (
-    "stable release selection must model push validation and workflow_dispatch receipt evidence"
+    "stable release must promote only the immutable live Continuous publication"
 )
 
 
@@ -2261,24 +2317,32 @@ def stable_release_trigger_issues(text: str) -> list[str]:
     triggers = workflow_trigger_mapping(text)
     if triggers is None or set(triggers) != {"workflow_dispatch"}:
         return [STABLE_TRIGGER_MESSAGE]
-    value, _ = triggers["workflow_dispatch"]
-    return [] if value == "" else [STABLE_TRIGGER_MESSAGE]
+    value, block = triggers["workflow_dispatch"]
+    active = [line for line in block if strip_yaml_comment(line)]
+    return [] if value == "" and len(active) == 1 else [STABLE_TRIGGER_MESSAGE]
 
 
 def continuous_release_trigger_issues(text: str) -> list[str]:
     triggers = workflow_trigger_mapping(text)
-    if triggers is None or set(triggers) != {"workflow_run"}:
+    if triggers is None or set(triggers) != {"workflow_dispatch"}:
         return [CONTINUOUS_TRIGGER_MESSAGE]
-    value, block = triggers["workflow_run"]
+    value, block = triggers["workflow_dispatch"]
     if value:
         return [CONTINUOUS_TRIGGER_MESSAGE]
-    fields = workflow_mapping_block(block, "workflow_run", 2)
-    if fields is None or set(fields) != {"workflows", "types"}:
+    dispatch_fields = workflow_mapping_block(block, "workflow_dispatch", 2)
+    if dispatch_fields is None or set(dispatch_fields) != {"inputs"}:
         return [CONTINUOUS_TRIGGER_MESSAGE]
-    workflows = parse_inline_yaml_list(fields["workflows"][0])
-    event_types = parse_inline_yaml_list(fields["types"][0])
-    if workflows != {"CI Build"} or event_types != {"completed"}:
+    input_block = dispatch_fields["inputs"][1]
+    inputs = workflow_mapping_block(input_block, "inputs", 4)
+    if inputs is None or set(inputs) != {"ci-run-id", "ci-run-sha"}:
         return [CONTINUOUS_TRIGGER_MESSAGE]
+    for input_name in ("ci-run-id", "ci-run-sha"):
+        fields = workflow_mapping_block(input_block, input_name, 6)
+        if fields is None or set(fields) != {"description", "required", "type"}:
+            return [CONTINUOUS_TRIGGER_MESSAGE]
+        values = {key: field[0] for key, field in fields.items()}
+        if not values["description"] or values["required"] != "true" or values["type"] != "string":
+            return [CONTINUOUS_TRIGGER_MESSAGE]
     return []
 
 
@@ -2286,26 +2350,81 @@ def stable_release_run_projection_issues(text: str) -> list[str]:
     release = workflow_job_blocks(text).get("release")
     if release is None:
         return [STABLE_RUN_PROJECTION_MESSAGE]
-    matches = []
-    for step in workflow_step_blocks(release):
-        fields, _ = workflow_step_fields(step)
-        if fields.get("name") == "Select trusted CI run":
-            matches.append(fields.get("run", ""))
-    if len(matches) != 1:
+    steps = [workflow_step_fields(step) for step in workflow_step_blocks(release)]
+    by_name: dict[str, list[tuple[dict[str, str], dict[str, dict[str, str]]]]] = {}
+    for parsed in steps:
+        by_name.setdefault(parsed[0].get("name", ""), []).append(parsed)
+    required_names = (
+        "Select live Continuous release snapshot",
+        "Download immutable Continuous release assets",
+        "Verify Continuous source publication and checkout",
+        "Promote verified Continuous publication to Stable",
+    )
+    if any(len(by_name.get(name, [])) != 1 for name in required_names):
         return [STABLE_RUN_PROJECTION_MESSAGE]
-    run_text = matches[0]
-    if shell_case_labels(run_text, "run_event") != {
-        "push",
-        "workflow_dispatch",
-        "*",
-    }:
-        return [STABLE_RUN_PROJECTION_MESSAGE]
-    active_lines = {
+    selection = by_name[required_names[0]][0][0].get("run", "")
+    download = by_name[required_names[1]][0][0].get("run", "")
+    verification = by_name[required_names[2]][0][0].get("run", "")
+    promotion = by_name[required_names[3]][0][0].get("run", "")
+    required_selection = (
+        "/releases/tags/continuous",
+        'release_draft="$(gh api',
+        'release_prerelease="$(gh api',
+        'test "$release_draft" = false',
+        'test "$release_prerelease" = true',
+        "/git/ref/tags/continuous",
+        "/branches/master",
+        "KLOGG_SOURCE_RELEASE_ID=",
+        "KLOGG_SOURCE_COMMIT=",
+    )
+    selection_lines = {
         active
-        for line in run_text.splitlines()
+        for line in selection.splitlines()
         if (active := strip_yaml_comment(line))
     }
-    if 'test "$KLOGG_EVIDENCE_LEVEL" = validation || {' not in active_lines:
+    required_selection_lines = {
+        'test "$release_draft" = false || { echo "::error::Live Continuous release is still a draft"; exit 1; }',
+        'test "$release_prerelease" = true || { echo "::error::Live Continuous release is not a pre-release"; exit 1; }',
+    }
+    required_download = (
+        '/releases/${KLOGG_SOURCE_RELEASE_ID}/assets?per_page=100',
+        "/releases/assets/${asset_id}",
+        "len(records) != 23",
+        '"metadata_kind": "klogg-continuous-publication-source"',
+        '"source_release_id": release_id',
+        '"source_tag_sha": tag_sha',
+    )
+    required_verification = (
+        "verify_source_publication_manifest.py",
+        "--expected-channel continuous",
+        "--expected-evidence-level validation",
+        "--expected-tag continuous",
+        'test "$manifest_commit" = "$KLOGG_SOURCE_COMMIT"',
+    )
+    required_promotion = (
+        "promote_release_publication.py",
+        "--source-manifest continuous-publication/klogg-source-publication-manifest.json",
+        "--source-assets-root continuous-publication",
+        "--source-metadata continuous-source-metadata.json",
+        "--output packages-publication",
+    )
+    if (
+        any(marker not in selection for marker in required_selection)
+        or not required_selection_lines.issubset(selection_lines)
+        or any(marker not in download for marker in required_download)
+        or any(marker not in verification for marker in required_verification)
+        or any(marker not in promotion for marker in required_promotion)
+    ):
+        return [STABLE_RUN_PROJECTION_MESSAGE]
+    forbidden = (
+        "KLOGG_REQUESTED_CI_RUN_ID",
+        "KLOGG_EVIDENCE_LEVEL",
+        "action-download-artifact",
+        "actions/workflows/ci-build.yml/runs",
+        "sentry-cli",
+        "--evidence-level signed",
+    )
+    if any(marker in text for marker in forbidden):
         return [STABLE_RUN_PROJECTION_MESSAGE]
     return []
 
@@ -2444,19 +2563,16 @@ def stable_release_workflow_issues(text: str) -> list[str]:
     master_guard = 'test "${GITHUB_REF}" = "refs/heads/master" || {'
     if commands.count(master_guard) != 1:
         issues.append("stable release dispatch must fail closed outside master")
-    if (
-        "KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}" not in text
-        or "[[ \"$requested_run_id\" =~ ^[0-9]+$ ]]" not in text
-    ):
-        issues.append("stable release run ID must use validated environment input")
-    if any(
-        re.search(r"\.inputs\b", jq_filter)
-        for jq_filter in re.findall(r"--jq\s+(?:'[^']*'|\"[^\"]*\")", text)
-    ):
-        issues.append("stable release evidence must come from downloaded receipts, not run API inputs")
+    if "group: release-publisher" not in text or "queue: max" not in text:
+        issues.append("release publishers must share one lossless serialized concurrency group")
+    if text.count(".schema_version'") < 2 or text.count(')\" = 3') < 2:
+        issues.append("stable release verification must require promotion manifest schema v3")
+    snapshot_checks = text.count('/releases/tags/continuous" --jq \'.id\'')
+    if snapshot_checks < 5 or text.count("/git/ref/tags/continuous") < 5:
+        issues.append("stable release must revalidate the selected Continuous snapshot")
     draft_verification = text.partition(
         "- name: Verify stable source publication after upload"
-    )[2].partition("- name: Recheck master tip before stable promotion")[0]
+    )[2].partition("- name: Recheck Continuous snapshot before stable promotion")[0]
     if "/git/ref/tags/" in draft_verification:
         issues.append("stable draft verification must not require an unpublished Git tag")
     draft_target_jq = re.search(r"--jq\s+'[^']*\.target_commitish", draft_verification)
@@ -2469,8 +2585,17 @@ def stable_release_workflow_issues(text: str) -> list[str]:
     if (
         "rollback_stable_promotion" not in text
         or "trap rollback_stable_promotion ERR" not in text
+        or "- name: Roll back failed or cancelled stable promotion" not in text
+        or "if: ${{ failure() || cancelled() }}" not in text
     ):
-        issues.append("stable release promotion must roll back every post-publish failure")
+        issues.append("stable release promotion must roll back failure and cancellation")
+    if (
+        '-f ref="refs/tags/${final_tag}" -f sha="$KLOGG_SOURCE_COMMIT"' not in text
+        or "final_ref_owned=true" not in text
+        or 'if [ "$final_ref_owned" = true ]' not in text
+        or "KLOGG_STABLE_FINAL_REF_OWNED=true" not in text
+    ):
+        issues.append("stable release promotion must own the final ref before rollback")
     issues.extend(
         release_download_workflow_issues(
             text, "release", "Create GitHub Release", "stable"
@@ -2492,20 +2617,68 @@ def continuous_release_workflow_issues(text: str) -> list[str]:
     blocks = workflow_job_blocks(text)
     select = blocks.get("select")
     publish = blocks.get("publish")
-    expected_select = (
-        "github.event.workflow_run.conclusion == 'success' "
-        "&& github.event.workflow_run.event == 'push' "
-        "&& github.event.workflow_run.head_branch == 'master' "
-        "&& github.event.workflow_run.head_repository.full_name == github.repository"
+    selection_message = (
+        "continuous release selection must validate the dispatched successful master CI receipt"
     )
-    if select is None or workflow_job_direct_value(select, "if") != expected_select:
-        issues.append("continuous release selection must require a trusted successful master push")
+    selection_valid = select is not None and workflow_job_direct_value(select, "if") is None
+    if selection_valid:
+        env_fields = workflow_mapping_block(select, "env", 4)
+        selection_steps = []
+        for step in workflow_step_blocks(select):
+            fields, children = workflow_step_fields(step)
+            if fields.get("name") == "Verify dispatched CI run and current master tip":
+                selection_steps.append((fields, children))
+        selection_valid = env_fields is not None and len(selection_steps) == 1
+    if selection_valid:
+        env = {key: value for key, (value, _) in env_fields.items()}
+        fields, _ = selection_steps[0]
+        active_run = "\n".join(
+            active
+            for line in fields.get("run", "").splitlines()
+            if (active := strip_yaml_comment(line))
+        )
+        required_markers = (
+            "gh_api_retry() {",
+            "GitHub API request failed after ${attempt} attempts",
+            '[[ "$run_id" =~ ^[0-9]+$ ]]',
+            '[[ "$run_sha" =~ ^[0-9a-f]{40}$ ]]',
+            'test "$run_sha" = "$KLOGG_DISPATCH_SHA"',
+            '".github/workflows/ci-build.yml"',
+            '"master"',
+            '"push"',
+            'select(.name == "ci-gate")',
+            'test "$gate_status" = "completed"',
+            'test "$gate_conclusion" = "success"',
+            'test "$run_conclusion" = "success"',
+            'Timed out waiting for source CI run',
+            '/branches/master',
+            'echo "ci-run-id=${run_id}"',
+            'echo "ci-run-sha=${run_sha}"',
+            'echo "should-publish=true"',
+        )
+        selection_valid = (
+            env.get("GITHUB_TOKEN") == "${{ github.token }}"
+            and env.get("KLOGG_REQUESTED_CI_RUN_ID") == "${{ inputs.ci-run-id }}"
+            and env.get("KLOGG_REQUESTED_CI_RUN_SHA") == "${{ inputs.ci-run-sha }}"
+            and env.get("KLOGG_DISPATCH_SHA") == "${{ github.sha }}"
+            and env.get("KLOGG_GH_API_RETRY_ATTEMPTS") == "4"
+            and env.get("KLOGG_GH_API_RETRY_DELAY_SECONDS") == "2"
+            and fields.get("shell") == "bash"
+            and all(marker in active_run for marker in required_markers)
+        )
+    if not selection_valid or "github.event.workflow_run" in text:
+        issues.append(selection_message)
     if (
         publish is None
         or workflow_job_direct_value(publish, "if")
         != "${{ needs.select.outputs.should-publish == 'true' }}"
+        or "KLOGG_CI_RUN_ID: ${{ needs.select.outputs.ci-run-id }}" not in text
+        or "KLOGG_CI_RUN_SHA: ${{ needs.select.outputs.ci-run-sha }}" not in text
+        or "run-id: ${{ env.KLOGG_CI_RUN_ID }}" not in text
     ):
         issues.append("continuous release publication must require the verified selection output")
+    if "group: release-publisher" not in text or "queue: max" not in text:
+        issues.append("release publishers must share one lossless serialized concurrency group")
     if "cancel-in-progress: false" not in text:
         issues.append("continuous release transaction must not be canceled in progress")
     if "${{ failure() || cancelled() }}" not in text:

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -387,15 +387,20 @@ def _check_unguarded_platform_helper(text: str, path: Path) -> list[tuple[int, s
     return findings
 
 
-def _extract_call_args(code: str, open_paren_pos: int) -> str:
+def _extract_call_args(
+    code: str, open_paren_pos: int, masked: str | None = None
+) -> str:
     """Return the substring inside the parentheses starting at
     ``open_paren_pos``, balancing nested ``()``. Returns '' if unbalanced.
 
-    Used by the qsizetype check so that ``.indexOf( QLatin1Char( '\\n' ), start )``
-    is recognised as passing ``start`` (the nested QLatin1Char call would defeat
-    a naive ``[^)]*`` capture).
+    ``masked`` may be supplied when a caller already has a same-length
+    comment/literal-stripped copy of ``code``. Used by the qsizetype check so
+    that ``.indexOf( QLatin1Char( '\\n' ), start )`` is recognised as passing
+    ``start`` (the nested QLatin1Char call would defeat a naive ``[^)]*``
+    capture).
     """
-    masked = _strip_cpp_literals(_strip_cpp_comments(code))
+    if masked is None:
+        masked = _strip_cpp_literals(_strip_cpp_comments(code))
     depth = 0
     start = open_paren_pos + 1
     for i in range(start, len(masked)):
@@ -1444,6 +1449,227 @@ def _check_qfileinfo_direct_include(text: str, path: Path) -> list[tuple[int, st
     ]
 
 
+# Catch2 assertions must account for native boundary formatting. Tab captions
+# vary by platform, and copied text retains Windows CRLF (PR #69). Keep this
+# deliberately limited to the two UI presentation APIs
+# that have caused those failures; this is not intended to parse C++ generally.
+_ASSERTION_RE = re.compile(r"\b(?:CHECK|REQUIRE)\s*\(")
+_NATIVE_ASSERTION_RE = re.compile(
+    r"\btabToolTip\s*\(|\bgetSelectedText\s*\(|\bAccess\s*::\s*mainText\s*\("
+)
+_PATH_IDENTIFIER_RE = re.compile(r"(?:[A-Za-z_]\w*)?[Pp]ath\w*")
+_STRING_LITERAL_RE = re.compile(r'"(?P<value>(?:\\.|[^"\\\n])*)"')
+_LF_ESCAPE_RE = re.compile(r"(?<!\\)(?:\\\\)*\\n")
+_TAB_TOOLTIP_CALL_RE = r"\btabToolTip\s*\("
+_MAIN_TEXT_CALL_RE = r"\bAccess\s*::\s*mainText\s*\("
+_MEMBER_CALL_RECEIVER_RE = (
+    r"\s*[A-Za-z_]\w*(?:\s*(?:->|\.)\s*[A-Za-z_]\w*)*\s*(?:->|\.)\s*"
+)
+
+
+def _balanced_close(masked: str, open_pos: int) -> int | None:
+    """Find an opening bracket's matching close, rejecting mismatched brackets."""
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    if open_pos >= len(masked) or masked[open_pos] not in pairs:
+        return None
+    stack = [masked[open_pos]]
+    for index in range(open_pos + 1, len(masked)):
+        ch = masked[index]
+        if ch in pairs:
+            stack.append(ch)
+        elif ch in ")]}":
+            if not stack or pairs[stack[-1]] != ch:
+                return None
+            stack.pop()
+            if not stack:
+                return index
+    return None
+
+
+def _strip_assertion_parentheses(expression: str) -> tuple[str, bool]:
+    """Remove enclosing parentheses and report unmatched brackets."""
+    expression = expression.strip()
+    while expression.startswith("("):
+        masked = _strip_cpp_literals(expression)
+        close = _balanced_close(masked, 0)
+        if close is None:
+            return expression, True
+        if close != len(masked.rstrip()) - 1:
+            break
+        expression = expression[1:close].strip()
+
+    masked = _strip_cpp_literals(expression)
+    return expression, bool(masked) and _balanced_close("(" + masked + ")", 0) is None
+
+
+def _split_assertion_equality(expression: str) -> tuple[tuple[str, str] | None, bool]:
+    """Return one top-level ``==`` pair, after peeling outer parentheses."""
+    expression, malformed = _strip_assertion_parentheses(expression)
+    if malformed:
+        return None, True
+    masked = _strip_cpp_literals(expression)
+    stack: list[str] = []
+    pairs = {"(": ")", "[": "]", "{": "}"}
+    equalities: list[int] = []
+    index = 0
+    while index < len(masked):
+        ch = masked[index]
+        if ch in pairs:
+            stack.append(ch)
+        elif ch in ")]}":
+            if not stack or pairs[stack[-1]] != ch:
+                return None, True
+            stack.pop()
+        elif (
+            ch == "="
+            and index + 1 < len(masked)
+            and masked[index + 1] == "="
+            and not stack
+        ):
+            equalities.append(index)
+            index += 1
+        index += 1
+    if stack:
+        return None, True
+    if len(equalities) != 1:
+        return None, False
+
+    equality = equalities[0]
+    left, left_malformed = _strip_assertion_parentheses(expression[:equality])
+    right, right_malformed = _strip_assertion_parentheses(expression[equality + 2 :])
+    if left_malformed or right_malformed:
+        return None, True
+    return (left, right), False
+
+
+def _is_bare_call(expression: str, call_re: str, receiver_re: str) -> bool:
+    """Match a specified call only when it is the whole operand."""
+    masked = _strip_cpp_literals(expression)
+    match = re.search(call_re, masked)
+    if match is None or not re.fullmatch(receiver_re, masked[: match.start()]):
+        return False
+    close = _balanced_close(masked, match.end() - 1)
+    return close is not None and not masked[close + 1 :].strip()
+
+
+def _simple_literal_value(expression: str) -> str | None:
+    """Return a plain/Qt literal's source spelling, excluding transformed text."""
+    expression, malformed = _strip_assertion_parentheses(expression)
+    if malformed:
+        return None
+    match = _STRING_LITERAL_RE.fullmatch(expression)
+    if match is None:
+        match = re.fullmatch(
+            r"(?:QStringLiteral|QByteArrayLiteral|QLatin1String)\s*\(\s*"
+            + _STRING_LITERAL_RE.pattern
+            + r"\s*\)",
+            expression,
+        )
+    return None if match is None else match.group("value")
+
+
+def _native_assertion_allow_lines(text: str) -> set[int]:
+    """Find allow markers in actual comments, never in string/raw-string spoof."""
+    literal_free = _strip_cpp_literals(text)
+    marker_re = re.compile(
+        r"//[^\n]*" + re.escape(ALLOW_MARKER) + r"|/\*.*?" + re.escape(ALLOW_MARKER) + r".*?\*/",
+        re.DOTALL,
+    )
+    return {
+        literal_free.count("\n", 0, match.start()) + 1
+        for match in marker_re.finditer(literal_free)
+    }
+
+
+def _check_native_presentation_test_assertion(
+    text: str, path: Path
+) -> list[tuple[int, str]]:
+    """Reject direct native-caption and CRLF-sensitive Catch2 comparisons."""
+    if "tests" not in path.parts:
+        return []
+
+    comment_free = _strip_cpp_comments(text)
+    code = _strip_cpp_literals(comment_free)
+    allow_lines = _native_assertion_allow_lines(text)
+    findings: list[tuple[int, str]] = []
+    for assertion in _ASSERTION_RE.finditer(code):
+        open_pos = assertion.end() - 1
+        line_num = code.count("\n", 0, assertion.start()) + 1
+        close = _balanced_close(code, open_pos)
+        end_pos = close if close is not None else code.find(";", open_pos)
+        if end_pos < 0:
+            end_pos = len(code)
+        end_line = code.count("\n", 0, end_pos) + 1
+        if any(line in allow_lines for line in range(line_num, end_line + 1)):
+            continue
+
+        candidate = code[open_pos + 1 : end_pos]
+        comparison, malformed = (
+            (None, True)
+            if close is None
+            else _split_assertion_equality(
+                _extract_call_args(comment_free, open_pos, code)
+            )
+        )
+        if malformed:
+            if _NATIVE_ASSERTION_RE.search(candidate):
+                findings.append(
+                    (
+                        line_num,
+                        "Malformed native-presentation assertion: unbalanced "
+                        "brackets prevent verifying portable output.",
+                    )
+                )
+            continue
+        if comparison is None:
+            continue
+        left, right = comparison
+
+        tooltip, other = (
+            (left, right)
+            if _is_bare_call(left, _TAB_TOOLTIP_CALL_RE, _MEMBER_CALL_RECEIVER_RE)
+            else (right, left)
+            if _is_bare_call(right, _TAB_TOOLTIP_CALL_RE, _MEMBER_CALL_RECEIVER_RE)
+            else ("", "")
+        )
+        literal = _simple_literal_value(other)
+        if tooltip and (
+            _PATH_IDENTIFIER_RE.fullmatch(other.strip())
+            or (literal is not None and bool(re.match(r"(?:/|[A-Za-z]:[\\/])", literal)))
+        ):
+            findings.append(
+                (
+                    line_num,
+                    "tabToolTip() is native presentation; compare it with "
+                    "QDir::toNativeSeparators(path), not a raw portable path.",
+                )
+            )
+            continue
+
+        text_call, expected = (
+            (left, right)
+            if _is_bare_call(left, r"\bgetSelectedText\s*\(", _MEMBER_CALL_RECEIVER_RE)
+            or _is_bare_call(left, _MAIN_TEXT_CALL_RE, r"\s*")
+            else (right, left)
+            if _is_bare_call(right, r"\bgetSelectedText\s*\(", _MEMBER_CALL_RECEIVER_RE)
+            or _is_bare_call(right, _MAIN_TEXT_CALL_RE, r"\s*")
+            else ("", "")
+        )
+        if (
+            text_call
+            and (literal := _simple_literal_value(expected)) is not None
+            and _LF_ESCAPE_RE.search(literal)
+        ):
+            findings.append(
+                (
+                    line_num,
+                    "Copied text may retain native CRLF; normalize the result "
+                    "before comparing it with a multi-line literal.",
+                )
+            )
+    return findings
+
+
 MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "writable-reopen-of-live-qlockfile",
@@ -1460,6 +1686,10 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "qfileinfo-direct-include",
         "check": _check_qfileinfo_direct_include,
+    },
+    {
+        "name": "native-presentation-test-assertion",
+        "check": _check_native_presentation_test_assertion,
     },
     {
         "name": "unguarded-platform-helper",

--- a/scripts/promote_release_publication.py
+++ b/scripts/promote_release_publication.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Promote one downloaded Continuous publication into an immutable Stable set."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import pathlib
+import re
+import shutil
+import sys
+import tempfile
+
+from prepare_source_publication import CHECKSUMS_NAME, MANIFEST_NAME, write_checksums
+from source_publication_identity import normalize_base_url, source_asset_url
+from verify_source_publication_manifest import (
+    PublicationError,
+    read_json,
+    regular_asset_name,
+    require_fields,
+    require_sha256,
+    sha256,
+    verify_manifest,
+)
+
+
+SOURCE_METADATA_FIELDS = {
+    "schema_version",
+    "metadata_kind",
+    "source_release_id",
+    "source_tag_sha",
+    "source_assets",
+}
+SOURCE_ASSET_FIELDS = {"id", "name", "sha256"}
+SOURCE_METADATA_KIND = "klogg-continuous-publication-source"
+
+
+def infer_base_url(page_url: object) -> str:
+    suffix = "/releases/tag/continuous"
+    if not isinstance(page_url, str) or not page_url.endswith(suffix):
+        raise PublicationError("Continuous release page URL is malformed")
+    return normalize_base_url(page_url[: -len(suffix)])
+
+
+def read_source_metadata(path: pathlib.Path) -> tuple[int, str, dict[str, dict]]:
+    document = require_fields(
+        read_json(path, "Continuous release metadata"),
+        SOURCE_METADATA_FIELDS,
+        "Continuous release metadata",
+    )
+    if type(document["schema_version"]) is not int or document["schema_version"] != 1:
+        raise PublicationError("invalid Continuous release metadata schema version")
+    if document["metadata_kind"] != SOURCE_METADATA_KIND:
+        raise PublicationError("invalid Continuous release metadata identity")
+    release_id = document["source_release_id"]
+    if type(release_id) is not int or release_id <= 0:
+        raise PublicationError("invalid Continuous source release ID")
+    tag_sha = document["source_tag_sha"]
+    if not isinstance(tag_sha, str) or re.fullmatch(r"[0-9a-f]{40}", tag_sha) is None:
+        raise PublicationError("invalid Continuous source tag SHA")
+
+    raw_assets = document["source_assets"]
+    if not isinstance(raw_assets, list):
+        raise PublicationError("invalid Continuous source asset list")
+    assets: dict[str, dict] = {}
+    asset_ids: set[int] = set()
+    for offset, raw_asset in enumerate(raw_assets):
+        asset = require_fields(
+            raw_asset, SOURCE_ASSET_FIELDS, f"Continuous source asset {offset}"
+        )
+        asset_id = asset["id"]
+        if type(asset_id) is not int or asset_id <= 0:
+            raise PublicationError(f"invalid Continuous source asset ID: {offset}")
+        if asset_id in asset_ids:
+            raise PublicationError(f"duplicate Continuous source asset ID: {asset_id}")
+        asset_ids.add(asset_id)
+        name = regular_asset_name(asset["name"], "Continuous source asset")
+        if name in assets:
+            raise PublicationError(f"duplicate Continuous source asset name: {name}")
+        digest = require_sha256(asset["sha256"], f"Continuous source asset {name}")
+        assets[name] = {"id": asset_id, "name": name, "sha256": digest}
+    return release_id, tag_sha, assets
+
+
+def verify_source_inventory(
+    source_root: pathlib.Path, source_assets: dict[str, dict]
+) -> None:
+    actual_assets: set[str] = set()
+    for path in source_root.iterdir():
+        if path.is_symlink():
+            raise PublicationError(f"Continuous publication contains symlink: {path.name}")
+        if not path.is_file():
+            raise PublicationError(
+                f"Continuous publication contains non-asset entry: {path.name}"
+            )
+        name = regular_asset_name(path.name, "Continuous release asset")
+        actual_assets.add(name)
+    if actual_assets != set(source_assets):
+        missing = sorted(set(source_assets) - actual_assets)
+        extra = sorted(actual_assets - set(source_assets))
+        raise PublicationError(
+            f"Continuous release metadata coverage mismatch; missing={missing}, extra={extra}"
+        )
+    for name, record in source_assets.items():
+        path = source_root / name
+        if sha256(path) != record["sha256"]:
+            raise PublicationError(f"Continuous source asset hash mismatch: {name}")
+
+
+def stable_manifest(
+    source_document: dict,
+    base_url: str,
+    source_release_id: int,
+    source_tag_sha: str,
+    source_manifest_sha256: str,
+    source_assets: dict[str, dict],
+) -> dict:
+    document = copy.deepcopy(source_document)
+    release = document["release"]
+    version = release["version"]
+    stable_tag = f"v{version}"
+    document["schema_version"] = 3
+    document["channel"] = "stable"
+    release.update(
+        {
+            "tag": stable_tag,
+            "mutable": False,
+            "public_name": f"Release v{version}",
+            "page_url": f"{base_url}/releases/tag/{stable_tag}",
+            "direct_asset_urls_are_archival": True,
+        }
+    )
+    for component in document["components"].values():
+        archive = component["source_archive"]
+        archive["url"] = source_asset_url(base_url, stable_tag, archive["file_name"])
+    document["promotion"] = {
+        "source_release_id": source_release_id,
+        "source_tag_sha": source_tag_sha,
+        "source_manifest_sha256": source_manifest_sha256,
+        "source_commit": release["commit"],
+        "source_assets": [source_assets[name] for name in sorted(source_assets)],
+    }
+    return document
+
+
+def promote_publication(
+    source_manifest: pathlib.Path,
+    source_assets_root: pathlib.Path,
+    source_metadata: pathlib.Path,
+    output: pathlib.Path,
+) -> None:
+    if source_manifest.name != MANIFEST_NAME:
+        raise PublicationError(f"invalid Continuous manifest file name: {source_manifest.name}")
+    if source_assets_root.is_symlink():
+        raise PublicationError("Continuous publication root must not be a symlink")
+    if output.exists() or output.is_symlink():
+        raise PublicationError(f"promotion output already exists: {output}")
+
+    source_document = read_json(source_manifest, "Continuous publication manifest")
+    release = source_document.get("release")
+    if not isinstance(release, dict):
+        raise PublicationError("Continuous publication release identity is missing")
+    version = release.get("version")
+    commit = release.get("commit")
+    if not isinstance(version, str) or not version or not isinstance(commit, str) or not commit:
+        raise PublicationError("Continuous publication release identity is malformed")
+    base_url = infer_base_url(release.get("page_url"))
+    verify_manifest(
+        source_manifest,
+        source_assets_root,
+        "continuous",
+        "validation",
+        "continuous",
+        version,
+        commit,
+        base_url,
+    )
+    if source_document.get("schema_version") != 2:
+        raise PublicationError("promotion source must use publication schema v2")
+
+    source_release_id, source_tag_sha, source_assets = read_source_metadata(
+        source_metadata
+    )
+    if source_tag_sha != commit:
+        raise PublicationError("Continuous source tag SHA does not match source commit")
+    verify_source_inventory(source_assets_root, source_assets)
+    source_manifest_sha256 = sha256(source_manifest)
+    manifest_record = source_assets.get(MANIFEST_NAME)
+    if manifest_record is None or manifest_record["sha256"] != source_manifest_sha256:
+        raise PublicationError("Continuous source manifest metadata binding mismatch")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    staging = pathlib.Path(
+        tempfile.mkdtemp(prefix=f".{output.name}.promotion-", dir=str(output.parent))
+    )
+    try:
+        for name, record in source_assets.items():
+            if name in {MANIFEST_NAME, CHECKSUMS_NAME}:
+                continue
+            source = source_assets_root / name
+            destination = staging / name
+            if source.is_symlink() or not source.is_file():
+                raise PublicationError(f"Continuous source asset changed during promotion: {name}")
+            shutil.copy2(str(source), str(destination))
+            if (
+                source.is_symlink()
+                or sha256(source) != record["sha256"]
+                or destination.is_symlink()
+                or sha256(destination) != record["sha256"]
+            ):
+                raise PublicationError(f"promoted payload differs from source asset: {name}")
+
+        document = stable_manifest(
+            source_document,
+            base_url,
+            source_release_id,
+            source_tag_sha,
+            source_manifest_sha256,
+            source_assets,
+        )
+        promoted_manifest = staging / MANIFEST_NAME
+        promoted_manifest.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        write_checksums(staging)
+        verify_manifest(
+            promoted_manifest,
+            staging,
+            "stable",
+            "validation",
+            f"v{version}",
+            version,
+            commit,
+            base_url,
+        )
+        os.replace(str(staging), str(output))
+    finally:
+        if staging.exists():
+            shutil.rmtree(str(staging))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source-manifest", required=True, type=pathlib.Path)
+    parser.add_argument("--source-assets-root", required=True, type=pathlib.Path)
+    parser.add_argument("--source-metadata", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    try:
+        promote_publication(
+            args.source_manifest,
+            args.source_assets_root,
+            args.source_metadata,
+            args.output,
+        )
+        print(f"promoted Continuous publication to Stable in {args.output}")
+        return 0
+    except (OSError, PublicationError, ValueError) as error:
+        print(f"release publication promotion failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_source_publication_manifest.py
+++ b/scripts/verify_source_publication_manifest.py
@@ -588,6 +588,15 @@ MANIFEST_V2_FIELDS = {
     "evidence_archive",
     "checksums",
 }
+MANIFEST_V3_FIELDS = MANIFEST_V2_FIELDS | {"promotion"}
+PROMOTION_FIELDS = {
+    "source_release_id",
+    "source_tag_sha",
+    "source_manifest_sha256",
+    "source_commit",
+    "source_assets",
+}
+PROMOTION_ASSET_FIELDS = {"id", "name", "sha256"}
 RELEASE_V2_FIELDS = {
     "tag",
     "version",
@@ -1065,6 +1074,70 @@ def verify_component_v2(
     return receipt_hash, {receipt_path.name, archive_path.name, *referenced_support}
 
 
+def verify_promotion_lineage(
+    record: object,
+    manifest_path: pathlib.Path,
+    assets_root: pathlib.Path,
+    release: dict,
+    publication_assets: set[str],
+) -> None:
+    promotion = require_fields(record, PROMOTION_FIELDS, "promotion lineage")
+    release_id = promotion["source_release_id"]
+    if type(release_id) is not int or release_id <= 0:
+        raise PublicationError("invalid promotion source release ID")
+    source_tag_sha = promotion["source_tag_sha"]
+    if not isinstance(source_tag_sha, str) or re.fullmatch(r"[0-9a-f]{40}", source_tag_sha) is None:
+        raise PublicationError("invalid promotion source tag SHA")
+    source_manifest_sha256 = require_sha256(
+        promotion["source_manifest_sha256"], "promotion source manifest"
+    )
+    source_commit = promotion["source_commit"]
+    if not isinstance(source_commit, str) or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None:
+        raise PublicationError("invalid promotion source commit")
+    if source_commit != release["commit"] or source_tag_sha != source_commit:
+        raise PublicationError("promotion source identity mismatch")
+
+    raw_assets = promotion["source_assets"]
+    if not isinstance(raw_assets, list):
+        raise PublicationError("invalid promotion source asset list")
+    source_assets: dict[str, dict] = {}
+    source_asset_ids: set[int] = set()
+    source_asset_names: list[str] = []
+    for offset, raw_asset in enumerate(raw_assets):
+        asset = require_fields(
+            raw_asset, PROMOTION_ASSET_FIELDS, f"promotion source asset {offset}"
+        )
+        asset_id = asset["id"]
+        if type(asset_id) is not int or asset_id <= 0:
+            raise PublicationError(f"invalid promotion source asset ID: {offset}")
+        if asset_id in source_asset_ids:
+            raise PublicationError(f"duplicate promotion source asset ID: {asset_id}")
+        source_asset_ids.add(asset_id)
+        name = regular_asset_name(asset["name"], "promotion source asset")
+        if name in source_assets:
+            raise PublicationError(f"duplicate promotion source asset name: {name}")
+        require_sha256(asset["sha256"], f"promotion source asset {name}")
+        source_assets[name] = asset
+        source_asset_names.append(name)
+    if source_asset_names != sorted(source_asset_names):
+        raise PublicationError("promotion source asset records are not sorted")
+    if set(source_assets) != publication_assets:
+        missing = sorted(publication_assets - set(source_assets))
+        extra = sorted(set(source_assets) - publication_assets)
+        raise PublicationError(
+            f"promotion source asset coverage mismatch; missing={missing}, extra={extra}"
+        )
+    manifest_record = source_assets[manifest_path.name]
+    if manifest_record["sha256"] != source_manifest_sha256:
+        raise PublicationError("promotion source manifest lineage mismatch")
+
+    for name, asset in source_assets.items():
+        if name in {manifest_path.name, "SHA256SUMS"}:
+            continue
+        if sha256(regular_asset(assets_root, name, "promoted payload asset")) != asset["sha256"]:
+            raise PublicationError(f"promoted payload differs from source asset: {name}")
+
+
 def verify_manifest_v2(
     manifest_path: pathlib.Path,
     assets_root: pathlib.Path,
@@ -1074,11 +1147,17 @@ def verify_manifest_v2(
     expected_version: str,
     expected_commit: str,
     expected_base_url: str,
+    expected_schema_version: int = 2,
 ) -> None:
     document = read_json(manifest_path, "release publication manifest")
-    require_fields(document, MANIFEST_V2_FIELDS, "release publication manifest")
+    manifest_fields = (
+        MANIFEST_V2_FIELDS
+        if expected_schema_version == 2
+        else MANIFEST_V3_FIELDS
+    )
+    require_fields(document, manifest_fields, "release publication manifest")
     require_schema_version(
-        document["schema_version"], 2, "release publication manifest"
+        document["schema_version"], expected_schema_version, "release publication manifest"
     )
     if document["manifest_kind"] != "klogg-release-publication":
         raise PublicationError("unsupported release publication manifest schema")
@@ -1086,6 +1165,10 @@ def verify_manifest_v2(
         raise PublicationError("publication channel mismatch")
     if expected_evidence_level not in EVIDENCE_LEVELS or document["evidence_level"] != expected_evidence_level:
         raise PublicationError("publication evidence level mismatch")
+    if expected_schema_version == 3 and (
+        document["channel"] != "stable" or document["evidence_level"] != "validation"
+    ):
+        raise PublicationError("promotion manifest must describe a stable validation publication")
     release = require_fields(document["release"], RELEASE_V2_FIELDS, "release identity")
     base_url = normalize_base_url(expected_base_url)
     expected_release = {
@@ -1310,6 +1393,14 @@ def verify_manifest_v2(
             f"unlisted or unreferenced release asset; missing={missing}, extra={extra}"
         )
     verify_sha256sums(assets_root, document["checksums"], logical_assets - {"SHA256SUMS"})
+    if expected_schema_version == 3:
+        verify_promotion_lineage(
+            document["promotion"],
+            manifest_path,
+            assets_root,
+            release,
+            actual_regular_assets,
+        )
 
 
 def verify_manifest(
@@ -1346,7 +1437,7 @@ def verify_manifest(
             expected_base_url,
         )
         return
-    if schema == 2 and kind == "klogg-release-publication":
+    if schema in (2, 3) and kind == "klogg-release-publication":
         verify_manifest_v2(
             root_manifest,
             assets_root,
@@ -1356,6 +1447,7 @@ def verify_manifest(
             expected_version,
             expected_commit,
             expected_base_url,
+            expected_schema_version=schema,
         )
         return
     raise PublicationError("unsupported source publication manifest schema")

--- a/src/livecapture/include/iosnativestream.h
+++ b/src/livecapture/include/iosnativestream.h
@@ -119,6 +119,8 @@ public:
     void shutdown() noexcept override;
     std::optional<LiveDataBatch> drain() override;
     LiveDataStatistics statistics() const override;
+    // Observe native producer backpressure without changing the session ABI.
+    std::size_t waitingProducerCount() const;
 
 private:
     struct State;

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -285,6 +285,10 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
         if ( !shouldPublish ) {
             return;
         }
+        // A callback may be waiting for queue capacity, including inside native
+        // start. Release it before observers or the serial cleanup dispatcher can
+        // wait for startup/callback completion. Never hold controlMutex here.
+        queue.close();
         const auto state = weak_from_this().lock();
         if ( state == nullptr ) {
             return;
@@ -333,7 +337,10 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
     {
         LiveDataEnqueueResult result = LiveDataEnqueueResult::Closed;
         try {
-            result = queue.tryEnqueue( LiveDataChunk{ config.generation, std::move( bytes ) } );
+            // Native readers deliver callbacks serially off the GUI thread.
+            // Retain the complete pending record while the bounded queue waits
+            // for the consumer; stop/failure closes the queue to cancel the wait.
+            result = queue.enqueueWait( LiveDataChunk{ config.generation, std::move( bytes ) } );
         } catch ( ... ) {
             publishBoundaryFailure( ErrorCategory::Backend, "ios-live-queue-failed",
                                     ErrorScope::Stream, RetryPolicy::Backoff,
@@ -342,10 +349,13 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             return;
         }
         if ( result == LiveDataEnqueueResult::Backpressure ) {
-            publishBoundaryFailure( ErrorCategory::Stream, "ios-live-queue-saturated",
-                                    ErrorScope::Stream, RetryPolicy::Backoff,
-                                    "The iOS live-data queue is saturated.",
-                                    "The bounded queue rejected a complete log record." );
+            // enqueueWait only rejects records that can never fit, not transient
+            // pressure. Retrying this same record cannot restore progress.
+            publishBoundaryFailure( ErrorCategory::Stream, "ios-live-record-too-large",
+                                    ErrorScope::Stream, RetryPolicy::Never,
+                                    "The iOS log record exceeds the live-data queue byte limit.",
+                                    "A complete formatted log record cannot fit in the bounded "
+                                    "queue, even when empty." );
         }
     }
 
@@ -542,6 +552,14 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
     void runStartupImpl()
     {
         if ( cancelled() ) {
+            return;
+        }
+
+        if ( config.queueLimits.maxQueuedBytes == 0u || config.queueLimits.maxQueuedChunks == 0u ) {
+            publishFailure( localError(
+                ErrorCategory::Configuration, "ios-live-queue-invalid-capacity", ErrorScope::Stream,
+                RetryPolicy::Never, "The iOS live-data queue capacity must be positive.",
+                "Both byte and chunk limits must allow at least one complete log record." ) );
             return;
         }
 
@@ -785,14 +803,13 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
                 startCode,
                 nativeDetail( osTrace ? "ostrace_start_activity" : "syslog_relay_start_capture",
                               startCode ) } ) );
-            return;
         }
         const auto startedOsTrace = openedOsTrace.get();
         const auto startedSyslog = openedSyslog.get();
         bool committed = false;
         {
             std::lock_guard<std::mutex> lock( controlMutex );
-            if ( !retired && !terminal ) {
+            if ( startCode == 0 && !retired && !terminal ) {
                 device = std::move( openedDevice );
                 lockdown = std::move( openedLockdown );
                 service = std::move( openedService );
@@ -807,6 +824,10 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             }
         }
         if ( !committed ) {
+            // Failed start may still have entered a native callback. Cancellation
+            // and start failure share the same close/quiesce/stop/join boundary
+            // before these locally owned clients can be freed.
+            queue.close();
             {
                 std::unique_lock<std::mutex> lock( controlMutex );
                 callbacksChanged.wait( lock, [ this ] { return callbacksInFlight == 0u; } );
@@ -824,6 +845,7 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
 
     void runCleanup() noexcept
     {
+        queue.close();
         {
             std::lock_guard<std::mutex> lock( controlMutex );
             cleanupRunning = true;
@@ -872,7 +894,6 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
         closingService.reset();
         closingLockdown.reset();
         closingDevice.reset();
-        queue.close();
         admissionLease.reset();
         publishStopped();
         {
@@ -960,6 +981,9 @@ void IosNativeStreamWorker::stop( Generation generation ) noexcept
         state->retired = true;
         state->acceptingCallbacks = false;
     }
+    // Startup can itself be inside a blocked native callback. Close before
+    // dispatch, not just inside cleanup queued behind that startup task.
+    state->queue.close();
     // scheduleCleanup() retains State when neither the configured executor nor
     // the emergency thread can accept cleanup. Do not acknowledge stopped until
     // runCleanup() has actually quiesced callbacks and released native clients.
@@ -977,6 +1001,11 @@ void IosNativeStreamWorker::shutdown() noexcept
 std::optional<LiveDataBatch> IosNativeStreamWorker::drain()
 {
     return state_ != nullptr ? state_->queue.drain() : std::nullopt;
+}
+
+std::size_t IosNativeStreamWorker::waitingProducerCount() const
+{
+    return state_ != nullptr ? state_->queue.waitingProducerCount() : 0u;
 }
 
 LiveDataStatistics IosNativeStreamWorker::statistics() const

--- a/src/logdata/include/capturestore.h
+++ b/src/logdata/include/capturestore.h
@@ -170,6 +170,19 @@ class CaptureStore {
     bool holdCapturePathGateForTesting( std::function<void()> gateAcquired,
                                         std::function<void()> waitForRelease );
     static int setCapturePathGateTimeoutForTesting( int timeoutMs );
+    // Operation counts stay outside business Stats and are scoped to one path state.
+    struct MaintenanceOperationsForTesting {
+        std::uint64_t markerScans = 0;
+        std::uint64_t retryGateAttempts = 0;
+    };
+    MaintenanceOperationsForTesting maintenanceOperationsForTesting() const;
+    struct MaintenanceRetryForTesting {
+        std::uint64_t requested = 0;
+        std::uint64_t completed = 0;
+        bool scheduled = false;
+    };
+    MaintenanceRetryForTesting maintenanceRetryForTesting() const;
+    void setBeforeRetryHandoffCallbackForTesting( std::function<void()> callback );
     bool hasCapturePathCoordinationOwnershipForTesting() const;
     QString capturePathActiveMarkerPathForTesting() const;
     QString capturePathIdentity() const;

--- a/src/logdata/include/streaminglogdata.h
+++ b/src/logdata/include/streaminglogdata.h
@@ -92,6 +92,9 @@ class StreamingLogData : public SearchableLogData {
     void doDetachReader() const override;
 
   private:
+    // Tests deliver the existing single-shot timer, never a synthetic completion signal.
+    friend struct StreamingLogDataTimerTestAccess;
+
       struct OutputBindResult {
           bool success = false;
           CaptureOutputError error = CaptureOutputError::Open;

--- a/src/logdata/src/capturestore.cpp
+++ b/src/logdata/src/capturestore.cpp
@@ -611,6 +611,7 @@ struct CaptureStore::CapturePathState
     bool hasActiveProcessMarker() const
     {
         const QFileInfo coordinationInfo( coordinationStem_ );
+        markerScansForTesting_.fetch_add( 1, std::memory_order_relaxed );
         const auto markerFiles = coordinationInfo.dir().entryList(
             QStringList{ coordinationInfo.fileName() + QStringLiteral( ".active.*" ) },
             QDir::Files | QDir::Hidden, QDir::Name );
@@ -724,6 +725,27 @@ struct CaptureStore::CapturePathState
             std::move( callback ) );
     }
 
+    MaintenanceOperationsForTesting maintenanceOperationsForTesting() const
+    {
+        // Independent observations, not a transactional snapshot. Relaxed atomics
+        // also count background maintenance without adding state/gate lock ordering.
+        return { markerScansForTesting_.load( std::memory_order_relaxed ),
+                 retryGateAttemptsForTesting_.load( std::memory_order_relaxed ) };
+    }
+
+    MaintenanceRetryForTesting maintenanceRetryForTesting() const
+    {
+        return { gateRetryRequestEpoch_.load( std::memory_order_acquire ),
+                 gateRetryCompletedEpoch_.load( std::memory_order_acquire ),
+                 retryScheduled_.load( std::memory_order_acquire ) };
+    }
+
+    void setBeforeRetryHandoffCallbackForTesting( std::function<void()> callback )
+    {
+        const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+        beforeRetryHandoffCallbackForTesting_ = std::move( callback );
+    }
+
     bool hasLocalCoordinationOwnershipForTesting() const
     {
         const std::lock_guard<std::recursive_mutex> lock( mutex_ );
@@ -829,6 +851,15 @@ struct CaptureStore::CapturePathState
                 ++lease;
             }
         }
+    }
+
+    bool needsCoordinatedMaintenanceLocked() const
+    {
+        // This is owner-level work, not the background scheduler's narrower
+        // retry policy: a sole active requester may promote retirements or
+        // finish directory deletion synchronously.
+        return !retiredFiles_.isEmpty() || !pendingRetirementRequesters_.isEmpty()
+               || directoryDeletionRequested_ || hasPendingGateRetry();
     }
 
     qint64 promotePendingRetirementsLocked()
@@ -988,11 +1019,14 @@ struct CaptureStore::CapturePathState
     std::atomic<bool> retryScheduled_{ false };
     std::atomic<std::uint64_t> gateRetryRequestEpoch_{ 0 };
     std::atomic<std::uint64_t> gateRetryCompletedEpoch_{ 0 };
+    mutable std::atomic<std::uint64_t> markerScansForTesting_{ 0 };
+    std::atomic<std::uint64_t> retryGateAttemptsForTesting_{ 0 };
     qint64 tombstoneEpoch_ = 0;
     qint64 pendingTombstoneRegistryReleaseEpoch_ = 0;
     bool failNextRetiredFileRemovalForTesting_ = false;
     bool failNextCaptureDirectoryRemovalForTesting_ = false;
     std::function<void()> beforeActivationCallbackForTesting_;
+    std::function<void()> beforeRetryHandoffCallbackForTesting_;
     std::unique_ptr<QLockFile> processMarker_;
     std::shared_ptr<CaptureSegmentIdState> segmentIds_;
     QHash<QString, std::weak_ptr<SpilledSegmentFile>> fileLeases_;
@@ -1427,7 +1461,30 @@ void CaptureStore::CapturePathState::releaseRetiredFile(
 
 void CaptureStore::CapturePathState::retryRetiredFilesAndReleaseRegistry()
 {
+    bool needsCoordination = false;
+    qint64 releaseEpoch = 0;
+    {
+        const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+        pruneExpiredLeases();
+        needsCoordination = needsCoordinatedMaintenanceLocked();
+        if ( !needsCoordination ) {
+            releaseEpoch = takeTombstoneRegistryReleaseEpochLocked();
+        }
+    }
+    // Registry updates must stay outside the state mutex. A historical
+    // tombstone epoch still qualifies release, but is not filesystem work.
+    if ( !needsCoordination ) {
+        if ( releaseEpoch > 0 ) {
+            releaseTombstones( registryKey_, registrySlotEpoch_, shared_from_this(),
+                               releaseEpoch );
+        }
+        return;
+    }
+
+    // Never wait for the cross-process gate while holding the state mutex.
+    // The gate-held entry re-evaluates leases and pending work after acquisition.
     CapturePathGate gate( gatePath() );
+    retryGateAttemptsForTesting_.fetch_add( 1, std::memory_order_relaxed );
     if ( !gate.lock() ) {
         scheduleRetry( true );
         return;
@@ -1440,33 +1497,40 @@ void CaptureStore::CapturePathState::retryRetiredFilesAndReleaseRegistry()
 
 void CaptureStore::CapturePathState::retryRetiredFilesAndReleaseRegistryGateHeld()
 {
-    const auto foreignProcessActive = hasActiveProcessMarker();
     qint64 retainEpoch = 0;
     qint64 releaseEpoch = 0;
     {
         const std::lock_guard<std::recursive_mutex> lock( mutex_ );
         pruneExpiredLeases();
         retainEpoch = promotePendingRetirementsLocked();
-        if ( !foreignProcessActive ) {
-            for ( auto retired = retiredFiles_.begin();
-                  retired != retiredFiles_.end(); ) {
-                if ( !fileLeases_.value( retired.key() ).expired() ) {
-                    ++retired;
-                    continue;
+        // A pinned tombstone needs local bookkeeping, not a foreign-owner
+        // scan. Check markers lazily at the first physical deletion candidate;
+        // the gate keeps that observation valid for this deletion pass only.
+        bool markersChecked = false;
+        for ( auto retired = retiredFiles_.begin();
+              retired != retiredFiles_.end(); ) {
+            if ( !fileLeases_.value( retired.key() ).expired() ) {
+                ++retired;
+                continue;
+            }
+            if ( !markersChecked ) {
+                if ( hasActiveProcessMarker() ) {
+                    break;
                 }
-                if ( removeRetiredFile( retired.value() ) ) {
-                    const auto& retiredFile = retired.value();
-                    if ( processFileOwnership_->ownedFiles.value(
-                             retiredFile.name )
-                         == retiredFile.identity ) {
-                        processFileOwnership_->ownedFiles.remove(
-                            retiredFile.name );
-                    }
-                    retired = retiredFiles_.erase( retired );
-                    ++tombstoneEpoch_;
-                } else {
-                    ++retired;
+                markersChecked = true;
+            }
+            if ( removeRetiredFile( retired.value() ) ) {
+                const auto& retiredFile = retired.value();
+                if ( processFileOwnership_->ownedFiles.value(
+                         retiredFile.name )
+                     == retiredFile.identity ) {
+                    processFileOwnership_->ownedFiles.remove(
+                        retiredFile.name );
                 }
+                retired = retiredFiles_.erase( retired );
+                ++tombstoneEpoch_;
+            } else {
+                ++retired;
             }
         }
         if ( retiredFiles_.isEmpty() ) {
@@ -1551,6 +1615,17 @@ void CaptureStore::CapturePathState::scheduleRetry( bool force )
                     }
                     if ( !state->hasPendingGateRetry()
                          && !state->hasRetryableMaintenance() ) {
+                        std::function<void()> beforeHandoff;
+                        {
+                            const std::lock_guard<std::recursive_mutex> lock(
+                                state->mutex_ );
+                            beforeHandoff = std::move(
+                                state->beforeRetryHandoffCallbackForTesting_ );
+                            state->beforeRetryHandoffCallbackForTesting_ = {};
+                        }
+                        if ( beforeHandoff ) {
+                            beforeHandoff();
+                        }
                         state->retryScheduled_.store(
                             false, std::memory_order_release );
                         if ( state->hasPendingGateRetry()
@@ -1957,6 +2032,27 @@ int CaptureStore::setCapturePathGateTimeoutForTesting( int timeoutMs )
 {
     return capturePathGateTimeoutMs.exchange( timeoutMs,
                                               std::memory_order_acq_rel );
+}
+
+CaptureStore::MaintenanceOperationsForTesting
+CaptureStore::maintenanceOperationsForTesting() const
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    return capturePathState_->maintenanceOperationsForTesting();
+}
+
+CaptureStore::MaintenanceRetryForTesting
+CaptureStore::maintenanceRetryForTesting() const
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    return capturePathState_->maintenanceRetryForTesting();
+}
+
+void CaptureStore::setBeforeRetryHandoffCallbackForTesting(
+    std::function<void()> callback )
+{
+    const std::lock_guard<std::recursive_mutex> lock( mutex_ );
+    capturePathState_->setBeforeRetryHandoffCallbackForTesting( std::move( callback ) );
 }
 
 bool CaptureStore::hasCapturePathCoordinationOwnershipForTesting() const

--- a/src/logdata/src/streaminglogdata.cpp
+++ b/src/logdata/src/streaminglogdata.cpp
@@ -102,6 +102,9 @@ void StreamingLogData::appendUtf8( const QByteArray& data )
     }
     if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
+    }
+    // A rolling replacement is dirty even when its retained count is unchanged.
+    if ( appendResult.lineCount > 0_lcount || wasTrimmed ) {
         scheduleLoadingFinished( LiveAppendRefreshIntervalMs );
     }
 
@@ -146,6 +149,8 @@ void StreamingLogData::finishInput()
     const auto currentLineCount = captureStore_.lineCount();
     if ( currentLineCount != previousLineCount ) {
         Q_EMIT fileChanged( MonitoredFileStatus::DataAdded );
+    }
+    if ( appendResult.lineCount > 0_lcount || wasTrimmed ) {
         scheduleLoadingFinished();
     }
     if ( outputSaveAnsiMode_ == LiveLogSaveAnsiMode::Strip

--- a/src/ui/include/livelogcontroller.h
+++ b/src/ui/include/livelogcontroller.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 
 #include <QByteArray>
 
@@ -55,6 +56,31 @@ struct LiveLogControllerConfig {
     livecapture::Timestamp maximumRetryDelay{ std::chrono::seconds{ 30 } };
 };
 
+// Only visible control state belongs here. Content and metrics are refreshed
+// by StreamingLogData's existing coalescer, independently of this value.
+struct LiveLogControlPresentation {
+    struct OutputError {
+        std::string code;
+        std::string message;
+
+        bool operator==( const OutputError& other ) const;
+    };
+
+    livecapture::PresentationStatus status{ livecapture::PresentationStatus::Stopped };
+    bool disconnectEnabled{ false };
+    bool reconnectEnabled{ false };
+    std::optional<unsigned> retryAttempt;
+    std::optional<livecapture::AwaitingUserReason> awaitingUserReason;
+    std::string failureMessage;
+    livecapture::OutputBindingState outputBinding{ livecapture::OutputBindingState::Healthy };
+    std::optional<OutputError> outputBindingError;
+    std::optional<std::int64_t> retryCountdownSeconds;
+
+    bool sameControlState( const LiveLogControlPresentation& other ) const;
+};
+
+enum class LiveLogPresentationChange : std::uint8_t { Control, CountdownOnly };
+
 class LiveLogController {
 public:
     LiveLogController( LiveLogSessionSpec spec, LiveLogControllerConfig config,
@@ -71,7 +97,12 @@ public:
     const livecapture::LiveStateSnapshot& snapshot() const noexcept;
     livecapture::LiveStatePresentation presentation() const;
 
-    void setChangedCallback( std::function<void()> callback );
+    LiveLogControlPresentation controlPresentation() const;
+
+    using PresentationChangedCallback
+        = std::function<void( LiveLogControlPresentation, LiveLogPresentationChange )>;
+    // Registration establishes a fresh comparison baseline, without replay.
+    void setPresentationChangedCallback( PresentationChangedCallback callback );
 
     void armRunIntent();
     void startRequested();
@@ -101,6 +132,7 @@ public:
                                std::optional<livecapture::LiveSourceError> error = std::nullopt );
 
 private:
+    friend struct LiveLogControllerTimeTestAccess;
     class ProductionRuntime;
 
     struct PendingDispatch {
@@ -113,7 +145,7 @@ private:
     livecapture::Timestamp retryDelay( unsigned attempt ) const;
     LiveSourceTransportConfig transportConfig() const;
     void cancelScheduledRetry();
-    void notifyChanged();
+    void notifyPresentationChanged();
 
     LiveLogSessionSpec spec_;
     LiveLogControllerConfig config_;
@@ -126,7 +158,8 @@ private:
     LiveLogControllerEffects& effects_;
     std::optional<LiveLogScheduler::Token> retryToken_;
     std::deque<PendingDispatch> pendingDispatches_;
-    std::function<void()> changedCallback_;
+    LiveLogControlPresentation lastControlPresentation_;
+    PresentationChangedCallback presentationChangedCallback_;
     bool dispatching_{ false };
 };
 

--- a/src/ui/src/iosnativetransport.cpp
+++ b/src/ui/src/iosnativetransport.cpp
@@ -326,24 +326,18 @@ void IosNativeTransport::drainCurrent( Generation generation )
     if ( session_ == nullptr || activeGeneration_ != generation ) {
         return;
     }
-    while ( activeGeneration_ == generation ) {
-        const auto batch = session_->drain();
-        if ( !batch.has_value() || batch->generation != generation ) {
-            return;
-        }
-        if ( batch->bytes.empty() ) {
-            continue;
-        }
-        const auto maximum = static_cast<std::size_t>( std::numeric_limits<int>::max() );
-        const auto byteCount = std::min( batch->bytes.size(), maximum );
-        const QByteArray bytes( reinterpret_cast<const char*>( batch->bytes.data() ),
-                                static_cast<int>( byteCount ) );
-        QPointer<IosNativeTransport> guard( this );
-        Q_EMIT bytesReceived( generation, bytes );
-        if ( guard == nullptr || guard->activeGeneration_ != generation ) {
-            return;
-        }
+    // drain() removes the entire pending batch and wakes the native producer.
+    // A refill schedules its own empty-to-nonempty notification; do not chase it
+    // here or a busy stream can starve queued stop requests on the Qt thread.
+    const auto batch = session_->drain();
+    if ( !batch.has_value() || batch->generation != generation || batch->bytes.empty() ) {
+        return;
     }
+    const auto maximum = static_cast<std::size_t>( std::numeric_limits<int>::max() );
+    const auto byteCount = std::min( batch->bytes.size(), maximum );
+    const QByteArray bytes( reinterpret_cast<const char*>( batch->bytes.data() ),
+                            static_cast<int>( byteCount ) );
+    Q_EMIT bytesReceived( generation, bytes );
 }
 
 void IosNativeTransport::publishState( Generation generation, State state )

--- a/src/ui/src/livelogcontroller.cpp
+++ b/src/ui/src/livelogcontroller.cpp
@@ -261,9 +261,48 @@ live::LiveStatePresentation LiveLogController::presentation() const
     return live::projectLiveState( snapshot_ );
 }
 
-void LiveLogController::setChangedCallback( std::function<void()> callback )
+bool LiveLogControlPresentation::OutputError::operator==( const OutputError& other ) const
 {
-    changedCallback_ = std::move( callback );
+    return code == other.code && message == other.message;
+}
+
+bool LiveLogControlPresentation::sameControlState( const LiveLogControlPresentation& other ) const
+{
+    return status == other.status && disconnectEnabled == other.disconnectEnabled
+           && reconnectEnabled == other.reconnectEnabled && retryAttempt == other.retryAttempt
+           && awaitingUserReason == other.awaitingUserReason && failureMessage == other.failureMessage
+           && outputBinding == other.outputBinding && outputBindingError == other.outputBindingError;
+}
+
+LiveLogControlPresentation LiveLogController::controlPresentation() const
+{
+    const auto projection = presentation();
+    LiveLogControlPresentation result;
+    result.status = projection.status;
+    result.disconnectEnabled = projection.disconnectEnabled;
+    result.reconnectEnabled = projection.reconnectEnabled;
+    result.retryAttempt = projection.retryAttempt;
+    result.awaitingUserReason = projection.awaitingUserReason;
+    result.failureMessage = projection.failureMessage;
+    result.outputBinding = projection.outputBinding;
+    if ( snapshot_.outputBindingError.has_value() ) {
+        result.outputBindingError = LiveLogControlPresentation::OutputError{
+            snapshot_.outputBindingError->code, snapshot_.outputBindingError->message };
+    }
+    if ( projection.retryCountdownVisible ) {
+        const auto remaining = std::max<std::int64_t>( 0, projection.retryRemaining.count() );
+        constexpr std::int64_t MillisecondsPerSecond = 1000;
+        // Divide before rounding so even the largest duration cannot overflow.
+        result.retryCountdownSeconds
+            = remaining / MillisecondsPerSecond + ( remaining % MillisecondsPerSecond != 0 ? 1 : 0 );
+    }
+    return result;
+}
+
+void LiveLogController::setPresentationChangedCallback( PresentationChangedCallback callback )
+{
+    lastControlPresentation_ = controlPresentation();
+    presentationChangedCallback_ = std::move( callback );
 }
 
 void LiveLogController::armRunIntent()
@@ -443,7 +482,7 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
             for ( const auto& effect : transition.effects ) {
                 execute( effect, pendingBytes );
             }
-            notifyChanged();
+            notifyPresentationChanged();
         }
     } catch ( ... ) {
         pendingDispatches_.clear();
@@ -572,10 +611,23 @@ void LiveLogController::cancelScheduledRetry()
     }
 }
 
-void LiveLogController::notifyChanged()
+void LiveLogController::notifyPresentationChanged()
 {
-    if ( changedCallback_ ) {
-        changedCallback_();
+    auto current = controlPresentation();
+    const auto controlChanged = !current.sameControlState( lastControlPresentation_ );
+    if ( !controlChanged
+         && current.retryCountdownSeconds == lastControlPresentation_.retryCountdownSeconds ) {
+        return;
+    }
+
+    const auto change = controlChanged ? LiveLogPresentationChange::Control
+                                       : LiveLogPresentationChange::CountdownOnly;
+    // Commit before observers run; nested events are still serialized by dispatch.
+    // A local callable and a value argument also permit self replacement/removal.
+    lastControlPresentation_ = current;
+    const auto callback = presentationChangedCallback_;
+    if ( callback ) {
+        callback( std::move( current ), change );
     }
 }
 

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -1726,8 +1726,9 @@ void MainWindow::saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode )
 
     auto suggestedPath = adbSource->sessionData().boundOutputFile;
     if ( suggestedPath.isEmpty() ) {
-        suggestedPath = QDir::home().filePath( session_.getDisplayName( crawler )
-                                               + QStringLiteral( ".log" ) );
+        const auto stem = klogg::suggestedFileNameStem( session_.getDisplayName( crawler ),
+                                                        QStringLiteral( "live-log" ) );
+        suggestedPath = QDir::home().filePath( stem + QStringLiteral( ".log" ) );
     }
 
     QString outputPath;

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -3143,8 +3143,7 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
     QString toolTip = baseTip;
     LiveTabStatus liveStatus = LiveTabStatus::Disconnected;
     if ( controller != nullptr ) {
-        const auto& snapshot = controller->snapshot();
-        const auto projection = klogg::livecapture::projectLiveState( snapshot );
+        const auto projection = controller->controlPresentation();
         switch ( projection.status ) {
         case klogg::livecapture::PresentationStatus::Connected:
             liveStatus = LiveTabStatus::Connected;
@@ -3197,9 +3196,9 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
 
         if ( projection.outputBinding == klogg::livecapture::OutputBindingState::Degraded ) {
             liveStatus = LiveTabStatus::Error;
-            if ( snapshot.outputBindingError.has_value() ) {
+            if ( projection.outputBindingError.has_value() ) {
                 QString outputError;
-                const auto& error = *snapshot.outputBindingError;
+                const auto& error = *projection.outputBindingError;
                 if ( error.code == "output-open-failed" ) {
                     outputError = tr( "The bound capture output could not be opened." );
                 }
@@ -3240,17 +3239,23 @@ void MainWindow::registerAdbLogcatSource( CrawlerWidget* crawler )
 
     const QPointer<MainWindow> windowGuard( this );
     const QPointer<CrawlerWidget> crawlerGuard( crawler );
-    controller->setChangedCallback( [ windowGuard, crawlerGuard ] {
-        if ( windowGuard == nullptr || crawlerGuard == nullptr ) {
-            return;
-        }
-        if ( windowGuard->currentCrawlerWidget() == crawlerGuard ) {
-            windowGuard->updateMenuBarFromDocument( crawlerGuard );
-            windowGuard->updateInfoLine();
-        }
-        windowGuard->updateOpenedFilesMenu();
-        windowGuard->updateLiveTabAppearance( crawlerGuard );
-    } );
+    controller->setPresentationChangedCallback(
+        [ windowGuard, crawlerGuard ]( const klogg::livelog::LiveLogControlPresentation&,
+                                      klogg::livelog::LiveLogPresentationChange change ) {
+            if ( windowGuard == nullptr || crawlerGuard == nullptr ) {
+                return;
+            }
+            const auto controlChanged = change == klogg::livelog::LiveLogPresentationChange::Control;
+            if ( windowGuard->currentCrawlerWidget() == crawlerGuard ) {
+                if ( controlChanged ) {
+                    windowGuard->updateMenuBarFromDocument( crawlerGuard );
+                }
+                windowGuard->updateInfoLine();
+            }
+            if ( controlChanged ) {
+                windowGuard->updateLiveTabAppearance( crawlerGuard );
+            }
+        } );
 
     connect( adbSource, &AdbLogcatSource::clearFailed, this,
              [ windowGuard, crawlerGuard ]( const QString& error ) {
@@ -3399,8 +3404,8 @@ void MainWindow::updateMenuBarFromDocument( const CrawlerWidget* crawler )
     const auto isReadOnlyCompatibility
         = adbSource != nullptr && adbSource->isReadOnlyCompatibility();
     const auto projection = controller != nullptr
-                                ? klogg::livecapture::projectLiveState( controller->snapshot() )
-                                : klogg::livecapture::LiveStatePresentation{};
+                                ? controller->controlPresentation()
+                                : klogg::livelog::LiveLogControlPresentation{};
     disconnectSourceAction->setEnabled( isLiveDocument && !isReadOnlyCompatibility
                                         && projection.disconnectEnabled );
     reconnectSourceAction->setEnabled( isLiveDocument && !isReadOnlyCompatibility
@@ -3503,13 +3508,11 @@ void MainWindow::updateInfoLine()
     }
 
     if ( const auto* controller = session_.getLiveLogController( crawler ) ) {
-        const auto projection
-            = klogg::livecapture::projectLiveState( controller->snapshot() );
-        if ( projection.retryCountdownVisible ) {
-            const auto remainingMs = projection.retryRemaining.count();
-            const auto remainingSec = ( remainingMs + 999 ) / 1000;
+        const auto projection = controller->controlPresentation();
+        if ( projection.retryCountdownSeconds.has_value() ) {
             infoLine->setText( QDir::toNativeSeparators( session_.getDisplayName( crawler ) )
-                               + tr( " - Reconnect in %1 seconds..." ).arg( remainingSec ) );
+                               + tr( " - Reconnect in %1 seconds..." )
+                                     .arg( *projection.retryCountdownSeconds ) );
             infoLine->displayGauge( 0 );
             return;
         }

--- a/src/ui/src/tabbedcrawlerwidget.cpp
+++ b/src/ui/src/tabbedcrawlerwidget.cpp
@@ -483,11 +483,10 @@ void TabbedCrawlerWidget::updateCrawler( int index, const QString& displayName,
     // Strip any old-format live status suffix from both the display name and custom name
     const auto cleanDisplayName = tabLabelWithoutLiveStatus( displayName );
     const auto customName = tabLabelWithoutLiveStatus( rawCustomName );
-    if ( customName.isEmpty() ) {
-        myTabBar_.setTabText( index, cleanDisplayName );
-    }
-    else {
-        myTabBar_.setTabText( index, customName );
+    const auto& label = customName.isEmpty() ? cleanDisplayName : customName;
+    // Qt refreshes tab layout even when setTabText receives unchanged text.
+    if ( myTabBar_.tabText( index ) != label ) {
+        myTabBar_.setTabText( index, label );
     }
 }
 
@@ -1018,7 +1017,8 @@ void TabbedCrawlerWidget::updateIcon( int index )
         icon = &live_icons_[ static_cast<int>( liveStatus ) ][ static_cast<int>( dataStatus ) ];
     }
 
-    if ( icon && !icon->isNull() ) {
+    if ( icon && !icon->isNull()
+         && myTabBar_.tabIcon( index ).cacheKey() != icon->cacheKey() ) {
         myTabBar_.setTabIcon( index, *icon );
     }
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/include/cpu_info.h
   ${CMAKE_CURRENT_SOURCE_DIR}/include/runnable_lambda.h
   ${CMAKE_CURRENT_SOURCE_DIR}/src/cpu_info.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/pathutils.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/src/platform_files.cpp
 )
 

--- a/src/utils/include/pathutils.h
+++ b/src/utils/include/pathutils.h
@@ -43,6 +43,10 @@ inline QString displayNameForPath( const QString& path )
     return base.isEmpty() ? path : base;
 }
 
+// Normalize characters in an automatically suggested filename stem, not an existing
+// path or a user-selected destination. The caller owns the directory and extension.
+QString suggestedFileNameStem( const QString& label, const QString& fallback );
+
 } // namespace klogg
 
 #endif

--- a/src/utils/src/pathutils.cpp
+++ b/src/utils/src/pathutils.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "pathutils.h"
+
+#include <QChar>
+#include <QVector>
+
+namespace {
+
+QString normalizeFileNameStem( const QString& label )
+{
+    const auto invalidCharacters = QStringLiteral( "<>:\"/\\|?*" );
+    const auto separator = QLatin1Char( '-' );
+    QString stem;
+    stem.reserve( label.size() );
+    bool separatorPending = false;
+    // Classify Unicode scalars rather than UTF-16 halves, preserving supplementary
+    // characters while still excluding format controls outside the BMP.
+    for ( const auto codePoint : label.toUcs4() ) {
+        const auto category = QChar::category( codePoint );
+        const auto excluded = QChar::isSpace( codePoint ) || category == QChar::Other_Control
+                              || category == QChar::Other_Format
+                              || category == QChar::Punctuation_Open
+                              || category == QChar::Punctuation_Close
+                              || ( codePoint < 128
+                                   && invalidCharacters.contains(
+                                       QChar{ static_cast<ushort>( codePoint ) } ) );
+        if ( excluded || codePoint == '-' ) {
+            separatorPending = !stem.isEmpty();
+            continue;
+        }
+        if ( stem.isEmpty() && codePoint == '.' ) {
+            continue;
+        }
+        if ( separatorPending ) {
+            stem += separator;
+            separatorPending = false;
+        }
+        if ( QChar::requiresSurrogates( codePoint ) ) {
+            stem += QChar{ QChar::highSurrogate( codePoint ) };
+            stem += QChar{ QChar::lowSurrogate( codePoint ) };
+        }
+        else {
+            stem += QChar{ static_cast<ushort>( codePoint ) };
+        }
+    }
+    while ( stem.endsWith( QLatin1Char( '.' ) ) || stem.endsWith( separator ) ) {
+        stem.chop( 1 );
+    }
+    return stem;
+}
+
+bool isReservedDeviceStem( const QString& stem )
+{
+    // Windows reserves these even with an extension (including an embedded one).
+    const auto base = stem.section( QLatin1Char( '.' ), 0, 0 ).toUpper();
+    if ( base == QStringLiteral( "CON" ) || base == QStringLiteral( "PRN" )
+         || base == QStringLiteral( "AUX" ) || base == QStringLiteral( "NUL" )
+         || base == QStringLiteral( "CONIN$" ) || base == QStringLiteral( "CONOUT$" ) ) {
+        return true;
+    }
+    if ( base.size() != 4
+         || ( !base.startsWith( QStringLiteral( "COM" ) )
+              && !base.startsWith( QStringLiteral( "LPT" ) ) ) ) {
+        return false;
+    }
+    // Win32 also treats superscript 1, 2 and 3 as device-number suffixes.
+    return QStringLiteral( "123456789¹²³" ).contains( base.at( 3 ) );
+}
+
+} // namespace
+
+QString klogg::suggestedFileNameStem( const QString& label, const QString& fallback )
+{
+    auto stem = normalizeFileNameStem( label );
+    if ( stem.isEmpty() ) {
+        stem = normalizeFileNameStem( fallback );
+    }
+    if ( stem.isEmpty() ) {
+        stem = QStringLiteral( "log" );
+    }
+    if ( isReservedDeviceStem( stem ) ) {
+        stem.prepend( QStringLiteral( "log-" ) );
+    }
+    return stem;
+}

--- a/tests/scripts/test_adb_helper_release_contract.py
+++ b/tests/scripts/test_adb_helper_release_contract.py
@@ -15,6 +15,7 @@ APP_CMAKE = ROOT / "src" / "app" / "CMakeLists.txt"
 NOTICE = ROOT / "NOTICE"
 BUILD_ACTION = ROOT / ".github" / "actions" / "build-adb-helper" / "action.yml"
 CI_BUILD = ROOT / ".github" / "workflows" / "ci-build.yml"
+CI_CONTINUOUS = ROOT / ".github" / "workflows" / "ci-continuous.yml"
 CI_RELEASE = ROOT / ".github" / "workflows" / "ci-release.yml"
 DOCKER_PACKAGE = ROOT / ".github" / "actions" / "docker-package" / "action.yml"
 MAC_PACKAGE = ROOT / ".github" / "actions" / "agent-package-mac" / "action.yml"
@@ -571,8 +572,9 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
     def test_release_matrix_builds_every_target_and_publishes_source_assets(self):
         build_action = self.required_text(BUILD_ACTION)
         ci_build = self.required_text(CI_BUILD)
+        ci_continuous = self.required_text(CI_CONTINUOUS)
         ci_release = self.required_text(CI_RELEASE)
-        combined = "\n".join((build_action, ci_build, ci_release))
+        combined = "\n".join((build_action, ci_build, ci_continuous, ci_release))
 
         for target in EXPECTED_TARGETS:
             self.assertIn(target, combined)
@@ -599,18 +601,22 @@ class AdbHelperReleaseContractTest(unittest.TestCase):
 
         for marker in (
             "prepare_source_publication.py",
-            "--adb-source-root ./adb-helper-legal-assets",
+            "--adb-source-root adb-helper-legal-assets",
             "klogg-source-publication-manifest.json",
             "packages-publication/SHA256SUMS",
             "./packages-publication/*",
         ):
-            self.assertIn(marker, ci_release)
+            self.assertIn(marker, ci_continuous)
+        self.assertIn("promote_release_publication.py", ci_release)
+        self.assertIn("continuous-publication", ci_release)
+        self.assertIn("./packages-publication/*", ci_release)
 
     def test_release_paths_do_not_use_prebuilt_sdk_path_or_floating_adb(self):
         paths = (
             ADB_CMAKE,
             BUILD_ACTION,
             CI_BUILD,
+            CI_CONTINUOUS,
             CI_RELEASE,
             DOCKER_PACKAGE,
             MAC_PACKAGE,

--- a/tests/scripts/test_external_source_asset_package_contract.py
+++ b/tests/scripts/test_external_source_asset_package_contract.py
@@ -349,59 +349,46 @@ publish_component(
         ):
             self.assertIn(marker, qualification)
 
-    def test_stable_release_publishes_content_addressed_adb_and_ios_sources_with_manifest(self):
+    def test_stable_release_promotes_verified_continuous_sources_and_manifest(self):
         workflow = required_text(CI_RELEASE)
-        preparer = required_text(PUBLICATION_PREPARER)
+        promoter = required_text(ROOT / "scripts" / "promote_release_publication.py")
         manifest = self.contract["publication_manifest"]["file_name"]
-        for name in (
-            self.adb["receipt_file"],
-            self.ios["receipt_file"],
+        for marker in (
+            "/releases/tags/continuous",
+            "/releases/assets/${asset_id}",
+            "continuous-source-metadata.json",
+            "promote_release_publication.py",
+            "verify_source_publication_manifest.py",
             manifest,
-            "adb-helper",
-            "ios-native",
         ):
-            self.assertIn(name, workflow)
-        self.assertIn(
-            "published_source_name(version, component, archive_hash)",
-            preparer,
-        )
-        for component in ("adb-helper", "ios-native"):
-            self.assertIn(f'"{component}"', preparer)
-        self.assertIn("prepare_source_publication.py", workflow)
-        self.assertIn("verify_source_publication_manifest.py", workflow)
-        self.assertRegex(workflow, r"(?i)channel[^\n]*stable")
-        self.assertIn('"mutable": args.channel == "continuous"', preparer)
+            self.assertIn(marker, workflow)
+        self.assertNotIn("prepare_source_publication.py", workflow)
+        self.assertIn('document["schema_version"] = 3', promoter)
+        self.assertIn('document["channel"] = "stable"', promoter)
+        self.assertIn('document["promotion"]', promoter)
         upload = workflow.index("- name: Create GitHub Release")
         post_upload = workflow.find("verify_source_publication_manifest.py", upload)
         self.assertGreater(post_upload, upload, "stable publication must verify after upload")
-        self.assertRegex(workflow[upload:], r"gh\s+(?:api|release\s+download)")
 
-    def test_stable_release_defaults_to_validation_and_keeps_signed_evidence_strict(self):
+    def test_stable_release_is_strict_validation_only_continuous_promotion(self):
         build = required_text(CI_BUILD)
         release = required_text(CI_RELEASE)
         self.assertIn("qualification-mode:", build)
         self.assertIn("- release", build)
-        self.assertIn("evidence-level:", release)
-        evidence_input = release.split("evidence-level:", 1)[1].split("jobs:", 1)[0]
-        self.assertIn("default: validation", evidence_input)
-        self.assertIn("- validation", evidence_input)
-        self.assertIn("- signed", evidence_input)
-        self.assertIn("--evidence-level \"${KLOGG_EVIDENCE_LEVEL}\"", release)
-        self.assertRegex(
-            release,
-            r"KLOGG_EVIDENCE_LEVEL.*signed[\s\S]+adb-helper-signing-receipt\.json[\s\S]+adb-helper-notarization-receipt\.json",
-        )
-        for secret in (
-            "CODESIGN_BASE64",
-            "CODESIGN_PASSWORD",
-            "APPLE_DEVELOPER_ID_APPLICATION",
-            "NOTARIZATION_USERNAME",
-            "NOTARIZATION_TEAM",
-            "NOTARIZATION_PASSWORD",
+        for obsolete in (
+            "evidence-level:",
+            "KLOGG_EVIDENCE_LEVEL",
+            "- signed",
+            "sentry-cli",
+            "SENTRY_TOKEN",
+            "adb-helper-signing-receipt.json",
+            "adb-helper-notarization-receipt.json",
         ):
-            self.assertNotIn(f"secrets.{secret}", release)
+            self.assertNotIn(obsolete, release)
+        self.assertIn("--expected-evidence-level validation", release)
+        self.assertIn("promoted byte-for-byte", release)
 
-    def test_required_ci_does_not_publish_and_workflow_run_publisher_is_trusted(self):
+    def test_required_ci_dispatches_only_a_trusted_continuous_publisher(self):
         build = required_text(CI_BUILD)
         for marker in (
             "CreatePreRelease:",
@@ -410,22 +397,29 @@ publish_component(
             "softprops/action-gh-release",
         ):
             self.assertNotIn(marker, build)
+        dispatch = build.split("  DispatchContinuous:", 1)[1]
+        self.assertIn("needs: [ci-gate]", dispatch)
+        for marker in (
+            "success()",
+            "needs.ci-gate.result == 'success'",
+            "github.event_name == 'push'",
+            "github.ref == 'refs/heads/master'",
+            "gh workflow run ci-continuous.yml",
+            "ci-run-id=\"$KLOGG_CI_RUN_ID\"",
+            "ci-run-sha=\"$KLOGG_CI_RUN_SHA\"",
+        ):
+            self.assertIn(marker, dispatch)
 
         continuous = required_text(CI_CONTINUOUS)
-        self.assertIn("workflow_run:", continuous)
-        self.assertRegex(continuous, r"workflows:\s*\[\s*[\"']CI Build[\"']\s*\]")
-        self.assertIn("types: [completed]", continuous)
-        trusted = (
-            "github.event.workflow_run.conclusion == 'success'"
-            " && github.event.workflow_run.event == 'push'"
-            " && github.event.workflow_run.head_branch == 'master'"
-            " && github.event.workflow_run.head_repository.full_name == github.repository"
-        )
-        self.assertIn(trusted, " ".join(continuous.split()))
-        self.assertIn("actions: read", continuous)
-        self.assertIn("contents: write", continuous)
+        self.assertIn("workflow_dispatch:", continuous)
+        self.assertNotIn("workflow_run:", continuous)
+        self.assertIn("ci-run-id:", continuous)
+        self.assertIn("ci-run-sha:", continuous)
+        self.assertIn("select(.name == \"ci-gate\")", continuous)
+        self.assertIn("Timed out waiting for source CI run", continuous)
+        self.assertIn("run-id: ${{ env.KLOGG_CI_RUN_ID }}", continuous)
+        self.assertNotIn("github.event.workflow_run", continuous)
         self.assertIn("cancel-in-progress: false", continuous)
-        self.assertIn("github.token", continuous)
         self.assertNotRegex(continuous, r"secrets\.(?:CODESIGN|APPLE|NOTARIZATION)")
         readme = required_text(README)
         self.assertIn("continuous release", readme.lower())
@@ -434,6 +428,7 @@ publish_component(
     def test_source_asset_producers_bind_release_version_and_flat_checksums(self):
         build = required_text(CI_BUILD)
         stable = required_text(CI_RELEASE)
+        promoter = required_text(ROOT / "scripts" / "promote_release_publication.py")
         adb_producer = section(build, "  PrefetchAdbHelperSources:", "  BuildAdbHelpers:")
         ios_producer = section(build, "  BuildIosNativeStacks:", "  MacPackages:")
         for producer in (adb_producer, ios_producer):
@@ -442,9 +437,10 @@ publish_component(
             self.assertIn("--base-url", producer)
         self.assertNotIn("packages-bin", stable)
         self.assertNotIn("source-publication-sha256.txt", stable)
-        self.assertIn("packages-publication/SHA256SUMS", stable)
+        self.assertIn("write_checksums(staging)", promoter)
+        self.assertIn("packages-publication", stable)
 
-    def test_publication_preparer_requires_adb_and_explicit_ios_source_qualifications(self):
+    def test_continuous_preparer_owns_source_qualification_before_stable_promotion(self):
         preparer = required_text(PUBLICATION_PREPARER)
         for marker in (
             "source_set_receipt_sha256",
@@ -453,52 +449,56 @@ publish_component(
             "missing external iOS qualification for DMG",
         ):
             self.assertIn(marker, preparer)
+        continuous = required_text(CI_CONTINUOUS)
         stable = required_text(CI_RELEASE)
-        self.assertIn("ios-native-dmg-package-verification.json", stable)
-        self.assertIn("--ios-qualification-receipt", stable)
-        self.assertNotIn("--ios-qualification-receipt", required_text(CI_BUILD))
+        self.assertIn("ios-native-dmg-package-verification.json", continuous)
+        self.assertIn("--ios-qualification-receipt", continuous)
+        self.assertNotIn("--ios-qualification-receipt", stable)
+        self.assertIn("promote_release_publication.py", stable)
 
-    def test_stable_release_selects_exact_trusted_ci_artifacts_without_expression_injection(self):
+    def test_stable_release_selects_exact_live_continuous_assets_without_override(self):
         workflow = required_text(CI_RELEASE)
         self.assertIn('test "${GITHUB_REF}" = "refs/heads/master"', workflow)
-        self.assertIn("KLOGG_REQUESTED_CI_RUN_ID: ${{ github.event.inputs.ci-run-id }}", workflow)
+        self.assertNotIn("ci-run-id:", workflow)
+        self.assertNotIn("KLOGG_REQUESTED_CI_RUN_ID", workflow)
         selection = section(
             workflow,
-            "- name: Select trusted CI run",
-            "- name: Download artifacts for selected CI workflow",
+            "- name: Select live Continuous release snapshot",
+            "- name: Download immutable Continuous release assets",
         )
-        self.assertNotIn("${{ github.event.inputs.ci-run-id }}", selection)
-        self.assertRegex(selection, r"\^\[0-9\]\+\$")
         for marker in (
-            'run_path="$(gh api',
-            'run_repository="$(gh api',
-            'run_branch="$(gh api',
-            'run_event="$(gh api',
-            'run_conclusion="$(gh api',
-            'KLOGG_CI_RUN_ID=',
-            'KLOGG_CI_RUN_SHA=',
-            '".github/workflows/ci-build.yml"',
-            '"${GITHUB_REPOSITORY}"',
-            '"master"',
-            '"success"',
-            "event=push",
-            'KLOGG_EVIDENCE_LEVEL" = validation',
-            "workflow-run API does not expose workflow_dispatch inputs",
+            "/releases/tags/continuous",
+            'release_id="$(gh api',
+            'release_draft="$(gh api',
+            'release_prerelease="$(gh api',
+            'test "$release_draft" = false',
+            'test "$release_prerelease" = true',
+            "/git/ref/tags/continuous",
             "/branches/master",
+            "KLOGG_SOURCE_RELEASE_ID=",
+            "KLOGG_SOURCE_COMMIT=",
         ):
             self.assertIn(marker, selection)
-        self.assertNotIn('.inputs["qualification-mode"]', selection)
-        self.assertIn("run_id: ${{ env.KLOGG_CI_RUN_ID }}", workflow)
-
-        metadata = workflow.index("klogg_commit.txt")
-        checkout = workflow.find('git checkout --detach "${KLOGG_SOURCE_COMMIT}"', metadata)
-        extract = workflow.index("- name: Extract package tarballs")
-        self.assertGreater(checkout, metadata)
-        self.assertLess(checkout, extract)
-        initialization = workflow[metadata:extract]
-        self.assertIn('test "${KLOGG_SOURCE_COMMIT}" = "${KLOGG_CI_RUN_SHA}"', initialization)
-        self.assertIn("git merge-base --is-ancestor", initialization)
-        changelog = section(workflow, "- name: Generate Changelog", "- name: Display structure")
+        download = section(
+            workflow,
+            "- name: Download immutable Continuous release assets",
+            "- name: Verify Continuous source publication and checkout",
+        )
+        self.assertIn("len(records) != 23", download)
+        self.assertIn("invalid or duplicate Continuous release asset ID", download)
+        self.assertIn("invalid or duplicate Continuous release asset name", download)
+        self.assertIn("/releases/assets/${asset_id}", download)
+        self.assertIn("continuous-source-metadata.json", download)
+        self.assertNotIn("action-download-artifact", workflow)
+        self.assertNotIn("actions/workflows/ci-build.yml/runs", workflow)
+        checkout = workflow.index('git checkout --detach "$KLOGG_SOURCE_COMMIT"')
+        promote = workflow.index("- name: Promote verified Continuous publication to Stable")
+        self.assertLess(checkout, promote)
+        changelog = section(
+            workflow,
+            "- name: Generate Changelog",
+            "- name: Promote verified Continuous publication to Stable",
+        )
         self.assertIn('--to-ref "${KLOGG_SOURCE_COMMIT}"', changelog)
 
     def test_stable_retry_recreates_a_clean_draft_asset_set(self):
@@ -518,12 +518,14 @@ publish_component(
         )
         self.assertNotIn("Create continuous candidate draft", required_text(CI_BUILD))
 
-    def test_stable_release_uses_selected_ci_commit_and_remains_draft_until_verified(self):
+    def test_stable_release_uses_continuous_commit_and_remains_draft_until_verified(self):
         workflow = required_text(CI_RELEASE)
-        self.assertIn("klogg_commit.txt", workflow)
+        self.assertIn("continuous-publication/klogg-source-publication-manifest.json", workflow)
         self.assertIn("KLOGG_SOURCE_COMMIT", workflow)
         publication = section(
-            workflow, "- name: Prepare coherent stable package and source publication", "- name: Discord notification"
+            workflow,
+            "- name: Promote verified Continuous publication to Stable",
+            "- name: Discord notification",
         )
         self.assertNotIn('--commit "${GITHUB_SHA}"', publication)
         self.assertIn("target_commitish: ${{ env.KLOGG_SOURCE_COMMIT }}", publication)
@@ -532,14 +534,17 @@ publish_component(
         self.assertLess(create, verify)
         self.assertIn("draft: true", publication[create:verify])
         self.assertIn("tag_name: v${{ env.KLOGG_VERSION }}-candidate", publication[create:verify])
-        verification = publication[verify:]
-        draft_verification = verification[: verification.index("- name: Recheck master tip")]
+        draft_verification = section(
+            publication,
+            "- name: Verify stable source publication after upload",
+            "- name: Recheck Continuous snapshot before stable promotion",
+        )
         self.assertIn(".target_commitish", draft_verification)
         self.assertIn(
             'test "${candidate_target}" = "${KLOGG_SOURCE_COMMIT}"',
             draft_verification,
         )
-        self.assertNotIn("/git/ref/tags/", draft_verification)
+        self.assertNotIn("/git/ref/tags/v${KLOGG_VERSION}-candidate", draft_verification)
         promotion = publication.find("draft=false", verify)
         self.assertGreater(promotion, verify, "stable release must publish only after verification")
 
@@ -548,7 +553,7 @@ publish_component(
         release = required_text(CI_RELEASE)
         create = release.index("- name: Create GitHub Release")
         verify = release.index("- name: Verify stable source publication after upload")
-        stale = release.index("- name: Recheck master tip before stable promotion")
+        stale = release.index("- name: Recheck Continuous snapshot before stable promotion")
         promote = release.index("- name: Publish verified stable release")
         self.assertLess(create, verify)
         self.assertLess(verify, stale)
@@ -557,14 +562,39 @@ publish_component(
         promotion = release[promote:]
         self.assertIn("draft=false", promotion)
         self.assertGreaterEqual(promotion.count("/branches/master"), 2)
+        self.assertGreaterEqual(promotion.count("/releases/tags/continuous"), 2)
         self.assertIn("Roll back failed stable promotion", promotion)
         self.assertIn('releases/${RELEASE_ID}', promotion)
         self.assertIn('delete_ref_if_present "$final_tag"', promotion)
-        before_create = release.index("- name: Recheck master tip before stable draft creation")
+        self.assertNotIn("promoted=", promotion)
+        self.assertIn('-f ref="refs/tags/${final_tag}"', promotion)
+        self.assertIn("final_ref_owned=true", promotion)
+        rollback = section(
+            release,
+            "rollback_stable_promotion() {",
+            "trap rollback_stable_promotion ERR",
+        )
+        self.assertIn('gh api -X DELETE "/repos/${repo}/releases/${RELEASE_ID}"', rollback)
+        self.assertIn('if [ "$final_ref_owned" = true ]', rollback)
+        self.assertIn('delete_ref_if_present "$final_tag"', rollback)
+        cancellation = section(
+            release,
+            "- name: Roll back failed or cancelled stable promotion",
+            "- name: Discord notification",
+        )
+        self.assertIn("failure() || cancelled()", cancellation)
+        self.assertIn('releases/${RELEASE_ID}', cancellation)
+        notification = release.split("- name: Discord notification", 1)[1]
+        self.assertIn("continue-on-error: true", notification)
+        before_create = release.index(
+            "- name: Recheck Continuous snapshot before stable draft creation"
+        )
         self.assertLess(before_create, create)
         for position in (before_create, stale):
-            check = release[position : release.find("\n    - name:", position + 1)]
+            end = release.find("\n      - name:", position + 1)
+            check = release[position : end if end != -1 else len(release)]
             self.assertIn("/branches/master", check)
+            self.assertIn("/releases/tags/continuous", check)
             self.assertIn("KLOGG_SOURCE_COMMIT", check)
 
     def test_continuous_publication_is_transactional_sha_bound_and_rollback_safe(self):
@@ -600,9 +630,10 @@ publish_component(
         self.assertIn('backup_tag="continuous-rollback-${KLOGG_CI_RUN_ID}"', workflow)
         self.assertNotIn("continuous-candidate-${GITHUB_RUN_ID}", workflow)
         self.assertNotIn("continuous-rollback-${GITHUB_RUN_ID}", workflow)
-        self.assertIn("run-id: ${{ github.event.workflow_run.id }}", workflow)
+        self.assertIn("run-id: ${{ env.KLOGG_CI_RUN_ID }}", workflow)
         self.assertIn("github-token: ${{ github.token }}", workflow)
-        self.assertIn("github.event.workflow_run.head_sha", workflow)
+        self.assertIn("KLOGG_REQUESTED_CI_RUN_SHA: ${{ inputs.ci-run-sha }}", workflow)
+        self.assertNotIn("github.event.workflow_run", workflow)
         self.assertIn('test "${KLOGG_SOURCE_COMMIT}" = "${KLOGG_CI_RUN_SHA}"', workflow)
         critical = section(
             workflow,
@@ -2178,16 +2209,19 @@ class ConsolidatedReleasePublicationContractTest(unittest.TestCase):
     def test_workflows_stage_only_consolidated_assets_and_use_rendered_body(self):
         stable = required_text(CI_RELEASE)
         continuous = required_text(CI_CONTINUOUS)
+        promoter = required_text(ROOT / "scripts" / "promote_release_publication.py")
         for workflow in (stable, continuous):
             self.assertIn("render_release_downloads.py", workflow)
             self.assertIn("body_path:", workflow)
-            self.assertIn(self.release_contract["evidence_archive"]["file_name"], workflow)
-            self.assertIn(self.release_contract["checksums"]["file_name"], workflow)
             self.assertNotRegex(workflow, r"packages-publication/[^\n]*\.sha256")
             self.assertNotRegex(
                 workflow,
                 r"packages-publication/[^\n]*(?:qualification|signing|notarization)\.json",
             )
+        self.assertIn(self.release_contract["evidence_archive"]["file_name"], continuous)
+        self.assertIn(self.release_contract["checksums"]["file_name"], continuous)
+        self.assertIn("write_checksums(staging)", promoter)
+        self.assertIn('test "$asset_count" -eq 23', stable)
         self.assertNotIn("Candidate", section(continuous, "- name: Create continuous candidate draft", "- name: Verify continuous candidate after upload").split("name:", 2)[-1])
         self.assertIn('-f name="Continuous Build ${KLOGG_VERSION}"', continuous)
         self.assertEqual(
@@ -2213,7 +2247,7 @@ class ConsolidatedReleasePublicationContractTest(unittest.TestCase):
         changelog = section(
             stable,
             "- name: Generate Changelog",
-            "- name: Display structure of downloaded files",
+            "- name: Promote verified Continuous publication to Stable",
         )
         self.assertIn("release-changelog.txt", changelog)
         self.assertNotIn("GITHUB_ENV", changelog)

--- a/tests/scripts/test_github_api_helpers.py
+++ b/tests/scripts/test_github_api_helpers.py
@@ -6,6 +6,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import textwrap
 import unittest
 
 
@@ -92,6 +93,169 @@ esac
         self.assertEqual(result.stdout, "status=2\nvalue=<>\n")
         self.assertIn("gh: Server Error (HTTP 500)", result.stderr)
 
+    def run_continuous_selection(self, mode: str) -> tuple[subprocess.CompletedProcess, str]:
+        workflow = CONTINUOUS_WORKFLOW.read_text(encoding="utf-8")
+        step = workflow.split(
+            "      - name: Verify dispatched CI run and current master tip", 1
+        )[1].split("\n\n  publish:", 1)[0]
+        script = textwrap.dedent(step.split("        run: |\n", 1)[1])
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            fake_gh = root / "gh"
+            state = root / "state"
+            output = root / "github-output"
+            fake_gh.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+if [ "$FAKE_GH_MODE" = api-error ]; then
+  printf 'gh: simulated API failure\\n' >&2
+  exit 1
+fi
+if [ "$FAKE_GH_MODE" = transient ] && [ ! -e "$FAKE_GH_TRANSIENT_STATE" ]; then
+  : > "$FAKE_GH_TRANSIENT_STATE"
+  printf 'gh: simulated transient API failure\\n' >&2
+  exit 1
+fi
+shift
+endpoint=""
+jq_filter=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --jq) jq_filter="$2"; shift 2 ;;
+    --paginate|--slurp) shift ;;
+    -*) shift ;;
+    *)
+      if [ -z "$endpoint" ]; then endpoint="$1"; fi
+      shift
+      ;;
+  esac
+done
+case "$endpoint" in
+  */branches/master)
+    printf '%s\\n' "$EXPECTED_SHA"
+    ;;
+  */jobs?*)
+    if [ "$FAKE_GH_MODE" = gate-failure ]; then
+      printf 'completed\\tfailure\\n'
+    elif [ "$FAKE_GH_MODE" = retry-gate ] && [[ "$endpoint" == */attempts/2/* ]]; then
+      printf '\\n'
+    else
+      printf 'completed\\tsuccess\\n'
+    fi
+    ;;
+  */actions/runs/*)
+    case "$jq_filter" in
+      *'.head_repository.full_name'*'@tsv'*)
+        if [ "$FAKE_GH_MODE" = identity-failure ]; then
+          printf '.github/workflows/other.yml\\tZEACENT/klogg\\tmaster\\tpush\\t%s\\n' "$EXPECTED_SHA"
+        else
+          printf '.github/workflows/ci-build.yml\\tZEACENT/klogg\\tmaster\\tpush\\t%s\\n' "$EXPECTED_SHA"
+        fi
+        ;;
+      .path)
+        if [ "$FAKE_GH_MODE" = identity-failure ]; then
+          printf '.github/workflows/other.yml\\n'
+        else
+          printf '.github/workflows/ci-build.yml\\n'
+        fi
+        ;;
+      '.head_repository.full_name // empty') printf 'ZEACENT/klogg\\n' ;;
+      '.head_branch // empty') printf 'master\\n' ;;
+      .event) printf 'push\\n' ;;
+      .head_sha) printf '%s\\n' "$EXPECTED_SHA" ;;
+      .run_attempt)
+        if [ "$FAKE_GH_MODE" = retry-gate ]; then printf '2\\n'; else printf '1\\n'; fi
+        ;;
+      '[.status, (.conclusion // "")] | @tsv')
+        count="$(cat "$FAKE_GH_STATE" 2>/dev/null || printf 0)"
+        case "$FAKE_GH_MODE" in
+          failure) printf 'completed\\tfailure\\n' ;;
+          transition)
+            count=$((count + 1))
+            printf '%s\\n' "$count" > "$FAKE_GH_STATE"
+            if [ "$count" -eq 1 ]; then printf 'in_progress\\t\\n'; else printf 'completed\\tsuccess\\n'; fi
+            ;;
+          timeout) printf 'in_progress\\t\\n' ;;
+          *) printf 'completed\\tsuccess\\n' ;;
+        esac
+        ;;
+      .status)
+        count="$(cat "$FAKE_GH_STATE" 2>/dev/null || printf 0)"
+        case "$FAKE_GH_MODE" in
+          transition)
+            count=$((count + 1))
+            printf '%s\\n' "$count" > "$FAKE_GH_STATE"
+            if [ "$count" -eq 1 ]; then printf 'in_progress\\n'; else printf 'completed\\n'; fi
+            ;;
+          timeout) printf 'in_progress\\n' ;;
+          *) printf 'completed\\n' ;;
+        esac
+        ;;
+      '.conclusion // ""')
+        case "$FAKE_GH_MODE" in
+          failure) printf 'failure\\n' ;;
+          transition)
+            count="$(cat "$FAKE_GH_STATE" 2>/dev/null || printf 0)"
+            if [ "$count" -le 1 ]; then printf '\\n'; else printf 'success\\n'; fi
+            ;;
+          timeout) printf '\\n' ;;
+          *) printf 'success\\n' ;;
+        esac
+        ;;
+      *) printf 'unexpected jq filter: %s\\n' "$jq_filter" >&2; exit 2 ;;
+    esac
+    ;;
+  *) printf 'unexpected endpoint: %s\\n' "$endpoint" >&2; exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{root}{os.pathsep}{env['PATH']}",
+                    "FAKE_GH_MODE": mode,
+                    "FAKE_GH_STATE": str(state),
+                    "FAKE_GH_TRANSIENT_STATE": str(root / "transient-state"),
+                    "EXPECTED_SHA": "a" * 40,
+                    "GITHUB_REPOSITORY": "ZEACENT/klogg",
+                    "GITHUB_OUTPUT": str(output),
+                    "KLOGG_REQUESTED_CI_RUN_ID": "12345",
+                    "KLOGG_REQUESTED_CI_RUN_SHA": "a" * 40,
+                    "KLOGG_DISPATCH_SHA": "a" * 40,
+                    "KLOGG_CI_POLL_ATTEMPTS": "2",
+                    "KLOGG_CI_POLL_INTERVAL_SECONDS": "0",
+                    "KLOGG_GH_API_RETRY_ATTEMPTS": "2",
+                    "KLOGG_GH_API_RETRY_DELAY_SECONDS": "0",
+                }
+            )
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            emitted = output.read_text(encoding="utf-8") if output.exists() else ""
+            return result, emitted
+
+    def test_continuous_selection_waits_for_success_and_fails_closed(self):
+        for mode in ("success", "transition", "retry-gate", "transient"):
+            with self.subTest(mode=mode):
+                result, emitted = self.run_continuous_selection(mode)
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn("ci-run-id=12345", emitted)
+                self.assertIn(f"ci-run-sha={'a' * 40}", emitted)
+                self.assertIn("should-publish=true", emitted)
+        for mode in ("failure", "timeout", "gate-failure", "identity-failure", "api-error"):
+            with self.subTest(mode=mode):
+                result, emitted = self.run_continuous_selection(mode)
+                self.assertNotEqual(result.returncode, 0, mode)
+                self.assertNotIn("should-publish=true", emitted)
+
     def test_release_cleanup_uses_the_optional_scalar_lookup(self):
         continuous = workflow_section(
             CONTINUOUS_WORKFLOW,
@@ -100,8 +264,8 @@ esac
         )
         stable = workflow_section(
             STABLE_WORKFLOW,
-            "    - name: Clean stale stable draft",
-            "    - name: Recheck master tip before stable draft creation",
+            "      - name: Clean stale stable draft",
+            "      - name: Recheck Continuous snapshot before stable draft creation",
         )
         for name, cleanup in (("continuous", continuous), ("stable", stable)):
             with self.subTest(workflow=name):

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -833,8 +833,8 @@ jobs:
             MODULE.stable_release_workflow_issues(misnamed),
         )
         bypassed = workflow.replace(
-            '        test "${GITHUB_REF}" = "refs/heads/master" || {',
-            '        true || test "${GITHUB_REF}" = "refs/heads/master" || {',
+            '          test "${GITHUB_REF}" = "refs/heads/master" || {',
+            '          true || test "${GITHUB_REF}" = "refs/heads/master" || {',
             1,
         )
         self.assertNotEqual(bypassed, workflow)
@@ -842,27 +842,30 @@ jobs:
             "stable release dispatch must fail closed outside master",
             MODULE.stable_release_workflow_issues(bypassed),
         )
-        run_api_inputs = workflow.replace(
-            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n',
-            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n'
-            '        run_qualification="$(gh api "$run_api" --jq \'.inputs["qualification-mode"] // empty\')"\n',
+        prerelease_bypassed = workflow.replace(
+            '          test "$release_prerelease" = true || {',
+            '          true || test "$release_prerelease" = true || {',
             1,
         )
-        self.assertNotEqual(run_api_inputs, workflow)
+        self.assertNotEqual(prerelease_bypassed, workflow)
         self.assertIn(
-            "stable release evidence must come from downloaded receipts, not run API inputs",
-            MODULE.stable_release_workflow_issues(run_api_inputs),
+            "stable release must promote only the immutable live Continuous publication",
+            MODULE.stable_release_workflow_issues(prerelease_bypassed),
         )
-        run_api_inputs_alias = workflow.replace(
-            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n',
-            '        run_event="$(gh api "$run_api" --jq \'.event\')"\n'
-            '        run_qualification="$(gh api "$run_api" --jq \'.inputs | .["qualification-mode"] // empty\')"\n',
+        v2_candidate = workflow.replace(')" = 3', ')" = 2', 1)
+        self.assertIn(
+            "stable release verification must require promotion manifest schema v3",
+            MODULE.stable_release_workflow_issues(v2_candidate),
+        )
+        without_snapshot_recheck = workflow.replace(
+            '          test "$(gh api "/repos/${repo}/releases/tags/continuous" --jq \'.id\')" = "$KLOGG_SOURCE_RELEASE_ID"\n',
+            "",
             1,
         )
-        self.assertNotEqual(run_api_inputs_alias, workflow)
+        self.assertNotEqual(without_snapshot_recheck, workflow)
         self.assertIn(
-            "stable release evidence must come from downloaded receipts, not run API inputs",
-            MODULE.stable_release_workflow_issues(run_api_inputs_alias),
+            "stable release must revalidate the selected Continuous snapshot",
+            MODULE.stable_release_workflow_issues(without_snapshot_recheck),
         )
         draft_target_swap = workflow.replace(
             "--jq '.target_commitish'", "--jq '.tag_name'", 1
@@ -872,23 +875,30 @@ jobs:
             "stable draft verification must compare the candidate target commit",
             MODULE.stable_release_workflow_issues(draft_target_swap),
         )
-        draft_ref_lookup = workflow.replace(
-            '        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq \'.target_commitish\')"',
-            '        ref_sha="$(gh api "/repos/${GITHUB_REPOSITORY}/git/ref/tags/v${KLOGG_VERSION}-candidate" --jq \'.object.sha\')"\n'
-            '        candidate_target="$(gh api "/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq \'.target_commitish\')"',
+        without_rollback = workflow.replace(
+            "          trap rollback_stable_promotion ERR\n", "", 1
+        )
+        self.assertIn(
+            "stable release promotion must roll back failure and cancellation",
+            MODULE.stable_release_workflow_issues(without_rollback),
+        )
+        without_ref_ownership = workflow.replace(
+            "          final_ref_owned=true",
+            "          final_ref_owned=false",
             1,
         )
-        self.assertNotEqual(draft_ref_lookup, workflow)
         self.assertIn(
-            "stable draft verification must not require an unpublished Git tag",
-            MODULE.stable_release_workflow_issues(draft_ref_lookup),
+            "stable release promotion must own the final ref before rollback",
+            MODULE.stable_release_workflow_issues(without_ref_ownership),
         )
-        without_rollback = workflow.replace(
-            "        trap rollback_stable_promotion ERR\n", "", 1
+        without_cancel_rollback = workflow.replace(
+            "        if: ${{ failure() || cancelled() }}",
+            "        if: ${{ failure() }}",
+            1,
         )
         self.assertIn(
-            "stable release promotion must roll back every post-publish failure",
-            MODULE.stable_release_workflow_issues(without_rollback),
+            "stable release promotion must roll back failure and cancellation",
+            MODULE.stable_release_workflow_issues(without_cancel_rollback),
         )
 
     def test_continuous_release_publish_requires_trusted_selection(self):
@@ -914,6 +924,39 @@ jobs:
             "continuous release publication must require the verified selection output",
             MODULE.continuous_release_workflow_issues(bypassed),
         )
+        selection_message = (
+            "continuous release selection must validate the dispatched successful master CI receipt"
+        )
+        unretried_api = workflow.replace("          gh_api_retry() {", "          gh_api_once() {", 1)
+        self.assertIn(
+            selection_message,
+            MODULE.continuous_release_workflow_issues(unretried_api),
+        )
+        unvalidated_sha = workflow.replace(
+            '          [[ "$run_sha" =~ ^[0-9a-f]{40}$ ]] || {',
+            '          test -n "$run_sha" || {',
+            1,
+        )
+        self.assertIn(
+            selection_message,
+            MODULE.continuous_release_workflow_issues(unvalidated_sha),
+        )
+        wrong_gate = workflow.replace(
+            'select(.name == "ci-gate")', 'select(.name == "LinuxPackages")', 1
+        )
+        self.assertIn(
+            selection_message,
+            MODULE.continuous_release_workflow_issues(wrong_gate),
+        )
+        raw_event = workflow.replace(
+            "      KLOGG_DISPATCH_SHA: ${{ github.sha }}",
+            "      KLOGG_DISPATCH_SHA: ${{ github.event.workflow_run.head_sha }}",
+            1,
+        )
+        self.assertIn(
+            selection_message,
+            MODULE.continuous_release_workflow_issues(raw_event),
+        )
         unreconciled_candidate = workflow.replace(
             'gh_api_optional_scalar orphan_id "/repos/${repo}/releases/tags/${candidate_tag}" .id',
             'gh_api_optional_scalar orphan_id "/repos/${repo}/releases/${candidate_id}" .id',
@@ -934,6 +977,98 @@ jobs:
             "continuous rollback must reconcile a candidate created without an emitted id",
             MODULE.continuous_release_workflow_issues(unguarded_draft_deletion),
         )
+
+    def test_ci_dispatches_continuous_only_after_successful_master_gate(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        needs = MODULE.workflow_job_needs(workflow)
+        self.assertEqual(needs.get("DispatchContinuous"), {"ci-gate"})
+        dispatch = MODULE.workflow_job_blocks(workflow)["DispatchContinuous"]
+        condition = MODULE.workflow_job_direct_value(dispatch, "if")
+        for marker in (
+            "success()",
+            "needs.ci-gate.result == 'success'",
+            "github.event_name == 'push'",
+            "github.ref == 'refs/heads/master'",
+            "github.event.repository.full_name == github.repository",
+        ):
+            self.assertIn(marker, condition)
+        dispatch_text = "\n".join(dispatch)
+        self.assertIn("actions: write", dispatch_text)
+        self.assertIn("ci-continuous.yml", dispatch_text)
+        self.assertIn("github.run_id", dispatch_text)
+        self.assertIn("github.sha", dispatch_text)
+        self.assertNotIn("softprops/action-gh-release", dispatch_text)
+        self.assertEqual(MODULE.ci_build_workflow_issues(workflow), [])
+        post_gate_message = "CI post-gate job DispatchContinuous must directly need only ci-gate"
+        wrong_need = workflow.replace(
+            "  DispatchContinuous:\n    needs: [ci-gate]",
+            "  DispatchContinuous:\n    needs: [LinuxPackages]",
+            1,
+        )
+        self.assertIn(post_gate_message, MODULE.ci_build_workflow_issues(wrong_need))
+        dispatch_message = (
+            "CI Continuous dispatch must be an exact successful trusted master post-gate job"
+        )
+        weakened = workflow.replace(
+            "        && github.event_name == 'push'",
+            "        && github.event_name != 'pull_request'",
+            1,
+        )
+        self.assertIn(dispatch_message, MODULE.ci_build_workflow_issues(weakened))
+        wrong_token = workflow.replace(
+            "          GH_TOKEN: ${{ github.token }}\n"
+            "          KLOGG_CI_RUN_ID: ${{ github.run_id }}",
+            "          GH_TOKEN: ${{ secrets.KLOGG_GITHUB_TOKEN }}\n"
+            "          KLOGG_CI_RUN_ID: ${{ github.run_id }}",
+            1,
+        )
+        self.assertIn(dispatch_message, MODULE.ci_build_workflow_issues(wrong_token))
+        missing_sha = workflow.replace(
+            '            -f ci-run-sha="$KLOGG_CI_RUN_SHA"',
+            '            # -f ci-run-sha="$KLOGG_CI_RUN_SHA"',
+            1,
+        )
+        self.assertIn(dispatch_message, MODULE.ci_build_workflow_issues(missing_sha))
+
+    def test_release_workflow_triggers_form_explicit_promotion_chain(self):
+        continuous = (
+            ROOT / ".github" / "workflows" / "ci-continuous.yml"
+        ).read_text()
+        stable = (ROOT / ".github" / "workflows" / "ci-release.yml").read_text()
+        self.assertIn("workflow_dispatch:", continuous)
+        self.assertNotIn("workflow_run:", continuous)
+        self.assertIn("ci-run-id:", continuous)
+        self.assertIn("ci-run-sha:", continuous)
+        self.assertNotIn("github.event.workflow_run", continuous)
+        self.assertIn("workflow_dispatch:", stable)
+        self.assertNotIn("ci-run-id:", stable)
+        self.assertNotIn("evidence-level:", stable)
+
+    def test_stable_selects_live_continuous_release_not_ci_artifacts(self):
+        continuous = (
+            ROOT / ".github" / "workflows" / "ci-continuous.yml"
+        ).read_text()
+        stable = (ROOT / ".github" / "workflows" / "ci-release.yml").read_text()
+        self.assertIn("/releases/tags/continuous", stable)
+        self.assertIn("/releases/assets/${asset_id}", stable)
+        self.assertNotIn("actions/workflows/ci-build.yml/runs", stable)
+        self.assertNotIn("action-download-artifact", stable)
+        self.assertNotIn("KLOGG_REQUESTED_CI_RUN_ID", stable)
+        self.assertNotIn("KLOGG_EVIDENCE_LEVEL", stable)
+        self.assertNotIn("sentry-cli", stable)
+        continuous_concurrency = MODULE.workflow_mapping_block(
+            continuous.splitlines(), "concurrency", 0
+        )
+        stable_concurrency = MODULE.workflow_mapping_block(
+            stable.splitlines(), "concurrency", 0
+        )
+        self.assertIsNotNone(continuous_concurrency)
+        self.assertIsNotNone(stable_concurrency)
+        self.assertEqual(
+            continuous_concurrency["group"][0], stable_concurrency["group"][0]
+        )
+        self.assertEqual(continuous_concurrency["queue"][0], "max")
+        self.assertEqual(stable_concurrency["queue"][0], "max")
 
     def test_publication_runs_outside_the_required_ci_workflow(self):
         message = "release publication must run outside the required CI workflow"
@@ -2266,6 +2401,11 @@ ${{ env.CHANGELOG }}
             "ci-release.yml" if channel == "stable" else "ci-continuous.yml"
         )
         workflow = path.read_text()
+        if "render_release_downloads.py" in workflow and (
+            channel == "stable"
+            or "Publish verified continuous release transaction" in workflow
+        ):
+            return workflow
         create_marker = (
             "    - name: Create GitHub Release"
             if channel == "stable"
@@ -2427,7 +2567,7 @@ jobs:
             "stable release workflow must support only workflow_dispatch publication"
         )
         continuous_message = (
-            "continuous release workflow must use only completed CI Build workflow_run events"
+            "continuous release workflow must use only reviewed CI dispatch receipts"
         )
         stable = self.projected_workflow("stable")
         continuous = self.projected_workflow("continuous")
@@ -2438,59 +2578,53 @@ jobs:
             "  workflow_dispatch:\n", "  push:\n    branches: [master]\n", 1
         )
         self.assertIn(stable_message, self.issues("stable", direct_stable_push))
-        stable_spoof = direct_stable_push.replace(
-            "jobs:\n",
-            "# workflow_dispatch:\n"
-            "env:\n"
-            "  TRIGGER_DESCRIPTION: 'workflow_dispatch publication'\n"
-            "jobs:\n",
+        stable_with_input = stable.replace(
+            "  workflow_dispatch:\n",
+            "  workflow_dispatch:\n    inputs:\n      ci-run-id:\n        required: false\n        type: string\n",
             1,
         )
-        self.assertIn(stable_message, self.issues("stable", stable_spoof))
+        self.assertIn(stable_message, self.issues("stable", stable_with_input))
 
         direct_continuous_push = continuous.replace(
-            '  workflow_run:\n    workflows: ["CI Build"]\n    types: [completed]\n',
-            "  push:\n    branches: [master]\n",
-            1,
+            "  workflow_dispatch:\n", "  push:\n    branches: [master]\n", 1
         )
         self.assertIn(
             continuous_message,
             self.issues("continuous", direct_continuous_push),
         )
-        malformed_workflow_run = continuous.replace(
-            "    types: [completed]", "    types: [completed", 1
-        )
-        self.assertIn(
-            continuous_message,
-            self.issues("continuous", malformed_workflow_run),
-        )
+        optional_input = continuous.replace("        required: true", "        required: false", 1)
+        self.assertIn(continuous_message, self.issues("continuous", optional_input))
+        malformed_input = continuous.replace("        type: string", "        type: [string", 1)
+        self.assertIn(continuous_message, self.issues("continuous", malformed_input))
 
-    def test_stable_selected_ci_run_projects_only_push_validation_and_dispatch_receipts(self):
+    def test_stable_projects_only_the_live_continuous_release(self):
         message = (
-            "stable release selection must model push validation and workflow_dispatch receipt evidence"
+            "stable release must promote only the immutable live Continuous publication"
         )
         workflow = self.projected_workflow("stable")
         self.assertNotIn(message, self.issues("stable", workflow))
 
-        near_miss = workflow.replace("          workflow_dispatch)", "          pull_request)", 1)
-        self.assertNotEqual(near_miss, workflow)
-        self.assertIn(message, self.issues("stable", near_miss))
-        spoofed = near_miss.replace(
-            "          pull_request)",
-            "          # workflow_dispatch)\n"
-            "          SPOOF='workflow_dispatch)'\n"
-            "          pull_request)",
+        not_prerelease = workflow.replace(
+            '          test "$release_prerelease" = true || {',
+            '          test "$release_prerelease" = false || {',
+            1,
+        )
+        self.assertNotEqual(not_prerelease, workflow)
+        self.assertIn(message, self.issues("stable", not_prerelease))
+        ci_fallback = workflow.replace(
+            '          release_api="/repos/${repo}/releases/tags/continuous"',
+            '          release_api="/repos/${repo}/actions/workflows/ci-build.yml/runs"',
+            1,
+        )
+        self.assertIn(message, self.issues("stable", ci_fallback))
+        spoofed = ci_fallback.replace(
+            '          release_api="/repos/${repo}/actions/workflows/ci-build.yml/runs"',
+            "          # /releases/tags/continuous\n"
+            "          SPOOF='/releases/tags/continuous'\n"
+            '          release_api="/repos/${repo}/actions/workflows/ci-build.yml/runs"',
             1,
         )
         self.assertIn(message, self.issues("stable", spoofed))
-
-        weakened_push = workflow.replace(
-            '            test "$KLOGG_EVIDENCE_LEVEL" = validation || {',
-            '            test "$KLOGG_EVIDENCE_LEVEL" != invalid || {',
-            1,
-        )
-        self.assertNotEqual(weakened_push, workflow)
-        self.assertIn(message, self.issues("stable", weakened_push))
 
     def test_body_path_near_miss_is_rejected(self):
         for channel in ("stable", "continuous"):

--- a/tests/scripts/test_lint_platform_fragile.py
+++ b/tests/scripts/test_lint_platform_fragile.py
@@ -898,5 +898,139 @@ class QtVersionMacroInTestsTest(unittest.TestCase):
         self.assertEqual(self.check(text), [])
 
 
+class NativePresentationAssertionTest(unittest.TestCase):
+    """PR #69: native paths and copied CRLF text are not internal Qt values."""
+
+    def check(self, text, name="tests/ui/example_test.cpp"):
+        # Exercise the registered lint entry point even before the rule exists:
+        # RED must mean a bad assertion escaped, not a missing function error.
+        return [
+            finding
+            for rule in lint.MULTI_LINE_CHECKS
+            if rule["name"] == "native-presentation-test-assertion"
+            for finding in rule["check"](text, Path(name))
+        ]
+
+    def test_exact_windows_failures_are_flagged(self):
+        cases = [
+            "CHECK( tabs->tabToolTip( 0 ) == savedPath );",
+            r'CHECK( Access::mainText( crawler ) == QStringLiteral( "old-001\nnew-002" ) );',
+            r'REQUIRE( view->getSelectedText() == QStringLiteral( "first\nsecond" ) );',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                findings = self.check(text)
+                self.assertEqual(len(findings), 1)
+                self.assertEqual(findings[0][0], 1)
+
+    def test_plain_path_identifier_is_not_a_loophole(self):
+        for name in ("path", "Path", "saved_path"):
+            with self.subTest(name=name):
+                self.assertEqual(
+                    len(self.check(f"CHECK( tabs->tabToolTip( 0 ) == {name} );")), 1
+                )
+
+    def test_truncated_native_assertion_without_semicolon_fails_closed(self):
+        cases = [
+            "CHECK( tabs->tabToolTip( 0 ) == savedPath",
+            r'CHECK( Access::mainText( crawler ) == QStringLiteral( "first\nsecond" )',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                findings = self.check(text)
+                self.assertEqual(len(findings), 1)
+                self.assertIn("malformed", findings[0][1].lower())
+
+    def test_multiline_reversed_and_parenthesized_comparisons(self):
+        cases = [
+            "\nCHECK(\n    (savedPath) == tabs.tabToolTip( currentIndex() )\n);",
+            'CHECK( QStringLiteral( "C:/logs/device.log" ) == tabs->tabToolTip( 0 ) );',
+            'CHECK( tabs->tabToolTip( 0 ) == QStringLiteral( "/tmp/device.log" ) );',
+            r'REQUIRE( QStringLiteral( "first\nsecond" ) == view->getSelectedText() );',
+            r'CHECK( (Access::mainText( crawler ) == QStringLiteral( "first\nsecond" )) );',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual(len(self.check(text)), 1)
+
+    def test_native_or_normalized_operands_are_accepted(self):
+        cases = [
+            "CHECK( tabs->tabToolTip( 0 ) == QDir::toNativeSeparators( savedPath ) );",
+            "CHECK( QDir::toNativeSeparators( savedPath ) == tabs->tabToolTip( 0 ) );",
+            "CHECK( QDir::fromNativeSeparators( tabs->tabToolTip( 0 ) ) == savedPath );",
+            r'CHECK( view->getSelectedText().replace( "\r\n", "\n" ) == QStringLiteral( "first\nsecond" ) );',
+            r'CHECK( QStringLiteral( "first\nsecond" ) == Access::mainText( crawler ).replace( "\r\n", "\n" ) );',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual(self.check(text), [])
+
+    def test_near_misses_and_other_output_contracts_are_accepted(self):
+        cases = [
+            "CHECK( tabs->tabToolTip( 0 ) == sentinel );",
+            'CHECK( tabs->tabToolTip( 0 ) == QStringLiteral( "Updated tooltip" ) );',
+            'REQUIRE( view->getSelectedText() == QStringLiteral( "ERROR alpha" ) );',
+            r'CHECK( file.readAll() == QByteArrayLiteral( "first\nsecond" ) );',
+            r'CHECK( view->getSelectedText() == QStringLiteral( "literal\\ntext" ) );',
+            r'CHECK( snapshot.text() == QStringLiteral( "first\nsecond" ) );',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                self.assertEqual(self.check(text), [])
+
+    def test_comments_and_string_spoofs_are_not_code(self):
+        bad = "CHECK( tabs->tabToolTip( 0 ) == savedPath );"
+        text = (
+            "// " + bad + "\n/* " + bad + " */\n"
+            'const auto quoted = "' + bad + '";\n'
+            'const auto raw = R"example(' + bad + ')example";\n'
+        )
+        self.assertEqual(self.check(text), [])
+        # Mentioning a normalization function in a comment/string cannot waive
+        # an actually unnormalized comparison.
+        text += 'const auto hint = "QDir::toNativeSeparators(savedPath)";\n'
+        text += bad + " // QDir::toNativeSeparators(savedPath)\n"
+        self.assertEqual(len(self.check(text)), 1)
+
+    def test_malformed_native_assertions_fail_closed(self):
+        cases = [
+            "CHECK( tabs->tabToolTip( 0 ) == savedPath;",
+            r'CHECK( Access::mainText( crawler ) == QStringLiteral( "first\nsecond" );',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                findings = self.check(text)
+                self.assertEqual(len(findings), 1)
+                self.assertIn("malformed", findings[0][1].lower())
+        self.assertEqual(self.check("CHECK( unrelated("), [])
+
+    def test_rule_is_test_only_and_allow_marker_is_local(self):
+        bad = "CHECK( tabs->tabToolTip( 0 ) == savedPath );"
+        self.assertEqual(self.check(bad, name="src/ui/src/example.cpp"), [])
+        self.assertEqual(self.check(bad + " // lint-allow: platform-fragile"), [])
+        text = bad + " // lint-allow: platform-fragile\n" + bad
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 2)
+        self.assertEqual(
+            len(self.check('const auto hint = "lint-allow: platform-fragile"; ' + bad)),
+            1,
+        )
+
+    def test_real_tree_mutations_restore_the_escaped_assertions(self):
+        path = REPO_ROOT / "tests" / "ui" / "mainwindow_test.cpp"
+        text = path.read_text(encoding="utf-8")
+        self.assertEqual(self.check(text, name=str(path)), [])
+        mutations = [
+            ("QDir::toNativeSeparators( savedPath )", "savedPath"),
+            (r'.replace( QStringLiteral( "\r\n" ), QStringLiteral( "\n" ) )', ""),
+        ]
+        for before, after in mutations:
+            with self.subTest(before=before):
+                mutated = text.replace(before, after)
+                self.assertNotEqual(mutated, text)
+                self.assertGreaterEqual(len(self.check(mutated, name=str(path))), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scripts/test_promote_release_publication.py
+++ b/tests/scripts/test_promote_release_publication.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).parents[2]
+PROMOTE_SCRIPT = ROOT / "scripts" / "promote_release_publication.py"
+VERIFY_SCRIPT = ROOT / "scripts" / "verify_source_publication_manifest.py"
+FIXTURE_TEST = ROOT / "tests" / "scripts" / "test_external_source_asset_package_contract.py"
+MANIFEST_NAME = "klogg-source-publication-manifest.json"
+CHECKSUMS_NAME = "SHA256SUMS"
+
+
+def load_fixture_module():
+    spec = importlib.util.spec_from_file_location("publication_fixture", FIXTURE_TEST)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("unable to load publication fixture helpers")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+FIXTURES = load_fixture_module()
+
+
+def sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PromoteReleasePublicationTest(unittest.TestCase):
+    SOURCE_RELEASE_ID = 987654321
+
+    def setUp(self):
+        self.fixture = FIXTURES.ConsolidatedReleasePublicationContractTest(
+            methodName="runTest"
+        )
+        self.fixture.setUp()
+        self.base = self.fixture.root
+        self.source = self.base / "continuous"
+        self.source.mkdir()
+        self.fixture.root = self.source
+        self.source_manifest, self.source_document = self.fixture.make_publication(
+            channel="continuous", evidence_level="validation"
+        )
+        self.output = self.base / "stable"
+        self.metadata_path = self.base / "source-release-metadata.json"
+        self.metadata = self.make_metadata()
+        self.write_metadata()
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
+    def make_metadata(self) -> dict:
+        records = []
+        for offset, path in enumerate(sorted(self.source.iterdir()), start=1):
+            records.append(
+                {
+                    "id": 100000 + offset,
+                    "name": path.name,
+                    "sha256": sha256(path),
+                }
+            )
+        return {
+            "schema_version": 1,
+            "metadata_kind": "klogg-continuous-publication-source",
+            "source_release_id": self.SOURCE_RELEASE_ID,
+            "source_tag_sha": self.source_document["release"]["commit"],
+            "source_assets": records,
+        }
+
+    def write_metadata(self) -> None:
+        self.metadata_path.write_text(
+            json.dumps(self.metadata, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def run_promoter(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(PROMOTE_SCRIPT),
+                "--source-manifest",
+                str(self.source_manifest),
+                "--source-assets-root",
+                str(self.source),
+                "--source-metadata",
+                str(self.metadata_path),
+                "--output",
+                str(self.output),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    def run_verifier(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(VERIFY_SCRIPT),
+                "--manifest",
+                str(self.output / MANIFEST_NAME),
+                "--assets-root",
+                str(self.output),
+                "--expected-channel",
+                "stable",
+                "--expected-evidence-level",
+                "validation",
+                "--expected-tag",
+                f"v{self.fixture.VERSION}",
+                "--expected-version",
+                self.fixture.VERSION,
+                "--expected-commit",
+                self.fixture.COMMIT,
+                "--expected-base-url",
+                self.fixture.BASE_URL,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
+    def refresh_output_checksums(self) -> None:
+        names = sorted(
+            path.name
+            for path in self.output.iterdir()
+            if path.is_file() and path.name != CHECKSUMS_NAME
+        )
+        (self.output / CHECKSUMS_NAME).write_text(
+            "".join(f"{sha256(self.output / name)} *{name}\n" for name in names),
+            encoding="utf-8",
+        )
+
+    def rewrite_output_manifest(self, document: dict) -> None:
+        (self.output / MANIFEST_NAME).write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        self.refresh_output_checksums()
+
+    def promote_successfully(self) -> dict:
+        result = self.run_promoter()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return json.loads((self.output / MANIFEST_NAME).read_text(encoding="utf-8"))
+
+    def test_promotes_verified_continuous_publication_without_mutating_payloads(self):
+        source_bytes = {
+            path.name: path.read_bytes()
+            for path in self.source.iterdir()
+            if path.name not in {MANIFEST_NAME, CHECKSUMS_NAME}
+        }
+        source_manifest_hash = sha256(self.source_manifest)
+
+        document = self.promote_successfully()
+
+        self.assertEqual(len(list(self.output.iterdir())), 23)
+        self.assertEqual(document["schema_version"], 3)
+        self.assertEqual(document["channel"], "stable")
+        self.assertEqual(document["evidence_level"], "validation")
+        self.assertEqual(
+            document["release"],
+            {
+                "tag": f"v{self.fixture.VERSION}",
+                "version": self.fixture.VERSION,
+                "commit": self.fixture.COMMIT,
+                "mutable": False,
+                "public_name": f"Release v{self.fixture.VERSION}",
+                "page_url": f"{self.fixture.BASE_URL}/releases/tag/v{self.fixture.VERSION}",
+                "direct_asset_urls_are_archival": True,
+            },
+        )
+        for component in document["components"].values():
+            archive = component["source_archive"]
+            self.assertEqual(
+                archive["url"],
+                f"{self.fixture.BASE_URL}/releases/download/v{self.fixture.VERSION}/{archive['file_name']}",
+            )
+        promotion = document["promotion"]
+        self.assertEqual(
+            set(promotion),
+            {
+                "source_release_id",
+                "source_tag_sha",
+                "source_manifest_sha256",
+                "source_commit",
+                "source_assets",
+            },
+        )
+        self.assertEqual(promotion["source_release_id"], self.SOURCE_RELEASE_ID)
+        self.assertEqual(promotion["source_tag_sha"], self.fixture.COMMIT)
+        self.assertEqual(promotion["source_manifest_sha256"], source_manifest_hash)
+        self.assertEqual(promotion["source_commit"], self.fixture.COMMIT)
+        self.assertEqual(
+            promotion["source_assets"],
+            sorted(self.metadata["source_assets"], key=lambda item: item["name"]),
+        )
+        for name, content in source_bytes.items():
+            self.assertEqual((self.output / name).read_bytes(), content, name)
+        self.assertEqual(
+            self.source_manifest.read_bytes(),
+            json.dumps(self.source_document, indent=2, sort_keys=True).encode("utf-8")
+            + b"\n",
+        )
+        verified = self.run_verifier()
+        self.assertEqual(verified.returncode, 0, verified.stdout + verified.stderr)
+
+    def test_rejects_malformed_duplicate_missing_and_extra_source_metadata(self):
+        mutations = {
+            "missing field": lambda value: value.pop("source_release_id"),
+            "extra field": lambda value: value.__setitem__("unexpected", True),
+            "boolean release id": lambda value: value.__setitem__(
+                "source_release_id", True
+            ),
+            "duplicate asset id": lambda value: value["source_assets"][1].__setitem__(
+                "id", value["source_assets"][0]["id"]
+            ),
+            "duplicate asset name": lambda value: value["source_assets"][1].__setitem__(
+                "name", value["source_assets"][0]["name"]
+            ),
+            "missing asset": lambda value: value["source_assets"].pop(),
+            "extra asset": lambda value: value["source_assets"].append(
+                {"id": 999999, "name": "extra.bin", "sha256": "0" * 64}
+            ),
+            "extra asset field": lambda value: value["source_assets"][0].__setitem__(
+                "size", 1
+            ),
+        }
+        original = json.loads(json.dumps(self.metadata))
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                self.metadata = json.loads(json.dumps(original))
+                mutate(self.metadata)
+                self.write_metadata()
+                result = self.run_promoter()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(self.output.exists())
+
+    def test_rejects_malformed_json_unsafe_names_and_non_asset_entries(self):
+        self.metadata_path.write_text("{", encoding="utf-8")
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+
+        self.metadata = self.make_metadata()
+        self.metadata["source_assets"][0]["name"] = "../escape"
+        self.write_metadata()
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+
+        self.metadata = self.make_metadata()
+        self.write_metadata()
+        (self.source / "unexpected-directory").mkdir()
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_rejects_wrong_source_identity_and_source_asset_hash_mismatch(self):
+        for label, mutate in (
+            (
+                "wrong tag sha",
+                lambda value: value.__setitem__("source_tag_sha", "b" * 40),
+            ),
+            (
+                "wrong manifest digest",
+                lambda value: next(
+                    item
+                    for item in value["source_assets"]
+                    if item["name"] == MANIFEST_NAME
+                ).__setitem__("sha256", "b" * 64),
+            ),
+            (
+                "wrong payload digest",
+                lambda value: next(
+                    item
+                    for item in value["source_assets"]
+                    if item["name"].endswith(".deb")
+                ).__setitem__("sha256", "b" * 64),
+            ),
+        ):
+            with self.subTest(label=label):
+                self.metadata = self.make_metadata()
+                mutate(self.metadata)
+                self.write_metadata()
+                result = self.run_promoter()
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(self.output.exists())
+
+    def test_rejects_mutated_source_payload_and_symlink(self):
+        payload = next(path for path in self.source.iterdir() if path.name.endswith(".deb"))
+        payload.write_bytes(payload.read_bytes() + b"mutation")
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+
+        self.fixture.tempdir.cleanup()
+        self.fixture.setUp()
+        self.base = self.fixture.root
+        self.source = self.base / "continuous"
+        self.source.mkdir()
+        self.fixture.root = self.source
+        self.source_manifest, self.source_document = self.fixture.make_publication(
+            channel="continuous", evidence_level="validation"
+        )
+        self.output = self.base / "stable"
+        self.metadata_path = self.base / "source-release-metadata.json"
+        self.metadata = self.make_metadata()
+        self.write_metadata()
+        payload = next(path for path in self.source.iterdir() if path.name.endswith(".deb"))
+        content = payload.read_bytes()
+        target = self.base / "payload-target"
+        target.write_bytes(content)
+        payload.unlink()
+        try:
+            os.symlink(target, payload)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks are unavailable")
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertFalse(self.output.exists())
+
+    def test_rejects_existing_output_without_modifying_it(self):
+        self.output.mkdir()
+        sentinel = self.output / "sentinel"
+        sentinel.write_bytes(b"preserve me")
+        result = self.run_promoter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(sentinel.read_bytes(), b"preserve me")
+
+    def test_v3_verifier_rejects_invalid_promotion_lineage(self):
+        original = self.promote_successfully()
+        mutations = {
+            "extra promotion field": lambda value: value["promotion"].__setitem__(
+                "unexpected", True
+            ),
+            "boolean source release id": lambda value: value["promotion"].__setitem__(
+                "source_release_id", True
+            ),
+            "extra source asset field": lambda value: value["promotion"][
+                "source_assets"
+            ][0].__setitem__("unexpected", True),
+            "duplicate source asset name": lambda value: value["promotion"][
+                "source_assets"
+            ][1].__setitem__(
+                "name", value["promotion"]["source_assets"][0]["name"]
+            ),
+            "wrong source commit": lambda value: value["promotion"].__setitem__(
+                "source_commit", "b" * 40
+            ),
+            "wrong tag sha": lambda value: value["promotion"].__setitem__(
+                "source_tag_sha", "b" * 40
+            ),
+            "wrong source manifest hash": lambda value: value["promotion"].__setitem__(
+                "source_manifest_sha256", "b" * 64
+            ),
+            "unsorted source assets": lambda value: value["promotion"][
+                "source_assets"
+            ].reverse(),
+            "missing source asset": lambda value: value["promotion"][
+                "source_assets"
+            ].pop(),
+            "duplicate source asset id": lambda value: value["promotion"][
+                "source_assets"
+            ][1].__setitem__(
+                "id", value["promotion"]["source_assets"][0]["id"]
+            ),
+            "payload lineage mismatch": lambda value: next(
+                item
+                for item in value["promotion"]["source_assets"]
+                if item["name"].endswith(".deb")
+            ).__setitem__("sha256", "b" * 64),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                document = json.loads(json.dumps(original))
+                mutate(document)
+                self.rewrite_output_manifest(document)
+                result = self.run_verifier()
+                self.assertNotEqual(result.returncode, 0, label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1447,7 +1447,10 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
             CHECK( completed.count() == 1 );
             CHECK( crawler->isFollowEnabled() );
             CHECK( follow->isChecked() );
-            CHECK( Access::mainText( crawler ) == QStringLiteral( "old-001\nnew-002" ) );
+            INFO( "Copied main-view text: " << Access::mainText( crawler ).toStdString() );
+            CHECK( Access::mainText( crawler )
+                       .replace( QStringLiteral( "\r\n" ), QStringLiteral( "\n" ) )
+                   == QStringLiteral( "old-001\nnew-002" ) );
             QTest::qWait( 200 ); // Retire the actual search/load completion before teardown.
             menu->removeEventFilter( &changes );
             controller->stopRequested();
@@ -1518,7 +1521,8 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
             REQUIRE( source->sessionData().boundOutputFile == savedPath );
             CHECK( appSession->getAssociatedPath( crawler ) == savedPath );
             CHECK( info->text() == QDir::toNativeSeparators( savedPath ) );
-            CHECK( tabs->tabToolTip( 0 ) == savedPath );
+            INFO( "Saved tab tooltip: " << tabs->tabToolTip( 0 ).toStdString() );
+            CHECK( tabs->tabToolTip( 0 ) == QDir::toNativeSeparators( savedPath ) );
             REQUIRE( changes.added > 0 );
             REQUIRE( changes.removed > 0 );
             const auto savedEntries = menu->actions();

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1176,6 +1176,38 @@ SCENARIO( "Closing one of several windows deletes its discarded live capture",
 }
 
 namespace {
+void exerciseLiveSaveDialog( QAction& action, const QString& expectedSuggestion,
+                             const QString& chosenPath = {} )
+{
+    REQUIRE( action.isEnabled() );
+    const auto nativeDialogsDisabled = QCoreApplication::testAttribute( Qt::AA_DontUseNativeDialogs );
+    QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, true );
+    QStringList suggestions;
+    bool closed = false;
+    QObject dialogDriver;
+    QTimer::singleShot( 0, Qt::PreciseTimer, &dialogDriver, [ & ] {
+        if ( auto* dialog = qobject_cast<QFileDialog*>( QApplication::activeModalWidget() ) ) {
+            suggestions = dialog->selectedFiles();
+            if ( chosenPath.isEmpty() ) {
+                dialog->reject();
+                closed = true;
+            }
+            else {
+                dialog->selectFile( chosenPath );
+                closed = QMetaObject::invokeMethod( dialog, "accept", Qt::DirectConnection );
+            }
+        }
+        else if ( auto* modal = qobject_cast<QDialog*>( QApplication::activeModalWidget() ) ) {
+            modal->reject();
+        }
+    } );
+    action.trigger();
+    QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, nativeDialogsDisabled );
+    REQUIRE( closed );
+    REQUIRE( suggestions.size() == 1 );
+    CHECK( suggestions.front().toStdString() == expectedSuggestion.toStdString() );
+}
+
 void exerciseLiveCountdownRouting( MainWindow& window, Session& session,
                                    TabbedCrawlerWidget& tabs, CrawlerWidget* crawler,
                                    QMenu& menu, MenuActionChanges& changes )
@@ -1294,6 +1326,10 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
             QString{},
             useIos ? LiveLogSourceType::IosLogStream : LiveLogSourceType::AdbLogcat,
         };
+        if ( preservationScenario == 4 ) {
+            data.deviceDescription = useIos ? QStringLiteral( "iPhone 15 Pro (USB)" )
+                                            : QStringLiteral( "Pixel 8 (ABC123)" );
+        }
         data.autoReconnectEnabled = true;
         data.adbBackend = AdbTransportBackend::SmartSocket;
         files.emplace_back( data.documentId(), 0, QString{}, data.persistedSourceType(),
@@ -1464,21 +1500,21 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
         CHECK_FALSE( tabs->tabToolTip( 0 ).contains( QStringLiteral( "Output error:" ) ) );
 
         if ( preservationScenario == 4 ) {
-            const auto savedPath = documents.filePath( "bound-live.log" );
-            const auto nativeDialogsDisabled = QCoreApplication::testAttribute( Qt::AA_DontUseNativeDialogs );
-            QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, true );
-            bool accepted = false;
-            QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
-                if ( auto* dialog = qobject_cast<QFileDialog*>( QApplication::activeModalWidget() ) ) {
-                    dialog->selectFile( savedPath );
-                    accepted = QMetaObject::invokeMethod( dialog, "accept", Qt::DirectConnection );
-                }
-            } );
+            const auto savedPath = documents.filePath( "chosen log (keep).log" );
+            const auto expectedSuggestion = QDir::home().filePath(
+                useIos ? QStringLiteral( "iPhone-15-Pro-USB.log" )
+                       : QStringLiteral( "Pixel-8-ABC123.log" ) );
+            const auto displayName = appSession->getDisplayName( crawler );
             auto* save = mainWindow->findChild<QAction*>( QStringLiteral( "saveCurrentLiveLogPreserveAnsiAction" ) );
+            auto* saveStripped = mainWindow->findChild<QAction*>( QStringLiteral( "saveCurrentLiveLogStripAnsiAction" ) );
             REQUIRE( save != nullptr );
-            save->trigger();
-            QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, nativeDialogsDisabled );
-            REQUIRE( accepted );
+            REQUIRE( saveStripped != nullptr );
+            exerciseLiveSaveDialog( *saveStripped, expectedSuggestion );
+            exerciseLiveSaveDialog( *save, expectedSuggestion );
+            CHECK( source->sessionData().boundOutputFile.isEmpty() );
+            CHECK_FALSE( QFile::exists( savedPath ) );
+            CHECK( appSession->getDisplayName( crawler ) == displayName );
+            exerciseLiveSaveDialog( *save, expectedSuggestion, savedPath );
             REQUIRE( source->sessionData().boundOutputFile == savedPath );
             CHECK( appSession->getAssociatedPath( crawler ) == savedPath );
             CHECK( info->text() == QDir::toNativeSeparators( savedPath ) );
@@ -1489,6 +1525,9 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
             CHECK( std::any_of( savedEntries.begin(), savedEntries.end(), [ & ]( const auto* action ) {
                 return action->toolTip() == savedPath;
             } ) );
+            exerciseLiveSaveDialog( *saveStripped, savedPath );
+            exerciseLiveSaveDialog( *save, savedPath );
+            CHECK( source->sessionData().boundOutputFile == savedPath );
             transport->publishBytes( QByteArrayLiteral( "saved tail\n" ) );
             source->disconnectSource();
             QFile saved{ savedPath };
@@ -1585,9 +1624,16 @@ TEST_CASE( "Live control routes preserve current file folder live and saved meta
            "[ui][session][live-presentation-preservation]" )
 {
     const auto useIos = GENERATE( false, true );
-    // Current live, other live, file, folder, Save Live binding, rolling search/follow.
-    const auto scenario = GENERATE( 0, 1, 2, 3, 4, 5 );
+    // Current live, other live, file, folder, rolling search/follow.
+    const auto scenario = GENERATE( 0, 1, 2, 3, 5 );
     exerciseLivePresentation( useIos, scenario >= 1 && scenario <= 3, scenario );
+}
+
+TEST_CASE( "Live save suggests clean filenames and preserves chosen paths",
+           "[ui][session][live-save-filename]" )
+{
+    const auto useIos = GENERATE( false, true );
+    exerciseLivePresentation( useIos, false, 4 );
 }
 
 SCENARIO( "MainWindow restored iOS live log tabs show disconnected state", "[ui][session][ios]" )

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -19,7 +19,12 @@
 
 #include <catch2/catch.hpp>
 
+#include <cstdio>
+#include <ctime>
+
 #include <QAction>
+#include <QElapsedTimer>
+#include <QPointer>
 #include <QApplication>
 #include <QComboBox>
 #include <QCoreApplication>
@@ -28,6 +33,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFileDialog>
 
 #include <QClipboard>
 #include <QLineEdit>
@@ -41,6 +47,7 @@
 #include <QTableWidget>
 #include <QTemporaryDir>
 #include <QTest>
+#include <QTimerEvent>
 #include <QToolButton>
 #include <QUuid>
 #include <QVariant>
@@ -58,15 +65,136 @@
 #include "folderfilteredview.h"
 #include "livelogcontroller.h"
 #include "livelogsession.h"
+#include "livesourcetransport.h"
 #include "log.h"
+#include "logfiltereddata.h"
+#include "logmainview.h"
+#include "searchtoolbar.h"
+#include "streaminglogdata.h"
 #include "mainwindow.h"
 #include "persistentinfo.h"
+#include "pathline.h"
 #include "predefinedfilters.h"
 #include "predefinedfilterscombobox.h"
 #include "session.h"
 #include "sessioninfo.h"
 #include "tabgroup.h"
 #include "uimessage.h"
+
+struct StreamingLogDataTimerTestAccess {
+    static bool pending( const StreamingLogData& data )
+    {
+        return data.loadingFinishedQueued_ && data.loadingFinishedTimer_.isActive();
+    }
+
+    static void deliver( StreamingLogData& data )
+    {
+        REQUIRE( pending( data ) );
+        const auto timerId = data.loadingFinishedTimer_.timerId();
+        REQUIRE( timerId >= 0 );
+        QTimerEvent event{ timerId };
+        QCoreApplication::sendEvent( &data.loadingFinishedTimer_, &event );
+        REQUIRE_FALSE( data.loadingFinishedTimer_.isActive() );
+        REQUIRE_FALSE( data.loadingFinishedQueued_ );
+    }
+};
+
+namespace klogg::livelog {
+
+// Keep the production-owned runtime and MainWindow callback intact. Substitute
+// time before any retry is registered, so no real retry timer can race the UI
+// assertions or tab switch. All scheduled callbacks remain owned by this scope.
+struct LiveLogControllerTimeTestAccess {
+    class ManualClock final : public LiveLogClock {
+    public:
+        livecapture::Timestamp now() const noexcept override { return value; }
+        livecapture::Timestamp value{ 0 };
+    } clock;
+
+    class ManualScheduler final : public LiveLogScheduler {
+    public:
+        Token schedule( livecapture::Timestamp deadline, std::function<void()> callback ) override
+        {
+            REQUIRE_FALSE( callback_ );
+            deadline_ = deadline;
+            callback_ = std::move( callback );
+            return ++token_;
+        }
+
+        void cancel( Token token ) override
+        {
+            CHECK( token == token_ );
+            callback_ = {};
+        }
+
+        void fire( ManualClock& manualClock )
+        {
+            REQUIRE( callback_ );
+            manualClock.value = deadline_;
+            auto callback = std::move( callback_ );
+            callback_ = {};
+            callback();
+        }
+
+        bool pending() const { return static_cast<bool>( callback_ ); }
+        livecapture::Timestamp deadline() const { return deadline_; }
+
+    private:
+        Token token_{ 0 };
+        livecapture::Timestamp deadline_{ 0 };
+        std::function<void()> callback_;
+    } scheduler;
+
+    explicit LiveLogControllerTimeTestAccess( LiveLogController& controller )
+        : controller_{ controller }
+        , previousClock_{ controller.clock_ }
+        , previousScheduler_{ controller.scheduler_ }
+    {
+        REQUIRE_FALSE( controller.retryToken_.has_value() );
+        clock.value = previousClock_->now();
+        controller_.clock_ = &clock;
+        controller_.scheduler_ = &scheduler;
+    }
+
+    ~LiveLogControllerTimeTestAccess()
+    {
+        // Cancel substituted scheduler tokens before either dependency expires.
+        controller_.stopRequested();
+        CHECK_FALSE( scheduler.pending() );
+        controller_.clock_ = previousClock_;
+        controller_.scheduler_ = previousScheduler_;
+    }
+
+    LiveLogControllerTimeTestAccess( const LiveLogControllerTimeTestAccess& ) = delete;
+    LiveLogControllerTimeTestAccess& operator=( const LiveLogControllerTimeTestAccess& ) = delete;
+
+private:
+    LiveLogController& controller_;
+    LiveLogClock* previousClock_;
+    LiveLogScheduler* previousScheduler_;
+};
+
+} // namespace klogg::livelog
+
+struct LivePresentationCrawlerAccess;
+template <>
+struct CrawlerWidget::access_by<LivePresentationCrawlerAccess> {
+    static StreamingLogData* data( CrawlerWidget* crawler )
+    {
+        return dynamic_cast<StreamingLogData*>( crawler->logData_.get() );
+    }
+
+    static LinesCount matches( CrawlerWidget* crawler )
+    {
+        return crawler->logFilteredData_->getNbMatches();
+    }
+
+    static QString mainText( CrawlerWidget* crawler )
+    {
+        crawler->logMainView_->selectAll();
+        return crawler->logMainView_->getSelectedText();
+    }
+};
 
 namespace {
 QString makeTestDir( const QString& prefix )
@@ -182,6 +310,55 @@ public:
 private:
     SessionInfo& sessionInfo_;
     std::vector<SessionInfoWindowSnapshot> snapshots_;
+};
+
+// Same direct transport/factory pattern as livelog_restore_arming_test.cpp: no
+// device service, native backend, network, or process is activated by this fixture.
+class MenuLiveSourceTransport final : public LiveSourceTransport {
+public:
+    void start( Generation generation ) override { startedGeneration = generation; }
+    void stop( Generation ) override {}
+    void clearRemoteAsync( Generation, ClearRequestId ) override {}
+    QString lastError() const override { return {}; }
+
+    void publishConnected()
+    {
+        Q_EMIT stateChanged( startedGeneration, State::Connected );
+    }
+    void publishBytes( const QByteArray& bytes )
+    {
+        Q_EMIT bytesReceived( startedGeneration, bytes );
+    }
+    Generation startedGeneration{ 0 };
+};
+
+class MenuLiveSourceTransportFactory final : public LiveSourceTransportFactory {
+public:
+    std::unique_ptr<LiveSourceTransport> create( const LiveSourceTransportConfig& ) const override
+    {
+        auto transport = std::make_unique<MenuLiveSourceTransport>();
+        created.push_back( transport.get() );
+        return transport;
+    }
+    mutable std::vector<MenuLiveSourceTransport*> created;
+};
+
+class MenuActionChanges final : public QObject {
+public:
+    int added = 0;
+    int removed = 0;
+
+protected:
+    bool eventFilter( QObject*, QEvent* event ) override
+    {
+        if ( event->type() == QEvent::ActionAdded ) {
+            ++added;
+        }
+        else if ( event->type() == QEvent::ActionRemoved ) {
+            ++removed;
+        }
+        return false;
+    }
 };
 
 QToolButton* findGroupChipButton( QTabBar* tabBar, int tabIndex )
@@ -996,6 +1173,421 @@ SCENARIO( "Closing one of several windows deletes its discarded live capture",
 
     config.setMinimizeToTray( previousMinimizeToTray );
     config.save();
+}
+
+namespace {
+void exerciseLiveCountdownRouting( MainWindow& window, Session& session,
+                                   TabbedCrawlerWidget& tabs, CrawlerWidget* crawler,
+                                   QMenu& menu, MenuActionChanges& changes )
+{
+    namespace live = klogg::livecapture;
+    auto* controller = session.getLiveLogController( crawler );
+    REQUIRE( controller != nullptr );
+    auto* info = window.findChild<PathLine*>();
+    auto* disconnect = window.findChild<QAction*>( QStringLiteral( "disconnectSourceAction" ) );
+    REQUIRE( info != nullptr );
+    REQUIRE( disconnect != nullptr );
+    const auto current = tabs.currentWidget() == crawler;
+    const auto tabIndex = tabs.indexOf( crawler );
+    REQUIRE( tabIndex >= 0 );
+    klogg::livelog::LiveLogControllerTimeTestAccess time{ *controller };
+    const auto failStream = [ & ] {
+        controller->streamFailed(
+            controller->snapshot().generation,
+            live::LiveSourceError{ live::ErrorCategory::Stream, "countdown-route-retry",
+                                   live::ErrorScope::Stream, live::RetryPolicy::Backoff,
+                                   "Deterministic countdown interruption", {} } );
+        REQUIRE( controller->snapshot().source.status == live::SourceStatus::RetryWait );
+        REQUIRE( time.scheduler.pending() );
+    };
+    // Real retry transitions establish a four-second backoff, leaving room for
+    // multiple delivered second boundaries before switching into the countdown.
+    for ( int attempt = 0; attempt < 2; ++attempt ) {
+        failStream();
+        time.scheduler.fire( time.clock );
+        REQUIRE( controller->snapshot().source.status == live::SourceStatus::OpeningStream );
+    }
+    failStream();
+    REQUIRE( controller->controlPresentation().retryCountdownSeconds == 4 );
+    const auto before = controller->controlPresentation();
+    const auto deadline = time.scheduler.deadline();
+    const auto entries = menu.actions();
+    const auto sentinel = QStringLiteral( "countdown-route-sentinel" );
+    const auto seedRouteProbes = [ & ] {
+        info->setText( sentinel );
+        disconnect->setEnabled( !before.disconnectEnabled );
+        tabs.setTabToolTip( tabIndex, sentinel );
+        changes.added = 0;
+        changes.removed = 0;
+    };
+    const auto checkNoControlWrites = [ & ] {
+        CHECK( disconnect->isEnabled() == !before.disconnectEnabled );
+        CHECK( tabs.tabToolTip( tabIndex ) == sentinel );
+        CHECK( changes.added == 0 );
+        CHECK( changes.removed == 0 );
+        CHECK( menu.actions() == entries );
+        CHECK( time.scheduler.pending() );
+        CHECK( time.scheduler.deadline() == deadline );
+    };
+    const auto countdownText = [ & ]( int seconds ) {
+        return QDir::toNativeSeparators( session.getDisplayName( crawler ) )
+               + QCoreApplication::translate( "MainWindow", " - Reconnect in %1 seconds..." )
+                     .arg( seconds );
+    };
+    seedRouteProbes();
+    time.clock.value = deadline - std::chrono::milliseconds{ 3001 };
+    controller->refreshPresentationTime();
+    REQUIRE( controller->controlPresentation().retryCountdownSeconds == 4 );
+    CHECK( info->text() == sentinel );
+    checkNoControlWrites();
+
+    time.clock.value += std::chrono::milliseconds{ 1 };
+    controller->refreshPresentationTime(); // Genuine CountdownOnly through the registered route.
+    const auto after = controller->controlPresentation();
+    REQUIRE( after.sameControlState( before ) );
+    REQUIRE( after.retryCountdownSeconds == 3 );
+    CHECK( info->text() == ( current ? countdownText( 3 ) : sentinel ) );
+    checkNoControlWrites();
+
+    if ( !current ) {
+        // Another background tick advances controller state without touching
+        // the UI. Switching in must render that current two-second projection.
+        time.clock.value += std::chrono::seconds{ 1 };
+        controller->refreshPresentationTime();
+        REQUIRE( controller->controlPresentation().retryCountdownSeconds == 2 );
+        CHECK( info->text() == sentinel );
+        checkNoControlWrites();
+        tabs.setCurrentWidget( crawler );
+        CHECK( info->text() == countdownText( 2 ) );
+        CHECK( disconnect->isEnabled() == before.disconnectEnabled );
+        CHECK( controller->snapshot().source.status == live::SourceStatus::RetryWait );
+        CHECK( time.scheduler.pending() );
+        CHECK( time.scheduler.deadline() == deadline );
+    }
+}
+
+void exerciseLivePresentation( bool useIos, bool background, int preservationScenario = -1,
+                               bool countdown = false )
+{
+    namespace live = klogg::livecapture;
+    CAPTURE( useIos, background, preservationScenario );
+    MenuLiveSourceTransportFactory factory;
+    auto appSession = std::make_shared<Session>( factory );
+    auto& sessionInfo = SessionInfo::getSynced();
+    SessionInfoRestoreGuard restoreGuard{ sessionInfo };
+    const auto windowIds = sessionInfo.windows();
+    const auto windowId = QStringLiteral( "menu-live-%1" )
+                              .arg( QUuid::createUuid().toString( QUuid::WithoutBraces ) );
+    sessionInfo.add( windowId );
+    for ( const auto& id : windowIds ) {
+        sessionInfo.remove( id );
+    }
+
+    std::vector<SessionInfo::OpenFile> files;
+    for ( int index = 0; index < 2; ++index ) {
+        AdbLogcatSessionData data{
+            QStringLiteral( "unused-test-backend" ),
+            QStringLiteral( "menu-device-%1" ).arg( index ),
+            QStringLiteral( "Menu device %1" ).arg( index ),
+            QString{},
+            QUuid::createUuid().toString( QUuid::WithoutBraces ),
+            QString{},
+            useIos ? LiveLogSourceType::IosLogStream : LiveLogSourceType::AdbLogcat,
+        };
+        data.autoReconnectEnabled = true;
+        data.adbBackend = AdbTransportBackend::SmartSocket;
+        files.emplace_back( data.documentId(), 0, QString{}, data.persistedSourceType(),
+                            data.displayName(), klogg::livelog::serializeSpec(
+                                                    klogg::livelog::sessionSpecFromSessionData( data ) ) );
+    }
+    sessionInfo.setOpenFiles( windowId, files );
+    sessionInfo.setCurrentFileIndex( windowId, background ? 1 : 0 );
+    sessionInfo.save();
+
+    WindowSession windowSession{ appSession, windowId, 0 };
+    auto mainWindow = std::make_unique<MainWindow>( windowSession );
+    mainWindow->resize( 900, 600 );
+    mainWindow->show();
+    mainWindow->reloadSession();
+    auto* tabs = mainWindow->findChild<TabbedCrawlerWidget*>();
+    REQUIRE( tabs != nullptr );
+    REQUIRE( tabs->count() == 2 );
+    auto* crawler = qobject_cast<CrawlerWidget*>( tabs->widget( 0 ) );
+    auto* otherCrawler = qobject_cast<CrawlerWidget*>( tabs->widget( 1 ) );
+    REQUIRE( crawler != nullptr );
+    REQUIRE( otherCrawler != nullptr );
+    REQUIRE( waitUiState( [ & ] {
+        return crawler->isFirstLoadDone() && otherCrawler->isFirstLoadDone();
+    } ) );
+    QTest::qWait( 200 ); // Retire initial load callbacks before observing the menu.
+    tabs->setCurrentIndex( background ? 1 : 0 );
+    REQUIRE( tabs->currentWidget() == ( background ? otherCrawler : crawler ) );
+    REQUIRE( factory.created.empty() ); // Restore is inert.
+    auto* source = appSession->getAdbLogcatSource( crawler );
+    auto* controller = appSession->getLiveLogController( crawler );
+    REQUIRE( source != nullptr );
+    REQUIRE( controller != nullptr );
+    REQUIRE( source->reconnectSource() );
+    REQUIRE( factory.created.size() == 1u );
+    auto* transport = factory.created.front();
+    transport->publishConnected();
+    REQUIRE( controller->snapshot().source.status == live::SourceStatus::Streaming );
+    REQUIRE( transport->startedGeneration == controller->snapshot().generation );
+    auto* menu = mainWindow->findChild<QMenu*>( QStringLiteral( "openedFilesMenu" ) );
+    REQUIRE( menu != nullptr );
+    REQUIRE( menu->actions().size() == 4 ); // Selector, separator, two live documents.
+    MenuActionChanges changes;
+    menu->installEventFilter( &changes );
+    QPointer<QAction> firstEntry{ menu->actions().at( 2 ) };
+    QPointer<QAction> secondEntry{ menu->actions().at( 3 ) };
+    REQUIRE( firstEntry != nullptr );
+    REQUIRE( secondEntry != nullptr );
+
+    if ( preservationScenario >= 0 ) {
+        QTemporaryDir documents;
+        REQUIRE( documents.isValid() );
+        const auto filePath = documents.filePath( "visible.log" );
+        QFile file{ filePath };
+        REQUIRE( file.open( QIODevice::WriteOnly ) );
+        REQUIRE( file.write( "current file\n" ) == 13 );
+        file.close();
+        if ( preservationScenario == 2 ) {
+            mainWindow->loadFileNonInteractive( filePath );
+            auto* fileCrawler = qobject_cast<CrawlerWidget*>( tabs->currentWidget() );
+            REQUIRE( fileCrawler != nullptr );
+            REQUIRE( waitUiState( [ & ] { return fileCrawler->isFirstLoadDone(); } ) );
+            QTest::qWait( 200 );
+        }
+        else if ( preservationScenario == 3 ) {
+            mainWindow->openFolderByPath( documents.path() );
+            REQUIRE( qobject_cast<FolderCrawlerWidget*>( tabs->currentWidget() ) != nullptr );
+            QTest::qWait( 200 );
+        }
+        else {
+            tabs->setCurrentIndex( preservationScenario == 1 ? 1 : 0 );
+        }
+        if ( countdown ) {
+            exerciseLiveCountdownRouting( *mainWindow, *appSession, *tabs, crawler, *menu, changes );
+            menu->removeEventFilter( &changes );
+            mainWindow->close();
+            return;
+        }
+        if ( preservationScenario == 5 ) {
+            using Access = CrawlerWidget::access_by<LivePresentationCrawlerAccess>;
+            auto* data = Access::data( crawler );
+            REQUIRE( data != nullptr );
+            if ( StreamingLogDataTimerTestAccess::pending( *data ) ) {
+                StreamingLogDataTimerTestAccess::deliver( *data );
+            }
+            CaptureStore::Limits limits;
+            limits.segmentTargetBytes = 8;
+            limits.memoryBudgetBytes = 4096;
+            limits.rollingMaxFileSize = 8;
+            limits.rollingBackupCount = 2;
+            data->setCaptureLimits( limits );
+            REQUIRE( source->bindOutputFile( documents.filePath( "rolling-follow.log" ),
+                                             LiveLogSaveAnsiMode::Preserve ) );
+            transport->publishBytes( QByteArrayLiteral( "old-000\nold-001\n" ) );
+            StreamingLogDataTimerTestAccess::deliver( *data );
+            REQUIRE( data->getNbLine() == 2_lcount );
+            auto* search = crawler->findChild<SearchToolbar*>();
+            REQUIRE( search != nullptr );
+            search->setAutoRefresh( true );
+            search->searchLineEdit()->setEditText( QStringLiteral( "new" ) );
+            search->searchButton()->click();
+            REQUIRE( waitUiState( [ & ] { return search->stopButton()->isHidden(); } ) );
+            REQUIRE( Access::matches( crawler ) == 0_lcount );
+            auto* follow = mainWindow->findChild<QAction*>( QStringLiteral( "followAction" ) );
+            REQUIRE( follow != nullptr );
+            follow->setChecked( true );
+            REQUIRE( crawler->isFollowEnabled() );
+            SafeQSignalSpy completed{ crawler, &CrawlerWidget::loadingFinished };
+            transport->publishBytes( QByteArrayLiteral( "new-002\n" ) );
+            REQUIRE( data->getNbLine() == 2_lcount );
+            REQUIRE( StreamingLogDataTimerTestAccess::pending( *data ) );
+            REQUIRE( completed.count() == 0 );
+            StreamingLogDataTimerTestAccess::deliver( *data );
+            REQUIRE( waitUiState( [ & ] { return Access::matches( crawler ) == 1_lcount; } ) );
+            CHECK( completed.count() == 1 );
+            CHECK( crawler->isFollowEnabled() );
+            CHECK( follow->isChecked() );
+            CHECK( Access::mainText( crawler ) == QStringLiteral( "old-001\nnew-002" ) );
+            QTest::qWait( 200 ); // Retire the actual search/load completion before teardown.
+            menu->removeEventFilter( &changes );
+            controller->stopRequested();
+            mainWindow->close();
+            return;
+        }
+
+        auto* info = mainWindow->findChild<PathLine*>();
+        auto* disconnect = mainWindow->findChild<QAction*>( QStringLiteral( "disconnectSourceAction" ) );
+        REQUIRE( info != nullptr );
+        REQUIRE( disconnect != nullptr );
+        const auto current = tabs->currentWidget() == crawler;
+        const auto sentinel = QStringLiteral( "presentation-route-sentinel" );
+        const auto seedRouteProbes = [ & ] {
+            // Deliberately diverge the actual widgets from their model. A redundant
+            // route would now perform an observable write; idempotent guards cannot
+            // hide it behind an unchanged final text/icon/action value.
+            info->setText( sentinel );
+            disconnect->setEnabled( false ); // The emitting source is streaming (enabled).
+            tabs->setTabToolTip( 0, sentinel );
+            changes.added = 0;
+            changes.removed = 0;
+        };
+        seedRouteProbes();
+        transport->publishBytes( QByteArrayLiteral( "preserved\n" ) );
+        CHECK( info->text() == sentinel );
+        CHECK_FALSE( disconnect->isEnabled() );
+        CHECK( tabs->tabToolTip( 0 ) == sentinel );
+        CHECK( changes.added == 0 );
+        CHECK( changes.removed == 0 );
+
+        auto error = live::LiveSourceError{ live::ErrorCategory::Capture, "unknown-output",
+                                            live::ErrorScope::Capture, live::RetryPolicy::Never,
+                                            "first output diagnostic", {} };
+        controller->outputBindingChanged( live::OutputBindingState::Degraded, error );
+        CHECK( info->text() == ( current ? appSession->getDisplayName( crawler ) : sentinel ) );
+        CHECK( disconnect->isEnabled() == current );
+        CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "first output diagnostic" ) ) );
+        CHECK( changes.added == 0 );
+        CHECK( changes.removed == 0 );
+        seedRouteProbes();
+        error.message = "replacement diagnostic";
+        controller->outputBindingChanged( live::OutputBindingState::Degraded, error );
+        CHECK( info->text() == ( current ? appSession->getDisplayName( crawler ) : sentinel ) );
+        CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "replacement diagnostic" ) ) );
+        CHECK( disconnect->isEnabled() == current );
+        CHECK( changes.added == 0 );
+        CHECK( changes.removed == 0 );
+        controller->outputBindingChanged( live::OutputBindingState::Healthy );
+        CHECK_FALSE( tabs->tabToolTip( 0 ).contains( QStringLiteral( "Output error:" ) ) );
+
+        if ( preservationScenario == 4 ) {
+            const auto savedPath = documents.filePath( "bound-live.log" );
+            const auto nativeDialogsDisabled = QCoreApplication::testAttribute( Qt::AA_DontUseNativeDialogs );
+            QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, true );
+            bool accepted = false;
+            QTimer::singleShot( 0, Qt::PreciseTimer, mainWindow.get(), [ & ] {
+                if ( auto* dialog = qobject_cast<QFileDialog*>( QApplication::activeModalWidget() ) ) {
+                    dialog->selectFile( savedPath );
+                    accepted = QMetaObject::invokeMethod( dialog, "accept", Qt::DirectConnection );
+                }
+            } );
+            auto* save = mainWindow->findChild<QAction*>( QStringLiteral( "saveCurrentLiveLogPreserveAnsiAction" ) );
+            REQUIRE( save != nullptr );
+            save->trigger();
+            QCoreApplication::setAttribute( Qt::AA_DontUseNativeDialogs, nativeDialogsDisabled );
+            REQUIRE( accepted );
+            REQUIRE( source->sessionData().boundOutputFile == savedPath );
+            CHECK( appSession->getAssociatedPath( crawler ) == savedPath );
+            CHECK( info->text() == QDir::toNativeSeparators( savedPath ) );
+            CHECK( tabs->tabToolTip( 0 ) == savedPath );
+            REQUIRE( changes.added > 0 );
+            REQUIRE( changes.removed > 0 );
+            const auto savedEntries = menu->actions();
+            CHECK( std::any_of( savedEntries.begin(), savedEntries.end(), [ & ]( const auto* action ) {
+                return action->toolTip() == savedPath;
+            } ) );
+            transport->publishBytes( QByteArrayLiteral( "saved tail\n" ) );
+            source->disconnectSource();
+            QFile saved{ savedPath };
+            REQUIRE( saved.open( QIODevice::ReadOnly ) );
+            CHECK( saved.readAll() == QByteArrayLiteral( "preserved\nsaved tail\n" ) );
+        }
+        menu->removeEventFilter( &changes );
+        controller->stopRequested();
+        mainWindow->close();
+        return;
+    }
+
+    uint64_t initialBytes = 0;
+    uint64_t initialLines = 0;
+    QDateTime modified;
+    appSession->getFileInfo( crawler, &initialBytes, &initialLines, &modified );
+    REQUIRE_FALSE( logging::needLogging( QtInfoMsg ) );
+    REQUIRE_FALSE( logging::needLogging( QtDebugMsg ) );
+    constexpr int BatchCount = 64;
+    QElapsedTimer elapsed;
+    elapsed.start();
+    const auto cpuStart = std::clock();
+    for ( int batch = 0; batch < BatchCount; ++batch ) {
+        transport->publishBytes( QByteArray::number( batch ).rightJustified( 63, '0' ) + '\n' );
+    }
+    const auto cpuTicks = std::clock() - cpuStart;
+    const auto elapsedNs = elapsed.nsecsElapsed();
+    uint64_t bytes = 0;
+    uint64_t lines = 0;
+    appSession->getFileInfo( crawler, &bytes, &lines, &modified );
+    REQUIRE( bytes == initialBytes + 4096u );
+    REQUIRE( lines == initialLines + 64u );
+    REQUIRE( controller->snapshot().source.status == live::SourceStatus::Streaming );
+    if ( qEnvironmentVariableIsSet( "KLOGG_MEASURE_LIVE_PRESENTATION" ) ) {
+        std::fprintf( stderr,
+                      "LIVE_REPLAY ios=%d background=%d batches=64 bytes=4096 lines=64 "
+                      "window=900x600 shown=1 output=unbound info_logging=0 debug_logging=0 "
+                      "follow=%d added=%d removed=%d cpu_ticks=%lld clocks_per_sec=%lld elapsed_ns=%lld\n",
+                      static_cast<int>( useIos ), static_cast<int>( background ),
+                      static_cast<int>( crawler->isFollowEnabled() ), changes.added, changes.removed,
+                      static_cast<long long>( cpuTicks ), static_cast<long long>( CLOCKS_PER_SEC ),
+                      static_cast<long long>( elapsedNs ) );
+    }
+    CHECK( changes.added == 0 );
+    CHECK( changes.removed == 0 );
+    CHECK( firstEntry != nullptr );
+    CHECK( secondEntry != nullptr );
+    CHECK( menu->actions().at( 2 ) == firstEntry.data() );
+    CHECK( menu->actions().at( 3 ) == secondEntry.data() );
+
+    controller->streamFailed( controller->snapshot().generation,
+                             live::LiveSourceError{ live::ErrorCategory::Stream, "menu-retry",
+                                                    live::ErrorScope::Stream, live::RetryPolicy::Backoff,
+                                                    "Deterministic stream interruption", {} } );
+    REQUIRE( controller->presentation().retryCountdownVisible );
+    changes.added = 0;
+    changes.removed = 0;
+    firstEntry = menu->actions().at( 2 );
+    secondEntry = menu->actions().at( 3 );
+    controller->refreshPresentationTime();
+    REQUIRE( controller->presentation().retryCountdownVisible );
+    CHECK( changes.added == 0 );
+    CHECK( changes.removed == 0 );
+    CHECK( firstEntry != nullptr );
+    CHECK( secondEntry != nullptr );
+    CHECK( menu->actions().at( 2 ) == firstEntry.data() );
+    CHECK( menu->actions().at( 3 ) == secondEntry.data() );
+
+    menu->removeEventFilter( &changes );
+    controller->stopRequested();
+    mainWindow->close();
+}
+
+} // namespace
+
+TEST_CASE( "Live bytes and retry countdown preserve opened-files menu actions",
+           "[ui][session][live-presentation-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    const auto background = GENERATE( false, true );
+    exerciseLivePresentation( useIos, background );
+}
+
+TEST_CASE( "Live countdown boundaries route only current info and tab switches read current time",
+           "[ui][session][live-presentation-preservation][live-countdown-routing]" )
+{
+    const auto useIos = GENERATE( false, true );
+    // Current live, other live, file, folder: all use the real controller callback.
+    const auto scenario = GENERATE( 0, 1, 2, 3 );
+    exerciseLivePresentation( useIos, scenario != 0, scenario, true );
+}
+
+TEST_CASE( "Live control routes preserve current file folder live and saved metadata ownership",
+           "[ui][session][live-presentation-preservation]" )
+{
+    const auto useIos = GENERATE( false, true );
+    // Current live, other live, file, folder, Save Live binding, rolling search/follow.
+    const auto scenario = GENERATE( 0, 1, 2, 3, 4, 5 );
+    exerciseLivePresentation( useIos, scenario >= 1 && scenario <= 3, scenario );
 }
 
 SCENARIO( "MainWindow restored iOS live log tabs show disconnected state", "[ui][session][ios]" )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -143,7 +143,7 @@ if(KLOGG_BUILD_BENCHMARKS)
   )
   target_link_libraries(
     klogg_live_capture_benchmark_contract_tests
-    PRIVATE klogg_live_capture_benchmark_core klogg_logdata Catch2
+    PRIVATE klogg_live_capture_benchmark_core klogg_livecapture klogg_logdata Catch2
             Qt${QT_VERSION_MAJOR}::Core project_options project_warnings
   )
   add_dependencies(klogg_live_capture_benchmark_contract_tests live_capture_fixture_producer)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -192,6 +192,7 @@ add_executable(klogg_tests
     mergefileorder_test.cpp
     overview_test.cpp
     optionsdialog_test.cpp
+    pathutils_test.cpp
     patternmatcher_test.cpp
     quicklabelpattern_test.cpp
     qt_event_queue_test.cpp

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <ctime>
+#include <iostream>
 #include <exception>
 #include <functional>
 #include <limits>
@@ -46,11 +48,30 @@
 #endif
 
 #include "capturestore.h"
+#include "logger.h"
 #include "platform/platform_files.h"
 #include "rollingfilemanager.h"
 
 class CaptureStoreTestAccess {
   public:
+    static CaptureStore::MaintenanceOperationsForTesting maintenanceOperations(
+        const CaptureStore& store )
+    {
+        return store.maintenanceOperationsForTesting();
+    }
+
+    static CaptureStore::MaintenanceRetryForTesting maintenanceRetry(
+        const CaptureStore& store )
+    {
+        return store.maintenanceRetryForTesting();
+    }
+
+    static void setBeforeRetryHandoffCallback( CaptureStore& store,
+                                              std::function<void()> callback )
+    {
+        store.setBeforeRetryHandoffCallbackForTesting( std::move( callback ) );
+    }
+
     static void setBeforeRawSnapshotCopyCallback( CaptureStore& store,
                                                   std::function<void()> callback )
     {
@@ -284,6 +305,126 @@ bool createSignalFile( const QString& filePath )
     QFile file( filePath );
     return file.open( QIODevice::WriteOnly | QIODevice::Truncate );
 }
+
+// This directory is shared with real captures. Never glob-delete its contents,
+// or create entries matching an ambient capture's active-marker/gate stem.
+class ScopedCoordinationEntries {
+  public:
+    ScopedCoordinationEntries() = default;
+    ScopedCoordinationEntries( const ScopedCoordinationEntries& ) = delete;
+    ScopedCoordinationEntries& operator=( const ScopedCoordinationEntries& ) = delete;
+
+    ~ScopedCoordinationEntries()
+    {
+        for ( const auto& path : paths_ ) {
+            QFile::remove( path );
+        }
+    }
+
+    void create( int count )
+    {
+        const auto root = captureCoordinationRoot();
+        REQUIRE_FALSE( root.isEmpty() );
+        const QDir directory( root );
+        REQUIRE( directory.exists() );
+        const auto prefix = QStringLiteral( "test-owned-capture-replay-%1-" )
+                                .arg( makeCaptureId() );
+        for ( int index = 0; index < count; ++index ) {
+            const auto path = directory.filePath( prefix + QString::number( index ) );
+            QFile file( path );
+            REQUIRE( file.open( QIODevice::WriteOnly | QIODevice::NewOnly ) );
+            paths_.push_back( path );
+        }
+    }
+
+  private:
+    QStringList paths_;
+};
+
+constexpr int SmallAppendCrowdEntries = 256;
+constexpr int SmallAppendRegressionBatches = 512;
+constexpr int SmallAppendReplayBatches = 512;
+constexpr int SmallAppendReplayRepetitions = 3;
+
+enum class SmallAppendLimit { Bytes, Lines, Both };
+
+CaptureStore::Limits smallAppendLimits( SmallAppendLimit mode )
+{
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 4 * 1024 * 1024;
+    limits.memoryBudgetBytes = 8 * 1024 * 1024;
+    if ( mode != SmallAppendLimit::Lines ) {
+        limits.rollingMaxFileSize = 8 * 1024 * 1024;
+        limits.rollingBackupCount = 2;
+    }
+    if ( mode != SmallAppendLimit::Bytes ) {
+        limits.maxTotalLines = 100000;
+    }
+    return limits;
+}
+
+struct SmallAppendWorkload {
+    klogg::vector<QByteArray> batches;
+    klogg::vector<QString> lines;
+    QByteArray bytes;
+};
+
+SmallAppendWorkload smallAppendWorkload( int batchCount )
+{
+    SmallAppendWorkload workload;
+    for ( int batchIndex = 0; batchIndex < batchCount; ++batchIndex ) {
+        QByteArray batch;
+        for ( int lineIndex = 0; lineIndex < 2; ++lineIndex ) {
+            const auto line = QStringLiteral( "batch-%1 line-%2 café 日志" )
+                                  .arg( batchIndex, 4, 10, QLatin1Char( '0' ) )
+                                  .arg( lineIndex );
+            workload.lines.push_back( line );
+            batch += line.toUtf8() + '\n';
+        }
+        workload.bytes += batch;
+        workload.batches.push_back( std::move( batch ) );
+    }
+    return workload;
+}
+
+void requireSmallAppendContent( const CaptureStore& store,
+                                const SmallAppendWorkload& workload )
+{
+    REQUIRE( store.boundOutputFile().isEmpty() );
+    REQUIRE( store.stats().fileSize == workload.bytes.size() );
+    REQUIRE( store.stats().memoryBytes == workload.bytes.size() );
+    REQUIRE( store.stats().totalLines == static_cast<qint64>( workload.lines.size() ) );
+    REQUIRE( store.lineCount().get() == workload.lines.size() );
+    REQUIRE( store.lastTrimResult().trimmedLines == 0_lcount );
+    REQUIRE( store.lastTrimResult().trimmedBytes == 0 );
+    REQUIRE( segmentFiles( store.capturePath() ).isEmpty() );
+    auto* codec = QTextCodec::codecForName( "UTF-8" );
+    const auto raw = store.buildRawLines( 0_lnum, store.lineCount(), codec, {} );
+    REQUIRE( QByteArray( raw.buffer.data(), static_cast<int>( raw.buffer.size() ) )
+             == workload.bytes );
+    const auto decoded = raw.decodeLines();
+    REQUIRE( decoded.size() == workload.lines.size() );
+    for ( size_t index = 0; index < decoded.size(); ++index ) {
+        REQUIRE( decoded[ index ] == workload.lines[ index ] );
+    }
+}
+
+class ScopedReplayLogging {
+  public:
+    explicit ScopedReplayLogging( bool debug )
+    {
+        const auto level = debug ? logging::LogLevel::Debug : logging::LogLevel::None;
+        logging::enableLogging( debug, level );
+        logging::enableFileLogging( debug, level );
+    }
+
+    ~ScopedReplayLogging()
+    {
+        // Restore tests_main.cpp's logging configuration for subsequent cases.
+        logging::enableFileLogging( false );
+        logging::enableLogging( true, logging::LogLevel::Warning );
+    }
+};
 
 #if defined( Q_OS_WIN )
 class ScopedWindowsTestHandle {
@@ -520,6 +661,264 @@ class ActiveCaptureChild {
     QString readyContents_;
 };
 } // namespace
+
+TEST_CASE( "CaptureStore small appends below limits avoid coordinated maintenance",
+           "[capturestore][maintenance-no-work]" )
+{
+    const auto mode = GENERATE( SmallAppendLimit::Bytes, SmallAppendLimit::Lines,
+                               SmallAppendLimit::Both );
+    const auto crowdEntries = GENERATE( 0, SmallAppendCrowdEntries );
+    CAPTURE( static_cast<int>( mode ), crowdEntries );
+    const auto limits = smallAppendLimits( mode );
+    const auto workload = smallAppendWorkload( SmallAppendRegressionBatches );
+    REQUIRE( workload.bytes.size() < limits.segmentTargetBytes );
+    REQUIRE( workload.bytes.size() < limits.memoryBudgetBytes );
+    REQUIRE( ( limits.rollingMaxFileSize == 0
+               || workload.bytes.size() < limits.rollingMaxFileSize ) );
+    REQUIRE( ( limits.maxTotalLines == 0
+               || static_cast<qint64>( workload.lines.size() ) < limits.maxTotalLines ) );
+    ScopedCoordinationEntries crowd;
+    crowd.create( crowdEntries );
+    CaptureStore store( makeCaptureId(), makeTestDir( "capturestore_small_appends" ),
+                        limits );
+    const auto before = CaptureStoreTestAccess::maintenanceOperations( store );
+    for ( const auto& batch : workload.batches ) {
+        const auto appended = store.appendUtf8( batch );
+        REQUIRE( appended.lineCount == 2_lcount );
+        REQUIRE( appended.rawUtf8Lines == batch );
+    }
+    const auto after = CaptureStoreTestAccess::maintenanceOperations( store );
+    requireSmallAppendContent( store, workload );
+    CHECK( after.markerScans - before.markerScans == 0 );
+    CHECK( after.retryGateAttempts - before.retryGateAttempts == 0 );
+    store.deleteCaptureFiles();
+}
+
+TEST_CASE( "CaptureStore direct no-work trim avoids coordinated maintenance",
+           "[capturestore][maintenance-no-work]" )
+{
+    const auto mode = GENERATE( SmallAppendLimit::Bytes, SmallAppendLimit::Lines,
+                               SmallAppendLimit::Both );
+    const auto populated = GENERATE( false, true );
+    CAPTURE( static_cast<int>( mode ), populated );
+    ScopedCoordinationEntries crowd;
+    crowd.create( SmallAppendCrowdEntries );
+    CaptureStore store( makeCaptureId(), makeTestDir( "capturestore_no_work_trim" ),
+                        smallAppendLimits( mode ) );
+    const auto workload = smallAppendWorkload( populated ? 1 : 0 );
+    for ( const auto& batch : workload.batches ) {
+        store.appendUtf8( batch );
+    }
+    // Isolate direct trim from construction and from the append caller.
+    const auto before = CaptureStoreTestAccess::maintenanceOperations( store );
+    const auto trimmed = store.trimToLimits();
+    const auto after = CaptureStoreTestAccess::maintenanceOperations( store );
+    REQUIRE( trimmed.trimmedLines == 0_lcount );
+    REQUIRE( trimmed.trimmedBytes == 0 );
+    requireSmallAppendContent( store, workload );
+    CHECK( after.markerScans - before.markerScans == 0 );
+    CHECK( after.retryGateAttempts - before.retryGateAttempts == 0 );
+    store.deleteCaptureFiles();
+}
+
+TEST_CASE( "CaptureStore pinned maintenance scans only when the final lease releases",
+           "[capturestore][maintenance-lifecycle]" )
+{
+    const auto rootPath = makeTestDir( "capturestore_pinned_maintenance" );
+    const auto captureId = makeCaptureId();
+    std::weak_ptr<void> lifetime;
+    {
+        CaptureStore store( captureId, rootPath, smallAppendLimits( SmallAppendLimit::Both ) );
+        store.appendUtf8( QByteArrayLiteral( "pinned-a\npinned-b\n" ) );
+        REQUIRE( CaptureStoreTestAccess::spillFirstSegment( store ) );
+        const auto files = segmentFiles( store.capturePath() );
+        REQUIRE( files.size() == 1 );
+        const auto spilledPath = QDir( store.capturePath() ).filePath( files.front() );
+        auto pinned = CaptureStoreTestAccess::pinFirstSpilledSegment( store );
+        REQUIRE( pinned );
+        lifetime = CaptureStoreTestAccess::capturePathStateLifetime( store );
+
+        const auto before = CaptureStoreTestAccess::maintenanceOperations( store );
+        store.clear();
+        store.trimToLimits();
+        const auto whilePinned = CaptureStoreTestAccess::maintenanceOperations( store );
+        CHECK( whilePinned.markerScans == before.markerScans );
+        REQUIRE( QFileInfo::exists( spilledPath ) );
+
+        pinned.reset();
+        REQUIRE_FALSE( QFileInfo::exists( spilledPath ) );
+        const auto afterRelease = CaptureStoreTestAccess::maintenanceOperations( store );
+        CHECK( afterRelease.markerScans > whilePinned.markerScans );
+        // A completed retirement leaves a historical epoch, not perpetual work.
+        store.trimToLimits();
+        const auto afterNoOp = CaptureStoreTestAccess::maintenanceOperations( store );
+        CHECK( afterNoOp.markerScans == afterRelease.markerScans );
+        CHECK( afterNoOp.retryGateAttempts == afterRelease.retryGateAttempts );
+    }
+    REQUIRE( lifetime.expired() );
+    CaptureStore replacement( captureId, rootPath );
+    REQUIRE( replacement.lineCount() == 0_lcount );
+    replacement.deleteCaptureFiles();
+}
+
+TEST_CASE( "CaptureStore pending gate epochs survive the background handoff window",
+           "[capturestore][maintenance-lifecycle]" )
+{
+    const auto rootPath = makeTestDir( "capturestore_retry_handoff" );
+    const auto captureId = makeCaptureId();
+    CaptureStore store( captureId, rootPath );
+    struct Handoff {
+        std::atomic<bool> paused{ false };
+        std::atomic<bool> release{ false };
+    };
+    const auto handoff = std::make_shared<Handoff>();
+    CaptureStoreTestAccess::setBeforeRetryHandoffCallback( store, [ handoff ] {
+        handoff->paused.store( true, std::memory_order_release );
+        while ( !handoff->release.load( std::memory_order_acquire ) ) {
+            std::this_thread::yield();
+        }
+    } );
+    const auto previousTimeout = CaptureStoreTestAccess::setCapturePathGateTimeout( 20 );
+    struct Attempt {
+        bool held = false;
+        bool holderCompleted = false;
+        bool pending = false;
+        std::uint64_t gateAttempts = 0;
+        std::uint64_t markerScans = 0;
+    };
+    // A deactivation timeout creates a gate epoch with NO physical deletion
+    // work. Keep the gate held through public trim to isolate the epoch guard.
+    const auto attempt = [ & ] {
+        auto sibling = std::make_unique<CaptureStore>( captureId, rootPath );
+        Attempt result;
+        std::atomic<bool> gateHeld{ false };
+        std::atomic<bool> releaseGate{ false };
+        std::thread holder( [ & ] {
+            result.holderCompleted = CaptureStoreTestAccess::holdCapturePathGate(
+                store, [ & ] { gateHeld.store( true, std::memory_order_release ); },
+                [ & ] {
+                    while ( !releaseGate.load( std::memory_order_acquire ) ) {
+                        std::this_thread::yield();
+                    }
+                } );
+        } );
+        result.held = waitForFlag( gateHeld );
+        sibling.reset();
+        const auto retry = CaptureStoreTestAccess::maintenanceRetry( store );
+        result.pending = retry.requested != retry.completed;
+        const auto before = CaptureStoreTestAccess::maintenanceOperations( store );
+        store.trimToLimits();
+        const auto after = CaptureStoreTestAccess::maintenanceOperations( store );
+        result.gateAttempts = after.retryGateAttempts - before.retryGateAttempts;
+        result.markerScans = after.markerScans - before.markerScans;
+        releaseGate.store( true, std::memory_order_release );
+        holder.join();
+        return result;
+    };
+    const auto first = attempt();
+    const auto reachedHandoff = waitForFlag( handoff->paused );
+    const auto beforeSecond = CaptureStoreTestAccess::maintenanceRetry( store );
+    const auto second = attempt();
+    const auto duringHandoff = CaptureStoreTestAccess::maintenanceRetry( store );
+    handoff->release.store( true, std::memory_order_release );
+
+    bool settled = false;
+    QElapsedTimer waitForRetry;
+    waitForRetry.start();
+    while ( !settled && waitForRetry.elapsed() < 15000 ) {
+        const auto retry = CaptureStoreTestAccess::maintenanceRetry( store );
+        settled = retry.requested == retry.completed && !retry.scheduled;
+        std::this_thread::yield();
+    }
+    CaptureStoreTestAccess::setCapturePathGateTimeout( previousTimeout );
+    // All holder threads have joined and the background hook has been released
+    // before any assertion; its captured state is shared even on test failure.
+    REQUIRE( first.held );
+    REQUIRE( first.holderCompleted );
+    REQUIRE( first.pending );
+    CHECK( first.gateAttempts == 1 );
+    CHECK( first.markerScans == 0 );
+    REQUIRE( reachedHandoff );
+    REQUIRE( beforeSecond.requested == beforeSecond.completed );
+    REQUIRE( beforeSecond.scheduled );
+    REQUIRE( second.held );
+    REQUIRE( second.holderCompleted );
+    REQUIRE( second.pending );
+    CHECK( second.gateAttempts == 1 );
+    CHECK( second.markerScans == 0 );
+    REQUIRE( duringHandoff.requested > beforeSecond.requested );
+    REQUIRE( duringHandoff.completed == beforeSecond.completed );
+    REQUIRE( settled );
+    const auto beforeNoOp = CaptureStoreTestAccess::maintenanceOperations( store );
+    store.trimToLimits();
+    CHECK( CaptureStoreTestAccess::maintenanceOperations( store ).retryGateAttempts
+           == beforeNoOp.retryGateAttempts );
+    store.deleteCaptureFiles();
+}
+
+// Opt-in capture-boundary replay, not an Android real-device benchmark. Run the
+// same test before/after a fix; timings are observations, never pass thresholds.
+// KLOGG_CAPTURESTORE_REPLAY_DEBUG=2 enables Debug console+file logging separately.
+TEST_CASE( "CaptureStore fixed small-append maintenance replay",
+           "[.capturestore-replay]" )
+{
+    const auto debugSetting = qgetenv( "KLOGG_CAPTURESTORE_REPLAY_DEBUG" );
+    REQUIRE( ( debugSetting.isEmpty() || debugSetting == "0" || debugSetting == "2" ) );
+    const auto debug = debugSetting == "2";
+    const ScopedReplayLogging loggingGuard( debug );
+    const auto limits = smallAppendLimits( SmallAppendLimit::Both );
+    const auto workload = smallAppendWorkload( SmallAppendReplayBatches );
+    ScopedCoordinationEntries crowd;
+    crowd.create( SmallAppendCrowdEntries );
+    const QDir coordinationDirectory( captureCoordinationRoot() );
+    const auto rootPath = makeTestDir( "capturestore_replay" );
+    const auto captureId = makeCaptureId();
+    for ( int repetition = 0; repetition < SmallAppendReplayRepetitions; ++repetition ) {
+        CaptureStore store( captureId, rootPath, limits );
+        const auto directoryEntriesBefore = coordinationDirectory.entryList(
+            QDir::Files | QDir::Hidden | QDir::NoDotAndDotDot ).size();
+        const auto before = CaptureStoreTestAccess::maintenanceOperations( store );
+        const auto cpuStart = std::clock();
+        QElapsedTimer elapsed;
+        elapsed.start();
+        for ( const auto& batch : workload.batches ) {
+            store.appendUtf8( batch );
+        }
+        const auto elapsedNs = elapsed.nsecsElapsed();
+        const auto cpuEnd = std::clock();
+        const auto after = CaptureStoreTestAccess::maintenanceOperations( store );
+        const auto directoryEntriesAfter = coordinationDirectory.entryList(
+            QDir::Files | QDir::Hidden | QDir::NoDotAndDotDot ).size();
+        const auto cpuAvailable = cpuStart != static_cast<std::clock_t>( -1 )
+                                  && cpuEnd != static_cast<std::clock_t>( -1 );
+        const auto cpuMs = cpuAvailable
+                               ? 1000.0 * static_cast<double>( cpuEnd - cpuStart )
+                                     / static_cast<double>( CLOCKS_PER_SEC )
+                               : -1.0;
+        std::cout << "capturestore_replay repetition=" << repetition + 1
+                  << " batches=" << workload.batches.size()
+                  << " lines=" << workload.lines.size()
+                  << " bytes=" << workload.bytes.size()
+                  << " segment_target=" << limits.segmentTargetBytes
+                  << " memory_budget=" << limits.memoryBudgetBytes
+                  << " rolling_bytes=" << limits.rollingMaxFileSize
+                  << " backups=" << limits.rollingBackupCount
+                  << " max_lines=" << limits.maxTotalLines
+                  << " test_owned_entries=" << SmallAppendCrowdEntries
+                  << " directory_entries_before=" << directoryEntriesBefore
+                  << " directory_entries_after=" << directoryEntriesAfter
+                  << " output=unbound logging=" << ( debug ? "debug2-console-file" : "off" )
+                  << " elapsed_ms=" << static_cast<double>( elapsedNs ) / 1000000.0
+                  << " process_cpu_ms=" << cpuMs
+                  << " marker_scans=" << after.markerScans - before.markerScans
+                  << " retry_gate_attempts=" << after.retryGateAttempts - before.retryGateAttempts
+                  << '\n';
+        requireSmallAppendContent( store, workload );
+        // Outside the measured region: remove this capture through its owner so
+        // repeated runs do not accumulate generation sidecars in the directory.
+        store.deleteCaptureFiles();
+    }
+}
 
 TEST_CASE( "Published content wait tolerates a transient empty publication" )
 {
@@ -1339,7 +1738,16 @@ TEST_CASE( "CaptureStore deferred file retirement completes after its local sibl
     REQUIRE( deletingStore.loadFromDisk() );
     deletingStore.deleteCaptureFiles();
     REQUIRE( QFileInfo::exists( capturePath ) );
+    const auto before = CaptureStoreTestAccess::maintenanceOperations( deletingStore );
+    deletingStore.trimToLimits();
+    const auto after = CaptureStoreTestAccess::maintenanceOperations( deletingStore );
+    // Pending retirement is coordinated work even though the background retry
+    // policy cannot run it yet. No file is eligible for physical deletion.
+    CHECK( after.retryGateAttempts - before.retryGateAttempts == 1 );
+    CHECK( after.markerScans == before.markerScans );
 
+    // The deleting store becomes the sole active retirement requester. Its
+    // pending files must promote even though it has not itself deactivated.
     activeSibling.reset();
 
     REQUIRE_FALSE( QFileInfo::exists( capturePath ) );
@@ -1390,7 +1798,8 @@ TEST_CASE( "CaptureStore deferred deletion completes after its local sibling exi
     REQUIRE_FALSE( QFileInfo::exists( capturePath ) );
 }
 
-TEST_CASE( "CaptureStore deletion never adopts another process generation" )
+TEST_CASE( "CaptureStore deletion never adopts another process generation",
+           "[maintenance-lifecycle]" )
 {
     CaptureStore::Limits limits;
     limits.segmentTargetBytes = 64;
@@ -1405,7 +1814,18 @@ TEST_CASE( "CaptureStore deletion never adopts another process generation" )
     REQUIRE( CaptureStoreTestAccess::spillFirstSegment( original ) );
     auto pinnedSegment = CaptureStoreTestAccess::pinFirstSpilledSegment( original );
     REQUIRE( pinnedSegment );
+    const auto originalFiles = segmentFiles( capturePath );
+    REQUIRE( originalFiles.size() == 1 );
+    const auto originalPath = QDir( capturePath ).filePath( originalFiles.front() );
+    const auto beforeNoOps = CaptureStoreTestAccess::maintenanceOperations( original );
+    for ( int call = 0; call < 8; ++call ) {
+        original.trimToLimits();
+    }
+    const auto afterNoOps = CaptureStoreTestAccess::maintenanceOperations( original );
+    CHECK( afterNoOps.markerScans == beforeNoOps.markerScans );
+    CHECK( afterNoOps.retryGateAttempts == beforeNoOps.retryGateAttempts );
 
+    // The foreign owner arrives only AFTER repeated no-work maintenance.
     ActiveCaptureChild child( rootPath, captureId, false );
     REQUIRE( child.startAndWaitUntilReady() );
     REQUIRE( child.captureIdentity()
@@ -1413,9 +1833,19 @@ TEST_CASE( "CaptureStore deletion never adopts another process generation" )
 
     original.deleteCaptureFiles();
     pinnedSegment.reset();
+    const auto beforeRetry = CaptureStoreTestAccess::maintenanceOperations( original );
+    original.trimToLimits();
+    const auto afterRetry = CaptureStoreTestAccess::maintenanceOperations( original );
+    const auto filePreservedWhileForeignActive = QFileInfo::exists( originalPath );
+    const auto directoryPreservedWhileForeignActive = QFileInfo::exists( capturePath );
+    const auto childExited = child.releaseAndWait();
 
-    REQUIRE( QFileInfo::exists( capturePath ) );
-    REQUIRE( child.releaseAndWait() );
+    REQUIRE( filePreservedWhileForeignActive );
+    REQUIRE( directoryPreservedWhileForeignActive );
+    CHECK( afterRetry.markerScans > beforeRetry.markerScans );
+    CHECK( afterRetry.retryGateAttempts > beforeRetry.retryGateAttempts );
+    REQUIRE( childExited );
+    REQUIRE( waitForMissingFile( originalPath ) );
 }
 
 TEST_CASE( "CaptureStore deletion refreshes a generation left by an exited process" )

--- a/tests/unit/ios_native_stream_worker_test.cpp
+++ b/tests/unit/ios_native_stream_worker_test.cpp
@@ -75,6 +75,7 @@ struct FakeNative {
     bool nullOsTraceOnSuccess{ false };
     bool nullSyslogOnSuccess{ false };
     bool emitOsTraceErrorDuringStart{ false };
+    std::function<void()> duringStreamStart;
     bool throwDuringDeviceNew{ false };
     std::atomic_bool stopOnCallbackThread{ false };
     std::atomic_bool freeInsideCallback{ false };
@@ -88,6 +89,7 @@ struct FakeNative {
     bool blockCallbackReturn{ false };
     bool callbackBodyReturned{ false };
     bool callbackReturnReleased{ false };
+    bool callbackReturnWaitCancelled{ false };
     bool stopEntered{ false };
     std::thread::id callbackThread;
     NativeOsTraceRelayRecordCallback osTraceRecordCallback{ nullptr };
@@ -222,7 +224,7 @@ struct FakeNative {
         callbackBodyReturned = true;
         callbackChanged.notify_all();
         callbackChanged.wait( lock, [ this ] {
-            return !blockCallbackReturn || callbackReturnReleased;
+            return !blockCallbackReturn || callbackReturnReleased || callbackReturnWaitCancelled;
         } );
         callbackActive = false;
         callbackThread = {};
@@ -247,6 +249,15 @@ struct FakeNative {
     {
         std::lock_guard<std::mutex> lock( callbackMutex );
         callbackReturnReleased = true;
+        callbackChanged.notify_all();
+    }
+
+    void cancelCallbackReturnWaits()
+    {
+        std::lock_guard<std::mutex> lock( callbackMutex );
+        // Unlike releaseCallbackReturn(), watchdog cleanup must also release
+        // callbacks that have not entered yet and will reset the per-call gate.
+        callbackReturnWaitCancelled = true;
         callbackChanged.notify_all();
     }
 
@@ -498,6 +509,9 @@ std::int32_t startOsTraceWithRecordType( NativeOsTraceClient client,
             error( -2, context );
         }
     }
+    if ( fake->duringStreamStart ) {
+        fake->duringStreamStart();
+    }
     return fake->osTraceStartResult;
 }
 
@@ -545,6 +559,9 @@ std::int32_t startSyslog( NativeSyslogRelayClient client, NativeSyslogRelayCallb
     fake->syslogCallback = callback;
     fake->syslogErrorCallback = error;
     fake->syslogContext = context;
+    if ( fake->duringStreamStart ) {
+        fake->duringStreamStart();
+    }
     return fake->syslogStartResult;
 }
 
@@ -595,16 +612,21 @@ class ManualExecutor {
 public:
     IosNativeStreamExecutor executor()
     {
-        return [ this ]( IosNativeStreamTask task ) { tasks_.push_back( std::move( task ) ); };
+        return [ this ]( IosNativeStreamTask task ) {
+            std::lock_guard<std::mutex> lock( mutex_ );
+            tasks_.push_back( std::move( task ) );
+        };
     }
 
     std::size_t pending() const
     {
+        std::lock_guard<std::mutex> lock( mutex_ );
         return tasks_.size();
     }
 
     std::thread startNextOnWorker()
     {
+        std::lock_guard<std::mutex> lock( mutex_ );
         REQUIRE_FALSE( tasks_.empty() );
         auto task = std::move( tasks_.front() );
         tasks_.erase( tasks_.begin() );
@@ -619,12 +641,13 @@ public:
 
     void runAllOnWorker()
     {
-        while ( !tasks_.empty() ) {
+        while ( pending() != 0u ) {
             runNextOnWorker();
         }
     }
 
 private:
+    mutable std::mutex mutex_;
     std::vector<IosNativeStreamTask> tasks_;
 };
 
@@ -634,21 +657,30 @@ struct ObservedCallbacks {
     std::vector<std::pair<Generation, ClassifiedIosNativeError>> errors;
     std::vector<Generation> stopped;
     bool throwFromBytesAvailable{ false };
+    std::mutex mutex;
 
     IosNativeStreamCallbacks callbacks()
     {
         IosNativeStreamCallbacks result;
-        result.ready = [ this ]( Generation generation ) { ready.push_back( generation ); };
+        result.ready = [ this ]( Generation generation ) {
+            std::lock_guard<std::mutex> lock( mutex );
+            ready.push_back( generation );
+        };
         result.bytesAvailable = [ this ]( Generation generation ) {
+            std::lock_guard<std::mutex> lock( mutex );
             bytesAvailable.push_back( generation );
             if ( throwFromBytesAvailable ) {
                 throw std::runtime_error( "observer failure" );
             }
         };
         result.failed = [ this ]( Generation generation, const ClassifiedIosNativeError& error ) {
+            std::lock_guard<std::mutex> lock( mutex );
             errors.emplace_back( generation, error );
         };
-        result.stopped = [ this ]( Generation generation ) { stopped.push_back( generation ); };
+        result.stopped = [ this ]( Generation generation ) {
+            std::lock_guard<std::mutex> lock( mutex );
+            stopped.push_back( generation );
+        };
         return result;
     }
 };
@@ -730,6 +762,21 @@ std::vector<std::uint8_t> osTracePacket( const std::string& message = "native lo
     packet.insert( packet.end(), message.begin(), message.end() );
     packet.push_back( 0u );
     return packet;
+}
+
+// The deadline is only a failure watchdog; success requires the queue's locked
+// waiter count or an explicit producer completion signal, never elapsed time.
+template <typename Predicate>
+bool waitForNativeCondition( Predicate predicate )
+{
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while ( !predicate() ) {
+        if ( std::chrono::steady_clock::now() >= deadline ) {
+            return false;
+        }
+        std::this_thread::yield();
+    }
+    return true;
 }
 
 std::size_t indexOf( const std::vector<std::string>& calls, const std::string& value )
@@ -1657,34 +1704,311 @@ TEST_CASE( "legacy syslog terminal errors use syslog relay ABI codes",
     }
 }
 
-TEST_CASE( "bounded native queue reports backpressure and statistics without silent drops",
+TEST_CASE( "bounded native queue waits for capacity and resumes complete records losslessly",
            "[ios][native][stream][queue][backpressure][statistics]" )
 {
+    const auto limits = GENERATE( LiveDataQueueLimits{ 2u, 8u },
+                                  LiveDataQueueLimits{ 1024u, 1u } );
     FakeNative state;
     fake = &state;
     ManualExecutor executor;
     ObservedCallbacks observed;
     auto options = config( 52u, "8.4" );
-    options.queueLimits = LiveDataQueueLimits{ 2u, 1u };
+    options.queueLimits = limits;
     IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
     REQUIRE( worker.start() );
     executor.runAllOnWorker();
 
     state.emitSyslog( "a\0"s );
-    state.emitSyslog( "b\0"s );
+    std::atomic_bool returned{ false };
+    std::thread producer( [ & ] {
+        state.emitSyslog( "b\0"s );
+        returned = true;
+    } );
+    const bool reachedBarrier = waitForNativeCondition( [ & ] {
+        return worker.waitingProducerCount() == 1u || returned.load();
+    } );
+    const bool waited = reachedBarrier && worker.waitingProducerCount() == 1u;
+    const auto first = worker.drain();
+    producer.join();
+    const auto second = worker.drain();
+    worker.stop( 52u );
+    executor.runAllOnWorker();
 
-    REQUIRE( observed.errors.size() == 1u );
-    CHECK( observed.errors.front().second.error.code == "ios-live-queue-saturated" );
+    CHECK( waited );
+    CHECK( observed.errors.empty() );
+    REQUIRE( first.has_value() );
+    REQUIRE( second.has_value() );
+    CHECK( first->bytes == std::vector<std::uint8_t>{ 'a', '\n' } );
+    CHECK( second->bytes == std::vector<std::uint8_t>{ 'b', '\n' } );
+    CHECK( first->sourceChunks == 1u );
+    CHECK( second->sourceChunks == 1u );
     const auto statistics = worker.statistics();
     CHECK( statistics.receivedBytes == 4u );
     CHECK( statistics.receivedChunks == 2u );
-    CHECK( statistics.queuedBytes == 2u );
-    CHECK( statistics.queuedChunks == 1u );
-    CHECK( statistics.backpressuredBytes == 2u );
-    CHECK( statistics.backpressuredChunks == 1u );
+    CHECK( statistics.deliveredBytes == 4u );
+    CHECK( statistics.deliveredChunks == 2u );
+    CHECK( statistics.queuedBytes == 0u );
+    CHECK( statistics.queuedChunks == 0u );
+    CHECK( statistics.backpressuredBytes == 0u );
+    CHECK( statistics.backpressuredChunks == 0u );
     CHECK( statistics.highWaterQueuedBytes == 2u );
+    CHECK( statistics.highWaterQueuedChunks == 1u );
     CHECK_FALSE( state.callbackTeardownViolation() );
+}
+
+TEST_CASE( "native synchronous startup bursts drain before ready without losing records",
+           "[ios][native][stream][queue][backpressure][startup]" )
+{
+    const auto limits = GENERATE( LiveDataQueueLimits{ 8u, 2u },
+                                  IosNativeStreamConfig{}.queueLimits );
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 53u, "8.4" );
+    options.queueLimits = limits;
+    constexpr std::size_t recordCount = 300u;
+    std::string expected;
+    for ( std::size_t index = 0u; index < recordCount; ++index ) {
+        expected += std::to_string( index ) + '\n';
+    }
+    std::atomic_bool startReturned{ false };
+    std::atomic_bool readyBeforeStartReturned{ false };
+    auto callbacks = observed.callbacks();
+    const auto observeReady = callbacks.ready;
+    callbacks.ready = [ & ]( Generation generation ) {
+        readyBeforeStartReturned = !startReturned.load();
+        observeReady( generation );
+    };
+    state.duringStreamStart = [ & ] {
+        for ( std::size_t index = 0u; index < recordCount; ++index ) {
+            state.emitSyslog( std::to_string( index ) + '\0' );
+        }
+        startReturned = true;
+    };
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), options, callbacks );
+    REQUIRE( worker.start() );
+    auto startup = executor.startNextOnWorker();
+    // This waiter proves a callback inside native start is blocked before ready.
+    const bool reachedBarrier = waitForNativeCondition( [ & ] {
+        return worker.waitingProducerCount() == 1u || startReturned.load();
+    } );
+    const bool waitedBeforeReady = worker.waitingProducerCount() == 1u && !startReturned.load();
+    std::string actual;
+    std::size_t chunks = 0u;
+    const bool completed = waitForNativeCondition( [ & ] {
+        if ( const auto batch = worker.drain() ) {
+            actual.append( batch->bytes.begin(), batch->bytes.end() );
+            chunks += batch->sourceChunks;
+        }
+        return startReturned.load();
+    } );
+    if ( !completed ) {
+        worker.shutdown();
+    }
+    startup.join();
+    if ( const auto batch = worker.drain() ) {
+        actual.append( batch->bytes.begin(), batch->bytes.end() );
+        chunks += batch->sourceChunks;
+    }
+    worker.shutdown();
     executor.runAllOnWorker();
+    CHECK( reachedBarrier );
+    CHECK( waitedBeforeReady );
+    CHECK( completed );
+    CHECK_FALSE( readyBeforeStartReturned );
+    CHECK( observed.ready == std::vector<Generation>{ 53u } );
+    CHECK( observed.errors.empty() );
+    CHECK( actual == expected );
+    CHECK( chunks == recordCount );
+    const auto statistics = worker.statistics();
+    CHECK( statistics.receivedChunks == recordCount );
+    CHECK( statistics.deliveredChunks == recordCount );
+    CHECK( statistics.receivedBytes == expected.size() );
+    CHECK( statistics.deliveredBytes == expected.size() );
+    CHECK( statistics.highWaterQueuedBytes <= limits.maxQueuedBytes );
+    CHECK( statistics.highWaterQueuedChunks <= limits.maxQueuedChunks );
+    CHECK( statistics.backpressuredChunks == 0u );
+    CHECK_FALSE( state.callbackTeardownViolation() );
+}
+
+TEST_CASE( "native terminal paths unblock full queues before cleanup or consumer drain",
+           "[ios][native][stream][queue][backpressure][cancellation]" )
+{
+    const bool duringStartup = GENERATE( false, true );
+    const auto terminalPath = GENERATE( 0, 1, 2 ); // stop, shutdown, native failure
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 54u, "8.4" );
+    options.queueLimits = LiveDataQueueLimits{ 2u, 1u };
+    std::atomic_bool producerReturned{ false };
+    auto produce = [ & ] {
+        state.emitSyslog( "a\0"s );
+        state.emitSyslog( "b\0"s );
+        producerReturned = true;
+    };
+    if ( duringStartup ) {
+        state.duringStreamStart = produce;
+    }
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
+    REQUIRE( worker.start() );
+    std::thread producer;
+    if ( duringStartup ) {
+        producer = executor.startNextOnWorker();
+    }
+    else {
+        executor.runAllOnWorker();
+        producer = std::thread( produce );
+    }
+    const bool reachedBarrier = waitForNativeCondition( [ & ] {
+        return worker.waitingProducerCount() == 1u || producerReturned.load();
+    } );
+    const bool waited = worker.waitingProducerCount() == 1u;
+    if ( !reachedBarrier ) {
+        // Startup may not have installed the native callbacks before the watchdog.
+        worker.shutdown();
+    }
+    else if ( terminalPath == 0 ) {
+        worker.stop( 54u );
+    }
+    else if ( terminalPath == 1 ) {
+        worker.shutdown();
+    }
+    else {
+        // Inject the terminal notification without nesting FakeNative's single
+        // reader ownership tracker inside the blocked data callback.
+        state.syslogErrorCallback( -2, state.syslogContext );
+    }
+    const bool unblockedWithoutDrain = waitForNativeCondition( [ & ] {
+        return producerReturned.load();
+    } );
+    if ( !unblockedWithoutDrain ) {
+        // Failure recovery only: release the test thread before any assertions.
+        static_cast<void>( worker.drain() );
+    }
+    producer.join();
+    executor.runAllOnWorker();
+    const auto retained = worker.drain();
+    CHECK( reachedBarrier );
+    CHECK( waited );
+    CHECK( unblockedWithoutDrain );
+    CHECK( worker.waitingProducerCount() == 0u );
+    REQUIRE( retained.has_value() );
+    CHECK( retained->bytes == std::vector<std::uint8_t>{ 'a', '\n' } );
+    CHECK( retained->sourceChunks == 1u );
+    CHECK( worker.statistics().receivedChunks == 1u );
+    CHECK( worker.statistics().backpressuredChunks == 0u );
+    CHECK( observed.stopped == std::vector<Generation>{ 54u } );
+    CHECK( observed.errors.size() == ( terminalPath == 2 ? 1u : 0u ) );
+    CHECK( observed.ready.size() == ( duringStartup ? 0u : 1u ) );
+    CHECK( std::count( state.calls.begin(), state.calls.end(), "syslog-stop" ) == 1 );
+    CHECK( std::count( state.calls.begin(), state.calls.end(), "syslog-free" ) == 1 );
+    CHECK_FALSE( state.callbackTeardownViolation() );
+}
+
+TEST_CASE( "native startup failure closes a full queue and joins callback return before freeing",
+           "[ios][native][stream][queue][backpressure][startup][ownership]" )
+{
+    FakeNative state;
+    fake = &state;
+    state.syslogStartResult = -2;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 57u, "8.4" );
+    options.queueLimits = LiveDataQueueLimits{ 2u, 1u };
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
+    std::thread producer;
+    std::atomic_bool reachedWait{ false };
+    state.duringStreamStart = [ & ] {
+        state.emitSyslog( "a\0"s );
+        state.blockCallbackReturn = true;
+        producer = std::thread( [ & ] { state.emitSyslog( "b\0"s ); } );
+        reachedWait = waitForNativeCondition( [ & ] {
+            return worker.waitingProducerCount() == 1u;
+        } );
+    };
+    REQUIRE( worker.start() );
+    auto startup = executor.startNextOnWorker();
+    const bool startupReachedWait = waitForNativeCondition( [ & ] { return reachedWait.load(); } );
+    const bool bodyReturned = state.waitUntilCallbackBodyReturned();
+    const bool stopEntered = state.waitUntilStopEntered();
+    if ( !bodyReturned ) {
+        static_cast<void>( worker.drain() );
+    }
+    // Keep the native callback beyond its C++ guard until stop/join is reached.
+    // Cancellation also releases a producer that enters after the watchdog fired.
+    state.cancelCallbackReturnWaits();
+    startup.join();
+    producer.join();
+    executor.runAllOnWorker();
+    CHECK( startupReachedWait );
+    CHECK( reachedWait );
+    CHECK( bodyReturned );
+    CHECK( stopEntered );
+    CHECK_FALSE( state.callbackTeardownViolation() );
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-device-disconnected" );
+    CHECK( observed.ready.empty() );
+    CHECK( observed.stopped == std::vector<Generation>{ 57u } );
+    CHECK( std::find( state.calls.begin(), state.calls.end(), "syslog-stop" )
+           < std::find( state.calls.begin(), state.calls.end(), "syslog-free" ) );
+    const auto retained = worker.drain();
+    REQUIRE( retained.has_value() );
+    CHECK( retained->bytes == std::vector<std::uint8_t>{ 'a', '\n' } );
+}
+
+TEST_CASE( "native records that cannot fit are explicit nonretryable failures",
+           "[ios][native][stream][queue][backpressure][oversize]" )
+{
+    const bool osTrace = GENERATE( false, true );
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 55u, osTrace ? "17.6.1" : "8.4" );
+    options.queueLimits = LiveDataQueueLimits{ 2u, 1u };
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+    if ( osTrace ) {
+        state.emitOsTrace( 2u, osTracePacket() );
+    }
+    else {
+        state.emitSyslog( "ab\0"s ); // The appended newline counts toward the limit.
+    }
+    executor.runAllOnWorker();
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-live-record-too-large" );
+    CHECK( observed.errors.front().second.error.retryPolicy == RetryPolicy::Never );
+    CHECK( worker.waitingProducerCount() == 0u );
+    CHECK_FALSE( worker.drain().has_value() );
+    CHECK( observed.stopped == std::vector<Generation>{ 55u } );
+    CHECK_FALSE( state.callbackTeardownViolation() );
+}
+
+TEST_CASE( "native zero capacity is rejected before starting a reader",
+           "[ios][native][stream][queue][backpressure][configuration]" )
+{
+    const auto limits = GENERATE( LiveDataQueueLimits{ 2u, 0u }, LiveDataQueueLimits{ 0u, 1u } );
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    auto options = config( 56u, "8.4" );
+    options.queueLimits = limits;
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), options, observed.callbacks() );
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+    worker.shutdown();
+    executor.runAllOnWorker();
+    REQUIRE( observed.errors.size() == 1u );
+    CHECK( observed.errors.front().second.error.code == "ios-live-queue-invalid-capacity" );
+    CHECK( observed.errors.front().second.error.retryPolicy == RetryPolicy::Never );
+    CHECK( observed.ready.empty() );
+    CHECK( state.calls.empty() );
 }
 
 TEST_CASE( "native stop interrupts a blocked partial-frame receive before cleanup acknowledgement",

--- a/tests/unit/ios_native_transport_test.cpp
+++ b/tests/unit/ios_native_transport_test.cpp
@@ -12,6 +12,7 @@
 #include <QCoreApplication>
 #include <QElapsedTimer>
 #include <QEvent>
+#include <QMetaObject>
 #include <QPointer>
 #include <QString>
 
@@ -284,6 +285,72 @@ TEST_CASE( "iOS native transport tolerates synchronous stop from readiness state
         drainQtEvents();
         CHECK( factory.sessions.front()->stopCalls == 1 );
     }
+}
+
+TEST_CASE( "iOS native transport drains records while native startup is still pending",
+           "[ios][native][transport][backpressure][readiness]" )
+{
+    ScriptedWorkerFactory factory;
+    auto config = nativeConfig();
+    config.queueLimits = klogg::livecapture::LiveDataQueueLimits{ 2u, 1u };
+    IosNativeTransport transport( factory, config );
+    QByteArray received;
+    std::vector<LiveSourceTransport::State> states;
+    QObject::connect( &transport, &LiveSourceTransport::bytesReceived,
+                      [ &received ]( Generation, const QByteArray& bytes ) { received += bytes; } );
+    QObject::connect( &transport, &LiveSourceTransport::stateChanged,
+                      [ &states ]( Generation, LiveSourceTransport::State state ) {
+                          states.push_back( state );
+                      } );
+
+    transport.start( 105u );
+    for ( const auto* record : { "a\n", "b\n", "c\n" } ) {
+        factory.publishBytes( 0u, record );
+        drainQtEvents();
+        CHECK( factory.latest()->queue.statistics().queuedBytes == 0u );
+    }
+    CHECK( received == "a\nb\nc\n" );
+    REQUIRE( states.size() == 1u );
+    CHECK( states.back() == LiveSourceTransport::State::Connecting );
+
+    factory.publishReady( 0u );
+    drainQtEvents();
+    CHECK( states.back() == LiveSourceTransport::State::Connected );
+}
+
+TEST_CASE( "iOS native transport yields between replenished batches so stop is not starved",
+           "[ios][native][transport][backpressure][fairness][stop]" )
+{
+    ScriptedWorkerFactory factory;
+    IosNativeTransport transport( factory, nativeConfig() );
+    QByteArray received;
+    int deliveredBatches = 0;
+    QObject::connect( &transport, &LiveSourceTransport::bytesReceived, &transport,
+                      [ & ]( Generation generation, const QByteArray& bytes ) {
+                          received += bytes;
+                          ++deliveredBatches;
+                          if ( deliveredBatches == 1 ) {
+                              QMetaObject::invokeMethod(
+                                  &transport, [ &transport, generation ] { transport.stop( generation ); },
+                                  Qt::QueuedConnection );
+                          }
+                          // Model the native producer resuming as soon as drain frees capacity.
+                          // Bound the old busy-loop behavior so RED fails rather than hangs.
+                          if ( deliveredBatches < 4 ) {
+                              factory.publishBytes( 0u, "next\n" );
+                          }
+                      } );
+
+    transport.start( 106u );
+    factory.publishReady( 0u );
+    drainQtEvents();
+    factory.publishBytes( 0u, "first\n" );
+    drainQtEvents();
+
+    CHECK( deliveredBatches == 1 );
+    CHECK( received == "first\n" );
+    CHECK( factory.latest()->stopCalls == 1 );
+    CHECK( transport.lastError().isEmpty() );
 }
 
 TEST_CASE( "iOS native transport marshals worker callbacks back to its Qt thread",

--- a/tests/unit/live_capture_process_integrated_benchmark_test.cpp
+++ b/tests/unit/live_capture_process_integrated_benchmark_test.cpp
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "iosnativestream.h"
 #include "live_capture_benchmark_core.h"
 
 namespace {
@@ -170,6 +171,69 @@ void requireCanonicalObservation( const benchmark::ArmObservation& observation,
 }
 
 } // namespace
+
+TEST_CASE( "Synthetic native session drains its whole pending batch after one notification",
+           "[benchmark][live-capture][synthetic-drain][contract]" )
+{
+    constexpr klogg::livecapture::Generation generation = 17u;
+    std::vector<std::string> notifications;
+    klogg::livecapture::ios::IosNativeStreamCallbacks callbacks;
+    callbacks.ready = [ & ]( auto observedGeneration ) {
+        CHECK( observedGeneration == generation );
+        notifications.push_back( "ready" );
+    };
+    callbacks.bytesAvailable = [ & ]( auto observedGeneration ) {
+        CHECK( observedGeneration == generation );
+        notifications.push_back( "bytes" );
+    };
+    callbacks.stopped = [ & ]( auto observedGeneration ) {
+        CHECK( observedGeneration == generation );
+        notifications.push_back( "stopped" );
+    };
+
+    auto session = benchmark::SyntheticNativeSessionTestAccess::create(
+        generation, { ascii( "a" ), ascii( "bc" ) }, std::move( callbacks ) );
+    REQUIRE( session != nullptr );
+    REQUIRE( notifications.empty() );
+    const auto queued = session->statistics();
+    REQUIRE( queued.generation == generation );
+    REQUIRE( queued.receivedBytes == 3u );
+    REQUIRE( queued.receivedChunks == 2u );
+    REQUIRE( queued.queuedBytes == 3u );
+    REQUIRE( queued.queuedChunks == 2u );
+    REQUIRE( queued.highWaterQueuedBytes == 3u );
+    REQUIRE( queued.highWaterQueuedChunks == 2u );
+    REQUIRE( queued.deliveredBytes == 0u );
+    REQUIRE( queued.deliveredChunks == 0u );
+
+    REQUIRE( session->start() );
+    const std::vector<std::string> startedNotifications{ "ready", "bytes" };
+    REQUIRE( notifications == startedNotifications );
+
+    // The production transport consumes one pending batch per notification;
+    // preloaded source fragments must not depend on a drain-until-empty loop.
+    const auto batch = session->drain();
+    REQUIRE( batch.has_value() );
+    CHECK( batch->generation == generation );
+    CHECK( batch->bytes == ascii( "abc" ) );
+    CHECK( batch->sourceChunks == 2u );
+    const auto drained = session->statistics();
+    CHECK( drained.generation == generation );
+    CHECK( drained.queuedBytes == 0u );
+    CHECK( drained.queuedChunks == 0u );
+    CHECK( drained.deliveredBytes == 3u );
+    CHECK( drained.deliveredChunks == 2u );
+    CHECK( drained.receivedBytes == queued.receivedBytes );
+    CHECK( drained.receivedChunks == queued.receivedChunks );
+    CHECK( drained.highWaterQueuedBytes == queued.highWaterQueuedBytes );
+    CHECK( drained.highWaterQueuedChunks == queued.highWaterQueuedChunks );
+    CHECK_FALSE( session->drain().has_value() );
+    CHECK( notifications == startedNotifications );
+
+    session->stop( generation );
+    const std::vector<std::string> stoppedNotifications{ "ready", "bytes", "stopped" };
+    CHECK( notifications == stoppedNotifications );
+}
 
 TEST_CASE( "Synthetic live-capture records have a deterministic versioned binary frame",
            "[benchmark][live-capture][framing][contract]" )

--- a/tests/unit/livelog_controller_test.cpp
+++ b/tests/unit/livelog_controller_test.cpp
@@ -328,6 +328,256 @@ void checkProjectionMatches( const livelog::LiveLogController& controller )
 
 } // namespace
 
+TEST_CASE( "Live byte batches advance data without control presentation notifications",
+           "[livelog-controller][live-presentation-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto generation = controller.snapshot().generation;
+    effects.records.clear();
+    int notifications = 0;
+    controller.setPresentationChangedCallback( [ & ]( auto, auto ) { ++notifications; } );
+    REQUIRE( notifications == 0 ); // Registration is not a replay.
+
+    constexpr int BatchCount = 64;
+    for ( int batch = 0; batch < BatchCount; ++batch ) {
+        clock.set( at( 100 + batch ) );
+        controller.streamBytesReceived(
+            generation, QByteArray::number( batch ).rightJustified( 63, '0' ) + '\n' );
+    }
+    REQUIRE( effects.records.size() == static_cast<std::size_t>( BatchCount ) );
+    for ( int batch = 0; batch < BatchCount; ++batch ) {
+        const auto& record = effects.records.at( static_cast<std::size_t>( batch ) );
+        REQUIRE( record.kind == RecordingEffects::Kind::AppendBytes );
+        REQUIRE( record.generation == generation );
+        REQUIRE( record.bytes
+                 == QByteArray::number( batch ).rightJustified( 63, '0' ) + '\n' );
+    }
+    REQUIRE( controller.snapshot().now == at( 163 ) );
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    checkProjectionMatches( controller );
+    CHECK( notifications == 0 );
+}
+
+TEST_CASE( "Live time ticks notify only when a visible retry second changes",
+           "[livelog-controller][live-presentation-red]" )
+{
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    auto config = controllerConfig();
+    config.initialRetryDelay = 3s;
+    livelog::LiveLogController controller{ androidSpec(), config, clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    int notifications = 0;
+    controller.setPresentationChangedCallback( [ & ]( auto, auto ) { ++notifications; } );
+
+    clock.set( at( 100 ) );
+    controller.refreshPresentationTime();
+    REQUIRE( controller.snapshot().now == at( 100 ) );
+    REQUIRE_FALSE( controller.presentation().retryCountdownVisible );
+    CHECK( notifications == 0 );
+
+    controller.streamFailed( controller.snapshot().generation, retryableStreamError() );
+    REQUIRE( controller.presentation().retryCountdownVisible );
+    REQUIRE( controller.presentation().retryRemaining == 3s );
+    REQUIRE( scheduler.activeCount() == 1u );
+    const auto retryToken = scheduler.latestToken();
+    REQUIRE( scheduler.deadline( retryToken ) == at( 3100 ) );
+    notifications = 0;
+    for ( const auto tick : { 101, 500, 1099 } ) {
+        clock.set( at( tick ) );
+        controller.refreshPresentationTime();
+        REQUIRE( controller.snapshot().now == at( tick ) );
+    }
+    REQUIRE( controller.presentation().retryRemaining == live::Timestamp{ 2001 } );
+    CHECK( notifications == 0 ); // Every tick still displays ceil(remaining) == 3 seconds.
+
+    notifications = 0;
+    clock.set( at( 1100 ) );
+    controller.refreshPresentationTime();
+    REQUIRE( controller.presentation().retryRemaining == 2s );
+    CHECK( notifications == 1 );
+    CHECK( scheduler.activeCount() == 1u );
+    CHECK( scheduler.latestToken() == retryToken );
+    checkProjectionMatches( controller );
+}
+
+TEST_CASE( "Control presentation preserves diagnostics gates and recovery",
+           "[livelog-controller][live-presentation-preservation]" )
+{
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ iosSpec(), controllerConfig(), clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    std::vector<livelog::LiveLogControlPresentation> observed;
+    std::vector<livelog::LiveLogPresentationChange> changes;
+    controller.setPresentationChangedCallback( [ & ]( auto value, auto change ) {
+        observed.push_back( value );
+        changes.push_back( change );
+    } );
+    REQUIRE( observed.empty() );
+
+    auto error = outputBindingError();
+    controller.outputBindingChanged( live::OutputBindingState::Degraded, error );
+    REQUIRE( observed.size() == 1u );
+    CHECK( observed.back().status == live::PresentationStatus::Connected );
+    REQUIRE( observed.back().outputBindingError.has_value() );
+    CHECK( observed.back().outputBindingError->code == error.code );
+    CHECK( observed.back().outputBindingError->message == error.message );
+    error.code = "unknown-output-code";
+    controller.outputBindingChanged( live::OutputBindingState::Degraded, error );
+    REQUIRE( observed.size() == 2u );
+    CHECK( observed.back().outputBindingError->code == error.code );
+    error.message = "A different visible diagnostic";
+    controller.outputBindingChanged( live::OutputBindingState::Degraded, error );
+    REQUIRE( observed.size() == 3u );
+    CHECK( observed.back().outputBindingError->message == error.message );
+    error.nativeDetail = "Not part of the control presentation";
+    controller.outputBindingChanged( live::OutputBindingState::Degraded, error );
+    CHECK( observed.size() == 3u );
+    controller.outputBindingChanged( live::OutputBindingState::Healthy );
+    REQUIRE( observed.size() == 4u );
+    CHECK_FALSE( observed.back().outputBindingError.has_value() );
+    CHECK( observed.back().outputBinding == live::OutputBindingState::Healthy );
+
+    for ( const auto reason : { live::AwaitingUserReason::Trust, live::AwaitingUserReason::Unlock,
+                               live::AwaitingUserReason::Pair, live::AwaitingUserReason::Authorize } ) {
+        const auto count = observed.size();
+        controller.userActionRequired( controller.snapshot().generation, reason );
+        REQUIRE( observed.size() == count + 1u );
+        CHECK( observed.back().status == live::PresentationStatus::AwaitingUser );
+        CHECK( observed.back().awaitingUserReason == reason );
+    }
+    for ( const auto* message : { "Infrastructure failed", "Changed infrastructure diagnostic" } ) {
+        auto failure = retryableStreamError();
+        failure.message = message;
+        failure.retryPolicy = live::RetryPolicy::Never;
+        controller.deviceAbsent( controller.snapshot().generation );
+        const auto count = observed.size();
+        controller.availabilityFailed( controller.snapshot().generation, failure );
+        REQUIRE( observed.size() == count + 1u );
+        CHECK( observed.back().status == live::PresentationStatus::Failed );
+        CHECK( observed.back().failureMessage == message );
+        auto changedDiagnostic = observed.back();
+        changedDiagnostic.failureMessage += " updated";
+        CHECK_FALSE( changedDiagnostic.sameControlState( observed.back() ) );
+    }
+    CHECK( std::all_of( changes.begin(), changes.end(), []( auto change ) {
+        return change == livelog::LiveLogPresentationChange::Control;
+    } ) );
+}
+
+TEST_CASE( "Nested append failure notifies after the byte effect and observers own stable values",
+           "[livelog-controller][live-presentation-preservation]" )
+{
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ androidSpec(), controllerConfig(), clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    effects.records.clear();
+    effects.beforeRecord = [ & ]( auto kind, auto ) {
+        if ( kind == RecordingEffects::Kind::AppendBytes ) {
+            controller.outputBindingChanged( live::OutputBindingState::Degraded, outputBindingError() );
+        }
+    };
+    int firstCalls = 0;
+    int replacementCalls = 0;
+    int depth = 0;
+    auto lifetime = std::make_shared<int>( 42 );
+    const std::weak_ptr<int> weakLifetime = lifetime;
+    controller.setPresentationChangedCallback(
+        [ &, lifetime ]( const livelog::LiveLogControlPresentation& value, auto change ) {
+            ++depth;
+            ++firstCalls;
+            CHECK( depth == 1 );
+            CHECK( change == livelog::LiveLogPresentationChange::Control );
+            REQUIRE( effects.count( RecordingEffects::Kind::AppendBytes ) == 1u );
+            CHECK( value.outputBinding == live::OutputBindingState::Degraded );
+            controller.setPresentationChangedCallback( [ & ]( auto replacement, auto replacementChange ) {
+                ++depth;
+                ++replacementCalls;
+                CHECK( depth == 1 );
+                CHECK( replacementChange == livelog::LiveLogPresentationChange::Control );
+                CHECK( replacement.outputBinding == live::OutputBindingState::Healthy );
+                controller.setPresentationChangedCallback( {} );
+                controller.refreshPresentationTime();
+                --depth;
+            } );
+            CHECK_FALSE( weakLifetime.expired() ); // The executing callable owns its captures.
+            controller.outputBindingChanged( live::OutputBindingState::Healthy );
+            CHECK( replacementCalls == 0 ); // Nested dispatch is queued, not recursive.
+            CHECK( value.outputBinding == live::OutputBindingState::Degraded );
+            --depth;
+        } );
+    lifetime.reset();
+    controller.streamBytesReceived( controller.snapshot().generation, QByteArrayLiteral( "kept\n" ) );
+    CHECK( firstCalls == 1 );
+    CHECK( replacementCalls == 1 );
+    CHECK( weakLifetime.expired() );
+    CHECK( effects.latest( RecordingEffects::Kind::AppendBytes ).bytes == QByteArrayLiteral( "kept\n" ) );
+    CHECK( controller.controlPresentation().outputBinding == live::OutputBindingState::Healthy );
+    controller.outputBindingChanged( live::OutputBindingState::Degraded, outputBindingError() );
+    CHECK( replacementCalls == 1 );
+}
+
+TEST_CASE( "Presentation countdown uses nonnegative ceil seconds without changing retry deadlines",
+           "[livelog-controller][live-presentation-preservation]" )
+{
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    auto config = controllerConfig();
+    config.initialRetryDelay = 3s;
+    livelog::LiveLogController controller{ androidSpec(), config, clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    std::vector<livelog::LiveLogPresentationChange> changes;
+    controller.setPresentationChangedCallback( [ & ]( auto, auto change ) { changes.push_back( change ); } );
+    controller.streamFailed( controller.snapshot().generation, retryableStreamError() );
+    REQUIRE( changes.size() == 1u );
+    CHECK( changes.back() == livelog::LiveLogPresentationChange::Control );
+    CHECK( controller.controlPresentation().retryAttempt == 1u );
+    CHECK( controller.controlPresentation().retryCountdownSeconds == 3 );
+    const auto token = scheduler.latestToken();
+    CHECK( scheduler.deadline( token ) == at( 3050 ) );
+    for ( const auto tick : { 51, 999, 1049 } ) {
+        clock.set( at( tick ) );
+        controller.refreshPresentationTime();
+        CHECK( controller.controlPresentation().retryCountdownSeconds == 3 );
+        CHECK( changes.size() == 1u );
+    }
+    for ( const auto tick : { 1050, 2050, 3050 } ) {
+        clock.set( at( tick ) );
+        controller.refreshPresentationTime();
+        CHECK( changes.back() == livelog::LiveLogPresentationChange::CountdownOnly );
+        CHECK( controller.controlPresentation().retryCountdownSeconds == ( 3050 - tick ) / 1000 );
+    }
+    REQUIRE( changes.size() == 4u );
+    clock.set( at( 3100 ) );
+    controller.refreshPresentationTime();
+    CHECK( controller.controlPresentation().retryCountdownSeconds == 0 );
+    CHECK( changes.size() == 4u );
+    CHECK( scheduler.latestToken() == token );
+    scheduler.fire( token );
+    REQUIRE( changes.size() == 5u );
+    CHECK( changes.back() == livelog::LiveLogPresentationChange::Control );
+    CHECK_FALSE( controller.controlPresentation().retryCountdownSeconds.has_value() );
+    controller.stopRequested();
+    const auto count = changes.size();
+    controller.streamBytesReceived( controller.snapshot().generation - 1u, QByteArrayLiteral( "stale\n" ) );
+    controller.streamFailed( controller.snapshot().generation - 1u, retryableStreamError() );
+    CHECK( changes.size() == count );
+    CHECK( effects.count( RecordingEffects::Kind::AppendBytes ) == 0u );
+}
+
 TEST_CASE( "Running session intent is reduced before any startup effect executes",
            "[livelog-controller][red][ordering]" )
 {

--- a/tests/unit/pathutils_test.cpp
+++ b/tests/unit/pathutils_test.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Anton Filimonov and other contributors
+ *
+ * This file is part of klogg.
+ *
+ * klogg is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * klogg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with klogg.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <QString>
+
+#include <utility>
+
+#include "pathutils.h"
+
+TEST_CASE( "Suggested filename stems separate device labels without UI punctuation",
+           "[pathutils][save-filename]" )
+{
+    const auto example = GENERATE(
+        std::make_pair( "Pixel 8 (ABC123)", "Pixel-8-ABC123" ),
+        std::make_pair( "iPhone 15 Pro (USB)", "iPhone-15-Pro-USB" ),
+        std::make_pair( "device [online] {USB}", "device-online-USB" ),
+        std::make_pair( "测试设备（USB）［在线］｛记录｝", "测试设备-USB-在线-记录" ),
+        std::make_pair( "设备【在线】「日志」《备份》", "设备-在线-日志-备份" ),
+        std::make_pair( "  --device ( [USB] )--  ", "device-USB" ),
+        std::make_pair( "device<>:\"/\\|?*name", "device-name" ),
+        std::make_pair( "../../device/name", "device-name" ),
+        std::make_pair( "...device...", "device" ),
+        std::make_pair( "device_01.trace", "device_01.trace" ),
+        std::make_pair( "中文-é-é-📱-𠮷", "中文-é-é-📱-𠮷" ),
+        std::make_pair( "ZEACENT's iPhone", "ZEACENT's-iPhone" ),
+        std::make_pair( "device\U000e0001USB", "device-USB" ) );
+    const auto label = QString::fromUtf8( example.first );
+    const auto expected = QString::fromUtf8( example.second );
+    CAPTURE( example.first );
+    const auto stem = klogg::suggestedFileNameStem( label, QStringLiteral( "live-log" ) );
+    CHECK( stem == expected );
+    CHECK( klogg::suggestedFileNameStem( stem, QStringLiteral( "live-log" ) ) == stem );
+}
+
+TEST_CASE( "Suggested filename stems exclude whitespace and invisible characters",
+           "[pathutils][save-filename]" )
+{
+    // Include NUL, C0, DEL, C1, non-breaking/Unicode spaces, and format controls.
+    const auto codePoint = GENERATE( 0x0000, 0x0009, 0x000a, 0x000d, 0x001b, 0x001f,
+                                     0x007f, 0x0085, 0x009f, 0x00a0, 0x1680, 0x2003,
+                                     0x200b, 0x2028, 0x2029, 0x202e, 0x202f, 0x2060,
+                                     0x3000, 0xfeff );
+    const auto character = QChar{ static_cast<ushort>( codePoint ) };
+    CAPTURE( codePoint );
+    const auto label = QStringLiteral( "device" ) + character + character + QStringLiteral( "USB" );
+    CHECK( klogg::suggestedFileNameStem( label, QStringLiteral( "live-log" ) )
+           == QStringLiteral( "device-USB" ) );
+}
+
+TEST_CASE( "Suggested filename stems use a clean fallback when labels have no filename",
+           "[pathutils][save-filename]" )
+{
+    const auto label = GENERATE( "", " ()[]{} ", "...", "--", "/\\:*?\"<>|", "\t\r\n" );
+    CHECK( klogg::suggestedFileNameStem( QString::fromUtf8( label ), QStringLiteral( "live-log" ) )
+           == QStringLiteral( "live-log" ) );
+    CHECK( klogg::suggestedFileNameStem( QString::fromUtf8( label ), QStringLiteral( "fallback (log)" ) )
+           == QStringLiteral( "fallback-log" ) );
+    CHECK( klogg::suggestedFileNameStem( QString::fromUtf8( label ), QStringLiteral( "[]" ) )
+           == QStringLiteral( "log" ) );
+}
+
+TEST_CASE( "Suggested filename stems avoid Windows reserved device names on every platform",
+           "[pathutils][save-filename]" )
+{
+    const auto reserved = GENERATE( "CON", "con", "PRN", "AUX", "NUL", "COM1", "COM9",
+                                    "LPT1", "LPT9", "COM¹", "COM²", "LPT³", "CON.trace",
+                                    "CONIN$", "CONOUT$", "conin$", "CONOUT$.trace" );
+    const auto label = QString::fromUtf8( reserved );
+    const auto expected = QStringLiteral( "log-" ) + label;
+    CAPTURE( reserved );
+    CHECK( klogg::suggestedFileNameStem( label, QStringLiteral( "live-log" ) ) == expected );
+    CHECK( klogg::suggestedFileNameStem( expected, QStringLiteral( "live-log" ) ) == expected );
+    CHECK( klogg::suggestedFileNameStem( {}, label ) == expected );
+}
+
+TEST_CASE( "Suggested filename stems retain names merely resembling reserved devices",
+           "[pathutils][save-filename]" )
+{
+    const auto label = QString::fromUtf8( GENERATE( "console", "CONSOLE", "COM0", "COM10",
+                                                  "LPT0", "LPT10", "device.CON", "_NUL" ) );
+    CHECK( klogg::suggestedFileNameStem( label, QStringLiteral( "live-log" ) ) == label );
+}

--- a/tests/unit/streaminglogdata_test.cpp
+++ b/tests/unit/streaminglogdata_test.cpp
@@ -27,11 +27,13 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QTime>
+#include <QTimerEvent>
 #include <QTemporaryDir>
 #include <QThread>
 #include <QUuid>
 
 #include <filesystem>
+#include <optional>
 #include <string_view>
 
 #include "capturestore.h"
@@ -39,6 +41,24 @@
 #include "logfiltereddata.h"
 #include "streaminglogdata.h"
 #include "test_utils.h"
+
+struct StreamingLogDataTimerTestAccess {
+    static bool pending( const StreamingLogData& data )
+    {
+        return data.loadingFinishedQueued_ && data.loadingFinishedTimer_.isActive();
+    }
+
+    static void deliver( StreamingLogData& data )
+    {
+        REQUIRE( pending( data ) );
+        const auto timerId = data.loadingFinishedTimer_.timerId();
+        REQUIRE( timerId >= 0 );
+        QTimerEvent event{ timerId };
+        QCoreApplication::sendEvent( &data.loadingFinishedTimer_, &event );
+        REQUIRE_FALSE( data.loadingFinishedTimer_.isActive() );
+        REQUIRE_FALSE( data.loadingFinishedQueued_ );
+    }
+};
 
 namespace {
 QString makeCaptureId()
@@ -120,6 +140,33 @@ bool waitForTerminalMatchCount( LogFilteredData& filteredData, LinesCount expect
     return false;
 }
 
+// The caller arms the spy before starting the search, including synchronous cache hits.
+// Return any terminal result for this generation so an incorrect count fails explicitly.
+std::optional<LinesCount>
+waitForTerminalResult( SafeQSignalSpy& searchProgressSpy,
+                       LogFilteredData::SearchGeneration expectedGeneration,
+                       int timeoutMs = 10000 )
+{
+    QElapsedTimer timer;
+    timer.start();
+    int consumedSignals = 0;
+    while ( true ) {
+        while ( consumedSignals < searchProgressSpy.count() ) {
+            const auto args = searchProgressSpy.at( consumedSignals++ );
+            if ( args.size() >= 4 && args.at( 1 ).toInt() == 100
+                 && args.at( 3 ).toULongLong() == expectedGeneration ) {
+                return args.at( 0 ).value<LinesCount>();
+            }
+        }
+
+        const auto remaining = timeoutMs - static_cast<int>( timer.elapsed() );
+        if ( remaining <= 0 ) {
+            return std::nullopt;
+        }
+        searchProgressSpy.wait( qMin( 100, remaining ) );
+    }
+}
+
 QByteArray makeStreamingSearchLines( int firstLine, int count, bool matchFinalLine = false )
 {
     QByteArray data;
@@ -137,12 +184,14 @@ QByteArray makeStreamingSearchLines( int firstLine, int count, bool matchFinalLi
 struct SearchConfigGuard {
     Configuration& cfg;
     bool prevParallel;
+    bool prevResultsCache;
     int prevBufferLines;
     int prevThreadPoolSize;
 
     explicit SearchConfigGuard( Configuration& c )
         : cfg( c )
         , prevParallel( c.useParallelSearch() )
+        , prevResultsCache( c.useSearchResultsCache() )
         , prevBufferLines( c.searchReadBufferSizeLines() )
         , prevThreadPoolSize( c.searchThreadPoolSize() )
     {
@@ -151,6 +200,7 @@ struct SearchConfigGuard {
     ~SearchConfigGuard()
     {
         cfg.setUseParallelSearch( prevParallel );
+        cfg.setUseSearchResultsCache( prevResultsCache );
         cfg.setSearchReadBufferSizeLines( prevBufferLines );
         cfg.setSearchThreadPoolSize( prevThreadPoolSize );
     }
@@ -159,6 +209,203 @@ struct SearchConfigGuard {
     SearchConfigGuard& operator=( const SearchConfigGuard& ) = delete;
 };
 } // namespace
+
+TEST_CASE( "Rolling replacements refresh even when the retained line count is unchanged",
+           "[streaming][live-presentation-red]" )
+{
+    const auto finishPartial = GENERATE( false, true );
+    CAPTURE( finishPartial );
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+    StreamingLogData logData{ makeCaptureId(), tempDir.path() };
+    SafeQSignalSpy loadingSpy{ &logData, SIGNAL( loadingFinished( LoadingStatus ) ) };
+    StreamingLogDataTimerTestAccess::deliver( logData );
+    REQUIRE( loadingSpy.count() == 1 );
+
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 8;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 8;
+    limits.rollingBackupCount = 2;
+    logData.setCaptureLimits( limits );
+    REQUIRE( logData.bindOutputFile( QDir{ tempDir.path() }.filePath( "rolling.log" ),
+                                     LiveLogSaveAnsiMode::Preserve ) );
+    logData.appendUtf8( QByteArrayLiteral( "old-000\n" ) );
+    logData.appendUtf8( QByteArrayLiteral( "old-001\n" ) );
+    REQUIRE( logData.getNbLine() == 2_lcount );
+    StreamingLogDataTimerTestAccess::deliver( logData );
+    loadingSpy.clear();
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( logData ) );
+    SafeQSignalSpy fileSpy{ &logData, SIGNAL( fileChanged( MonitoredFileStatus ) ) };
+
+    if ( finishPartial ) {
+        // Eight unterminated bytes fill the output segment on finishInput,
+        // forcing an actual rotation/trim rather than merely growing the tail.
+        logData.appendUtf8( QByteArrayLiteral( "new-002!" ) );
+        REQUIRE( logData.getNbLine() == 2_lcount );
+        REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( logData ) );
+        REQUIRE( loadingSpy.count() == 0 );
+        logData.finishInput();
+    }
+    else {
+        logData.appendUtf8( QByteArrayLiteral( "new-002\n" ) );
+    }
+
+    // Data and normal invalidation must survive; the RED is only the missing refresh.
+    REQUIRE( logData.getNbLine() == 2_lcount );
+    REQUIRE( logData.getLineString( 0_lnum ) == QStringLiteral( "old-001" ) );
+    REQUIRE( logData.getLineString( 1_lnum )
+             == ( finishPartial ? QStringLiteral( "new-002!" ) : QStringLiteral( "new-002" ) ) );
+    int truncations = 0;
+    for ( int i = 0; i < fileSpy.count(); ++i ) {
+        if ( fileSpy.at( i ).at( 0 ).value<MonitoredFileStatus>()
+             == MonitoredFileStatus::Truncated ) {
+            ++truncations;
+        }
+    }
+    REQUIRE( truncations == 1 );
+    REQUIRE( loadingSpy.count() == 0 );
+    REQUIRE( StreamingLogDataTimerTestAccess::pending( logData ) );
+    StreamingLogDataTimerTestAccess::deliver( logData );
+    REQUIRE( loadingSpy.count() == 1 );
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( logData ) );
+}
+
+TEST_CASE( "Streaming coalescer preserves empty partial UTF8 CRLF and repeat burst delivery",
+           "[streaming][live-presentation-preservation]" )
+{
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+    StreamingLogData data{ makeCaptureId(), tempDir.path() };
+    SafeQSignalSpy loadingSpy{ &data, SIGNAL( loadingFinished( LoadingStatus ) ) };
+    StreamingLogDataTimerTestAccess::deliver( data );
+    loadingSpy.clear();
+    data.appendUtf8( {} );
+    data.finishInput();
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( data ) );
+    const auto utf8 = QString::fromUtf8( "雪" ).toUtf8();
+    data.appendUtf8( utf8.left( 1 ) );
+    data.appendUtf8( {} );
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( data ) );
+    data.appendUtf8( utf8.mid( 1 ) + '\r' );
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( data ) );
+    data.appendUtf8( QByteArrayLiteral( "\n" ) );
+    REQUIRE( StreamingLogDataTimerTestAccess::pending( data ) );
+    for ( int batch = 0; batch < 64; ++batch ) {
+        data.appendUtf8( QByteArray::number( batch ) + '\n' );
+    }
+    data.finishInput(); // Does not cause a second delivery while a refresh is pending.
+    REQUIRE( loadingSpy.count() == 0 );
+    StreamingLogDataTimerTestAccess::deliver( data );
+    REQUIRE( loadingSpy.count() == 1 );
+    CHECK( data.getNbLine() == 65_lcount );
+    CHECK( data.getLineString( 0_lnum ) == QString::fromUtf8( "雪" ) );
+    CHECK( data.getLineString( 64_lnum ) == QStringLiteral( "63" ) );
+    data.appendUtf8( QByteArrayLiteral( "tail" ) );
+    REQUIRE_FALSE( StreamingLogDataTimerTestAccess::pending( data ) );
+    data.finishInput();
+    REQUIRE( StreamingLogDataTimerTestAccess::pending( data ) );
+    StreamingLogDataTimerTestAccess::deliver( data );
+    REQUIRE( loadingSpy.count() == 2 );
+    CHECK( data.getNbLine() == 66_lcount );
+    CHECK( data.getLineString( 65_lnum ) == QStringLiteral( "tail" ) );
+    data.finishInput();
+    data.appendUtf8( {} );
+    QCoreApplication::processEvents();
+    CHECK_FALSE( StreamingLogDataTimerTestAccess::pending( data ) );
+    CHECK( loadingSpy.count() == 2 );
+}
+
+TEST_CASE( "Rolling coalesced delivery exposes the replacement to filtered search",
+           "[streaming][live-presentation-preservation]" )
+{
+    const auto useResultsCache = GENERATE( true, false );
+    CAPTURE( useResultsCache );
+    auto& config = Configuration::get();
+    SearchConfigGuard configGuard{ config };
+    config.setUseSearchResultsCache( useResultsCache );
+
+    QTemporaryDir tempDir;
+    REQUIRE( tempDir.isValid() );
+    StreamingLogData data{ makeCaptureId(), tempDir.path() };
+    StreamingLogDataTimerTestAccess::deliver( data );
+    CaptureStore::Limits limits;
+    limits.segmentTargetBytes = 8;
+    limits.memoryBudgetBytes = 4096;
+    limits.rollingMaxFileSize = 8;
+    limits.rollingBackupCount = 2;
+    data.setCaptureLimits( limits );
+    REQUIRE( data.bindOutputFile( QDir{ tempDir.path() }.filePath( "search.log" ),
+                                  LiveLogSaveAnsiMode::Preserve ) );
+    data.appendUtf8( QByteArrayLiteral( "old-000\nold-001\n" ) );
+    StreamingLogDataTimerTestAccess::deliver( data );
+    REQUIRE( data.getNbLine().get() == 2 );
+    auto filtered = data.getNewFilteredData();
+    const RegularExpressionPattern pattern{ QStringLiteral( "new" ) };
+    SafeQSignalSpy searchProgressSpy{ filtered.get(), &LogFilteredData::searchProgressed };
+    filtered->runSearch( pattern, 0_lnum, LineNumber{ data.getNbLine().get() } );
+    const auto initialResult
+        = waitForTerminalResult( searchProgressSpy, filtered->currentSearchGeneration() );
+    REQUIRE( initialResult.has_value() );
+    REQUIRE( initialResult->get() == 0 );
+    CHECK( filtered->getNbMatches().get() == 0 );
+
+    // Prove the configured path with a completed unchanged search: a cache hit
+    // emits synchronously without starting an operation; cache OFF searches again.
+    const auto initialOperations = filtered->searchPerformanceCounters().operationStarts;
+    REQUIRE( initialOperations == 1 );
+    searchProgressSpy.clear();
+    filtered->runSearch( pattern, 0_lnum, LineNumber{ data.getNbLine().get() } );
+    if ( useResultsCache ) {
+        REQUIRE( searchProgressSpy.count() == 1 );
+    }
+    const auto repeatedResult
+        = waitForTerminalResult( searchProgressSpy, filtered->currentSearchGeneration() );
+    REQUIRE( repeatedResult.has_value() );
+    REQUIRE( repeatedResult->get() == 0 );
+    REQUIRE( filtered->searchPerformanceCounters().operationStarts
+             == initialOperations + ( useResultsCache ? 0u : 1u ) );
+
+    // Mirror both view boundaries: truncation invalidates the old search/cache,
+    // then coalesced loading completion restarts against the committed window.
+    int truncations = 0;
+    int restarts = 0;
+    QObject::connect( &data, &StreamingLogData::fileChanged, filtered.get(),
+                      [ & ]( MonitoredFileStatus status ) {
+                          if ( status == MonitoredFileStatus::Truncated ) {
+                              ++truncations;
+                              filtered->clearSearch( true );
+                          }
+                      } );
+    QObject::connect( &data, &StreamingLogData::loadingFinished, filtered.get(),
+                      [ & ]( auto ) {
+                          ++restarts;
+                          filtered->runSearch( pattern, 0_lnum,
+                                               LineNumber{ data.getNbLine().get() } );
+                      } );
+    searchProgressSpy.clear();
+    const auto previousOperations = filtered->searchPerformanceCounters().operationStarts;
+    data.appendUtf8( QByteArrayLiteral( "new-002\n" ) );
+    REQUIRE( data.getNbLine().get() == 2 );
+    REQUIRE( truncations == 1 );
+    REQUIRE( restarts == 0 );
+    REQUIRE( StreamingLogDataTimerTestAccess::pending( data ) );
+    // Measure restart's generation advance separately from any invalidation advance.
+    const auto generationBeforeRestart = filtered->currentSearchGeneration();
+    StreamingLogDataTimerTestAccess::deliver( data );
+    REQUIRE( restarts == 1 );
+    REQUIRE( filtered->currentSearchGeneration() == generationBeforeRestart + 1 );
+    const auto replacementResult
+        = waitForTerminalResult( searchProgressSpy, filtered->currentSearchGeneration() );
+    REQUIRE( replacementResult.has_value() );
+    REQUIRE( replacementResult->get() == 1 );
+    CHECK( filtered->searchPerformanceCounters().operationStarts == previousOperations + 1 );
+    CHECK( filtered->getNbMatches().get() == 1 );
+    CHECK( filtered->getMatchingLineNumber( 0_lnum ).get() == 1 );
+    CHECK( data.getLineString( 0_lnum ) == QStringLiteral( "old-001" ) );
+    CHECK( data.getLineString( 1_lnum ) == QStringLiteral( "new-002" ) );
+    filtered->interruptSearch();
+}
 
 TEST_CASE( "StreamingLogData emits its ready signal asynchronously after listeners attach" )
 {

--- a/tests/unit/tabbedcrawlerwidget_test.cpp
+++ b/tests/unit/tabbedcrawlerwidget_test.cpp
@@ -22,7 +22,10 @@
 #include <QApplication>
 #include <QCoreApplication>
 #include <QDir>
+#include <QEvent>
 #include <QMenu>
+#include <QProxyStyle>
+#include <QStyleFactory>
 #include <QTabBar>
 #include <QTimer>
 #include <QTranslator>
@@ -585,6 +588,22 @@ TEST_CASE( "generateColoredDotIcon creates non-null icons for all live status an
 }
 
 namespace {
+class TabSizingStyle final : public QProxyStyle {
+  public:
+    TabSizingStyle() : QProxyStyle( QStyleFactory::create( QStringLiteral( "Fusion" ) ) ) {}
+
+    QSize sizeFromContents( ContentsType type, const QStyleOption* option, const QSize& size,
+                            const QWidget* widget = nullptr ) const override
+    {
+        if ( type == CT_TabBarTab ) {
+            ++tabSizingCalls;
+        }
+        return QProxyStyle::sizeFromContents( type, option, size, widget );
+    }
+
+    mutable int tabSizingCalls = 0;
+};
+
 // Runs just enough of the event loop to process any queued metacalls
 // (e.g. the deferred loadIcons() dispatched via Qt::QueuedConnection).
 void runPendingMainThreadEvents()
@@ -595,6 +614,99 @@ void runPendingMainThreadEvents()
     }
 }
 } // namespace
+
+TEST_CASE( "Unchanged live tab presentation does not repeat tab layout",
+           "[live-tab][icon-layout]" )
+{
+    const auto path = QString::fromLatin1( GENERATE( "adb://icon-layout", "ios-log://icon-layout" ) );
+    ScopedStyleSetting styleSetting( StyleManager::ModernKey );
+    TabSizingStyle sizingStyle;
+    TabbedCrawlerWidget tabWidget;
+    auto* const tabBar = tabWidget.findChild<CrawlerTabBar*>();
+    REQUIRE( tabBar != nullptr );
+    tabBar->setStyle( &sizingStyle );
+    auto* crawler = new DummyCrawlerWidget();
+    auto index = tabWidget.addCrawler( crawler, path, QStringLiteral( "Live tab" ) );
+    tabWidget.addCrawler( new DummyCrawlerWidget(), QStringLiteral( "other.log" ),
+                         QStringLiteral( "Other tab" ) );
+    tabWidget.resize( 600, 300 );
+    tabWidget.show();
+    runPendingMainThreadEvents();
+    tabWidget.setLiveTabStatus( index, LiveTabStatus::Connected );
+    runPendingMainThreadEvents();
+    REQUIRE_FALSE( tabWidget.tabIcon( index ).isNull() );
+
+    // Calibrate the layout observer using an actual size change, not a timer.
+    // Qt versions may legitimately optimize layout for equal-sized icon changes.
+    sizingStyle.tabSizingCalls = 0;
+    tabBar->setIconSize( tabBar->iconSize() + QSize( 1, 1 ) );
+    static_cast<void>( tabBar->tabRect( index ) );
+    REQUIRE( sizingStyle.tabSizingCalls > 0 );
+    runPendingMainThreadEvents();
+
+    SECTION( "existing tab" ) {}
+    SECTION( "moved tab" )
+    {
+        tabBar->moveTab( index, 1 );
+        index = tabWidget.indexOf( crawler );
+    }
+    SECTION( "replacement tab" )
+    {
+        tabWidget.removeCrawler( index );
+        delete crawler;
+        crawler = new DummyCrawlerWidget();
+        index = tabWidget.addCrawler( crawler, path, QStringLiteral( "Replacement" ) );
+        tabWidget.setLiveTabStatus( index, LiveTabStatus::Connected );
+    }
+    SECTION( "palette reload" )
+    {
+        const auto oldKey = tabWidget.tabIcon( index ).cacheKey();
+        QEvent paletteChange( QEvent::PaletteChange );
+        QCoreApplication::sendEvent( &tabWidget, &paletteChange );
+        runPendingMainThreadEvents();
+        REQUIRE_FALSE( tabWidget.tabIcon( index ).isNull() );
+        CHECK( tabWidget.tabIcon( index ).cacheKey() != oldKey );
+    }
+    runPendingMainThreadEvents();
+
+    const auto requireNoRepeatedLayout = [ & ]( LiveTabStatus liveStatus, DataStatus dataStatus ) {
+        const auto key = tabWidget.tabIcon( index ).cacheKey();
+        const auto title = tabWidget.tabText( index );
+        const auto toolTip = tabWidget.tabToolTip( index );
+        sizingStyle.tabSizingCalls = 0;
+        for ( int repeat = 0; repeat < 64; ++repeat ) {
+            tabWidget.setLiveTabStatus( index, liveStatus );
+            tabWidget.setTabDataStatus( index, dataStatus );
+            tabWidget.updateCrawler( index, title, toolTip );
+        }
+        CHECK( tabWidget.tabIcon( index ).cacheKey() == key );
+        CHECK( sizingStyle.tabSizingCalls == 0 );
+    };
+    requireNoRepeatedLayout( LiveTabStatus::Connected, DataStatus::OLD_DATA );
+
+    auto previousKey = tabWidget.tabIcon( index ).cacheKey();
+    tabWidget.setLiveTabStatus( index, LiveTabStatus::Error );
+    CHECK( tabWidget.tabIcon( index ).cacheKey() != previousKey );
+    requireNoRepeatedLayout( LiveTabStatus::Error, DataStatus::OLD_DATA );
+
+    for ( const auto dataStatus : { DataStatus::NEW_DATA, DataStatus::NEW_FILTERED_DATA } ) {
+        previousKey = tabWidget.tabIcon( index ).cacheKey();
+        tabWidget.setTabDataStatus( index, dataStatus );
+        CHECK( tabWidget.tabIcon( index ).cacheKey() != previousKey );
+        requireNoRepeatedLayout( LiveTabStatus::Error, dataStatus );
+    }
+
+    sizingStyle.tabSizingCalls = 0;
+    tabWidget.updateCrawler( index, QStringLiteral( "Renamed live tab" ),
+                             QStringLiteral( "Updated tooltip" ) );
+    CHECK( tabWidget.tabText( index ) == QStringLiteral( "Renamed live tab" ) );
+    CHECK( tabWidget.tabToolTip( index ) == QStringLiteral( "Updated tooltip" ) );
+    CHECK( sizingStyle.tabSizingCalls > 0 );
+    runPendingMainThreadEvents();
+    requireNoRepeatedLayout( LiveTabStatus::Error, DataStatus::NEW_FILTERED_DATA );
+    tabWidget.hide();
+    runPendingMainThreadEvents();
+}
 
 TEST_CASE( "setLiveTabStatus updates the tab icon with colored dots" )
 {


### PR DESCRIPTION
## Summary

This PR combines verified release promotion, live-capture reliability and responsiveness, safe save-file suggestions, and Windows UI-test portability fixes.

### Verified release promotion
- Dispatch Continuous from a successful trusted-master CI gate using the exact producer run ID and SHA, with workflow/repository/event/gate validation and bounded retries.
- Make Stable a manual promotion of the current verified Continuous inventory, downloaded by immutable asset IDs rather than rebuilt or independently selected from CI.
- Preserve package/source/support/evidence payloads byte-for-byte, regenerate Stable metadata/checksums, and record source-release and asset provenance in schema-v3 manifests.
- Serialize both publishers, recheck source release and current-master identity, retain draft read-back verification and PAT-authenticated publication, and clean up owned unpublished transactions on failure/cancellation. Discord notification failure remains nonfatal.
- Remove Stable's separate signed-evidence/Sentry publication path and update README and release lint/contracts. macOS artifacts remain explicitly unsigned validation packages; signing/notarization is not added here.

### Live-capture reliability and avoidable work
- Preserve native iOS records under transient bounded-queue pressure, with cancellable producer waits and safe startup/callback cleanup; keep invalid-capacity and oversized-record failures explicit.
- Drain one complete native batch per Qt notification so sustained traffic cannot starve queued stop requests. Align the synthetic native benchmark with the real whole-batch drain contract.
- Skip filesystem coordination when CaptureStore has no physical maintenance work, while retaining ownership, lease, retirement, registry and retry-handoff safeguards.
- Separate visible control/countdown changes from coalesced content updates. Eliminate byte-driven Opened Files menu rebuilds and unchanged tab text/icon writes, preserving same-state errors, background-tab isolation, observer reentrancy and Save Live metadata.
- Refresh rolling replacements even when retained line count is unchanged; add deterministic queue, lifecycle, operation-count, menu, countdown, cache-enabled search and rendering-preservation coverage.

### Portable save suggestions and Windows CI follow-up
- Normalize generated live-save filename stems: replace Unicode whitespace/control/format characters, brackets and platform-invalid characters with separators, preserve visible text, and handle empty names and Windows reserved device names.
- Keep display titles, manually selected paths and existing output bindings unchanged. Other content/configuration exporters have no generated default filename and retain their existing behavior.
- Fix the three Windows CI legs' shared test-only assumptions: native tooltip separators must match native path expectations, and copied CRLF text must be normalized before logical-line comparisons. Product clipboard/path formatting and CI strictness are unchanged.
- Add a local/PR platform lint guard with precise bad/valid fixtures, multiline/reversed assertions, comment/string spoof coverage, malformed-input handling and real-tree mutations.

## Background

- **Introduced by:** native queue/transport and unconditional live-presentation behavior in `ee211008` (#64); unconditional capture coordination in `3f6ec51c` (#50); count-delta streaming refresh in `f93ab94e` (#18), with coalescing under that condition in `11ba6d0f` (#21). Release changes replace Stable's prior independent artifact-selection pipeline.
- **Use case / reproduction:** start iOS live logging and deliver a burst while the consumer is briefly behind; append many small batches with rolling limits enabled; or replace a retained two-line window with another two-line window. Previously these could stop capture, enumerate unrelated coordination markers, rebuild unchanged UI, or miss a content refresh. The synthetic native fixture also stranded fragments after one availability notification.
- **Root cause / fix:** distinguish temporary pressure from terminal failure, respect whole-batch notification semantics, separate local housekeeping from coordinated deletion, and give control presentation and content refresh distinct owners. Stable now promotes an identified, verified publication instead of reconstructing its input independently.

- **Windows follow-up introduced by:** `22161a2f`. [CI Build 34014958810](https://github.com/ZEACENT/klogg/actions/runs/34014958810) compiled successfully but failed the same four UI assertions on Windows x86 Qt5, x64 Qt6 and x64 ASan. The tests assumed internal `/` paths and LF while the UI intentionally exposes native separators and CRLF. macOS Qt5/Qt6/sanitizer runs could not exercise those OS differences; the new fast guard closes that preflight gap without changing application behavior.
- **Filename reproduction:** save a stream titled `Pixel 8 (ABC123)` or `iPhone 15 Pro (USB)`. Suggestions now become `Pixel-8-ABC123.log` and `iPhone-15-Pro-USB.log`; user-selected destinations remain untouched.

## Tests

- Full local build and serial CTest: **27/27 passed**.
- `python3 scripts/run_ci_quality.py`: passed, including complete Python contract discovery.
- Changed-header self-containment using real `build_root/compile_commands.json`: passed.
- Changed-line source and benchmark clang-tidy, plus full pre-push changed-header fan-out (`python3 scripts/run_changed_clang_tidy.py --base origin/master --build-dir build_root --jobs 3`): passed.
- **Actionlint caveat:** local actionlint 1.7.12 exits nonzero. Comparison with `origin/master` found no new ShellCheck diagnostics; its only newly reported issues are the two `concurrency.queue: max` keys. This is [documented GitHub syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax), used here with `cancel-in-progress: false`, but is not recognized by that actionlint version. Existing master ShellCheck diagnostics remain visible; no linter suppression or workflow weakening was added.
- The original release/live-capture commits were validated with the relevant unit/UI/controller/restore/native/benchmark suites on **Qt 6.10.1 and Qt 5.15.18**, including macOS **ASan/UBSan and TSan**. The latest filename/Windows-assertion follow-up results are recorded separately below.
- Behavioral RED/GREEN: queue pressure and cancellation; synthetic drain/accounting; no-work maintenance; menu/notification churn; equal-count rolling refresh; search cache ON/OFF; eight source/current-background countdown scenarios.
- Manual macOS acceptance: isolated app bundle passed single-Qt/Cocoa and native receipt/hash/ABI checks. The attached-device test confirmed unexpected iOS stopping no longer occurs.

### Latest follow-up validation
- Filename commit: `7627dc0b`; Windows assertion/guard commit: `5635fb19`.
- Final full build and serial CTest: **27/27 passed**.
- Live presentation/save UI regression: **1,130 assertions passed** on Qt 6.10.1, Qt 5.15.18 and macOS ASan/UBSan.
- Filename unit regression: **123 assertions passed**, with the real save-dialog coverage also checked on Qt5 and ASan/UBSan.
- Platform lint module: **90/90 tests passed**. Complete `python3 scripts/run_ci_quality.py`: all gates and **699 Python tests passed**.
- All **five PR-changed headers** compiled standalone with actual build flags; full `python3 scripts/run_changed_clang_tidy.py --base origin/master --build-dir build_root --jobs 3` passed, including changed-header fan-out. `git diff --check` passed.
- The guard reproduces exactly the two historical bad assertions in the pre-fix source and accepts the corrected tree. Replacement native Windows CI is required; local macOS checks are not presented as Windows runtime execution.

### Review triage
- [Codex concurrency comment](https://github.com/ZEACENT/klogg/pull/69#discussion_r3943130130): no change. `concurrency.queue: max` is currently [documented GitHub syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency); the existing serialized publisher design is intentional.
- [CodeRabbit callback-gate comment](https://github.com/ZEACENT/klogg/pull/69#discussion_r3943140580): no change after synchronization review. The first fake callback returns synchronously before the flag write; the write precedes producer-thread construction, whose synchronization orders the producer's subsequent read. The cited test has no unordered concurrent access to that flag.

### Scope and limitations

Fixed-workload replay verifies removal of redundant operations: 512 maintenance gate/scans became zero; 64 byte batches produced zero unnecessary presentation notifications and zero menu additions/removals instead of 256 each. These are **not whole-application speedup claims**. Live profiles now primarily show text measurement/drawing; renderer optimization is deliberately deferred. Android hardware performance, Qt 5.12 runtime, and Linux/Windows execution were not validated locally; PR CI remains required. Existing legacy-only Qt timer warnings were reproduced independently of the new tests and were not suppressed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live capture now applies lossless backpressure handling and reports clearer permanent errors for oversized records.
  * Live-log controls provide structured status, retry countdowns, output-binding diagnostics, and safer suggested filenames.
  * Stable releases are promoted from verified Continuous releases with manifest validation, integrity checks, and rollback protection.
* **Bug Fixes**
  * Improved rolling log refreshes, search visibility, transport draining, tab updates, and maintenance coordination.
* **Documentation**
  * Updated continuous-build documentation to reflect the revised stable-release promotion process.
* **Tests**
  * Expanded coverage for release validation, live capture, UI presentation, maintenance, and publication integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
