### PR TITLE
Harden live capture lifecycle, tracking, and integrity reporting

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2143,10 +2143,11 @@ jobs:
         id: run-tests
         # Keep the job alive only long enough to collect diagnostics; the final
         # outcome gate below still fails the job when this step fails.
-        continue-on-error: ${{ matrix.config.os == 'windows-2022' }}
+        continue-on-error: true
 
       - name: Collect Windows diagnostics on test failure
-        if: ${{ steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: true
         shell: pwsh
         run: |
           $workspace = $env:GITHUB_WORKSPACE
@@ -2179,7 +2180,7 @@ jobs:
             Format-List | Out-File -FilePath (Join-Path $diagRoot "eventlog_system.txt") -Width 300
 
       - name: Upload Windows diagnostics artifact
-        if: ${{ steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Use label (defined on every config, including the asan leg which
@@ -2190,7 +2191,8 @@ jobs:
           if-no-files-found: warn
 
       - name: Collect Windows ASan diagnostics
-        if: ${{ matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}
+        continue-on-error: true
         shell: pwsh
         run: |
           $workspace = $env:GITHUB_WORKSPACE
@@ -2211,7 +2213,7 @@ jobs:
           }
 
       - name: Upload Windows ASan diagnostics artifact
-        if: ${{ matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-x64-asan-diagnostics
@@ -2219,7 +2221,7 @@ jobs:
           if-no-files-found: error
 
       - name: Fail when tests fail
-        if: ${{ steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
         shell: sh
         run: exit 1
 

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -603,6 +603,151 @@ def workflow_job_steps(
     return direct_steps
 
 
+WINDOWS_TEST_JOBS = ("WindowsPackages", "WindowsX86", "WindowsAsan")
+WINDOWS_TEST_FAILURE_CONDITION = "${{ always() && steps.run-tests.outcome == 'failure' }}"
+WINDOWS_ASAN_FAILURE_CONDITION = (
+    "${{ always() && matrix.config.sanitizer == 'address' && "
+    "steps.run-tests.outcome == 'failure' }}"
+)
+WINDOWS_DIAGNOSTIC_RUN_MARKERS = {
+    "Collect Windows diagnostics on test failure": (
+        "build_root\\Testing\\Temporary",
+        "build_root\\crash_dumps",
+        "klogg_itests.pdb",
+        "eventlog_application.txt",
+    ),
+    "Collect Windows ASan diagnostics": (
+        "build_root\\asan_diagnostics",
+        "klogg_vectorscan_tests.pdb",
+    ),
+}
+WINDOWS_DIAGNOSTIC_UPLOADS = {
+    "Upload Windows diagnostics artifact": {
+        "name": "windows-${{ matrix.config.label }}-test-diagnostics",
+        "path": "${{ github.workspace }}\\build_root\\diagnostics\\**\\*",
+        "if-no-files-found": "warn",
+    },
+    "Upload Windows ASan diagnostics artifact": {
+        "name": "windows-x64-asan-diagnostics",
+        "path": "${{ github.workspace }}\\build_root\\asan_diagnostics\\**\\*",
+        "if-no-files-found": "error",
+    },
+}
+
+
+def windows_test_diagnostics_issues(text: str) -> list[str]:
+    """Validate the fail-closed Windows test diagnostics sequence."""
+    issues: list[str] = []
+    steps_by_job = workflow_job_steps(text)
+    expected = (
+        ("run-tests", "uses", "./.github/actions/agent-run-tests"),
+        (
+            "Collect Windows diagnostics on test failure",
+            "name",
+            "Collect Windows diagnostics on test failure",
+        ),
+        (
+            "Upload Windows diagnostics artifact",
+            "name",
+            "Upload Windows diagnostics artifact",
+        ),
+        (
+            "Collect Windows ASan diagnostics",
+            "name",
+            "Collect Windows ASan diagnostics",
+        ),
+        (
+            "Upload Windows ASan diagnostics artifact",
+            "name",
+            "Upload Windows ASan diagnostics artifact",
+        ),
+        ("Fail when tests fail", "name", "Fail when tests fail"),
+    )
+
+    for job in WINDOWS_TEST_JOBS:
+        if job not in steps_by_job:
+            continue
+        parsed = [workflow_step_fields(step) for step in steps_by_job[job]]
+        selected: list[
+            tuple[int, dict[str, str], dict[str, dict[str, str]]]
+        ] = []
+        for label, key, value in expected:
+            matches = [
+                (index, fields, children)
+                for index, (fields, children) in enumerate(parsed)
+                if fields.get(key) == value
+                and (label != "run-tests" or fields.get("id") == "run-tests")
+            ]
+            if len(matches) != 1:
+                issues.append(
+                    f"CI build job {job} must define exactly one Windows test diagnostics step {label}"
+                )
+                continue
+            selected.append(matches[0])
+        if len(selected) != len(expected):
+            continue
+        if [index for index, _, _ in selected] != sorted(
+            index for index, _, _ in selected
+        ):
+            issues.append(f"CI build job {job} Windows test diagnostics steps are out of order")
+
+        fields_by_label = {
+            label: fields for (label, _, _), (_, fields, _) in zip(expected, selected)
+        }
+        children_by_label = {
+            label: children for (label, _, _), (_, _, children) in zip(expected, selected)
+        }
+        run_tests = fields_by_label["run-tests"]
+        if run_tests.get("continue-on-error") != "true":
+            issues.append(
+                f"CI build job {job} run-tests must continue on error so diagnostics can run"
+            )
+        if "if" in run_tests:
+            issues.append(f"CI build job {job} run-tests must execute unconditionally")
+
+        for label in (
+            "Collect Windows diagnostics on test failure",
+            "Upload Windows diagnostics artifact",
+            "Fail when tests fail",
+        ):
+            if fields_by_label[label].get("if") != WINDOWS_TEST_FAILURE_CONDITION:
+                issues.append(
+                    f"CI build job {job} step {label} must use {WINDOWS_TEST_FAILURE_CONDITION}"
+                )
+        for label in (
+            "Collect Windows ASan diagnostics",
+            "Upload Windows ASan diagnostics artifact",
+        ):
+            if fields_by_label[label].get("if") != WINDOWS_ASAN_FAILURE_CONDITION:
+                issues.append(
+                    f"CI build job {job} step {label} must use {WINDOWS_ASAN_FAILURE_CONDITION}"
+                )
+        for label, required_markers in WINDOWS_DIAGNOSTIC_RUN_MARKERS.items():
+            fields = fields_by_label[label]
+            if fields.get("continue-on-error") != "true":
+                issues.append(f"CI build job {job} step {label} must be best-effort")
+            run = fields.get("run", "")
+            if fields.get("shell") != "pwsh" or any(
+                marker not in run for marker in required_markers
+            ):
+                issues.append(f"CI build job {job} step {label} must collect diagnostics")
+        for label, expected_with in WINDOWS_DIAGNOSTIC_UPLOADS.items():
+            if not fields_by_label[label].get("uses", "").startswith(
+                "actions/upload-artifact@"
+            ) or children_by_label[label].get("with") != expected_with:
+                issues.append(f"CI build job {job} step {label} must upload diagnostics")
+        failure = fields_by_label["Fail when tests fail"]
+        if (
+            failure.get("shell") != "sh"
+            or failure.get("run") != "exit 1"
+            or failure.get("continue-on-error") not in {None, "false"}
+        ):
+            issues.append(
+                f"CI build job {job} must explicitly fail after collecting test diagnostics"
+            )
+    return issues
+
+
 def workflow_artifact_records(
     text: str,
 ) -> dict[str, list[tuple[str, str, str | None]]]:
@@ -772,6 +917,7 @@ def ci_build_workflow_issues(text: str) -> list[str]:
     try:
         artifact_records = workflow_artifact_records(text)
         artifacts = workflow_artifact_actions(text)
+        issues.extend(windows_test_diagnostics_issues(text))
     except ValueError as error:
         issues.append(str(error))
         return issues

--- a/src/livecapture/include/livedatastatistics.h
+++ b/src/livecapture/include/livedatastatistics.h
@@ -38,6 +38,8 @@ struct LiveDataStatistics {
     // Complete source records rejected before queue admission, not queued or delivered bytes.
     std::size_t rejectedBeforeEnqueueBytes{ 0 };
     std::size_t rejectedBeforeEnqueueChunks{ 0 };
+    // Terminal bytes from incomplete source records that could never be enqueued.
+    std::size_t incompleteSourceRecordBytes{ 0 };
     std::size_t highWaterQueuedBytes{ 0 };
     std::size_t highWaterQueuedChunks{ 0 };
 };

--- a/src/livecapture/include/livestate.h
+++ b/src/livecapture/include/livestate.h
@@ -67,7 +67,6 @@ struct LiveIntegritySummary {
     std::uint64_t outputBytes{ 0 };
     std::uint64_t olderEvents{ 0 };
     bool outputProgressUnknown{ false };
-    bool sourceCompletenessUnknown{ true };
     bool gapPossible{ false };
     bool replayPossible{ false };
     std::vector<IntegrityEvent> recentEvents;

--- a/src/livecapture/src/adbdevicetracker.cpp
+++ b/src/livecapture/src/adbdevicetracker.cpp
@@ -57,32 +57,22 @@ TrackedDevicesParseResult parseTrackedDevices( const QByteArray& payload )
     result.devices.reserve( static_cast<std::size_t>( lines.size() ) );
 
     for ( decltype( lines.size() ) index = 0; index < lines.size(); ++index ) {
-        auto line = lines.at( index ).trimmed();
+        const auto line = lines.at( index ).simplified();
         if ( line.isEmpty() ) {
             continue;
         }
 
         const auto lineNumber = index + 1;
-        const auto separator = line.indexOf( '\t' );
-        if ( separator <= 0 ) {
+        const auto parts = line.split( ' ' );
+        if ( parts.size() < 2 ) {
             result.diagnostic
                 = QStringLiteral( "Malformed ADB track-devices snapshot line %1: expected a "
-                                  "serial and state separated by a tab." )
+                                  "serial and state separated by whitespace." )
                       .arg( lineNumber );
             return result;
         }
 
-        const auto serial = line.left( separator ).trimmed();
-        const auto details = line.mid( separator + 1 ).simplified();
-        const auto parts = details.split( ' ' );
-        if ( serial.isEmpty() || parts.isEmpty() || parts.front().isEmpty() ) {
-            result.diagnostic
-                = QStringLiteral( "Malformed ADB track-devices snapshot line %1: serial or state "
-                                  "is empty." )
-                      .arg( lineNumber );
-            return result;
-        }
-
+        const auto& serial = parts.front();
         const auto serialBytes = serial.toStdString();
         if ( std::any_of( result.devices.begin(), result.devices.end(),
                           [ &serialBytes ]( const auto& device ) {
@@ -97,9 +87,9 @@ TrackedDevicesParseResult parseTrackedDevices( const QByteArray& payload )
 
         AdbDeviceInfo device;
         device.serial = serialBytes;
-        device.stateText = parts.front().toStdString();
-        device.state = stateFromText( parts.front() );
-        for ( decltype( parts.size() ) partIndex = 1; partIndex < parts.size(); ++partIndex ) {
+        device.stateText = parts.at( 1 ).toStdString();
+        device.state = stateFromText( parts.at( 1 ) );
+        for ( decltype( parts.size() ) partIndex = 2; partIndex < parts.size(); ++partIndex ) {
             const auto& part = parts.at( partIndex );
             if ( part.startsWith( QStringLiteral( "product:" ) ) ) {
                 device.product = part.mid( 8 ).replace( '_', ' ' ).toStdString();

--- a/src/livecapture/src/iosnativestream.cpp
+++ b/src/livecapture/src/iosnativestream.cpp
@@ -348,6 +348,30 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
         }
     }
 
+    void recordIncompleteSourceRecordBytes( std::size_t byteCount ) noexcept
+    {
+        auto current = incompleteSourceRecordBytes.load( std::memory_order_relaxed );
+        const auto maximum = std::numeric_limits<std::size_t>::max();
+        while ( true ) {
+            const auto updated = byteCount > maximum - current ? maximum : current + byteCount;
+            if ( incompleteSourceRecordBytes.compare_exchange_weak(
+                     current, updated, std::memory_order_relaxed ) ) {
+                return;
+            }
+        }
+    }
+
+    void snapshotIncompleteSourceRecord() noexcept
+    {
+        std::lock_guard<std::mutex> lock( controlMutex );
+        if ( incompleteSourceRecordSnapshotted ) {
+            return;
+        }
+        incompleteSourceRecordSnapshotted = true;
+        recordIncompleteSourceRecordBytes( syslogRecord.size() );
+        syslogRecord.clear();
+    }
+
     void publishStopped() noexcept
     {
         bool shouldPublish = false;
@@ -529,6 +553,8 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             }
             if ( byte != '\0' ) {
                 if ( state->syslogRecord.size() >= state->config.maximumSyslogRecordBytes ) {
+                    state->recordIncompleteSourceRecordBytes( state->syslogRecord.size() );
+                    state->recordIncompleteSourceRecordBytes( 1u );
                     state->syslogRecord.clear();
                     state->publishFailure( localError(
                         ErrorCategory::Stream, "ios-syslog-record-too-large", ErrorScope::Stream,
@@ -935,6 +961,11 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
             api.syslogRelayStop( closingSyslog.get() );
         }
 
+        // Native stop/join is the final callback quiescence boundary. Snapshot the
+        // legacy assembler only here so an incomplete source record is terminal
+        // accounting, never a complete-record queue rejection.
+        snapshotIncompleteSourceRecord();
+
         // One-shot ownership order is deliberate: callback completion first,
         // then stop/join, stream client, service descriptor, lockdownd client,
         // and finally idevice.
@@ -960,6 +991,7 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
     LiveDataQueue queue;
     std::atomic<std::size_t> rejectedBeforeEnqueueBytes{ 0u };
     std::atomic<std::size_t> rejectedBeforeEnqueueChunks{ 0u };
+    std::atomic<std::size_t> incompleteSourceRecordBytes{ 0u };
 
     mutable std::mutex controlMutex;
     std::condition_variable callbacksChanged;
@@ -980,6 +1012,7 @@ struct IosNativeStreamWorker::State final : public std::enable_shared_from_this<
     bool streamIsOsTrace{ false };
     bool retired{ false };
     bool terminal{ false };
+    bool incompleteSourceRecordSnapshotted{ false };
     bool stoppedPublished{ false };
 };
 
@@ -1066,6 +1099,8 @@ LiveDataStatistics IosNativeStreamWorker::statistics() const
             = state_->rejectedBeforeEnqueueBytes.load( std::memory_order_relaxed );
         result.rejectedBeforeEnqueueChunks
             = state_->rejectedBeforeEnqueueChunks.load( std::memory_order_relaxed );
+        result.incompleteSourceRecordBytes
+            = state_->incompleteSourceRecordBytes.load( std::memory_order_relaxed );
         return result;
     }
     return {};

--- a/src/livecapture/src/livedatastatistics.cpp
+++ b/src/livecapture/src/livedatastatistics.cpp
@@ -68,6 +68,9 @@ void accumulateLiveDataStatistics( LiveDataStatistics& total,
     addSaturating( total.deliveredChunks, increment.deliveredChunks );
     addSaturating( total.backpressuredBytes, increment.backpressuredBytes );
     addSaturating( total.backpressuredChunks, increment.backpressuredChunks );
+    addSaturating( total.rejectedBeforeEnqueueBytes, increment.rejectedBeforeEnqueueBytes );
+    addSaturating( total.rejectedBeforeEnqueueChunks, increment.rejectedBeforeEnqueueChunks );
+    addSaturating( total.incompleteSourceRecordBytes, increment.incompleteSourceRecordBytes );
     total.highWaterQueuedBytes
         = std::max( total.highWaterQueuedBytes, increment.highWaterQueuedBytes );
     total.highWaterQueuedChunks

--- a/src/livecapture/src/livestate.cpp
+++ b/src/livecapture/src/livestate.cpp
@@ -606,12 +606,12 @@ bool LiveIntegritySummary::operator==( const LiveIntegritySummary& other ) const
 {
     return std::tie( offeredBytes, dequeuedBytes, acceptedBytes, committedBytes, committedLines,
                     discardedBytes, uncertainBytes, outputBytes, olderEvents, outputProgressUnknown,
-                    sourceCompletenessUnknown, gapPossible, replayPossible, recentEvents )
+                    gapPossible, replayPossible, recentEvents )
         == std::tie( other.offeredBytes, other.dequeuedBytes, other.acceptedBytes,
                      other.committedBytes, other.committedLines, other.discardedBytes,
                      other.uncertainBytes, other.outputBytes, other.olderEvents,
-                     other.outputProgressUnknown, other.sourceCompletenessUnknown,
-                     other.gapPossible, other.replayPossible, other.recentEvents );
+                     other.outputProgressUnknown, other.gapPossible, other.replayPossible,
+                     other.recentEvents );
 }
 
 LiveStateSnapshot initialLiveState()

--- a/src/ui/include/adblogcatsource.h
+++ b/src/ui/include/adblogcatsource.h
@@ -127,9 +127,9 @@ private:
     klogg::livecapture::StopDisposition retiringDisposition_{
         klogg::livecapture::StopDisposition::DiscardPending };
     bool stopRequested_{ false };
-    StoppedCallback stoppedCallback_;
-    FinalizedCallback finalizedCallback_;
-    void finalizeInput( Generation generation );
+    std::shared_ptr<StoppedCallback> stoppedCallback_;
+    std::shared_ptr<FinalizedCallback> finalizedCallback_;
+    std::optional<klogg::livecapture::CaptureDeliveryResult> finalizeInput();
     void beginDeliveryGeneration( Generation generation );
     void settleOfferedDelivery( Generation generation, DeliverySequence sequence );
     void completeRetirementIfSettled( Generation generation );

--- a/src/ui/include/livelogcontroller.h
+++ b/src/ui/include/livelogcontroller.h
@@ -173,6 +173,7 @@ private:
     void dispatch( const livecapture::LiveStateEvent& event, const QByteArray* bytes = nullptr,
                    DeliverySettledCallback deliverySettled = {} );
     void execute( const livecapture::LiveStateEffect& effect, const QByteArray* bytes );
+    void observeIntegrityTransition( const livecapture::LiveStateSnapshot& previousSnapshot );
     void settleDelivery( livecapture::Generation generation,
                          const livecapture::CaptureDeliveryResult& result, std::uint64_t offered );
     livecapture::Timestamp retryDelay( unsigned attempt ) const;
@@ -190,7 +191,7 @@ private:
     std::unique_ptr<ProductionRuntime> productionRuntime_;
     LiveLogControllerEffects& effects_;
     std::optional<LiveLogScheduler::Token> retryToken_;
-    std::optional<livecapture::Generation> openedGeneration_;
+    bool replayRiskPending_{ false };
     std::deque<PendingDispatch> pendingDispatches_;
     LiveLogControlPresentation lastControlPresentation_;
     PresentationChangedCallback presentationChangedCallback_;

--- a/src/ui/include/livelogcontroller.h
+++ b/src/ui/include/livelogcontroller.h
@@ -172,10 +172,15 @@ private:
 
     void dispatch( const livecapture::LiveStateEvent& event, const QByteArray* bytes = nullptr,
                    DeliverySettledCallback deliverySettled = {} );
+    void drainPendingDispatches();
     void execute( const livecapture::LiveStateEffect& effect, const QByteArray* bytes );
+    void commitAcceptedSnapshot( livecapture::LiveStateSnapshot snapshot );
     void observeIntegrityTransition( const livecapture::LiveStateSnapshot& previousSnapshot );
     void settleDelivery( livecapture::Generation generation,
                          const livecapture::CaptureDeliveryResult& result, std::uint64_t offered );
+    void settleDeliveryNow( livecapture::Generation generation,
+                            const livecapture::CaptureDeliveryResult& result,
+                            std::uint64_t offered );
     livecapture::Timestamp retryDelay( unsigned attempt ) const;
     LiveSourceTransportConfig transportConfig() const;
     void cancelScheduledRetry();

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -490,7 +490,9 @@ void AdbLogcatSource::invalidateTransportGeneration( Generation generation )
 
 void AdbLogcatSource::setStoppedCallback( StoppedCallback callback )
 {
-    stoppedCallback_ = std::move( callback );
+    stoppedCallback_ = callback
+                           ? std::make_shared<StoppedCallback>( std::move( callback ) )
+                           : std::shared_ptr<StoppedCallback>{};
 }
 
 void AdbLogcatSource::cancelTransport(
@@ -502,7 +504,11 @@ void AdbLogcatSource::cancelTransport(
     }
     if ( retiringGeneration_ != generation ) {
         // Startup may have no transport at all: this owner has nothing to release.
-        if ( !retiringGeneration_ && stoppedCallback_ ) { stoppedCallback_( generation, 0u ); }
+        const auto callback = stoppedCallback_;
+        if ( !retiringGeneration_ && callback ) {
+            try { ( *callback )( generation, 0u ); }
+            catch ( ... ) { LOG_ERROR << "Failed to acknowledge an empty live source stop"; }
+        }
         return;
     }
     const auto effectiveDisposition
@@ -634,7 +640,9 @@ klogg::livecapture::CaptureDeliveryResult AdbLogcatSource::mapCaptureOutcome(
 
 void AdbLogcatSource::setFinalizedCallback( FinalizedCallback callback )
 {
-    finalizedCallback_ = std::move( callback );
+    finalizedCallback_ = callback
+                             ? std::make_shared<FinalizedCallback>( std::move( callback ) )
+                             : std::shared_ptr<FinalizedCallback>{};
 }
 
 void AdbLogcatSource::setDeliveryFailedCallback(
@@ -683,31 +691,68 @@ void AdbLogcatSource::completeRetirementIfSettled( Generation generation )
         = state_ == State::Error
           && retiringDisposition_ == klogg::livecapture::StopDisposition::SettleAccepted;
     const QPointer<AdbLogcatSource> guard( this );
+
     // Only real producer completion plus settlement of every registered delivery
-    // seals partial input. Arbitrary stale callbacks cannot register after stopped.
-    finalizeInput( generation );
+    // seals partial input. Produce the capture result before entering any external
+    // observer; production or observer failure must not own or strand retirement.
+    std::optional<klogg::livecapture::CaptureDeliveryResult> finalization;
+    try { finalization = finalizeInput(); }
+    catch ( ... ) { LOG_ERROR << "Failed to finalize live source input"; }
+    if ( !guard ) { return; }
+    const auto finalizedCallback = guard->finalizedCallback_;
+    if ( finalization && finalizedCallback ) {
+        try { ( *finalizedCallback )( generation, *finalization ); }
+        catch ( ... ) { LOG_ERROR << "Failed to report live source finalization"; }
+    }
     if ( !guard ) { return; }
 
+    // Shared observer handles make callback capture non-throwing. Clear the source-
+    // owned retirement barrier before notifications so every surviving source is
+    // reusable even when an observer throws or requests another lifecycle action.
+    const auto stoppedCallback = guard->stoppedCallback_;
     guard->retiringGeneration_.reset();
     guard->stopRequested_ = false;
     guard->deliverySettlement_.reset();
-    const auto callback = guard->stoppedCallback_;
     const bool clear = std::exchange( guard->clearAfterStop_, false );
     const bool restart = std::exchange( guard->restartAfterStop_, false );
-    if ( !preserveTerminalError ) { guard->setState( State::Disconnected ); }
+    if ( !preserveTerminalError ) {
+        try { guard->setState( State::Disconnected ); }
+        catch ( ... ) { LOG_ERROR << "Failed to report disconnected live source state"; }
+    }
     if ( !guard ) { return; }
-    if ( callback ) { callback( generation, discarded ); }
+
+    if ( stoppedCallback ) {
+        try { ( *stoppedCallback )( generation, discarded ); }
+        catch ( ... ) { LOG_ERROR << "Failed to acknowledge live source stop"; }
+    }
     if ( !guard ) { return; }
-    if ( clear ) { guard->performClear( restart ); }
+
+    if ( clear ) {
+        try { guard->performClear( restart ); }
+        catch ( ... ) { LOG_ERROR << "Failed to continue live source clear after retirement"; }
+    }
     else if ( restart ) {
-        if ( guard->controllerRestart_ ) { guard->controllerRestart_(); }
-        else { guard->connectSource(); }
+        if ( guard->controllerRestart_ ) {
+            ControlCallback restartCallback;
+            try { restartCallback = guard->controllerRestart_; }
+            catch ( ... ) {
+                LOG_ERROR << "Failed to retain live source restart continuation";
+            }
+            if ( restartCallback ) {
+                try { restartCallback(); }
+                catch ( ... ) { LOG_ERROR << "Failed to continue live source restart"; }
+            }
+        }
+        else {
+            try { guard->connectSource(); }
+            catch ( ... ) { LOG_ERROR << "Failed to continue live source restart"; }
+        }
     }
 }
 
-void AdbLogcatSource::finalizeInput( Generation generation )
+std::optional<klogg::livecapture::CaptureDeliveryResult> AdbLogcatSource::finalizeInput()
 {
-    if ( !logData_ ) { return; }
+    if ( !logData_ ) { return std::nullopt; }
     klogg::livecapture::CaptureDeliveryResult result;
     try { result = mapCaptureOutcome( logData_->finishInput() ); }
     catch ( ... ) {
@@ -716,7 +761,7 @@ void AdbLogcatSource::finalizeInput( Generation generation )
         result.failureCode = "capture-finalization-unknown";
     }
     schedulePersistenceRetry();
-    if ( finalizedCallback_ ) { finalizedCallback_( generation, result ); }
+    return result;
 }
 
 bool AdbLogcatSource::isInputTerminated() const

--- a/src/ui/src/adblogcatsource.cpp
+++ b/src/ui/src/adblogcatsource.cpp
@@ -691,15 +691,21 @@ void AdbLogcatSource::completeRetirementIfSettled( Generation generation )
         = state_ == State::Error
           && retiringDisposition_ == klogg::livecapture::StopDisposition::SettleAccepted;
     const QPointer<AdbLogcatSource> guard( this );
+    // Callback registration changes apply to future retirements. Snapshot both
+    // observers before finalization can emit any external signal so this generation
+    // cannot be lost or delivered to a replacement observer through reentrancy.
+    const auto finalizedCallback = finalizedCallback_;
+    const auto stoppedCallback = stoppedCallback_;
 
     // Only real producer completion plus settlement of every registered delivery
-    // seals partial input. Produce the capture result before entering any external
-    // observer; production or observer failure must not own or strand retirement.
+    // seals partial input. Production or observer failure must not own or strand
+    // retirement.
     std::optional<klogg::livecapture::CaptureDeliveryResult> finalization;
     try { finalization = finalizeInput(); }
     catch ( ... ) { LOG_ERROR << "Failed to finalize live source input"; }
-    if ( !guard ) { return; }
-    const auto finalizedCallback = guard->finalizedCallback_;
+    if ( !guard ) {
+        return;
+    }
     if ( finalization && finalizedCallback ) {
         try { ( *finalizedCallback )( generation, *finalization ); }
         catch ( ... ) { LOG_ERROR << "Failed to report live source finalization"; }
@@ -709,7 +715,6 @@ void AdbLogcatSource::completeRetirementIfSettled( Generation generation )
     // Shared observer handles make callback capture non-throwing. Clear the source-
     // owned retirement barrier before notifications so every surviving source is
     // reusable even when an observer throws or requests another lifecycle action.
-    const auto stoppedCallback = guard->stoppedCallback_;
     guard->retiringGeneration_.reset();
     guard->stopRequested_ = false;
     guard->deliverySettlement_.reset();

--- a/src/ui/src/iosnativetransport.cpp
+++ b/src/ui/src/iosnativetransport.cpp
@@ -420,9 +420,11 @@ void IosNativeTransport::completeStopped()
         return;
     }
     // Native stopped follows callback quiescence and native join, so rejected
-    // records are final. Add them only on this terminal path, never per drain
-    // turn, and independently of already-accounted queued/pending bytes.
+    // complete records and the legacy assembler's incomplete tail are final. Add
+    // both only on this terminal path, never per drain turn, and independently of
+    // already-accounted queued/pending bytes.
     discardedBytes_ += static_cast<quint64>( finalStatistics.rejectedBeforeEnqueueBytes );
+    discardedBytes_ += static_cast<quint64>( finalStatistics.incompleteSourceRecordBytes );
     if ( drainFailed_ ) {
         discardedBytes_ += static_cast<quint64>( finalStatistics.queuedBytes );
     }

--- a/src/ui/src/livelogcontroller.cpp
+++ b/src/ui/src/livelogcontroller.cpp
@@ -545,6 +545,7 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
             auto pending = std::move( pendingDispatches_.front() );
             pendingDispatches_.pop_front();
 
+            const auto previousSnapshot = snapshot_;
             auto transition = live::reduce( snapshot_, pending.event, config_.reducer );
             if ( !transition.accepted ) {
                 if ( pending.bytes ) {
@@ -565,6 +566,7 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
             }
 
             snapshot_ = std::move( transition.snapshot );
+            observeIntegrityTransition( previousSnapshot );
             const auto* pendingBytes
                 = pending.bytes.has_value() ? &pending.bytes.value() : nullptr;
             for ( const auto& effect : transition.effects ) {
@@ -600,6 +602,41 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
     dispatching_ = false;
 }
 
+void LiveLogController::observeIntegrityTransition(
+    const live::LiveStateSnapshot& previousSnapshot )
+{
+    const bool connectedStreamInterrupted
+        = previousSnapshot.source.status == live::SourceStatus::Streaming
+          && snapshot_.source.status != live::SourceStatus::Streaming
+          && snapshot_.runIntent == live::RunIntent::Running;
+    if ( connectedStreamInterrupted ) {
+        if ( !spec_.integrity.gapPossible ) {
+            spec_.integrity.gapPossible = true;
+            spec_.integrity.record( "connected-stream-interrupted" );
+        }
+        if ( spec_.sourceKind == SourceKind::AndroidLogcat
+             && !spec_.integrity.replayPossible ) {
+            replayRiskPending_ = true;
+        }
+    }
+
+    if ( snapshot_.runIntent == live::RunIntent::Stopped ) {
+        replayRiskPending_ = false;
+        return;
+    }
+
+    const bool replacementConnected
+        = previousSnapshot.source.status != live::SourceStatus::Streaming
+          && snapshot_.source.status == live::SourceStatus::Streaming;
+    if ( replacementConnected && replayRiskPending_ ) {
+        replayRiskPending_ = false;
+        if ( !spec_.integrity.replayPossible ) {
+            spec_.integrity.replayPossible = true;
+            spec_.integrity.record( "source-replay-possible" );
+        }
+    }
+}
+
 void LiveLogController::execute( const live::LiveStateEffect& effect, const QByteArray* bytes )
 {
     switch ( effect.kind ) {
@@ -607,20 +644,12 @@ void LiveLogController::execute( const live::LiveStateEffect& effect, const QByt
         effects_.invalidateGeneration( effect.generation );
         break;
     case live::EffectKind::CancelStream:
-        if ( openedGeneration_ == effect.generation ) {
-            openedGeneration_.reset();
-            spec_.integrity.gapPossible = true;
-            if ( spec_.sourceKind == SourceKind::AndroidLogcat ) { spec_.integrity.replayPossible = true; }
-            spec_.integrity.record( effect.stopDisposition == live::StopDisposition::SettleAccepted
-                                      ? "stream-retired" : "user-stopped" );
-        }
         effects_.retireStream( effect.generation, effect.stopDisposition );
         break;
     case live::EffectKind::StartInfrastructure:
         effects_.startInfrastructure( effect.generation );
         break;
     case live::EffectKind::OpenStream:
-        openedGeneration_ = effect.generation;
         effects_.openStream( effect.generation, transportConfig() );
         break;
     case live::EffectKind::AppendBytes:

--- a/src/ui/src/livelogcontroller.cpp
+++ b/src/ui/src/livelogcontroller.cpp
@@ -461,7 +461,6 @@ void LiveLogController::streamDeliveryFailed(
     std::uint64_t offeredBytes )
 {
     settleDelivery( generation, result, offeredBytes );
-    notifyPresentationChanged();
 }
 
 void LiveLogController::streamStable( live::Generation generation )
@@ -536,6 +535,11 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
     pendingDispatches_.push_back(
         PendingDispatch{ event, bytes != nullptr ? std::optional<QByteArray>{ *bytes } : std::nullopt,
                          std::move( deliverySettled ) } );
+    drainPendingDispatches();
+}
+
+void LiveLogController::drainPendingDispatches()
+{
     if ( std::exchange( dispatching_, true ) ) {
         return;
     }
@@ -545,7 +549,6 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
             auto pending = std::move( pendingDispatches_.front() );
             pendingDispatches_.pop_front();
 
-            const auto previousSnapshot = snapshot_;
             auto transition = live::reduce( snapshot_, pending.event, config_.reducer );
             if ( !transition.accepted ) {
                 if ( pending.bytes ) {
@@ -565,8 +568,7 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
                 continue;
             }
 
-            snapshot_ = std::move( transition.snapshot );
-            observeIntegrityTransition( previousSnapshot );
+            commitAcceptedSnapshot( std::move( transition.snapshot ) );
             const auto* pendingBytes
                 = pending.bytes.has_value() ? &pending.bytes.value() : nullptr;
             for ( const auto& effect : transition.effects ) {
@@ -600,6 +602,13 @@ void LiveLogController::dispatch( const live::LiveStateEvent& event, const QByte
         throw;
     }
     dispatching_ = false;
+}
+
+void LiveLogController::commitAcceptedSnapshot( live::LiveStateSnapshot snapshot )
+{
+    const auto previousSnapshot = snapshot_;
+    snapshot_ = std::move( snapshot );
+    observeIntegrityTransition( previousSnapshot );
 }
 
 void LiveLogController::observeIntegrityTransition(
@@ -703,6 +712,28 @@ void LiveLogController::execute( const live::LiveStateEffect& effect, const QByt
 void LiveLogController::settleDelivery( live::Generation generation,
     const live::CaptureDeliveryResult& result, std::uint64_t offered )
 {
+    if ( dispatching_ ) {
+        settleDeliveryNow( generation, result, offered );
+        return;
+    }
+
+    dispatching_ = true;
+    try {
+        settleDeliveryNow( generation, result, offered );
+    } catch ( ... ) {
+        pendingDispatches_.clear();
+        dispatching_ = false;
+        throw;
+    }
+    dispatching_ = false;
+    drainPendingDispatches();
+    notifyPresentationChanged();
+}
+
+void LiveLogController::settleDeliveryNow( live::Generation generation,
+                                           const live::CaptureDeliveryResult& result,
+                                           std::uint64_t offered )
+{
     auto& integrity = spec_.integrity;
     const auto accepted = std::min( offered, result.acceptedBytes );
     addCount( integrity.acceptedBytes, accepted );
@@ -723,7 +754,7 @@ void LiveLogController::settleDelivery( live::Generation generation,
             live::RetryPolicy::Never, "The live capture could not accept all input safely.", {} },
         clock_->now() }, config_.reducer );
     if ( failure.accepted ) {
-        snapshot_ = std::move( failure.snapshot );
+        commitAcceptedSnapshot( std::move( failure.snapshot ) );
         for ( const auto& effect : failure.effects ) { execute( effect, nullptr ); }
     }
 }

--- a/src/ui/src/livelogsession.cpp
+++ b/src/ui/src/livelogsession.cpp
@@ -162,7 +162,6 @@ struct IntegrityFlag {
     bool Integrity::* member;
 };
 constexpr IntegrityFlag IntegrityFlags[]{
-    { "sourceCompletenessUnknown", &Integrity::sourceCompletenessUnknown },
     { "gapPossible", &Integrity::gapPossible }, { "replayPossible", &Integrity::replayPossible },
     { "outputProgressUnknown", &Integrity::outputProgressUnknown }
 };
@@ -202,11 +201,18 @@ bool parseExactCount( const QJsonValue& value, std::uint64_t& count )
 
 bool parseIntegrity( const QJsonValue& value, Integrity& result )
 {
-    if ( value.isUndefined() ) { return true; } // Historical sessions remain explicitly unknown.
+    // Missing metadata means no persisted host-side integrity evidence. It does
+    // not certify or deny completeness of records supplied by the source.
+    if ( value.isUndefined() ) { return true; }
     if ( !value.isObject() ) { return false; }
     const auto object = value.toObject();
     const auto version = object.value( QStringLiteral( "version" ) );
     if ( !version.isDouble() || version.toDouble() != Integrity::SchemaVersion ) { return false; }
+    const auto legacySourceCompleteness
+        = object.value( QStringLiteral( "sourceCompletenessUnknown" ) );
+    if ( !legacySourceCompleteness.isUndefined() && !legacySourceCompleteness.isBool() ) {
+        return false;
+    }
     for ( const auto& field : IntegrityCounters ) {
         const auto count = object.value( QLatin1String( field.key ) );
         if ( !count.isUndefined() && !parseExactCount( count, result.*field.member ) ) { return false; }
@@ -217,7 +223,6 @@ bool parseIntegrity( const QJsonValue& value, Integrity& result )
         if ( !flag.isBool() ) { return false; }
         result.*field.member = flag.toBool();
     }
-    if ( !result.sourceCompletenessUnknown ) { return false; }
     const auto events = object.value( QStringLiteral( "recentEvents" ) );
     if ( !events.isUndefined() && !events.isArray() ) { return false; }
     // Reject oversized untrusted metadata rather than allocating an unbounded event history.

--- a/src/ui/src/mainwindow.cpp
+++ b/src/ui/src/mainwindow.cpp
@@ -156,12 +156,11 @@ bool hasHistoricalCapturePersistenceWarning(
                         } );
 }
 
-bool hasUnresolvedLiveIntegrityWarning(
+bool hasLiveIntegrityWarning(
     const klogg::livelog::LiveLogControlPresentation& presentation )
 {
     const auto& integrity = presentation.integrity;
     return !presentation.captureHealthy || hasHistoricalCapturePersistenceWarning( integrity )
-           || integrity.sourceCompletenessUnknown
            || integrity.gapPossible || integrity.replayPossible || integrity.discardedBytes > 0
            || integrity.uncertainBytes > 0 || integrity.outputProgressUnknown;
 }
@@ -190,10 +189,6 @@ QString liveIntegrityWarningText(
     if ( integrity.uncertainBytes > 0 || integrity.outputProgressUnknown ) {
         warnings << QCoreApplication::translate(
             "MainWindow", "Some host-side capture or output progress is uncertain." );
-    }
-    if ( integrity.sourceCompletenessUnknown ) {
-        warnings << QCoreApplication::translate(
-            "MainWindow", "Completeness of records supplied by the device cannot be verified." );
     }
     return warnings.join( QLatin1Char( ' ' ) );
 }
@@ -1835,7 +1830,7 @@ void MainWindow::saveCurrentLiveLog( LiveLogSaveAnsiMode ansiMode )
 
     if ( controller != nullptr ) {
         const auto presentation = controller->controlPresentation();
-        if ( hasUnresolvedLiveIntegrityWarning( presentation ) ) {
+        if ( hasLiveIntegrityWarning( presentation ) ) {
             QMessageBox warning( QMessageBox::Warning, tr( "Save live log with integrity warning" ),
                                  tr( "The saved data may be incomplete or contain replayed records. %1" )
                                      .arg( liveIntegrityWarningText( presentation ) ),
@@ -3616,7 +3611,6 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
         }
 
         if ( projection.outputBinding == klogg::livecapture::OutputBindingState::Degraded ) {
-            liveStatus = LiveTabStatus::Error;
             if ( projection.outputBindingError.has_value() ) {
                 QString outputError;
                 const auto& error = *projection.outputBindingError;
@@ -3640,22 +3634,9 @@ void MainWindow::updateLiveTabAppearance( CrawlerWidget* crawler )
             }
         }
 
-        if ( hasUnresolvedLiveIntegrityWarning( projection ) ) {
-            const auto& integrity = projection.integrity;
-            const bool hostLossOrUncertainty
-                = !projection.captureHealthy
-                  || hasHistoricalCapturePersistenceWarning( integrity )
-                  || integrity.gapPossible || integrity.discardedBytes > 0
-                  || integrity.uncertainBytes > 0
-                  || integrity.outputProgressUnknown;
-            const bool tooltipWarning = hostLossOrUncertainty || integrity.replayPossible;
-            if ( hostLossOrUncertainty ) {
-                liveStatus = LiveTabStatus::Error;
-            }
-            if ( tooltipWarning ) {
-                toolTip = tr( "%1\nCapture integrity: %2" )
-                              .arg( toolTip, liveIntegrityWarningText( projection ) );
-            }
+        if ( hasLiveIntegrityWarning( projection ) ) {
+            toolTip = tr( "%1\nCapture integrity: %2" )
+                          .arg( toolTip, liveIntegrityWarningText( projection ) );
         }
     }
 
@@ -3964,7 +3945,7 @@ void MainWindow::updateInfoLine()
     auto currentFile = infoPath;
     if ( const auto* controller = session_.getLiveLogController( crawler ) ) {
         const auto projection = controller->controlPresentation();
-        if ( hasUnresolvedLiveIntegrityWarning( projection ) ) {
+        if ( hasLiveIntegrityWarning( projection ) ) {
             currentFile += tr( " - Capture integrity warning: %1" )
                                .arg( liveIntegrityWarningText( projection ) );
         }

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -168,10 +168,7 @@ public:
                     break;
                 case LiveSourceTransport::State::Disconnected:
                     if ( controller_->snapshot().runIntent
-                         == klogg::livecapture::RunIntent::Stopped ) {
-                        controller_->stopCompleted( generation );
-                    }
-                    else {
+                         != klogg::livecapture::RunIntent::Stopped ) {
                         controller_->streamFailed(
                             generation,
                             klogg::livecapture::LiveSourceError{

--- a/src/ui/src/session.cpp
+++ b/src/ui/src/session.cpp
@@ -93,7 +93,8 @@ klogg::livecapture::LiveSourceError outputBindingError( CaptureOutputError error
              {} };
 }
 
-class SessionLiveLogEffects final : public klogg::livelog::LiveLogControllerEffects {
+class SessionLiveLogEffects final : public klogg::livelog::LiveLogControllerEffects,
+                                    public std::enable_shared_from_this<SessionLiveLogEffects> {
 public:
     SessionLiveLogEffects(
         std::shared_ptr<AdbLogcatSource> source, klogg::livelog::LiveLogSessionSpec spec,
@@ -117,20 +118,34 @@ public:
         source_->setDeliveryFailedCallback( {} );
     }
 
-    void attach( klogg::livelog::LiveLogController& controller )
+    void attach( const std::shared_ptr<klogg::livelog::LiveLogController>& controller )
     {
-        controller_ = &controller;
-        source_->setFinalizedCallback( [ this ]( auto generation, const auto& result ) {
-            controller_->inputTerminated( generation, result );
-        } );
+        controller_ = controller.get();
+        const auto weakEffects = weak_from_this();
+        const std::weak_ptr<klogg::livelog::LiveLogController> weakController = controller;
+        source_->setFinalizedCallback(
+            [ weakEffects, weakController ]( auto generation, const auto& result ) {
+                const auto effects = weakEffects.lock();
+                const auto activeController = weakController.lock();
+                if ( !effects || !activeController ) {
+                    return;
+                }
+                activeController->inputTerminated( generation, result );
+            } );
         source_->setDeliveryFailedCallback(
             [ this ]( auto generation, const auto& result, std::uint64_t offeredBytes ) {
                 controller_->streamDeliveryFailed( generation, result,
                                                    offeredBytes );
             } );
-        source_->setStoppedCallback( [ this ]( auto generation, auto discarded ) {
-            controller_->stopCompleted( generation, discarded );
-        } );
+        source_->setStoppedCallback(
+            [ weakEffects, weakController ]( auto generation, auto discarded ) {
+                const auto effects = weakEffects.lock();
+                const auto activeController = weakController.lock();
+                if ( !effects || !activeController ) {
+                    return;
+                }
+                activeController->stopCompleted( generation, discarded );
+            } );
         persistenceConnection_ = QObject::connect(
             source_.get(), &AdbLogcatSource::capturePersistenceChanged, source_.get(),
             [ this ]( bool healthy, CaptureStore::PersistenceFailure error ) {
@@ -888,7 +903,7 @@ ViewInterface* Session::openAdbAlways( const AdbLogcatSessionData& sessionData,
         adbSource, liveSpec, adbInfrastructure_, iosCatalog_ );
     auto liveController = std::make_shared<klogg::livelog::LiveLogController>(
         liveSpec, controllerConfigFor( liveSpec ), *liveEffects );
-    liveEffects->attach( *liveController );
+    liveEffects->attach( liveController );
     const auto restoredOutputError = logData->captureOutputError();
     if ( restoredOutputError.has_value() ) {
         liveController->outputBindingChanged( klogg::livecapture::OutputBindingState::Degraded,

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -643,6 +643,109 @@ jobs:
             },
         )
 
+    def test_windows_test_diagnostics_contract_resolves_shared_steps(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        self.assertEqual(MODULE.windows_test_diagnostics_issues(workflow), [])
+
+    def test_windows_test_diagnostics_contract_rejects_broken_failure_path(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutations = {
+            "conditional test continuation": (
+                "        continue-on-error: true\n\n"
+                "      - name: Collect Windows diagnostics on test failure\n",
+                "        continue-on-error: ${{ matrix.config.os == 'windows-2022' }}\n\n"
+                "      - name: Collect Windows diagnostics on test failure\n",
+            ),
+            "disabled test step": (
+                "        id: run-tests\n"
+                "        # Keep the job alive",
+                "        id: run-tests\n"
+                "        if: false\n"
+                "        # Keep the job alive",
+            ),
+            "normal collection status guard": (
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
+                "        continue-on-error: true\n"
+                "        shell: pwsh\n",
+                "        if: ${{ steps.run-tests.outcome == 'failure' }}\n"
+                "        continue-on-error: true\n"
+                "        shell: pwsh\n",
+            ),
+            "normal upload status guard": (
+                "      - name: Upload Windows diagnostics artifact\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n",
+                "      - name: Upload Windows diagnostics artifact\n"
+                "        if: ${{ steps.run-tests.outcome == 'failure' }}\n",
+            ),
+            "normal collector contents": (
+                '          $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
+                '          $dumpDir = Join-Path $workspace "build_root\\missing_dumps"\n',
+            ),
+            "normal upload action": (
+                "      - name: Upload Windows diagnostics artifact\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
+                "        uses: actions/upload-artifact@",
+                "      - name: Upload Windows diagnostics artifact\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
+                "        uses: example/not-an-upload@",
+            ),
+            "normal upload path": (
+                "          path: '${{ github.workspace }}\\build_root\\diagnostics\\**\\*'\n",
+                "          path: '${{ github.workspace }}\\build_root\\missing\\**\\*'\n",
+            ),
+            "asan collection continuation": (
+                "      - name: Collect Windows ASan diagnostics\n"
+                "        if: ${{ always() && matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}\n"
+                "        continue-on-error: true\n",
+                "      - name: Collect Windows ASan diagnostics\n"
+                "        if: ${{ always() && matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}\n",
+            ),
+            "final failure status guard": (
+                "      - name: Fail when tests fail\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n",
+                "      - name: Fail when tests fail\n"
+                "        if: ${{ steps.run-tests.outcome == 'failure' }}\n",
+            ),
+            "strict final failure": (
+                "      - name: Fail when tests fail\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
+                "        shell: sh\n"
+                "        run: exit 1\n",
+                "      - name: Fail when tests fail\n"
+                "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
+                "        continue-on-error: true\n"
+                "        shell: sh\n"
+                "        run: exit 1\n",
+            ),
+        }
+        for label, (old, new) in mutations.items():
+            with self.subTest(label=label):
+                mutated = workflow.replace(old, new, 1)
+                self.assertNotEqual(mutated, workflow)
+                self.assertTrue(MODULE.windows_test_diagnostics_issues(mutated))
+
+    def test_windows_test_diagnostics_contract_checks_each_alias(self):
+        workflow = (ROOT / ".github" / "workflows" / "ci-build.yml").read_text()
+        mutated = workflow.replace(
+            "    steps: *windows_steps\n\n  WindowsAsan:",
+            "    steps: []\n\n  WindowsAsan:",
+            1,
+        )
+        self.assertNotEqual(mutated, workflow)
+        issues = MODULE.windows_test_diagnostics_issues(mutated)
+        self.assertTrue(any("WindowsX86" in issue for issue in issues))
+
+    def test_windows_test_diagnostics_contract_ignores_unrelated_steps(self):
+        workflow = """\
+jobs:
+  Other:
+    steps: &other_steps
+      - uses: ./.github/actions/agent-run-tests
+  OtherAlias:
+    steps: *other_steps
+"""
+        self.assertEqual(MODULE.windows_test_diagnostics_issues(workflow), [])
+
     def test_unknown_or_spoofed_steps_aliases_fail_closed(self):
         unknown = """\
 jobs:

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -1481,6 +1481,15 @@ void exerciseLiveCountdownRouting( MainWindow& window, Session& session,
     }
 }
 
+LiveTabStatus liveTabStatus( const TabbedCrawlerWidget& tabs, int index )
+{
+    const auto* tabBar = tabs.findChild<QTabBar*>();
+    REQUIRE( tabBar != nullptr );
+    const auto value = tabBar->tabData( index ).toMap().value( QStringLiteral( "liveStatus" ) );
+    REQUIRE( value.isValid() );
+    return static_cast<LiveTabStatus>( value.toInt() );
+}
+
 void exerciseLivePresentation( bool useIos, bool background, int preservationScenario = -1,
                                bool countdown = false )
 {
@@ -1721,6 +1730,43 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
         auto* disconnect = mainWindow->findChild<QAction*>( QStringLiteral( "disconnectSourceAction" ) );
         REQUIRE( info != nullptr );
         REQUIRE( disconnect != nullptr );
+        if ( preservationScenario == 14 ) {
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Connected );
+            CHECK_FALSE( info->text().contains( QStringLiteral( "Capture integrity warning:" ) ) );
+            CHECK_FALSE( tabs->tabToolTip( 0 ).contains( QStringLiteral( "Capture integrity:" ) ) );
+
+            controller->captureHealthChanged(
+                false,
+                live::LiveSourceError{ live::ErrorCategory::Capture,
+                                       "capture-persistence-degraded",
+                                       live::ErrorScope::Capture, live::RetryPolicy::Never,
+                                       "Capture spool persistence is degraded.", {} } );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Connected );
+            CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "currently degraded" ) ) );
+            controller->captureHealthChanged( true );
+
+            controller->outputBindingChanged(
+                live::OutputBindingState::Degraded,
+                live::LiveSourceError{ live::ErrorCategory::Capture, "output-write-failed",
+                                       live::ErrorScope::Capture, live::RetryPolicy::Never,
+                                       "The output file could not be written.", {} } );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Connected );
+            CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "Output error:" ) ) );
+            controller->outputBindingChanged( live::OutputBindingState::Healthy );
+
+            controller->streamFailed(
+                controller->snapshot().generation,
+                live::LiveSourceError{ live::ErrorCategory::Stream, "presentation-retry",
+                                       live::ErrorScope::Stream, live::RetryPolicy::Backoff,
+                                       "Deterministic stream interruption", {} } );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Reconnecting );
+            controller->stopRequested( live::StopDisposition::SettleAccepted );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Disconnected );
+
+            menu->removeEventFilter( &changes );
+            mainWindow->close();
+            return;
+        }
         if ( preservationScenario == 8 ) {
             using Access = CrawlerWidget::access_by<LivePresentationCrawlerAccess>;
             auto* data = Access::data( crawler );
@@ -1809,6 +1855,7 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
         if ( preservationScenario == 7 ) {
             REQUIRE( controller->controlPresentation().integrity.gapPossible );
             REQUIRE( controller->controlPresentation().integrity.replayPossible );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Connected );
             CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "Capture integrity:" ) ) );
             CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "gaps" ) ) );
             CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "replayed" ) ) );
@@ -1826,8 +1873,18 @@ void exerciseLivePresentation( bool useIos, bool background, int preservationSce
             CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "degraded earlier" ) ) );
             CHECK( tabs->tabToolTip( 0 ).contains( QStringLiteral( "gaps" ) ) );
             CHECK( controller->controlPresentation().integrity.discardedBytes == 17 );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Connected );
+
+            controller->streamFailed(
+                controller->snapshot().generation,
+                live::LiveSourceError{ live::ErrorCategory::Stream, "integrity-retry",
+                                       live::ErrorScope::Stream, live::RetryPolicy::Backoff,
+                                       "Deterministic stream interruption", {} } );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Reconnecting );
+            controller->stopRequested( live::StopDisposition::SettleAccepted );
+            CHECK( liveTabStatus( *tabs, 0 ) == LiveTabStatus::Disconnected );
+
             menu->removeEventFilter( &changes );
-            controller->stopRequested();
             mainWindow->close();
             return;
         }
@@ -2104,7 +2161,14 @@ TEST_CASE( "Live save repairs and switches an existing output without reopening 
     exerciseLivePresentation( useIos, false, 13 );
 }
 
-TEST_CASE( "Restored live integrity history remains visible after current health recovers",
+TEST_CASE( "Fresh live capture keeps lifecycle status separate from diagnostics",
+           "[ui][session][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    exerciseLivePresentation( useIos, false, 14 );
+}
+
+TEST_CASE( "Restored live integrity history remains visible without replacing lifecycle status",
            "[ui][session][live-integrity]" )
 {
     const auto useIos = GENERATE( false, true );
@@ -2356,7 +2420,7 @@ SCENARIO( "MainWindow restored iOS live log tabs show disconnected state", "[ui]
                && tabArea->tabToolTip( 0 ).contains(
                    QStringLiteral( "The bound capture output could not be written." ) );
     } ) );
-    CHECK( tabArea->tabIcon( 0 ).cacheKey() != disconnectedIconKey );
+    CHECK( tabArea->tabIcon( 0 ).cacheKey() == disconnectedIconKey );
 
     runInUiThread(
         [ source ] { Q_EMIT source->captureOutputChanged( true, CaptureOutputError::Write ); } );

--- a/tests/unit/adb_device_tracker_manager_test.cpp
+++ b/tests/unit/adb_device_tracker_manager_test.cpp
@@ -55,6 +55,7 @@ using DomainAdbDeviceInfo = klogg::livecapture::adb::AdbDeviceInfo;
 using DomainAdbDeviceState = klogg::livecapture::adb::AdbDeviceState;
 
 constexpr std::uint32_t SupportedProtocolVersion = 0x29u;
+constexpr auto AdbLongSerialFieldWidth = 22;
 constexpr auto FirstServerIdentity = "adb-server:first";
 constexpr auto ReplacementServerIdentity = "adb-server:replacement";
 
@@ -609,19 +610,27 @@ void requireKnownDevices( const AdbInfrastructureManager& manager,
     }
 }
 
+QByteArray trackDevicesLongRecord( const QByteArray& serial, const QByteArray& details )
+{
+    return serial.leftJustified( AdbLongSerialFieldWidth, ' ' ) + ' ' + details + '\n';
+}
+
 QByteArray firstDeviceSnapshot()
 {
-    return QByteArrayLiteral(
-        "online-1\tdevice product:foo model:Pixel_9 device:tokay transport_id:1\n"
-        "locked-2\tunauthorized usb:1-2 transport_id:2\n"
-        "sleeping-3\toffline transport_id:3\n" );
+    return trackDevicesLongRecord(
+               QByteArrayLiteral( "online-1" ),
+               QByteArrayLiteral( "device product:foo model:Pixel_9 device:tokay transport_id:1" ) )
+           + trackDevicesLongRecord( QByteArrayLiteral( "locked-2" ),
+                                     QByteArrayLiteral( "unauthorized usb:1-2 transport_id:2" ) )
+           + trackDevicesLongRecord( QByteArrayLiteral( "sleeping-3" ),
+                                     QByteArrayLiteral( "offline transport_id:3" ) );
 }
 
 } // namespace
 
 TEST_CASE( "shared ADB tracker starts only after infrastructure readiness and publishes typed "
            "track-devices snapshots",
-           "[livecapture][adb][tracker][manager][snapshot]" )
+           "[livecapture][adb][tracker][manager][snapshot][parse][long-text]" )
 {
     ManagerHarness harness;
     auto lease = harness.manager.acquireLease();
@@ -637,17 +646,23 @@ TEST_CASE( "shared ADB tracker starts only after infrastructure readiness and pu
     REQUIRE( drainEventsUntil( [ &harness ] { return harness.server.requestCount() == 1; } ) );
     REQUIRE( harness.server.requestAt( 0 ) == QByteArrayLiteral( "host:track-devices-l" ) );
     harness.server.sendTrackAccepted( 0, firstDeviceSnapshot() );
-    REQUIRE( drainEventsUntil(
-        [ &harness ] { return harness.manager.snapshot().devices.devices.size() == 3u; } ) );
+    REQUIRE( drainEventsUntil( [ &harness ] {
+        const auto snapshot = harness.manager.snapshot();
+        return snapshot.devices.devices.size() == 3u || snapshot.error.has_value();
+    } ) );
 
     const auto snapshot = harness.manager.snapshot();
+    const auto diagnostic
+        = snapshot.error.has_value() ? snapshot.error->nativeDetail : std::string{};
+    INFO( diagnostic );
+    REQUIRE_FALSE( snapshot.error.has_value() );
+    REQUIRE( snapshot.devices.devices.size() == 3u );
     CHECK( snapshot.generation == managerGeneration );
     CHECK( snapshot.infrastructureEpoch > 0u );
     CHECK( snapshot.devices.generation == managerGeneration );
     CHECK( snapshot.devices.infrastructureEpoch == snapshot.infrastructureEpoch );
     CHECK( snapshot.devices.requestGeneration > 0u );
     CHECK( snapshot.infrastructure.status == InfrastructureStatus::Ready );
-    CHECK_FALSE( snapshot.error.has_value() );
 
     const auto& online = deviceWithSerial( snapshot.devices.devices, "online-1" );
     CHECK( online.state == DomainAdbDeviceState::Online );
@@ -664,6 +679,36 @@ TEST_CASE( "shared ADB tracker starts only after infrastructure readiness and pu
     const auto& offline = deviceWithSerial( snapshot.devices.devices, "sleeping-3" );
     CHECK( offline.state == DomainAdbDeviceState::Offline );
     CHECK( offline.stateText == "offline" );
+}
+
+TEST_CASE( "track-devices-l parsing treats the serial field width as a minimum",
+           "[livecapture][adb][tracker][parse][long-text]" )
+{
+    ManagerHarness harness;
+    auto lease = harness.acquireAndReachReady();
+    const auto serial = QByteArrayLiteral( "serial-longer-than-twenty-two" );
+
+    harness.server.sendTrackAccepted(
+        0, trackDevicesLongRecord( serial,
+                                   QByteArrayLiteral( "device model:Pixel_10 transport_id:17" ) ) );
+    REQUIRE( drainEventsUntil( [ &harness ] {
+        const auto snapshot = harness.manager.snapshot();
+        return snapshot.devices.devices.size() == 1u || snapshot.error.has_value();
+    } ) );
+
+    const auto snapshot = harness.manager.snapshot();
+    const auto diagnostic
+        = snapshot.error.has_value() ? snapshot.error->nativeDetail : std::string{};
+    INFO( diagnostic );
+    REQUIRE_FALSE( snapshot.error.has_value() );
+    REQUIRE( snapshot.devices.devices.size() == 1u );
+    const auto& device = snapshot.devices.devices.front();
+    CHECK( device.serial == serial.toStdString() );
+    CHECK( device.state == DomainAdbDeviceState::Online );
+    CHECK( device.stateText == "device" );
+    CHECK( device.model == "Pixel 10" );
+    REQUIRE( device.transportId.has_value() );
+    CHECK( *device.transportId == 17u );
 }
 
 TEST_CASE( "unchanged ADB snapshots coalesce while detach and attach transitions publish",
@@ -687,8 +732,11 @@ TEST_CASE( "unchanged ADB snapshots coalesce while detach and attach transitions
     CHECK( harness.snapshots.snapshots.size() == eventCountAfterInitial );
     CHECK( harness.manager.snapshot().devices.requestGeneration == requestGeneration );
 
-    const auto detached = QByteArrayLiteral( "online-1\tdevice model:Pixel_9 transport_id:1\n"
-                                             "sleeping-3\toffline transport_id:3\n" );
+    const auto detached
+        = trackDevicesLongRecord( QByteArrayLiteral( "online-1" ),
+                                  QByteArrayLiteral( "device model:Pixel_9 transport_id:1" ) )
+          + trackDevicesLongRecord( QByteArrayLiteral( "sleeping-3" ),
+                                    QByteArrayLiteral( "offline transport_id:3" ) );
     harness.server.sendSnapshot( 0, detached );
     REQUIRE( drainEventsUntil(
         [ &harness ] { return harness.manager.snapshot().devices.devices.size() == 2u; } ) );
@@ -710,9 +758,13 @@ TEST_CASE( "latest tracked snapshot feeds discovery coordinator and selects an o
     ManagerHarness harness;
     auto lease = harness.acquireAndReachReady();
     harness.server.sendTrackAccepted(
-        0, QByteArrayLiteral( "offline-first\toffline transport_id:1\n"
-                              "locked-second\tunauthorized transport_id:2\n"
-                              "online-third\tdevice model:Pixel_8 transport_id:3\n" ) );
+        0, trackDevicesLongRecord( QByteArrayLiteral( "offline-first" ),
+                                   QByteArrayLiteral( "offline transport_id:1" ) )
+               + trackDevicesLongRecord( QByteArrayLiteral( "locked-second" ),
+                                         QByteArrayLiteral( "unauthorized transport_id:2" ) )
+               + trackDevicesLongRecord(
+                   QByteArrayLiteral( "online-third" ),
+                   QByteArrayLiteral( "device model:Pixel_8 transport_id:3" ) ) );
     REQUIRE( drainEventsUntil(
         [ &harness ] { return harness.manager.snapshot().devices.devices.size() == 3u; } ) );
 
@@ -732,7 +784,10 @@ TEST_CASE( "latest tracked snapshot feeds discovery coordinator and selects an o
     REQUIRE_FALSE( coordinator.currentError().has_value() );
 
     harness.server.sendSnapshot(
-        0, QByteArrayLiteral( "offline-only\toffline\nlocked-only\tunauthorized\n" ) );
+        0, trackDevicesLongRecord( QByteArrayLiteral( "offline-only" ),
+                                   QByteArrayLiteral( "offline" ) )
+               + trackDevicesLongRecord( QByteArrayLiteral( "locked-only" ),
+                                         QByteArrayLiteral( "unauthorized" ) ) );
     REQUIRE( drainEventsUntil( [ &harness ] {
         return harness.manager.snapshot().devices.devices.size() == 2u
                && harness.manager.snapshot().devices.devices.front().serial == "offline-only";
@@ -767,7 +822,8 @@ TEST_CASE( "track FAIL and EOF use bounded injected reconnect without withdrawin
 
     Q_EMIT harness.client.hostReplyReceived(
         firstOperation.generation, firstOperation.operationId,
-        QByteArrayLiteral( "stale-device\tdevice transport_id:99\n" ) );
+        trackDevicesLongRecord( QByteArrayLiteral( "stale-device" ),
+                                QByteArrayLiteral( "device transport_id:99" ) ) );
     requireKnownDevices( harness.manager, { "online-1", "locked-2", "sleeping-3" } );
 
     harness.server.sendFailure( 1, QByteArrayLiteral( "track service replaced" ) );
@@ -795,7 +851,8 @@ TEST_CASE( "track FAIL and EOF use bounded injected reconnect without withdrawin
     harness.trackerScheduler.fire( AdbServerScheduleKind::ReconnectBackoff );
     REQUIRE( drainEventsUntil( [ &harness ] { return harness.server.requestCount() == 3; } ) );
     harness.server.sendTrackAccepted(
-        2, QByteArrayLiteral( "replacement-device\tdevice model:Pixel_10 transport_id:7\n" ) );
+        2, trackDevicesLongRecord( QByteArrayLiteral( "replacement-device" ),
+                                   QByteArrayLiteral( "device model:Pixel_10 transport_id:7" ) ) );
     REQUIRE( drainEventsUntil( [ &harness ] {
         const auto snapshot = harness.manager.snapshot();
         const auto& devices = snapshot.devices.devices;
@@ -813,7 +870,9 @@ TEST_CASE( "malformed authoritative track snapshots retain known devices and rec
         [ &harness ] { return harness.manager.snapshot().devices.devices.size() == 3u; } ) );
 
     harness.server.sendSnapshot(
-        0, QByteArrayLiteral( "online-1\tdevice transport_id:1\nmissing-tab-separator\n" ) );
+        0, trackDevicesLongRecord( QByteArrayLiteral( "online-1" ),
+                                   QByteArrayLiteral( "device transport_id:1" ) )
+               + QByteArrayLiteral( "missing-whitespace-separator\n" ) );
     REQUIRE( drainEventsUntil( [ &harness ] {
         return harness.trackerScheduler.activeCount( AdbServerScheduleKind::ReconnectBackoff )
                == 1u;
@@ -824,7 +883,9 @@ TEST_CASE( "malformed authoritative track snapshots retain known devices and rec
     CHECK( harness.manager.snapshot().error->code == "adb-track-protocol" );
     CHECK( harness.manager.snapshot().error->scope == ErrorScope::Service );
     CHECK( harness.manager.snapshot().error->retryPolicy == RetryPolicy::Backoff );
-    CHECK( harness.manager.snapshot().error->nativeDetail.find( "line 2" ) != std::string::npos );
+    CHECK( harness.manager.snapshot().error->nativeDetail
+           == "Malformed ADB track-devices snapshot line 2: expected a serial and state separated "
+              "by whitespace." );
 }
 
 TEST_CASE( "server replacement advances infrastructure epoch and ignores stale tracker callbacks",
@@ -852,11 +913,13 @@ TEST_CASE( "server replacement advances infrastructure epoch and ignores stale t
 
     Q_EMIT harness.client.hostReplyReceived(
         firstOperation.generation, firstOperation.operationId,
-        QByteArrayLiteral( "stale-after-replacement\tdevice transport_id:88\n" ) );
+        trackDevicesLongRecord( QByteArrayLiteral( "stale-after-replacement" ),
+                                QByteArrayLiteral( "device transport_id:88" ) ) );
     requireKnownDevices( harness.manager, { "online-1", "locked-2", "sleeping-3" } );
 
     harness.server.sendTrackAccepted(
-        1, QByteArrayLiteral( "current-after-replacement\tdevice transport_id:9\n" ) );
+        1, trackDevicesLongRecord( QByteArrayLiteral( "current-after-replacement" ),
+                                   QByteArrayLiteral( "device transport_id:9" ) ) );
     REQUIRE( drainEventsUntil( [ &harness ] {
         const auto snapshot = harness.manager.snapshot();
         const auto& devices = snapshot.devices.devices;
@@ -901,7 +964,8 @@ TEST_CASE( "supervisor loss cancels tracking and publishes a structured infrastr
     Q_EMIT harness.client.hostReplyReceived(
         harness.clientOperations.operations.front().generation,
         harness.clientOperations.operations.front().operationId,
-        QByteArrayLiteral( "stale-after-loss\tdevice transport_id:5\n" ) );
+        trackDevicesLongRecord( QByteArrayLiteral( "stale-after-loss" ),
+                                QByteArrayLiteral( "device transport_id:5" ) ) );
     requireKnownDevices( harness.manager, { "online-1", "locked-2", "sleeping-3" } );
     CHECK( harness.clientOperations.operations.size() == operationCount );
 }
@@ -1100,7 +1164,8 @@ TEST_CASE(
 
     REQUIRE( drainEventsUntil( [ &harness ] { return harness.server.requestCount() == 2; } ) );
     harness.server.sendTrackAccepted(
-        1, QByteArrayLiteral( "replacement-online\tdevice transport_id:12\n" ) );
+        1, trackDevicesLongRecord( QByteArrayLiteral( "replacement-online" ),
+                                   QByteArrayLiteral( "device transport_id:12" ) ) );
     REQUIRE( drainEventsUntil( [ &harness ] {
         const auto selected = harness.manager.defaultOnlineDevice();
         return selected.has_value() && selected->serial == "replacement-online";

--- a/tests/unit/adb_live_services_composition_test.cpp
+++ b/tests/unit/adb_live_services_composition_test.cpp
@@ -1120,6 +1120,9 @@ TEST_CASE( "managed transport preserves retired statistics for owner aggregation
     first.deliveredChunks = 3u;
     first.backpressuredBytes = 5u;
     first.backpressuredChunks = 1u;
+    first.rejectedBeforeEnqueueBytes = std::numeric_limits<std::size_t>::max() - 3u;
+    first.rejectedBeforeEnqueueChunks = 2u;
+    first.incompleteSourceRecordBytes = 7u;
     first.highWaterQueuedBytes = 7u;
     first.highWaterQueuedChunks = 2u;
     innerFactory.created.front()->setStatistics( first );
@@ -1142,6 +1145,9 @@ TEST_CASE( "managed transport preserves retired statistics for owner aggregation
     second.deliveredChunks = 5u;
     second.backpressuredBytes = 13u;
     second.backpressuredChunks = 4u;
+    second.rejectedBeforeEnqueueBytes = 10u;
+    second.rejectedBeforeEnqueueChunks = 4u;
+    second.incompleteSourceRecordBytes = 11u;
     second.highWaterQueuedBytes = 5u;
     second.highWaterQueuedChunks = 3u;
     innerFactory.created.back()->setStatistics( second );
@@ -1157,6 +1163,9 @@ TEST_CASE( "managed transport preserves retired statistics for owner aggregation
     CHECK( statistics.deliveredChunks == 8u );
     CHECK( statistics.backpressuredBytes == 18u );
     CHECK( statistics.backpressuredChunks == 5u );
+    CHECK( statistics.rejectedBeforeEnqueueBytes == std::numeric_limits<std::size_t>::max() );
+    CHECK( statistics.rejectedBeforeEnqueueChunks == 6u );
+    CHECK( statistics.incompleteSourceRecordBytes == 18u );
     CHECK( statistics.highWaterQueuedBytes == 7u );
     CHECK( statistics.highWaterQueuedChunks == 3u );
 }

--- a/tests/unit/capturestore_test.cpp
+++ b/tests/unit/capturestore_test.cpp
@@ -645,6 +645,21 @@ bool waitForMissingFile( const QString& filePath, int timeoutMs = 5000 )
     return !QFileInfo::exists( filePath );
 }
 
+bool waitForMaintenanceRetryIdle( const CaptureStore& store, int timeoutMs = 15000 )
+{
+    QElapsedTimer deadline;
+    deadline.start();
+    while ( deadline.elapsed() < timeoutMs ) {
+        const auto retry = CaptureStoreTestAccess::maintenanceRetry( store );
+        if ( retry.requested == retry.completed && !retry.scheduled ) {
+            return true;
+        }
+        std::this_thread::yield();
+    }
+    const auto retry = CaptureStoreTestAccess::maintenanceRetry( store );
+    return retry.requested == retry.completed && !retry.scheduled;
+}
+
 bool waitForFlag( const std::atomic<bool>& flag, int timeoutMs = 5000 )
 {
     QElapsedTimer deadline;
@@ -952,14 +967,7 @@ TEST_CASE( "CaptureStore pending gate epochs survive the background handoff wind
     const auto duringHandoff = CaptureStoreTestAccess::maintenanceRetry( store );
     handoff->release.store( true, std::memory_order_release );
 
-    bool settled = false;
-    QElapsedTimer waitForRetry;
-    waitForRetry.start();
-    while ( !settled && waitForRetry.elapsed() < 15000 ) {
-        const auto retry = CaptureStoreTestAccess::maintenanceRetry( store );
-        settled = retry.requested == retry.completed && !retry.scheduled;
-        std::this_thread::yield();
-    }
+    const auto settled = waitForMaintenanceRetryIdle( store );
     CaptureStoreTestAccess::setCapturePathGateTimeout( previousTimeout );
     // All holder threads have joined and the background hook has been released
     // before any assertion; its captured state is shared even on test failure.
@@ -4183,7 +4191,8 @@ TEST_CASE( "CaptureStore buildRawLines reads from spilled disk segments" )
     REQUIRE( midDecoded[ 2 ] == QStringLiteral( "eee" ) );
 }
 
-TEST_CASE( "CaptureStore publishes spilled segments only after a complete write" )
+TEST_CASE( "CaptureStore publishes spilled segments only after a complete write",
+           "[capturestore][maintenance-lifecycle][windows-race]" )
 {
     CaptureStore::Limits limits;
     limits.segmentTargetBytes = 8;
@@ -4208,6 +4217,10 @@ TEST_CASE( "CaptureStore publishes spilled segments only after a complete write"
         REQUIRE( abandonedTemporaryFiles.size() == 1 );
         REQUIRE( waitForMissingFile( QDir( capturePath ).filePath(
             abandonedTemporaryFiles.front() ) ) );
+        // File disappearance is not the maintenance transaction boundary: the
+        // retry worker may still own the cross-process gate on Windows. Wait for
+        // its published lifecycle state before starting another spill.
+        REQUIRE( waitForMaintenanceRetryIdle( store ) );
 
         REQUIRE( CaptureStoreTestAccess::spillFirstSegment( store ) );
         REQUIRE( segmentFiles( capturePath ).size() == 1 );

--- a/tests/unit/ios_native_stream_worker_test.cpp
+++ b/tests/unit/ios_native_stream_worker_test.cpp
@@ -1654,6 +1654,44 @@ TEST_CASE(
     executor.runAllOnWorker();
 }
 
+TEST_CASE( "legacy syslog stop accounts an unterminated callback tail exactly once",
+           "[ios][native][stream][syslog][stop][partial][accounting][p0-red]" )
+{
+    FakeNative state;
+    fake = &state;
+    ManualExecutor executor;
+    ObservedCallbacks observed;
+    constexpr Generation generation = 508u;
+    const std::string partialRecord = "unterminated legacy bytes";
+    IosNativeStreamWorker worker( makeApi(), executor.executor(), config( generation, "8.4" ),
+                                  observed.callbacks() );
+    REQUIRE( worker.start() );
+    executor.runAllOnWorker();
+
+    state.emitSyslog( partialRecord );
+    state.waitUntilCallbackExited();
+    REQUIRE( observed.bytesAvailable.empty() );
+    REQUIRE_FALSE( worker.drain().has_value() );
+
+    worker.stop( generation );
+    executor.runAllOnWorker();
+    const auto terminalStatistics = worker.statistics();
+    CHECK( terminalStatistics.incompleteSourceRecordBytes == partialRecord.size() );
+    CHECK( terminalStatistics.rejectedBeforeEnqueueBytes == 0u );
+    CHECK( terminalStatistics.rejectedBeforeEnqueueChunks == 0u );
+    CHECK( terminalStatistics.receivedBytes == 0u );
+    CHECK( terminalStatistics.receivedChunks == 0u );
+    CHECK( observed.stopped == std::vector<Generation>{ generation } );
+
+    worker.stop( generation );
+    executor.runAllOnWorker();
+    const auto repeatedStopStatistics = worker.statistics();
+    CHECK( repeatedStopStatistics.incompleteSourceRecordBytes == partialRecord.size() );
+    CHECK( repeatedStopStatistics.rejectedBeforeEnqueueBytes == 0u );
+    CHECK( repeatedStopStatistics.rejectedBeforeEnqueueChunks == 0u );
+    CHECK( observed.stopped == std::vector<Generation>{ generation } );
+}
+
 TEST_CASE( "legacy syslog ignores empty NUL-delimited records",
            "[ios][native][stream][syslog][chunking][empty-record-red]" )
 {
@@ -1725,6 +1763,11 @@ TEST_CASE( "legacy syslog rejects an unterminated record at the configured bound
     CHECK_FALSE( worker.drain().has_value() );
     worker.stop( 511u );
     executor.runAllOnWorker();
+    CHECK( worker.statistics().incompleteSourceRecordBytes == 5u );
+
+    worker.stop( 511u );
+    executor.runAllOnWorker();
+    CHECK( worker.statistics().incompleteSourceRecordBytes == 5u );
 }
 
 TEST_CASE( "legacy syslog terminal errors use syslog relay ABI codes",

--- a/tests/unit/ios_native_transport_test.cpp
+++ b/tests/unit/ios_native_transport_test.cpp
@@ -18,9 +18,13 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -29,6 +33,7 @@
 #include <utility>
 #include <vector>
 
+#include "iosnativeapi.h"
 #include "iosnativestream.h"
 #include "iosnativetransport.h"
 #include "livedataqueue.h"
@@ -220,6 +225,164 @@ public:
 
     mutable std::vector<std::shared_ptr<ScriptedSessionState>> sessions;
 };
+
+struct LegacySyslogNativeState {
+    std::mutex mutex;
+    std::condition_variable changed;
+    NativeSyslogRelayCallback callback{ nullptr };
+    NativeSyslogRelayErrorCallback errorCallback{ nullptr };
+    void* context{ nullptr };
+    bool started{ false };
+
+    void reset()
+    {
+        std::lock_guard<std::mutex> lock( mutex );
+        callback = nullptr;
+        errorCallback = nullptr;
+        context = nullptr;
+        started = false;
+    }
+
+    bool waitUntilStarted()
+    {
+        std::unique_lock<std::mutex> lock( mutex );
+        return changed.wait_for( lock, std::chrono::seconds{ 2 }, [ this ] { return started; } );
+    }
+
+    void emit( const std::string& bytes )
+    {
+        NativeSyslogRelayCallback observedCallback = nullptr;
+        void* observedContext = nullptr;
+        {
+            std::lock_guard<std::mutex> lock( mutex );
+            observedCallback = callback;
+            observedContext = context;
+        }
+        REQUIRE( observedCallback != nullptr );
+        for ( const auto byte : bytes ) {
+            observedCallback( byte, observedContext );
+        }
+    }
+};
+
+LegacySyslogNativeState legacySyslogNative;
+const auto LegacyDeviceHandle = reinterpret_cast<NativeIdevice>( 0x1101 );
+const auto LegacyLockdownHandle = reinterpret_cast<NativeLockdownClient>( 0x1202 );
+const auto LegacyServiceHandle = reinterpret_cast<NativeServiceDescriptor>( 0x1303 );
+const auto LegacySyslogHandle = reinterpret_cast<NativeSyslogRelayClient>( 0x1505 );
+
+NativePairRecordResult legacyReadPairRecord( const char*, char** record, std::uint32_t* size )
+{
+    auto bytes = std::make_unique<char[]>( 1u );
+    bytes[ 0 ] = 'p';
+    *record = bytes.release();
+    *size = 1u;
+    return NativePairRecordResult::Present;
+}
+
+void legacyFreePairRecord( char* record )
+{
+    delete[] record;
+}
+
+std::int32_t legacyNewDevice( NativeIdevice* device, const char*, NativeConnectionOption )
+{
+    *device = LegacyDeviceHandle;
+    return 0;
+}
+
+std::int32_t legacyFreeDevice( NativeIdevice )
+{
+    return 0;
+}
+
+std::int32_t legacyNewLockdown( NativeIdevice, NativeLockdownClient* client, const char* )
+{
+    *client = LegacyLockdownHandle;
+    return 0;
+}
+
+std::int32_t legacyFreeLockdown( NativeLockdownClient )
+{
+    return 0;
+}
+
+std::int32_t legacyStartService( NativeLockdownClient, const char*,
+                                 NativeServiceDescriptor* service )
+{
+    *service = LegacyServiceHandle;
+    return 0;
+}
+
+std::int32_t legacyFreeService( NativeServiceDescriptor )
+{
+    return 0;
+}
+
+std::int32_t legacyGetString( NativeLockdownClient, const char*, const char* key, char** value )
+{
+    if ( key == nullptr || std::string{ key } != "ProductVersion" ) {
+        return -1;
+    }
+    auto bytes = std::make_unique<char[]>( 4u );
+    std::memcpy( bytes.get(), "8.4", 4u );
+    *value = bytes.release();
+    return 0;
+}
+
+void legacyFreeString( char* value )
+{
+    delete[] value;
+}
+
+std::int32_t legacyNewSyslog( NativeIdevice, NativeServiceDescriptor,
+                              NativeSyslogRelayClient* client )
+{
+    *client = LegacySyslogHandle;
+    return 0;
+}
+
+std::int32_t legacyStartSyslog( NativeSyslogRelayClient, NativeSyslogRelayCallback callback,
+                                NativeSyslogRelayErrorCallback error, void* context )
+{
+    std::lock_guard<std::mutex> lock( legacySyslogNative.mutex );
+    legacySyslogNative.callback = callback;
+    legacySyslogNative.errorCallback = error;
+    legacySyslogNative.context = context;
+    legacySyslogNative.started = true;
+    legacySyslogNative.changed.notify_all();
+    return 0;
+}
+
+std::int32_t legacyStopSyslog( NativeSyslogRelayClient )
+{
+    return 0;
+}
+
+std::int32_t legacyFreeSyslog( NativeSyslogRelayClient )
+{
+    return 0;
+}
+
+IosNativeApi legacySyslogApi()
+{
+    IosNativeApi api{};
+    api.deviceNewWithOptions = &legacyNewDevice;
+    api.deviceFree = &legacyFreeDevice;
+    api.lockdownClientNewWithExistingPair = &legacyNewLockdown;
+    api.lockdownClientFree = &legacyFreeLockdown;
+    api.lockdownStartService = &legacyStartService;
+    api.serviceDescriptorFree = &legacyFreeService;
+    api.lockdownGetStringValue = &legacyGetString;
+    api.nativeStringFree = &legacyFreeString;
+    api.readPairRecord = &legacyReadPairRecord;
+    api.pairRecordFree = &legacyFreePairRecord;
+    api.syslogRelayClientNew = &legacyNewSyslog;
+    api.syslogRelayStart = &legacyStartSyslog;
+    api.syslogRelayStop = &legacyStopSyslog;
+    api.syslogRelayClientFree = &legacyFreeSyslog;
+    return api;
+}
 
 IosNativeStreamConfig nativeConfig()
 {
@@ -437,6 +600,33 @@ TEST_CASE( "Native retirement counts final pre-enqueue rejections exactly once",
     REQUIRE( settlements.size() == 2u );
     CHECK( settlements.back().first == generation + 1u );
     CHECK( settlements.back().second == 0u );
+}
+
+TEST_CASE( "Native transport reports a quiescent legacy syslog partial exactly once",
+           "[ios][native][transport][syslog][stop][partial][accounting][p0-red]" )
+{
+    auto& nativeState = legacySyslogNative;
+    nativeState.reset();
+    DefaultIosNativeStreamWorkerFactory workerFactory( legacySyslogApi() );
+    IosNativeTransport transport( workerFactory, nativeConfig() );
+    SafeQSignalSpy stoppedSpy( &transport, &LiveSourceTransport::stopped );
+    constexpr Generation generation = 709u;
+    const std::string partialRecord = "unterminated transport bytes";
+
+    transport.start( generation );
+    REQUIRE( nativeState.waitUntilStarted() );
+    nativeState.emit( partialRecord );
+
+    transport.requestStop( generation, klogg::livecapture::StopDisposition::SettleAccepted );
+    REQUIRE( stoppedSpy.safeWait( 3000 ) );
+    REQUIRE( stoppedSpy.count() == 1 );
+    CHECK( stoppedSpy.at( 0 ).at( 0 ).toULongLong() == generation );
+    CHECK( stoppedSpy.at( 0 ).at( 1 ).toULongLong()
+           == static_cast<qulonglong>( partialRecord.size() ) );
+
+    transport.requestStop( generation, klogg::livecapture::StopDisposition::SettleAccepted );
+    drainQtEvents();
+    CHECK( stoppedSpy.count() == 1 );
 }
 
 TEST_CASE( "Native retiring drain can be cancelled fairly after one bounded delivery",

--- a/tests/unit/live_source_transport_contract_test.cpp
+++ b/tests/unit/live_source_transport_contract_test.cpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <memory>
 #include <new>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -134,6 +135,11 @@ public:
     {
         lastError_ = error;
         Q_EMIT errorOccurred( generation, error );
+    }
+
+    void publishStopped( Generation generation, quint64 discarded = 0u )
+    {
+        Q_EMIT stopped( generation, discarded );
     }
 
     void publishTerminalError( Generation generation,
@@ -479,6 +485,58 @@ TEST_CASE( "Source retirement consumes out-of-order delivery settlements",
 
     CHECK( stopped == 1 );
     CHECK( source.isInputTerminated() );
+}
+
+TEST_CASE( "Source retirement contains finalization callback exceptions and remains reusable",
+           "[livecapture][transport][finalization][exception][p0-red]" )
+{
+    QTemporaryDir root;
+    REQUIRE( root.isValid() );
+    auto data = std::make_shared<StreamingLogData>( makeCaptureId(), root.path() );
+    RecordingLiveSourceTransportFactory factory;
+    AdbLogcatSource source( AdbLogcatSessionData{}, data, factory );
+    unsigned settledDeliveries = 0u;
+    unsigned finalized = 0u;
+    unsigned stopped = 0u;
+    std::uint64_t observedDiscarded = 0u;
+    source.setControllerCallbacks(
+        [&]( Generation generation, const QByteArray& bytes, auto settled ) {
+            const auto result = source.appendTransportBytes( generation, bytes );
+            CHECK( result.disposition == klogg::livecapture::DeliveryDisposition::Complete );
+            ++settledDeliveries;
+            settled();
+        },
+        {}, {} );
+    source.setFinalizedCallback( [&]( Generation, const auto& ) {
+        ++finalized;
+        throw std::runtime_error( "injected finalization observer failure" );
+    } );
+    source.setStoppedCallback( [&]( Generation, std::uint64_t discarded ) {
+        ++stopped;
+        observedDiscarded = discarded;
+    } );
+
+    REQUIRE( source.connectSource() );
+    auto* const transport = factory.lastTransport;
+    REQUIRE( transport != nullptr );
+    const auto generation = transport->startGenerations.back();
+    transport->publishBytes( generation, QByteArrayLiteral( "settled before finalization\n" ) );
+    REQUIRE( settledDeliveries == 1u );
+    transport->deferStop = true;
+    source.cancelTransport( generation, klogg::livecapture::StopDisposition::SettleAccepted );
+
+    CHECK_NOTHROW( transport->publishStopped( generation, 13u ) );
+    CHECK( source.isInputTerminated() );
+    CHECK( finalized == 1u );
+    CHECK( stopped == 1u );
+    CHECK( observedDiscarded == 13u );
+    CHECK_NOTHROW( transport->publishStopped( generation, 13u ) );
+    CHECK( finalized == 1u );
+    CHECK( stopped == 1u );
+
+    source.setFinalizedCallback( {} );
+    REQUIRE( source.connectSource() );
+    CHECK( transport->startGenerations.size() == 2u );
 }
 
 TEST_CASE( "Controller callback exceptions report unknown delivery before settlement",

--- a/tests/unit/live_source_transport_contract_test.cpp
+++ b/tests/unit/live_source_transport_contract_test.cpp
@@ -539,6 +539,104 @@ TEST_CASE( "Source retirement contains finalization callback exceptions and rema
     CHECK( transport->startGenerations.size() == 2u );
 }
 
+TEST_CASE( "Source retirement preserves its stopped observer across finalization reentrancy",
+           "[livecapture][transport][finalization][reentrant][review-red]" )
+{
+    QTemporaryDir root;
+    REQUIRE( root.isValid() );
+    auto data = std::make_shared<StreamingLogData>( makeCaptureId(), root.path() );
+    RecordingLiveSourceTransportFactory factory;
+    AdbLogcatSource source( AdbLogcatSessionData{}, data, factory );
+    unsigned originalStopped = 0u;
+    unsigned replacementStopped = 0u;
+    std::vector<std::pair<Generation, std::uint64_t>> acknowledgements;
+    std::optional<Generation> firstGeneration;
+    source.setControllerCallbacks(
+        [ & ]( Generation generation, const QByteArray& bytes, auto settled ) {
+            (void)source.appendTransportBytes( generation, bytes );
+            settled();
+        },
+        {}, {} );
+    source.setStoppedCallback( [ & ]( Generation generation, std::uint64_t discarded ) {
+        ++originalStopped;
+        acknowledgements.emplace_back( generation, discarded );
+    } );
+    source.setFinalizedCallback( [ & ]( Generation generation, const auto& ) {
+        if ( firstGeneration == generation ) {
+            source.setStoppedCallback( [ & ]( Generation nextGeneration, std::uint64_t discarded ) {
+                ++replacementStopped;
+                acknowledgements.emplace_back( nextGeneration, discarded );
+            } );
+        }
+    } );
+
+    REQUIRE( source.connectSource() );
+    auto* const transport = factory.lastTransport;
+    REQUIRE( transport != nullptr );
+    firstGeneration = transport->startGenerations.back();
+    transport->publishBytes( *firstGeneration, QByteArrayLiteral( "first\n" ) );
+    transport->deferStop = true;
+    source.cancelTransport( *firstGeneration, klogg::livecapture::StopDisposition::SettleAccepted );
+    transport->publishStopped( *firstGeneration, 7u );
+
+    REQUIRE( acknowledgements.size() == 1u );
+    CHECK( acknowledgements.front() == std::make_pair( *firstGeneration, std::uint64_t{ 7u } ) );
+    CHECK( originalStopped == 1u );
+    CHECK( replacementStopped == 0u );
+    CHECK( source.isInputTerminated() );
+
+    REQUIRE( source.connectSource() );
+    const auto secondGeneration = transport->startGenerations.back();
+    REQUIRE( secondGeneration != *firstGeneration );
+    source.cancelTransport( secondGeneration, klogg::livecapture::StopDisposition::SettleAccepted );
+    transport->publishStopped( secondGeneration, 3u );
+
+    REQUIRE( acknowledgements.size() == 2u );
+    CHECK( acknowledgements.back() == std::make_pair( secondGeneration, std::uint64_t{ 3u } ) );
+    CHECK( originalStopped == 1u );
+    CHECK( replacementStopped == 1u );
+}
+
+TEST_CASE( "Retained retirement callback is harmless after observer destruction",
+           "[livecapture][transport][finalization][lifetime][review-red]" )
+{
+    QTemporaryDir root;
+    REQUIRE( root.isValid() );
+    auto data = std::make_shared<StreamingLogData>( makeCaptureId(), root.path() );
+    RecordingLiveSourceTransportFactory factory;
+    AdbLogcatSource source( AdbLogcatSessionData{}, data, factory );
+    auto observer = std::make_shared<unsigned>( 0u );
+    const std::weak_ptr<unsigned> weakObserver = observer;
+    unsigned callbackAttempts = 0u;
+    unsigned liveObserverCalls = 0u;
+    source.setStoppedCallback(
+        [ weakObserver, &callbackAttempts, &liveObserverCalls ]( Generation, std::uint64_t ) {
+            ++callbackAttempts;
+            if ( const auto locked = weakObserver.lock() ) {
+                ++*locked;
+                ++liveObserverCalls;
+            }
+        } );
+    source.setFinalizedCallback( [ & ]( Generation, const auto& ) {
+        observer.reset();
+        source.setStoppedCallback( {} );
+    } );
+
+    REQUIRE( source.connectSource() );
+    auto* const transport = factory.lastTransport;
+    REQUIRE( transport != nullptr );
+    const auto generation = transport->startGenerations.back();
+    transport->deferStop = true;
+    source.cancelTransport( generation, klogg::livecapture::StopDisposition::SettleAccepted );
+    transport->publishStopped( generation );
+
+    CHECK( weakObserver.expired() );
+    CHECK( callbackAttempts == 1u );
+    CHECK( liveObserverCalls == 0u );
+    CHECK( source.isInputTerminated() );
+    REQUIRE( source.connectSource() );
+}
+
 TEST_CASE( "Controller callback exceptions report unknown delivery before settlement",
            "[livecapture][transport][controller][review-red]" )
 {

--- a/tests/unit/livelog_controller_test.cpp
+++ b/tests/unit/livelog_controller_test.cpp
@@ -368,10 +368,16 @@ TEST_CASE( "Stop completion cannot hide a terminal capture finalization failure"
     const auto generation = controller.snapshot().generation;
     controller.streamBytesReceived( generation, QByteArrayLiteral( "partial" ) );
     controller.stopRequested( live::StopDisposition::SettleAccepted );
+    unsigned notifications = 0u;
+    controller.setPresentationChangedCallback( [ & ]( auto presentation, auto ) {
+        ++notifications;
+        CHECK( presentation.status == live::PresentationStatus::Failed );
+    } );
     live::CaptureDeliveryResult failure;
     failure.disposition = live::DeliveryDisposition::Rejected;
     failure.failureCode = "capture-directory";
     controller.inputTerminated( generation, failure );
+    CHECK( notifications == 1u );
     controller.stopCompleted( generation );
     REQUIRE( controller.snapshot().source.failure.has_value() );
     CHECK( controller.snapshot().source.status == live::SourceStatus::Failed );
@@ -587,6 +593,47 @@ TEST_CASE( "Automatic retirement waits for the stop barrier and reports real rec
     controller.streamReadArmed( replacementGeneration );
     REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
     CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "Capture failure interruption reports source-specific reconnect integrity",
+           "[livelog-controller][capture][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    live::CaptureDeliveryResult outcome;
+    outcome.disposition = live::DeliveryDisposition::Complete;
+    outcome.acceptedBytes = 5u;
+    outcome.notificationFailed = true;
+    effects.reportedResult = outcome;
+
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "lost\n" ) );
+
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Failed );
+    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+
+    controller.stopCompleted( retiredGeneration );
+    controller.reconnectRequested();
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+    const auto hasReplayEvent
+        = std::any_of( controller.spec().integrity.recentEvents.cbegin(),
+                       controller.spec().integrity.recentEvents.cend(),
+                       []( const auto& event ) { return event.code == "source-replay-possible"; } );
+    CHECK( hasReplayEvent == !useIos );
 }
 
 TEST_CASE( "Append exceptions are terminal and do not escape or replay buffered deliveries",

--- a/tests/unit/livelog_controller_test.cpp
+++ b/tests/unit/livelog_controller_test.cpp
@@ -460,7 +460,6 @@ TEST_CASE( "Authoritative acceptance settles known partial unknown and postcommi
     CHECK( integrity.committedBytes == 99u );
     CHECK( integrity.committedLines == 7u );
     CHECK( integrity.outputBytes == 11u );
-    CHECK( integrity.sourceCompletenessUnknown );
     CHECK( effects.count( RecordingEffects::Kind::AppendBytes ) == 1u );
     CHECK( controller.snapshot().source.status == live::SourceStatus::Failed );
 }
@@ -524,26 +523,70 @@ TEST_CASE( "Permanent capture failure survives later absence and availability",
     CHECK( controller.snapshot().source.status == live::SourceStatus::Failed );
 }
 
-TEST_CASE( "Automatic retirement waits for the registered stop barrier before opening",
-           "[livelog-controller][w2-control-red]" )
+TEST_CASE( "An unconnected stream attempt does not manufacture an integrity gap",
+           "[livelog-controller][live-integrity-policy-red]" )
 {
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
     ManualClock clock;
     ManualScheduler scheduler;
     RecordingEffects effects;
-    livelog::LiveLogController controller( androidSpec(), controllerConfig(), clock, scheduler, effects );
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToOpening( controller, clock );
+    controller.streamFailed( controller.snapshot().generation, retryableStreamError() );
+
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "A clean intentional stop does not manufacture an integrity gap",
+           "[livelog-controller][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
     armToStreaming( controller, clock );
-    const auto generation = controller.snapshot().generation;
-    controller.deviceAbsent( generation );
+    controller.stopRequested( live::StopDisposition::SettleAccepted );
+
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "Automatic retirement waits for the stop barrier and reports real reconnect semantics",
+           "[livelog-controller][w2-control-red][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.deviceAbsent( retiredGeneration );
     CHECK( controller.spec().integrity.gapPossible );
-    CHECK( controller.spec().integrity.replayPossible );
-    REQUIRE( controller.snapshot().generation != generation );
-    controller.deviceAvailable( controller.snapshot().generation );
-    controller.protocolServiceReady( generation );
-    controller.streamReadArmed( generation );
-    controller.stopCompleted( generation + 19u );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+    REQUIRE( controller.snapshot().generation != retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.protocolServiceReady( retiredGeneration );
+    controller.streamReadArmed( retiredGeneration );
+    controller.stopCompleted( retiredGeneration + 19u );
     CHECK( effects.count( RecordingEffects::Kind::OpenStream ) == 1u );
-    controller.stopCompleted( generation );
+    controller.stopCompleted( retiredGeneration );
     CHECK( effects.count( RecordingEffects::Kind::OpenStream ) == 2u );
+
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
 }
 
 TEST_CASE( "Append exceptions are terminal and do not escape or replay buffered deliveries",

--- a/tests/unit/livelog_restore_arming_test.cpp
+++ b/tests/unit/livelog_restore_arming_test.cpp
@@ -151,6 +151,9 @@ public:
     void stop( Generation generation ) override
     {
         stopGenerations.push_back( generation );
+        if ( deferStop ) {
+            return;
+        }
         // This in-memory fake owns no asynchronous producer. Real transports
         // publish the separate acknowledgement only after their cleanup barrier.
         Q_EMIT stateChanged( generation, State::Disconnected );
@@ -178,6 +181,11 @@ public:
         Q_EMIT bytesReceived( generation, bytes );
     }
 
+    void publishStopped( Generation generation, quint64 discarded )
+    {
+        Q_EMIT stopped( generation, discarded );
+    }
+
     void publishTerminalError( Generation generation, live::LiveSourceError error )
     {
         structuredError_ = std::move( error );
@@ -199,6 +207,7 @@ public:
 
     std::vector<Generation> startGenerations;
     std::vector<Generation> stopGenerations;
+    bool deferStop{ false };
     bool stopObservedBeforeTerminalText{ false };
     int terminalTextEmissions{ 0 };
 
@@ -651,6 +660,60 @@ TEST_CASE( "Real source effects settle capture rejection through the session con
         REQUIRE( QDir{ replacedCapturePath }.removeRecursively() );
         REQUIRE( QDir{}.rename( heldCapturePath, replacedCapturePath ) );
     }
+}
+
+TEST_CASE( "Session stop waits for authoritative stopped after transport Disconnected",
+           "[livelog-restore-arming][session][stop][ordering][integrity][p0-red]" )
+{
+    RecordingLiveSourceTransportFactory factory;
+    auto appSession = std::make_shared<Session>( factory );
+    auto spec = makeAndroidSpec();
+    spec.captureId = QUuid::createUuid().toString( QUuid::WithoutBraces );
+    auto* view = appSession->openAdbLogcat(
+        klogg::livelog::sessionDataFromSpec( spec ),
+        []() -> ViewInterface* {
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+            return new NullView();
+        },
+        true );
+    REQUIRE( view != nullptr );
+    auto* const source = appSession->getAdbLogcatSource( view );
+    auto* const controller = appSession->getLiveLogController( view );
+    REQUIRE( source != nullptr );
+    REQUIRE( controller != nullptr );
+    REQUIRE( factory.createdTransports.size() == 1u );
+    const auto generation = controller->snapshot().generation;
+    auto* const originalTransport = factory.createdTransports.front();
+    originalTransport->publishState( generation, LiveSourceTransport::State::Connected );
+    REQUIRE( controller->snapshot().source.status == live::SourceStatus::Streaming );
+
+    originalTransport->deferStop = true;
+    controller->stopRequested( live::StopDisposition::SettleAccepted );
+    REQUIRE( controller->snapshot().source.stoppingGeneration == generation );
+
+    // Model a source-owned transport callback that was already admitted while
+    // controller retirement was entering its authoritative stopped barrier.
+    source->openTransport( generation,
+                           klogg::livelog::makeLiveSourceTransportConfig( controller->spec() ) );
+    REQUIRE( factory.createdTransports.size() == 2u );
+    auto* const callbackTransport = factory.createdTransports.back();
+    callbackTransport->publishState( generation, LiveSourceTransport::State::Disconnected );
+
+    CHECK( controller->snapshot().source.stoppingGeneration == generation );
+    CHECK( controller->spec().integrity.discardedBytes == 0u );
+
+    constexpr quint64 discardedTailBytes = 23u;
+    callbackTransport->publishStopped( generation, discardedTailBytes );
+
+    CHECK_FALSE( controller->snapshot().source.stoppingGeneration.has_value() );
+    CHECK( controller->spec().integrity.discardedBytes == discardedTailBytes );
+    CHECK( controller->spec().integrity.gapPossible );
+
+    callbackTransport->publishStopped( generation, discardedTailBytes );
+    CHECK( controller->spec().integrity.discardedBytes == discardedTailBytes );
+
+    appSession->close( view );
+    delete view;
 }
 
 TEST_CASE( "Persisted Android running intent restores inert and reconnects once",

--- a/tests/unit/livelog_session_spec_test.cpp
+++ b/tests/unit/livelog_session_spec_test.cpp
@@ -240,7 +240,9 @@ TEST_CASE( "Live integrity persists exact uint64 values and bounded historical e
     spec.integrity.discardedBytes = 2u;
     spec.integrity.gapPossible = true;
     spec.integrity.replayPossible = true;
-    for ( unsigned i = 0; i < 100u; ++i ) { spec.integrity.record( "stream-retired", i ); }
+    for ( unsigned i = 0; i < 100u; ++i ) {
+        spec.integrity.record( "transport-tail-discarded", i );
+    }
     CHECK( spec.integrity.recentEvents.size() == live::LiveIntegritySummary::MaxRecentEvents );
     CHECK( spec.integrity.olderEvents == 68u );
     const auto json = serializeSpec( spec );
@@ -257,13 +259,36 @@ TEST_CASE( "Live integrity persists exact uint64 values and bounded historical e
     CHECK( json.contains( QStringLiteral( "18446744073709551613" ) ) );
 }
 
+TEST_CASE( "Live integrity persists evidence without source completeness capability state",
+           "[livelog-session-spec][live-integrity-policy-red]" )
+{
+    const auto legacyCompleteness = GENERATE( false, true );
+    auto object = objectFrom( serialized( makeAndroidSpec() ) );
+    auto integrity = object.value( QStringLiteral( "integrity" ) ).toObject();
+
+    CHECK_FALSE( integrity.contains( QStringLiteral( "sourceCompletenessUnknown" ) ) );
+
+    integrity.insert( QStringLiteral( "sourceCompletenessUnknown" ), legacyCompleteness );
+    object.insert( QStringLiteral( "integrity" ), integrity );
+    const auto parsed = parseSpec(
+        QString::fromUtf8( QJsonDocument( object ).toJson( QJsonDocument::Compact ) ) );
+    REQUIRE( parsed.ok() );
+    REQUIRE( parsed.spec.has_value() );
+
+    const auto normalized = objectFrom( serialized( *parsed.spec ) )
+                                .value( QStringLiteral( "integrity" ) )
+                                .toObject();
+    CHECK_FALSE( normalized.contains( QStringLiteral( "sourceCompletenessUnknown" ) ) );
+}
+
 TEST_CASE( "Malformed live integrity does not silently become a healthy history",
            "[livelog-session-spec][w2-integrity-red]" )
 {
     const auto bad = GENERATE( QStringLiteral( R"({"version":99})" ),
         QStringLiteral( R"({"version":1,"acceptedBytes":9007199254740993})" ),
         QStringLiteral( R"({"version":1,"acceptedBytes":"-1"})" ),
-        QStringLiteral( R"({"version":1,"acceptedBytes":"18446744073709551616"})" ) );
+        QStringLiteral( R"({"version":1,"acceptedBytes":"18446744073709551616"})" ),
+        QStringLiteral( R"({"version":1,"sourceCompletenessUnknown":"unknown"})" ) );
     auto object = QJsonDocument::fromJson( serializeSpec( makeAndroidSpec() ).toUtf8() ).object();
     object.insert( QStringLiteral( "integrity" ), QJsonDocument::fromJson( bad.toUtf8() ).object() );
     const auto result = klogg::livelog::parsePersistedSpec( QString::fromUtf8( QJsonDocument( object ).toJson() ) );


### PR DESCRIPTION
## Summary
- Make live capture stop completion authoritative and resilient to early disconnects, incomplete iOS records, finalization failures, and callback reentrancy.
- Parse standard whitespace-padded ADB `track-devices-l` snapshots so connected Android devices remain discoverable.
- Separate current connection status from persistent integrity history, recording only observed gaps, replay risk, and output diagnostics.
- Ensure capture-failure transitions use the same serialized snapshot-observation and presentation-notification invariants as normal reducer events.
- Stabilize the CaptureStore spill-publication regression by waiting for asynchronous maintenance to become fully idle.
- Repair the Windows CI failure path so test crashes retain CTest logs, WER dumps, PDBs, and ASan diagnostics before the job fails.
- Add structural CI lint contracts that resolve the shared Windows step anchor/aliases and reject skipped tests, softened failure gates, or nonfunctional diagnostic collection/uploads.

## Background
- **Introduced by:** PR #70's live-capture retirement and integrity hardening; the native ADB tracker introduced in `ee211008`; the spill regression added in `3f6ec51c`; and `ee211008`'s invalid Windows diagnostics condition.
- **Use case:** Start, monitor, reconnect, restore, stop, or preserve Android/iOS live streams while transport callbacks and persistence work settle; diagnose a hard Windows test crash without losing the dump and symbols.
- **How to reproduce:** Use a normal long-format ADB device snapshot; interrupt or reject an established capture and reconnect; replace or clear the stopped observer during finalization; run the Windows CI leg with a failing test while the matrix stores `os: windows` and `os_version: 2022`.
- **Root cause:** Stop completion had multiple owners; long ADB records were parsed as tab-delimited short records; lifecycle status was mixed with sticky integrity history; delivery settlement bypassed the controller's common commit/notification path; retirement selected callbacks after external finalization; retained callbacks captured raw owners; and CI compared `matrix.config.os` with the nonexistent value `windows-2022`.
- **How to fix:** Make stopped callbacks authoritative, account terminal partial records exactly once, parse long ADB records as whitespace-delimited fields, persist only observed integrity evidence, centralize accepted snapshot observation, serialize settlement notifications, bind retirement acknowledgements to their original lifetime-safe observer, and make Windows diagnostics run unconditionally after a test failure before an explicit fail-closed gate.

The isolated Windows x64 Qt 6 SIGSEGV in `FolderCrawlerWidget shared view-signal wiring` is not attributed to this PR: no folder code changed, the previous matching Windows run and this PR's Windows ASan run passed, and the known folder teardown UAF already has a deterministic ASan regression. No speculative timing or folder patch was added; if it recurs, the repaired diagnostics path will provide the dump/PDB evidence needed for a symbolized investigation.

## Review feedback
- Fixed Codex's capture-failure integrity finding: Android reconnects now retain replay-risk evidence after a capture interruption; iOS remains gap-only.
- Fixed CodeRabbit's retirement callback finding: callback replacement applies to future generations, while an in-flight retirement retains its original observer safely.
- Did not add explicit `stopped` emissions to the UI fake because `LiveSourceTransport::requestStop()` already converts matching `Disconnected` signals into the authoritative acknowledgement; adding another emission would duplicate the transport contract.
- Did not add unrelated docstrings solely for CodeRabbit's external coverage metric.

## Tests
- `python3 scripts/run_ci_quality.py` — passed, including 761 Python contract tests.
- `python3 -m unittest tests/scripts/test_lint_ci_quality.py` — passed, 143 tests.
- `python3 scripts/lint_ci_quality.py` — passed.
- `actionlint -shellcheck= .github/workflows/ci-build.yml` — passed structural workflow validation; full shellcheck output is unchanged from the base workflow.
- `python3 scripts/lint_header_self_contained.py --build-dir build_root src/ui/include/livelogcontroller.h` — passed.
- `python3 scripts/run_changed_clang_tidy.py --base origin/master --build-dir build_root` — passed with LLVM tools on `PATH`.
- Qt 5 focused build plus the complete live-controller suite and new callback regressions — passed.
- `ctest --test-dir build_root --build-config RelWithDebInfo --output-on-failure` — passed 27/27, including `klogg_itests`.
- `git diff --check` — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved live-capture integrity tracking, including possible gaps and replay after reconnection.
  - Added reporting for bytes discarded from incomplete source records.
  - Improved compatibility with whitespace-separated ADB device listings.

- **Bug Fixes**
  - Ensured stream finalization and stop notifications occur reliably and only once.
  - Preserved accurate live-tab connection status while showing health issues through tooltips.
  - Improved handling of incomplete iOS syslog records and session restoration.
  - Improved compatibility when loading sessions with legacy integrity metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->