### PR TITLE
Harden ADB adoption, stage iOS runtime closure, enable Xcode builds, and de-flake CI tests (#71 follow-up)

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -123,19 +123,48 @@ if(KLOGG_ENABLE_IOS_NATIVE_STACK)
       libusbmuxd-2.0.dylib
       libimobiledevice-1.0.dylib
   )
+  set(_klogg_ios_native_direct_aliases
+      libcrypto.dylib
+      libssl.dylib
+      libcurl.dylib
+      libtatsu.dylib
+  )
   add_library(klogg_ios_native_stack INTERFACE)
+  set(_klogg_ios_native_runtime_dylibs)
   foreach(_klogg_ios_dylib IN LISTS _klogg_ios_native_dylibs)
-    if(NOT EXISTS "${_klogg_ios_native_libdir}/${_klogg_ios_dylib}")
+    set(_klogg_ios_dylib_path "${_klogg_ios_native_libdir}/${_klogg_ios_dylib}")
+    if(NOT EXISTS "${_klogg_ios_dylib_path}")
       message(FATAL_ERROR "Required iOS native dylib is missing: ${_klogg_ios_dylib}")
     endif()
+    get_filename_component(_klogg_ios_dylib_real_path "${_klogg_ios_dylib_path}" REALPATH)
+    list(APPEND _klogg_ios_native_runtime_dylibs
+         "${_klogg_ios_dylib_path}" "${_klogg_ios_dylib_real_path}")
     string(MAKE_C_IDENTIFIER "${_klogg_ios_dylib}" _klogg_ios_target)
     add_library("klogg_ios_${_klogg_ios_target}" SHARED IMPORTED GLOBAL)
     set_target_properties(
       "klogg_ios_${_klogg_ios_target}"
-      PROPERTIES IMPORTED_LOCATION "${_klogg_ios_native_libdir}/${_klogg_ios_dylib}"
+      PROPERTIES IMPORTED_LOCATION "${_klogg_ios_dylib_path}"
     )
     target_link_libraries(klogg_ios_native_stack INTERFACE "klogg_ios_${_klogg_ios_target}")
   endforeach()
+  foreach(_klogg_ios_alias IN LISTS _klogg_ios_native_direct_aliases)
+    set(_klogg_ios_alias_path "${_klogg_ios_native_libdir}/${_klogg_ios_alias}")
+    if(NOT IS_SYMLINK "${_klogg_ios_alias_path}")
+      message(FATAL_ERROR "Required iOS native direct alias is missing: ${_klogg_ios_alias}")
+    endif()
+    get_filename_component(_klogg_ios_alias_real_path "${_klogg_ios_alias_path}" REALPATH)
+    list(FIND _klogg_ios_native_runtime_dylibs "${_klogg_ios_alias_real_path}"
+         _klogg_ios_alias_target_index)
+    if(_klogg_ios_alias_target_index EQUAL -1)
+      message(FATAL_ERROR "iOS native direct alias escapes the verified closure: ${_klogg_ios_alias}")
+    endif()
+    list(APPEND _klogg_ios_native_runtime_dylibs "${_klogg_ios_alias_path}")
+  endforeach()
+  list(REMOVE_DUPLICATES _klogg_ios_native_runtime_dylibs)
+  set_property(
+    TARGET klogg_ios_native_stack
+    PROPERTY KLOGG_IOS_NATIVE_RUNTIME_DYLIBS "${_klogg_ios_native_runtime_dylibs}"
+  )
   target_include_directories(
     klogg_ios_native_stack INTERFACE "${KLOGG_IOS_NATIVE_STACK_ROOT}/include"
   )

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -372,10 +372,11 @@ if(KLOGG_USE_VECTORSCAN)
     ${vectorscan_SOURCE_DIR}
     d29730e1cb9daaa66bda63426cdce83505d2c809
     04357c577d094b3ea8760c3635c776789fb671c1bff010c66a43f479f442eefd
-    bd842a94bd5ba6ba87cc475bcd0881f5d53ab6e9b45cd964bc3d4c2ea7f1298a
+    505337c394bf0b6ed954a62a865e6814eccab821e4fd22bba5ecbbdd3fb57e8d
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_vectorscan_msvc_warning_flags.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_vectorscan_msvc_aligned_free.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_vectorscan_null_history_ubsan.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix_vectorscan_xcode_ragel_targets.patch
   )
 
   # Set vectorscan build options before processing its cmake files

--- a/3rdparty/patches/fix_vectorscan_xcode_ragel_targets.patch
+++ b/3rdparty/patches/fix_vectorscan_xcode_ragel_targets.patch
@@ -1,0 +1,45 @@
+diff --git a/cmake/ragel.cmake b/cmake/ragel.cmake
+--- a/cmake/ragel.cmake
++++ b/cmake/ragel.cmake
+@@ -10,6 +10,5 @@ function(ragelmaker src_rl)
+         COMMAND ${RAGEL} ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl} -o ${rl_out} -G0
+         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${src_rl}
+         )
+-    add_custom_target(ragel_${src_file} DEPENDS ${rl_out})
+     set_source_files_properties(${rl_out} PROPERTIES GENERATED TRUE)
+ endfunction(ragelmaker)
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1162,7 +1162,3 @@ if (BUILD_SHARED_LIBS)
+ endif()
+-
+-if (BUILD_STATIC_LIBS)
+-    add_dependencies(hs ragel_Parser)
+-endif ()
+
+ if (BUILD_STATIC_LIBS)
+@@ -1189,4 +1185,3 @@ if (BUILD_SHARED_LIBS)
+     add_library(hs_shared SHARED ${hs_shared_SRCS} hs.def)
+
+-    add_dependencies(hs_shared ragel_Parser)
+     set_target_properties(hs_shared PROPERTIES
+diff --git a/util/CMakeLists.txt b/util/CMakeLists.txt
+--- a/util/CMakeLists.txt
++++ b/util/CMakeLists.txt
+@@ -22,6 +22,5 @@ set(expressionutil_SRCS
+     ExpressionParser.cpp
+     )
+ add_library(expressionutil STATIC ${expressionutil_SRCS})
+-add_dependencies(expressionutil ragel_ExpressionParser)
+
+ SET(corpusomatic_SRCS
+diff --git a/tools/hscollider/CMakeLists.txt b/tools/hscollider/CMakeLists.txt
+--- a/tools/hscollider/CMakeLists.txt
++++ b/tools/hscollider/CMakeLists.txt
+@@ -64,5 +64,4 @@ set_source_files_properties(${hscollider_SOURCES} PROPERTIES
+     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+ add_executable(hscollider ${hscollider_SOURCES})
+-add_dependencies(hscollider ragel_ColliderCorporaParser)
+
+ if (BUILD_CHIMERA)

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -170,7 +170,30 @@ should reach state X eventually", `waitUiState` (or any equivalent
 poll-with-deadline helper) is the right tool; a fixed `QTest::qWait`
 is not.
 
-### 8.5 Why these four rules and not more
+### 8.5 Observe semantic completion; time is only a failure bound
+
+```cpp
+// AVOID -- selecting starts an uncached asynchronous LogData index. A five-
+// second predicate budget passed in one TSan run and expired in the next even
+// though both runs tested the same source tree.
+widget.selectResultRow( row );
+REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == path; } ) );
+QTest::qWait( 200 );
+
+// PREFER -- use the shared arm/action/ready protocol. It returns as soon as
+// completion arrives; 30 s is only a deadlock bound. The ready predicate also
+// handles the same-current-file synchronous branch, which emits no change signal.
+triggerAndWaitForCompletion(
+    &widget, &FolderCrawlerWidget::mainViewFileChanged,
+    [ & ] { widget.selectResultRow( row ); },
+    [ & ] { return widget.currentMainFilePath() == path; } );
+```
+
+Elapsed wall-clock time is never evidence that asynchronous work completed. Use the narrowest real synchronization boundary: a main-thread completion signal, an explicit queued recorder for worker-thread signals, a condition variable/future, or an eventual-state predicate when the API has no completion event. Arm the observer before starting the operation so synchronous and cache-hit completion cannot be missed.
+
+A timer or fixed delay remains valid only when time is itself the behavior under test (debounce, retry/backoff, quiet-period negative assertion), as an outer deadlock bound that does not drive the success path, or as a documented grace/unwind period **after** a real completion condition has already been observed. `scripts/lint_platform_fragile.py` enforces the known `FolderCrawlerWidget::selectResultRow` / `mainViewFileChanged` mapping that escaped in master run 34597411626.
+
+### 8.6 Why these rules and not more
 
 Every rule in this section is the *direct generalisation* of a specific past klogg bug:
 
@@ -178,9 +201,10 @@ Every rule in this section is the *direct generalisation* of a specific past klo
 - §8.2 generalises PR #12's `runSearch()` helper drain-and-reread bug.
 - §8.3 generalises PR #12's `StreamingScriptTransport.connectTransport()` Windows flake.
 - §8.4 generalises PR #12's third-round `mainwindow_test.cpp:280` Tab-group-chip flake on the slow Ubuntu 20.04 runner.
+- §8.5 generalises master run 34597411626, where a deliberately large folder file exceeded a generic five-second polling budget under Linux TSan.
 
-When the next platform-specific failure shows up, add a §8.6+ rule grounded in the actual incident. Do not pre-emptively add abstract anti-patterns -- the value of this section is that each rule has a paid-for receipt.
+When the next platform-specific failure shows up, add another rule grounded in the actual incident. Do not pre-emptively add abstract anti-patterns -- the value of this section is that each rule has a paid-for receipt.
 
 ---
 
-_Last updated: 2026-04-25_
+_Last updated: 2026-09-11_

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -215,6 +215,78 @@ def strip_yaml_comment(value: str) -> str:
     return value.strip()
 
 
+def strip_powershell_comments(value: str) -> str:
+    """Blank PowerShell comments while preserving active code and layout.
+
+    Unlike ``strip_yaml_comment``, which only recognizes ``#`` preceded by
+    whitespace, PowerShell starts a comment at any unquoted ``#`` (for example
+    ``Write-Output ok;# disabled``) and at ``<#`` .. ``#>`` blocks. Required
+    markers must never be validated against text that still contains those
+    comment forms. Quotes, here-strings, and newlines are preserved so active
+    code keeps its line layout for downstream line-based parsing.
+    """
+    out: list[str] = []
+    index = 0
+    length = len(value)
+    quote: str | None = None
+    while index < length:
+        char = value[index]
+        pair = value[index : index + 2]
+        if quote is None and pair == "<#":
+            end = value.find("#>", index + 2)
+            if end == -1:
+                end = length - 2
+            out.extend(
+                "\n" if ch == "\n" else " " for ch in value[index : end + 2]
+            )
+            index = end + 2
+            continue
+        if (
+            quote is None
+            and pair in ("@'", '@"')
+            and value[index + 2 : index + 3] == "\n"
+        ):
+            terminator = "\n" + pair[1] + "@"
+            end = value.find(terminator, index + 3)
+            if end == -1:
+                out.append(value[index:])
+                index = length
+                continue
+            end += len(terminator)
+            out.append(value[index:end])
+            index = end
+            continue
+        if quote is None and char == "#":
+            line_end = value.find("\n", index)
+            if line_end == -1:
+                line_end = length
+            out.append(" " * (line_end - index))
+            index = line_end
+            continue
+        if quote is None and char in "'\"":
+            quote = char
+            out.append(char)
+            index += 1
+            continue
+        if quote is not None:
+            if quote == "'" and value[index : index + 2] == "''":
+                out.append("''")
+                index += 2
+                continue
+            if quote == '"' and char == "`":
+                out.append(value[index : index + 2])
+                index += 2
+                continue
+            if char == quote:
+                quote = None
+            out.append(char)
+            index += 1
+            continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
 def active_script_content(value: str) -> str:
     active_lines = []
     for line in value.splitlines():
@@ -730,7 +802,13 @@ def windows_test_diagnostics_issues(text: str) -> list[str]:
             fields = fields_by_label[label]
             if fields.get("continue-on-error") != "true":
                 issues.append(f"CI build job {job} step {label} must be best-effort")
-            run = active_script_content(fields.get("run", ""))
+            # Strip PowerShell comments first: strip_yaml_comment only
+            # removes "#" preceded by whitespace, so markers survive inside
+            # ";# ..." comments and "<# ... #>" blocks and would satisfy the
+            # check although the collector never runs that code.
+            run = active_script_content(
+                strip_powershell_comments(fields.get("run", ""))
+            )
             if fields.get("shell") != "pwsh" or any(
                 marker not in run for marker in required_markers
             ):

--- a/scripts/lint_ci_quality.py
+++ b/scripts/lint_ci_quality.py
@@ -215,6 +215,15 @@ def strip_yaml_comment(value: str) -> str:
     return value.strip()
 
 
+def active_script_content(value: str) -> str:
+    active_lines = []
+    for line in value.splitlines():
+        active = strip_yaml_comment(line)
+        if active:
+            active_lines.append(active)
+    return "\n".join(active_lines)
+
+
 def scalar(value: str) -> str:
     value = strip_yaml_comment(value).strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
@@ -249,12 +258,7 @@ def workflow_run_blocks(text: str) -> list[str]:
             continue
         indent = len(entry.group("indent"))
         value = yaml_value(lines, index, entry.group("value"), indent)
-        active_lines = []
-        for run_line in value.splitlines():
-            active = strip_yaml_comment(run_line)
-            if active:
-                active_lines.append(active)
-        blocks.append("\n".join(active_lines))
+        blocks.append(active_script_content(value))
     return blocks
 
 
@@ -726,7 +730,7 @@ def windows_test_diagnostics_issues(text: str) -> list[str]:
             fields = fields_by_label[label]
             if fields.get("continue-on-error") != "true":
                 issues.append(f"CI build job {job} step {label} must be best-effort")
-            run = fields.get("run", "")
+            run = active_script_content(fields.get("run", ""))
             if fields.get("shell") != "pwsh" or any(
                 marker not in run for marker in required_markers
             ):

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -1362,11 +1362,32 @@ _FOLDER_PATH_RECEIVER_RE = re.compile(
     r"\b(?P<receiver>[A-Za-z_]\w*)\s*(?:\.|->)\s*currentMainFilePath\s*\("
 )
 _FOLDER_FIXED_WAIT_RE = re.compile(r"\bQTest\s*::\s*qWait\s*\(\s*(?!0\s*\))[^)]*\)")
-_FOLDER_PATH_ASSERTION_RE = re.compile(
-    r"\b(?:CHECK|REQUIRE)\s*\(\s*(?P<receiver>[A-Za-z_]\w*)\s*"
-    r"(?:\.|->)\s*currentMainFilePath\s*\(\s*\)\s*==\s*"
-    r"(?P<expected>[A-Za-z_]\w*)\s*\)"
-)
+_FOLDER_ASSERTION_START_RE = re.compile(r"\b(?:CHECK|REQUIRE)\s*\(")
+
+
+def _folder_path_assertions(text: str) -> list[tuple[int, int, str, str]]:
+    """Return (start, end, receiver, key) for CHECK/REQUIRE equality
+    assertions whose operands include a receiver's ``currentMainFilePath()``.
+
+    Scans balanced assertion bodies instead of matching one operand shape, so
+    literals, calls, member expressions, and reversed comparisons are all
+    detected. The key is the whitespace-normalized body so repeated
+    assertions deduplicate.
+    """
+    assertions: list[tuple[int, int, str, str]] = []
+    for match in _FOLDER_ASSERTION_START_RE.finditer(text):
+        open_pos = match.end() - 1
+        close_pos = _balanced_close(text, open_pos)
+        if close_pos is None:
+            continue
+        body = text[open_pos + 1 : close_pos]
+        receiver_matches = list(_FOLDER_PATH_RECEIVER_RE.finditer(body))
+        if not receiver_matches or "==" not in body:
+            continue
+        receiver = receiver_matches[0].group("receiver")
+        key = " ".join(body.split())
+        assertions.append((match.start(), close_pos + 1, receiver, key))
+    return assertions
 _FOLDER_COMPLETION_SPY_RE = re.compile(
     r"\bSafeQSignalSpy\s+(?P<name>[A-Za-z_]\w*)\s*[({]\s*&?"
     r"(?P<receiver>[A-Za-z_]\w*)\s*,\s*&\s*FolderCrawlerWidget\s*::\s*"
@@ -1421,10 +1442,17 @@ def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[i
         selections = list(_FOLDER_RESULT_SELECTION_RE.finditer(case))
         for selection_index, selection in enumerate(selections):
             selection_receiver = selection.group("receiver")
-            segment_end = (
-                selections[selection_index + 1].start()
-                if selection_index + 1 < len(selections)
-                else len(case)
+            # End the segment at the next selection of the same receiver:
+            # another widget's selection must not truncate this receiver's
+            # wait cycle, or `a.select(); b.select(); waitFor(a...)` hides
+            # the wait from receiver a's segment.
+            segment_end = next(
+                (
+                    later.start()
+                    for later in selections[selection_index + 1 :]
+                    if later.group("receiver") == selection_receiver
+                ),
+                len(case),
             )
             segment = case[selection.end() : segment_end]
             completion_spies = [
@@ -1434,24 +1462,6 @@ def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[i
                 )
                 if match.group("receiver") == selection_receiver
             ]
-
-            polling = next(iter(_folder_path_polls(segment, selection_receiver)), None)
-            if polling is not None:
-                absolute = case_start.start() + selection.end() + polling.start()
-                line_num = code.count("\n", 0, absolute) + 1
-                if line_num not in allow_lines:
-                    findings.append(
-                        (
-                            line_num,
-                            "Do not poll currentMainFilePath() to infer completion of a "
-                            "folder result selection. Arm SafeQSignalSpy on the same "
-                            "FolderCrawlerWidget's mainViewFileChanged signal before "
-                            "selecting, use safeWait(timeout) only as a deadlock bound, "
-                            "then assert the resulting path. (Master TSan run "
-                            "34597411626.)",
-                        )
-                    )
-                continue
 
             def completion_observed_before(offset: int) -> bool:
                 before_boundary = segment[:offset]
@@ -1464,12 +1474,33 @@ def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[i
                     for spy in completion_spies
                 )
 
+            polling = next(iter(_folder_path_polls(segment, selection_receiver)), None)
+            if polling is not None:
+                # A poll after the completion signal was already observed is
+                # post-completion grace, not completion evidence.
+                if not completion_observed_before(polling.start()):
+                    absolute = case_start.start() + selection.end() + polling.start()
+                    line_num = code.count("\n", 0, absolute) + 1
+                    if line_num not in allow_lines:
+                        findings.append(
+                            (
+                                line_num,
+                                "Do not poll currentMainFilePath() to infer completion of a "
+                                "folder result selection. Arm SafeQSignalSpy on the same "
+                                "FolderCrawlerWidget's mainViewFileChanged signal before "
+                                "selecting, use safeWait(timeout) only as a deadlock bound, "
+                                "then assert the resulting path. (Master TSan run "
+                                "34597411626.)",
+                            )
+                        )
+                continue
+
             fixed_wait_violation = False
             for fixed_wait in _FOLDER_FIXED_WAIT_RE.finditer(segment):
                 remainder = segment[fixed_wait.end() :]
                 has_path_assertion = any(
-                    match.group("receiver") == selection_receiver
-                    for match in _FOLDER_PATH_ASSERTION_RE.finditer(remainder)
+                    receiver == selection_receiver
+                    for _, _, receiver, _ in _folder_path_assertions(remainder)
                 )
                 if not has_path_assertion:
                     continue
@@ -1494,18 +1525,20 @@ def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[i
                 continue
 
             prior_path_assertions = {
-                match.group("expected")
-                for match in _FOLDER_PATH_ASSERTION_RE.finditer(
+                key
+                for _, _, receiver, key in _folder_path_assertions(
                     case[: selection.start()]
                 )
-                if match.group("receiver") == selection_receiver
+                if receiver == selection_receiver
             }
-            for path_assertion in _FOLDER_PATH_ASSERTION_RE.finditer(segment):
-                if path_assertion.group("receiver") != selection_receiver:
+            for assertion_start, _, assertion_receiver, assertion_key in (
+                _folder_path_assertions(segment)
+            ):
+                if assertion_receiver != selection_receiver:
                     continue
-                if completion_observed_before(path_assertion.start()):
+                if completion_observed_before(assertion_start):
                     continue
-                if path_assertion.group("expected") in prior_path_assertions:
+                if assertion_key in prior_path_assertions:
                     continue
                 has_allowed_wait = any(
                     code.count(
@@ -1516,12 +1549,12 @@ def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[i
                     + 1
                     in allow_lines
                     for fixed_wait in _FOLDER_FIXED_WAIT_RE.finditer(
-                        segment[: path_assertion.start()]
+                        segment[:assertion_start]
                     )
                 )
                 if has_allowed_wait:
                     continue
-                absolute = case_start.start() + selection.end() + path_assertion.start()
+                absolute = case_start.start() + selection.end() + assertion_start
                 line_num = code.count("\n", 0, absolute) + 1
                 if line_num in allow_lines:
                     continue

--- a/scripts/lint_platform_fragile.py
+++ b/scripts/lint_platform_fragile.py
@@ -295,9 +295,10 @@ PATTERNS: list[dict] = [
         "name": "qtry-verify-macro",
         "regex": re.compile(r"\bQTRY_VERIFY[A-Z0-9_]*\s*\("),
         "fix": (
-            "Use a QElapsedTimer/QTest::qWait polling helper instead of QTRY_VERIFY. "
             "Qt 6.9's retry macros pass chrono duration reps through int timeout "
-            "internals, which GCC 13 rejects under -Werror=conversion."
+            "internals, which GCC 13 rejects under -Werror=conversion. Prefer a "
+            "semantic completion signal armed before the operation; when no such "
+            "signal exists, use a state-predicate helper with a deadline."
         ),
     },
 ]
@@ -1350,6 +1351,194 @@ def _check_writable_reopen_of_live_qlockfile(
     return findings
 
 
+_FOLDER_RESULT_SELECTION_RE = re.compile(
+    r"\b(?P<receiver>[A-Za-z_]\w*)\s*(?:\.|->)\s*(?:"
+    r"selectResultRow\s*\([^;]*\)"
+    r"|filteredView\s*\(\s*\)\s*->\s*selectAndDisplayLine\s*\([^;]*\)"
+    r")\s*;"
+)
+_FOLDER_WAIT_CALL_RE = re.compile(r"\b(?:waitFor|waitUiState)\s*\(")
+_FOLDER_PATH_RECEIVER_RE = re.compile(
+    r"\b(?P<receiver>[A-Za-z_]\w*)\s*(?:\.|->)\s*currentMainFilePath\s*\("
+)
+_FOLDER_FIXED_WAIT_RE = re.compile(r"\bQTest\s*::\s*qWait\s*\(\s*(?!0\s*\))[^)]*\)")
+_FOLDER_PATH_ASSERTION_RE = re.compile(
+    r"\b(?:CHECK|REQUIRE)\s*\(\s*(?P<receiver>[A-Za-z_]\w*)\s*"
+    r"(?:\.|->)\s*currentMainFilePath\s*\(\s*\)\s*==\s*"
+    r"(?P<expected>[A-Za-z_]\w*)\s*\)"
+)
+_FOLDER_COMPLETION_SPY_RE = re.compile(
+    r"\bSafeQSignalSpy\s+(?P<name>[A-Za-z_]\w*)\s*[({]\s*&?"
+    r"(?P<receiver>[A-Za-z_]\w*)\s*,\s*&\s*FolderCrawlerWidget\s*::\s*"
+    r"mainViewFileChanged\b",
+    re.DOTALL,
+)
+
+
+def _folder_path_polls(segment: str, receiver: str) -> list[re.Match[str]]:
+    """Return waits whose own balanced call body polls the selected widget path."""
+    polls: list[re.Match[str]] = []
+    for wait_call in _FOLDER_WAIT_CALL_RE.finditer(segment):
+        open_pos = wait_call.end() - 1
+        close_pos = _balanced_close(segment, open_pos)
+        call_body = segment[open_pos + 1 : close_pos if close_pos is not None else len(segment)]
+        if any(
+            match.group("receiver") == receiver
+            for match in _FOLDER_PATH_RECEIVER_RE.finditer(call_body)
+        ):
+            polls.append(wait_call)
+    return polls
+
+
+def _check_known_completion_event_polling(text: str, path: Path) -> list[tuple[int, str]]:
+    """Require FolderCrawlerWidget file opens to wait on their completion signal.
+
+    Master run 34597411626 exposed a five-second polling flake while a deliberately
+    large folder result was still being indexed under TSan. The widget already
+    publishes ``mainViewFileChanged`` after the successful data swap, so elapsed
+    time or polling ``currentMainFilePath`` is not a valid completion boundary.
+    """
+    if (
+        "tests" not in path.parts
+        or path.suffix not in (".cpp", ".cc")
+        or ("selectResultRow" not in text and "selectAndDisplayLine" not in text)
+    ):
+        return []
+
+    comment_free = _strip_cpp_comments(text)
+    code = _strip_cpp_literals(comment_free)
+    allow_lines = _cpp_allow_marker_lines(text)
+    case_starts = list(_CATCH_CASE_RE.finditer(code))
+    findings: list[tuple[int, str]] = []
+
+    for case_index, case_start in enumerate(case_starts):
+        case_end = (
+            case_starts[case_index + 1].start()
+            if case_index + 1 < len(case_starts)
+            else len(code)
+        )
+        case = code[case_start.start() : case_end]
+        selections = list(_FOLDER_RESULT_SELECTION_RE.finditer(case))
+        for selection_index, selection in enumerate(selections):
+            selection_receiver = selection.group("receiver")
+            segment_end = (
+                selections[selection_index + 1].start()
+                if selection_index + 1 < len(selections)
+                else len(case)
+            )
+            segment = case[selection.end() : segment_end]
+            completion_spies = [
+                match.group("name")
+                for match in _FOLDER_COMPLETION_SPY_RE.finditer(
+                    case[: selection.start()]
+                )
+                if match.group("receiver") == selection_receiver
+            ]
+
+            polling = next(iter(_folder_path_polls(segment, selection_receiver)), None)
+            if polling is not None:
+                absolute = case_start.start() + selection.end() + polling.start()
+                line_num = code.count("\n", 0, absolute) + 1
+                if line_num not in allow_lines:
+                    findings.append(
+                        (
+                            line_num,
+                            "Do not poll currentMainFilePath() to infer completion of a "
+                            "folder result selection. Arm SafeQSignalSpy on the same "
+                            "FolderCrawlerWidget's mainViewFileChanged signal before "
+                            "selecting, use safeWait(timeout) only as a deadlock bound, "
+                            "then assert the resulting path. (Master TSan run "
+                            "34597411626.)",
+                        )
+                    )
+                continue
+
+            def completion_observed_before(offset: int) -> bool:
+                before_boundary = segment[:offset]
+                return any(
+                    re.search(
+                        rf"\b(?:CHECK|REQUIRE)\s*\(\s*{re.escape(spy)}\s*\.\s*"
+                        r"safeWait\s*\(",
+                        before_boundary,
+                    )
+                    for spy in completion_spies
+                )
+
+            fixed_wait_violation = False
+            for fixed_wait in _FOLDER_FIXED_WAIT_RE.finditer(segment):
+                remainder = segment[fixed_wait.end() :]
+                has_path_assertion = any(
+                    match.group("receiver") == selection_receiver
+                    for match in _FOLDER_PATH_ASSERTION_RE.finditer(remainder)
+                )
+                if not has_path_assertion:
+                    continue
+                if completion_observed_before(fixed_wait.start()):
+                    continue
+                absolute = case_start.start() + selection.end() + fixed_wait.start()
+                line_num = code.count("\n", 0, absolute) + 1
+                if line_num in allow_lines:
+                    continue
+                findings.append(
+                    (
+                        line_num,
+                        "Do not use QTest::qWait() as evidence that selectResultRow() "
+                        "completed. Arm SafeQSignalSpy on the same widget's "
+                        "mainViewFileChanged signal before the selection and REQUIRE "
+                        "safeWait(timeout) as the outer failure bound.",
+                    )
+                )
+                fixed_wait_violation = True
+                break
+            if fixed_wait_violation:
+                continue
+
+            prior_path_assertions = {
+                match.group("expected")
+                for match in _FOLDER_PATH_ASSERTION_RE.finditer(
+                    case[: selection.start()]
+                )
+                if match.group("receiver") == selection_receiver
+            }
+            for path_assertion in _FOLDER_PATH_ASSERTION_RE.finditer(segment):
+                if path_assertion.group("receiver") != selection_receiver:
+                    continue
+                if completion_observed_before(path_assertion.start()):
+                    continue
+                if path_assertion.group("expected") in prior_path_assertions:
+                    continue
+                has_allowed_wait = any(
+                    code.count(
+                        "\n",
+                        0,
+                        case_start.start() + selection.end() + fixed_wait.start(),
+                    )
+                    + 1
+                    in allow_lines
+                    for fixed_wait in _FOLDER_FIXED_WAIT_RE.finditer(
+                        segment[: path_assertion.start()]
+                    )
+                )
+                if has_allowed_wait:
+                    continue
+                absolute = case_start.start() + selection.end() + path_assertion.start()
+                line_num = code.count("\n", 0, absolute) + 1
+                if line_num in allow_lines:
+                    continue
+                findings.append(
+                    (
+                        line_num,
+                        "Do not assert currentMainFilePath() immediately after a folder "
+                        "result selection unless the same path was already current. Arm "
+                        "SafeQSignalSpy on mainViewFileChanged before selecting and "
+                        "REQUIRE safeWait(timeout) before asserting the new path.",
+                    )
+                )
+                break
+
+    return findings
+
+
 _FOLDER_ENGINE_QSIGNALSPY_RE = re.compile(
     r"\bQSignalSpy\b[^;]*\bFolderSearchEngine::", re.DOTALL
 )
@@ -1568,17 +1757,33 @@ def _simple_literal_value(expression: str) -> str | None:
     return None if match is None else match.group("value")
 
 
-def _native_assertion_allow_lines(text: str) -> set[int]:
+def _cpp_allow_marker_lines(text: str) -> set[int]:
     """Find allow markers in actual comments, never in string/raw-string spoof."""
     literal_free = _strip_cpp_literals(text)
-    marker_re = re.compile(
-        r"//[^\n]*" + re.escape(ALLOW_MARKER) + r"|/\*.*?" + re.escape(ALLOW_MARKER) + r".*?\*/",
-        re.DOTALL,
-    )
-    return {
-        literal_free.count("\n", 0, match.start()) + 1
-        for match in marker_re.finditer(literal_free)
-    }
+    marker_lines: set[int] = set()
+    index = 0
+    while index < len(literal_free) - 1:
+        token = literal_free[index : index + 2]
+        if token == "//":
+            comment_end = literal_free.find("\n", index + 2)
+            if comment_end < 0:
+                comment_end = len(literal_free)
+        elif token == "/*":
+            close = literal_free.find("*/", index + 2)
+            comment_end = len(literal_free) if close < 0 else close + 2
+        else:
+            index += 1
+            continue
+
+        comment = literal_free[index:comment_end]
+        marker_offset = comment.find(ALLOW_MARKER)
+        while marker_offset >= 0:
+            marker_lines.add(
+                literal_free.count("\n", 0, index + marker_offset) + 1
+            )
+            marker_offset = comment.find(ALLOW_MARKER, marker_offset + len(ALLOW_MARKER))
+        index = comment_end
+    return marker_lines
 
 
 def _check_native_presentation_test_assertion(
@@ -1590,7 +1795,7 @@ def _check_native_presentation_test_assertion(
 
     comment_free = _strip_cpp_comments(text)
     code = _strip_cpp_literals(comment_free)
-    allow_lines = _native_assertion_allow_lines(text)
+    allow_lines = _cpp_allow_marker_lines(text)
     findings: list[tuple[int, str]] = []
     for assertion in _ASSERTION_RE.finditer(code):
         open_pos = assertion.end() - 1
@@ -1674,6 +1879,10 @@ MULTI_LINE_CHECKS: list[dict] = [
     {
         "name": "writable-reopen-of-live-qlockfile",
         "check": _check_writable_reopen_of_live_qlockfile,
+    },
+    {
+        "name": "known-completion-event-polling",
+        "check": _check_known_completion_event_polling,
     },
     {
         "name": "folder-engine-qsignalspy",

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -171,11 +171,48 @@ elseif(APPLE)
       KLOGG_QT_BUILD_RPATH "${${KLOGG_QT_PACKAGE_DIR_VARIABLE}}/../.." ABSOLUTE
     )
     set_target_properties(klogg PROPERTIES KLOGG_QT_BUILD_RPATH "${KLOGG_QT_BUILD_RPATH}")
-    target_link_options(
-      klogg PRIVATE
-      "LINKER:-rpath,@executable_path/../Frameworks"
-      "LINKER:-rpath,@executable_path/../Frameworks/ios-native/lib"
-    )
+    foreach(target IN ITEMS klogg klogg_portable)
+      target_link_options(
+        ${target} PRIVATE
+        "LINKER:-rpath,@executable_path/../Frameworks"
+        "LINKER:-rpath,@executable_path/../Frameworks/ios-native/lib"
+      )
+    endforeach()
+
+    function(klogg_stage_ios_native_stack target)
+      get_target_property(bundle_name ${target} OUTPUT_NAME)
+      if(NOT bundle_name)
+        set(bundle_name "${target}")
+      endif()
+      get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+      if(is_multi_config)
+        set(bundle_root "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>")
+      else()
+        set(bundle_root "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+      endif()
+      set(bundle_stack "${bundle_root}/${bundle_name}.app/Contents/Frameworks/ios-native")
+      set(bundle_lib "${bundle_stack}/lib")
+      get_target_property(
+        native_dylibs klogg_ios_native_stack KLOGG_IOS_NATIVE_RUNTIME_DYLIBS
+      )
+      if(NOT native_dylibs)
+        message(FATAL_ERROR "The verified iOS runtime closure is empty")
+      endif()
+      set(stage_target "${target}_ios_native_stack_stage")
+      add_custom_target(
+        ${stage_target}
+        COMMAND "${CMAKE_COMMAND}" -E remove_directory "${bundle_stack}"
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${bundle_lib}"
+        COMMAND /bin/cp -a ${native_dylibs} "${bundle_lib}"
+        COMMENT "Staging the verified private iOS runtime closure for ${target}"
+        COMMAND_EXPAND_LISTS
+        VERBATIM
+      )
+      add_dependencies(${target} ${stage_target})
+    endfunction()
+
+    klogg_stage_ios_native_stack(klogg)
+    klogg_stage_ios_native_stack(klogg_portable)
   endif()
   set_source_files_properties(${ICON_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   set_source_files_properties(${NOTICE_FILE} PROPERTIES MACOSX_PACKAGE_LOCATION SharedSupport)

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -40,16 +40,27 @@ include(TranslationUtils)
 add_app_translations_resource(KLOGG_I18N_RES ${QM_FILES})
 add_qt_translations_resource(KLOGG_QT_TRANSLATION_RES zh_CN zh_TW)
 
-set(MAIN_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cli.h
-                 ${CMAKE_CURRENT_SOURCE_DIR}/klogg.qrc 
-                 ${KLOGG_I18N_RES}
-                 ${KLOGG_QT_TRANSLATION_RES})
+set(MAIN_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cli.h)
+
+add_library(
+  klogg_common_resources OBJECT
+  ${CMAKE_CURRENT_SOURCE_DIR}/klogg.qrc
+  ${KLOGG_I18N_RES}
+  ${KLOGG_QT_TRANSLATION_RES}
+)
+add_library(
+  klogg_documentation_resources OBJECT
+  ${DOCUMENTATION_RESOURCE}
+)
+foreach(target IN ITEMS klogg_common_resources klogg_documentation_resources)
+  set_target_properties(${target} PROPERTIES AUTORCC ON)
+  target_link_libraries(${target} PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+endforeach()
 
 set(KLOGG_UI_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/messagereceiver.h
     ${CMAKE_CURRENT_SOURCE_DIR}/kloggapp.h
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
-    ${DOCUMENTATION_RESOURCE}
     ${ICON_FILE}
     ${COPYING_FILE}
     ${NOTICE_FILE}
@@ -64,9 +75,20 @@ set(MAIN_LIBS
     kdsingleapp
 )
 
-add_executable(klogg ${OS_BUNDLE} ${MAIN_SOURCES} ${KLOGG_UI_SOURCES})
-add_executable(klogg_portable ${OS_BUNDLE} ${MAIN_SOURCES} ${KLOGG_UI_SOURCES})
-add_executable(klogg_grep ${MAIN_SOURCES} ${KLOGG_GREP_SOURCES})
+add_executable(
+  klogg ${OS_BUNDLE} ${MAIN_SOURCES} ${KLOGG_UI_SOURCES}
+  $<TARGET_OBJECTS:klogg_common_resources>
+  $<TARGET_OBJECTS:klogg_documentation_resources>
+)
+add_executable(
+  klogg_portable ${OS_BUNDLE} ${MAIN_SOURCES} ${KLOGG_UI_SOURCES}
+  $<TARGET_OBJECTS:klogg_common_resources>
+  $<TARGET_OBJECTS:klogg_documentation_resources>
+)
+add_executable(
+  klogg_grep ${MAIN_SOURCES} ${KLOGG_GREP_SOURCES}
+  $<TARGET_OBJECTS:klogg_common_resources>
+)
 
 add_dependencies(klogg klogg_adb_helper)
 add_dependencies(klogg_portable klogg_adb_helper)

--- a/src/livecapture/include/adbserversupervisor.h
+++ b/src/livecapture/include/adbserversupervisor.h
@@ -145,10 +145,11 @@ struct AdbServerSupervisorConfig {
     std::chrono::milliseconds readinessProbeInterval{ 100 };
     std::chrono::milliseconds startupTimeout{ 5000 };
     std::chrono::milliseconds healthProbeInterval{ 1000 };
+    std::chrono::milliseconds startupCapabilityProbeInterval{ 2000 };
     std::vector<std::chrono::milliseconds> reconnectBackoff{ std::chrono::milliseconds{ 250 } };
-    // Optional app-layer preflight failure (for example, a missing packaged
-    // helper). The lower layer surfaces it without knowing package layout.
-    std::optional<LiveSourceError> configurationError;
+    // Optional app-layer launch-capability check (for example, packaged helper
+    // validation). It is evaluated only after a probe proves the endpoint absent.
+    std::function<std::optional<LiveSourceError>()> startupCapabilityCheck;
 };
 
 enum class AdbServerSupervisorStatus : std::uint8_t {

--- a/src/livecapture/include/livestate.h
+++ b/src/livecapture/include/livestate.h
@@ -185,6 +185,8 @@ struct LiveStateSnapshot {
     bool protocolServiceReady{ false };
     bool streamHandlePresent{ false };
     bool readArmed{ false };
+    bool payloadReceived{ false };
+    bool retiringAttemptInterrupted{ false };
     std::optional<Timestamp> streamingSince;
     std::optional<RetryTimer> retryTimer;
     bool devicePresent{ false };

--- a/src/livecapture/src/adbinfrastructuremanager.cpp
+++ b/src/livecapture/src/adbinfrastructuremanager.cpp
@@ -11,6 +11,8 @@
 
 #include "adbinfrastructuremanager.h"
 
+#include <QMetaObject>
+
 #include <algorithm>
 #include <utility>
 
@@ -207,11 +209,46 @@ private:
                || state.error->retryPolicy == RetryPolicy::Backoff;
     }
 
+    void scheduleIdleSuspension()
+    {
+        if ( idleSuspensionQueued_ || activeLeaseCount_ != 0u || !started_
+             || snapshot_.infrastructure.status == InfrastructureStatus::Ready ) {
+            return;
+        }
+
+        idleSuspensionQueued_ = true;
+        const std::weak_ptr<CallbackGate> weakGate = callbackGate_;
+        QMetaObject::invokeMethod(
+            &manager_,
+            [ weakGate ] {
+                const auto gate = weakGate.lock();
+                if ( gate == nullptr || gate->owner == nullptr ) {
+                    return;
+                }
+                gate->owner->idleSuspensionQueued_ = false;
+                gate->owner->suspendIfIdleAndUnavailable();
+            },
+            Qt::QueuedConnection );
+    }
+
+    void suspendIfIdleAndUnavailable()
+    {
+        if ( activeLeaseCount_ != 0u || !started_
+             || snapshot_.infrastructure.status == InfrastructureStatus::Ready ) {
+            return;
+        }
+
+        started_ = false;
+        tracker_.stop();
+        supervisor_.stop( snapshot_.generation );
+    }
+
     void releaseLease()
     {
         if ( activeLeaseCount_ > 0u ) {
             --activeLeaseCount_;
         }
+        scheduleIdleSuspension();
     }
 
     void supervisorChanged( Generation generation, std::uint64_t epoch,
@@ -249,6 +286,7 @@ private:
         else {
             tracker_.stop();
         }
+        scheduleIdleSuspension();
         if ( changed ) {
             Q_EMIT manager_.snapshotChanged( snapshot_ );
         }
@@ -277,6 +315,7 @@ private:
     Generation nextGeneration_{ 0 };
     std::size_t activeLeaseCount_{ 0 };
     bool started_{ false };
+    bool idleSuspensionQueued_{ false };
     bool shuttingDown_{ false };
 };
 

--- a/src/livecapture/src/adbserversupervisor.cpp
+++ b/src/livecapture/src/adbserversupervisor.cpp
@@ -25,6 +25,7 @@ enum class ProbePurpose : std::uint8_t {
     Initial,
     UnderStartupLock,
     LockContended,
+    ConsentRecheck,
     StartupReadiness,
     Health,
     Reconnect
@@ -97,15 +98,7 @@ public:
         ++runSerial_;
         resetRunState( generation );
 
-        if ( config_.configurationError.has_value() ) {
-            running_ = false;
-            const auto& error = *config_.configurationError;
-            fail( AdbServerSupervisorStatus::InvalidConfiguration, error.code, error.message,
-                  error.nativeDetail, error.retryPolicy, error.category );
-            return;
-        }
-
-        const auto validationError = validateConfiguration();
+        const auto validationError = validateProbeConfiguration();
         if ( !validationError.empty() ) {
             running_ = false;
             fail( AdbServerSupervisorStatus::InvalidConfiguration, "invalid-configuration",
@@ -147,16 +140,7 @@ public:
              || snapshot_.status != AdbServerSupervisorStatus::AwaitingKeyGenerationConsent ) {
             return;
         }
-        const auto generated = keyStore_.generateStandardKey();
-        if ( !generated.generated ) {
-            failStartup(
-                "key-generation-failed", "Unable to prepare the standard ADB key.",
-                diagnosticOr( generated.diagnostic, "Unable to prepare the standard ADB key." ),
-                false );
-            return;
-        }
-
-        launchPackagedServer();
+        beginProbe( ProbePurpose::ConsentRecheck );
     }
 
     const AdbServerSupervisorSnapshot& snapshot() const noexcept
@@ -186,29 +170,91 @@ private:
         bool terminal{ false };
     };
 
-    std::string validateConfiguration() const
+    std::string validateProbeConfiguration() const
     {
         if ( config_.endpoint.address != QHostAddress::LocalHost
              || config_.endpoint.port != 5037u ) {
             return "ADB server supervision requires the standard 127.0.0.1:5037 endpoint.";
         }
-        if ( config_.packagedServerPath.isEmpty()
-             || !QDir::isAbsolutePath( config_.packagedServerPath ) ) {
-            return "ADB server supervision requires an explicit absolute packaged executable path.";
-        }
-        if ( config_.lockPath.isEmpty() || !QDir::isAbsolutePath( config_.lockPath ) ) {
-            return "ADB server supervision requires an explicit per-user lock path.";
-        }
         if ( config_.minimumProtocolVersion == 0u ) {
             return "ADB server supervision requires a minimum protocol version.";
         }
-        if ( config_.readinessProbeInterval.count() < 0 || config_.startupTimeout.count() <= 0
-             || config_.healthProbeInterval.count() <= 0 || config_.reconnectBackoff.empty()
+        if ( config_.healthProbeInterval.count() <= 0 || config_.reconnectBackoff.empty()
              || std::any_of( config_.reconnectBackoff.begin(), config_.reconnectBackoff.end(),
                              []( const auto delay ) { return delay.count() < 0; } ) ) {
-            return "ADB server supervision requires valid monotonic scheduling intervals.";
+            return "ADB server supervision requires valid probe scheduling intervals.";
         }
         return {};
+    }
+
+    std::optional<LiveSourceError> startupConfigurationError() const
+    {
+        if ( config_.packagedServerPath.isEmpty()
+             || !QDir::isAbsolutePath( config_.packagedServerPath ) ) {
+            return makeSupervisorError(
+                ErrorCategory::Configuration, "invalid-configuration",
+                "Invalid ADB server startup configuration.",
+                "ADB server startup requires an explicit absolute packaged executable path.",
+                RetryPolicy::Never );
+        }
+        if ( config_.lockPath.isEmpty() || !QDir::isAbsolutePath( config_.lockPath ) ) {
+            return makeSupervisorError(
+                ErrorCategory::Configuration, "invalid-configuration",
+                "Invalid ADB server startup configuration.",
+                "ADB server startup requires an explicit per-user lock path.", RetryPolicy::Never );
+        }
+        if ( config_.readinessProbeInterval.count() < 0 || config_.startupTimeout.count() <= 0
+             || config_.startupCapabilityProbeInterval.count() <= 0 ) {
+            return makeSupervisorError(
+                ErrorCategory::Configuration, "invalid-configuration",
+                "Invalid ADB server startup configuration.",
+                "ADB server startup requires valid monotonic scheduling intervals.",
+                RetryPolicy::Never );
+        }
+        return std::nullopt;
+    }
+
+    bool waitForExternalServerIfStartupUnavailable()
+    {
+        const auto runSerial = runSerial_;
+        const auto generation = snapshot_.generation;
+        const auto epoch = snapshot_.epoch;
+        if ( const auto error = startupConfigurationError(); error.has_value() ) {
+            releaseStartupLock();
+            fail( AdbServerSupervisorStatus::InvalidConfiguration, error->code, error->message,
+                  error->nativeDetail, error->retryPolicy, error->category );
+            return true;
+        }
+
+        std::optional<LiveSourceError> error;
+        if ( config_.startupCapabilityCheck ) {
+            const auto capabilityCheck = config_.startupCapabilityCheck;
+            const std::weak_ptr<CallbackGate> weakGate = callbackGate_;
+            error = capabilityCheck();
+            const auto gate = weakGate.lock();
+            if ( gate == nullptr || gate->owner != this ) {
+                return true;
+            }
+        }
+        if ( !running_ || runSerial != runSerial_ || generation != snapshot_.generation
+             || epoch != snapshot_.epoch ) {
+            return true;
+        }
+        if ( !error.has_value() ) {
+            snapshot_.error.reset();
+            return false;
+        }
+        releaseStartupLock();
+        if ( !fail( AdbServerSupervisorStatus::RetryWait, error->code, error->message,
+                    error->nativeDetail, RetryPolicy::Backoff, error->category ) ) {
+            return true;
+        }
+        if ( running_ && runSerial == runSerial_ && generation == snapshot_.generation
+             && epoch == snapshot_.epoch
+             && snapshot_.status == AdbServerSupervisorStatus::RetryWait ) {
+            scheduleStartupCapabilityRetry();
+        }
+        return true;
     }
 
     void resetRunState( Generation generation )
@@ -349,6 +395,7 @@ private:
             case ProbePurpose::Initial:
             case ProbePurpose::UnderStartupLock:
             case ProbePurpose::LockContended:
+            case ProbePurpose::ConsentRecheck:
                 publishReady( std::move( result ), InfrastructureOwnership::ExternalShared );
                 return;
             case ProbePurpose::StartupReadiness:
@@ -371,7 +418,9 @@ private:
         switch ( purpose ) {
         case ProbePurpose::Initial:
             if ( result.state == AdbServerProbeState::Absent ) {
-                acquireStartupLock();
+                if ( !waitForExternalServerIfStartupUnavailable() ) {
+                    acquireStartupLock();
+                }
             }
             else {
                 fail( AdbServerSupervisorStatus::Failed, "probe-failed",
@@ -382,7 +431,9 @@ private:
             return;
         case ProbePurpose::UnderStartupLock:
             if ( result.state == AdbServerProbeState::Absent ) {
-                inspectStandardKey();
+                if ( !waitForExternalServerIfStartupUnavailable() ) {
+                    inspectStandardKey();
+                }
             }
             else {
                 failStartup(
@@ -394,10 +445,26 @@ private:
             return;
         case ProbePurpose::LockContended:
             if ( result.state == AdbServerProbeState::Absent ) {
-                acquireStartupLock();
+                if ( !waitForExternalServerIfStartupUnavailable() ) {
+                    acquireStartupLock();
+                }
             }
             else {
                 scheduleLockRetry();
+            }
+            return;
+        case ProbePurpose::ConsentRecheck:
+            if ( result.state == AdbServerProbeState::Absent ) {
+                if ( !waitForExternalServerIfStartupUnavailable() ) {
+                    generateStandardKeyAndLaunch();
+                }
+            }
+            else {
+                failStartup(
+                    "post-consent-probe-failed", "Unable to verify the ADB endpoint.",
+                    diagnosticOr( result.diagnostic,
+                                  "Unable to verify the ADB endpoint after key consent." ),
+                    false );
             }
             return;
         case ProbePurpose::StartupReadiness:
@@ -409,6 +476,12 @@ private:
             loseReadyServer( result );
             return;
         case ProbePurpose::Reconnect:
+            if ( result.state == AdbServerProbeState::Absent ) {
+                if ( !waitForExternalServerIfStartupUnavailable() ) {
+                    acquireStartupLock();
+                }
+                return;
+            }
             snapshot_.error = makeInfrastructureError(
                 "server-unavailable", "The ADB server remains unavailable.",
                 diagnosticOr( result.diagnostic, "ADB server remains unavailable." ),
@@ -584,6 +657,20 @@ private:
                   []( Impl& self ) { self.beginProbe( ProbePurpose::LockContended ); } );
     }
 
+    void generateStandardKeyAndLaunch()
+    {
+        const auto generated = keyStore_.generateStandardKey();
+        if ( !generated.generated ) {
+            failStartup(
+                "key-generation-failed", "Unable to prepare the standard ADB key.",
+                diagnosticOr( generated.diagnostic, "Unable to prepare the standard ADB key." ),
+                false );
+            return;
+        }
+
+        launchPackagedServer();
+    }
+
     void inspectStandardKey()
     {
         const auto inspection = keyStore_.inspectStandardKey();
@@ -593,6 +680,10 @@ private:
             launchPackagedServer();
             return;
         case AdbServerStandardKeyState::Absent:
+            if ( snapshot_.keyConsent == AdbServerKeyConsentState::Granted ) {
+                generateStandardKeyAndLaunch();
+                return;
+            }
             snapshot_.status = AdbServerSupervisorStatus::AwaitingKeyGenerationConsent;
             snapshot_.infrastructure
                 = InfrastructureState{ InfrastructureStatus::Connecting, std::nullopt };
@@ -756,6 +847,7 @@ private:
         snapshot_.serverIdentity = std::move( result.serverIdentity );
         snapshot_.protocolVersion = result.protocolVersion;
         snapshot_.error.reset();
+        snapshot_.keyConsent = AdbServerKeyConsentState::NotRequired;
         startupRetryAttempt_ = 0u;
         reconnectAttempt_ = 0u;
         if ( ownership == InfrastructureOwnership::AppShared ) {
@@ -804,6 +896,12 @@ private:
         }
     }
 
+    void scheduleStartupCapabilityRetry()
+    {
+        schedule( AdbServerScheduleKind::StartupRetry, config_.startupCapabilityProbeInterval,
+                  []( Impl& self ) { self.beginProbe( ProbePurpose::Initial ); } );
+    }
+
     void scheduleStartupRetry( RetryPolicy retryPolicy )
     {
         auto delay = std::chrono::milliseconds{ 0 };
@@ -832,7 +930,7 @@ private:
                   []( Impl& self ) { self.beginProbe( ProbePurpose::Reconnect ); } );
     }
 
-    void fail( AdbServerSupervisorStatus status, std::string code, std::string message,
+    bool fail( AdbServerSupervisorStatus status, std::string code, std::string message,
                std::string nativeDetail, RetryPolicy retryPolicy,
                ErrorCategory category = ErrorCategory::Infrastructure )
     {
@@ -844,10 +942,20 @@ private:
         const auto runSerial = runSerial_;
         const auto generation = snapshot_.generation;
         const auto epoch = snapshot_.epoch;
+        const std::weak_ptr<CallbackGate> weakGate = callbackGate_;
         publishState();
+        auto gate = weakGate.lock();
+        if ( gate == nullptr || gate->owner != this ) {
+            return false;
+        }
         if ( runSerial == runSerial_ && snapshot_.generation == generation
              && snapshot_.epoch == epoch && snapshot_.error.has_value() ) {
-            Q_EMIT supervisor_.errorOccurred( generation, epoch, *snapshot_.error );
+            const auto error = *snapshot_.error;
+            Q_EMIT supervisor_.errorOccurred( generation, epoch, error );
+            gate = weakGate.lock();
+            if ( gate == nullptr || gate->owner != this ) {
+                return false;
+            }
         }
         if ( running_ && runSerial == runSerial_ && snapshot_.generation == generation
              && snapshot_.epoch == epoch && snapshot_.status == AdbServerSupervisorStatus::Failed
@@ -856,6 +964,7 @@ private:
                   || snapshot_.error->retryPolicy == RetryPolicy::Backoff ) ) {
             scheduleStartupRetry( snapshot_.error->retryPolicy );
         }
+        return true;
     }
 
     void failStartup( std::string code, std::string message, std::string nativeDetail,

--- a/src/livecapture/src/adbserversupervisor.cpp
+++ b/src/livecapture/src/adbserversupervisor.cpp
@@ -236,7 +236,15 @@ private:
                 return true;
             }
         }
+        // The capability callback above may reenter the supervisor and retire
+        // this run, advancing the run serial, generation, or epoch after the
+        // snapshot taken at the top. cppcheck's value flow cannot see that
+        // reentrancy and concludes the revalidation below is constant
+        // (Static analysis run 34675223936); keep the guard that closed the
+        // ASan heap-use-after-free.
+        // cppcheck-suppress knownConditionTrueFalse
         if ( !running_ || runSerial != runSerial_ || generation != snapshot_.generation
+             // cppcheck-suppress knownConditionTrueFalse
              || epoch != snapshot_.epoch ) {
             return true;
         }

--- a/src/livecapture/src/livestate.cpp
+++ b/src/livecapture/src/livestate.cpp
@@ -80,9 +80,10 @@ void resetSourceAttempt( LiveStateTransition& transition )
 {
     clearRetry( transition );
     resetStreamReadiness( transition.snapshot );
+    transition.snapshot.payloadReceived = false;
 }
 
-void invalidateStreamAttempt( LiveStateTransition& transition )
+void invalidateStreamAttempt( LiveStateTransition& transition, bool interrupted )
 {
     auto& snapshot = transition.snapshot;
     if ( snapshot.source.stoppingGeneration.has_value() ) {
@@ -91,6 +92,7 @@ void invalidateStreamAttempt( LiveStateTransition& transition )
     const auto cancelledGeneration = snapshot.generation;
     snapshot.source.stoppingGeneration = cancelledGeneration;
     snapshot.source.stoppingDisposition = StopDisposition::SettleAccepted;
+    snapshot.retiringAttemptInterrupted = interrupted;
     ++snapshot.generation;
     transition.effects.push_back( LiveStateEffect{ EffectKind::InvalidateGeneration,
                                                    snapshot.generation, Timestamp{ 0 }, 0u } );
@@ -135,11 +137,13 @@ void apply( LiveStateTransition& transition, const StartRequested& event, const 
 {
     auto& snapshot = transition.snapshot;
     if ( snapshot.source.stoppingGeneration.has_value() || hasActiveStreamAttempt( snapshot ) ) {
+        const auto stoppingReason = snapshot.source.stopReason;
         snapshot.startAfterStop = true;
         snapshot.runIntent = RunIntent::Running;
-        invalidateStreamAttempt( transition );
+        invalidateStreamAttempt( transition, false );
         resetSourceAttempt( transition );
         enterSourceState( snapshot, SourceStatus::Stopping );
+        snapshot.source.stopReason = stoppingReason;
         transition.accepted = true;
         return;
     }
@@ -179,7 +183,7 @@ void apply( LiveStateTransition& transition, const StopRequested& event, const L
     snapshot.startAfterStop = false;
     const auto existingStoppingGeneration = snapshot.source.stoppingGeneration;
     const auto existingDisposition = snapshot.source.stoppingDisposition;
-    invalidateStreamAttempt( transition );
+    invalidateStreamAttempt( transition, false );
     snapshot.source.status = SourceStatus::Stopping;
     snapshot.source.stopReason = StopReason::User;
     const auto effectiveDisposition
@@ -224,6 +228,7 @@ void apply( LiveStateTransition& transition, const StopCompleted& event, const L
 
     advanceNow( snapshot, event.at );
     snapshot.source.stoppingGeneration.reset();
+    snapshot.retiringAttemptInterrupted = false;
     if ( snapshot.source.status == SourceStatus::Failed && snapshot.source.failure
          && snapshot.source.failure->category == ErrorCategory::Capture ) {
         snapshot.startAfterStop = false;
@@ -273,7 +278,7 @@ void apply( LiveStateTransition& transition, const InfrastructureChanged& event,
         else {
             const bool interrupted = hasActiveStreamAttempt( snapshot );
             if ( interrupted ) {
-                invalidateStreamAttempt( transition );
+                invalidateStreamAttempt( transition, true );
             }
             snapshot.devicePresent = false;
             resetSourceAttempt( transition );
@@ -360,7 +365,7 @@ void apply( LiveStateTransition& transition, const DeviceAbsent& event, const Li
     snapshot.devicePresent = false;
     const bool interrupted = hasActiveStreamAttempt( snapshot );
     if ( interrupted ) {
-        invalidateStreamAttempt( transition );
+        invalidateStreamAttempt( transition, true );
     }
     resetSourceAttempt( transition );
     enterSourceState( snapshot, snapshot.infrastructure.status == InfrastructureStatus::Ready
@@ -386,7 +391,7 @@ void apply( LiveStateTransition& transition, const UserActionRequired& event,
     advanceNow( snapshot, event.at );
     snapshot.devicePresent = false;
     if ( activeStreamAttempt ) {
-        invalidateStreamAttempt( transition );
+        invalidateStreamAttempt( transition, true );
     }
     resetSourceAttempt( transition );
     enterSourceState( snapshot, SourceStatus::AwaitingUser );
@@ -429,6 +434,9 @@ void apply( LiveStateTransition& transition, const StreamBytesReceived& event,
     }
 
     advanceNow( transition.snapshot, event.at );
+    if ( event.byteCount != 0u ) {
+        transition.snapshot.payloadReceived = true;
+    }
     transition.effects.push_back( LiveStateEffect{ EffectKind::AppendBytes, event.generation,
                                                    Timestamp{ 0 }, event.byteCount } );
     transition.accepted = true;
@@ -459,7 +467,7 @@ void apply( LiveStateTransition& transition, const RetryRequested& event,
     }
 
     advanceNow( snapshot, event.at );
-    invalidateStreamAttempt( transition );
+    invalidateStreamAttempt( transition, true );
     resetSourceAttempt( transition );
     snapshot.consecutiveFailures = std::max( snapshot.consecutiveFailures, event.attempt );
 
@@ -513,7 +521,7 @@ void apply( LiveStateTransition& transition, const CaptureFailed& event, const L
     if ( event.generation != snapshot.generation
          && event.generation != snapshot.source.stoppingGeneration ) { return; }
     advanceNow( snapshot, event.at );
-    if ( hasActiveStreamAttempt( snapshot ) ) { invalidateStreamAttempt( transition ); }
+    if ( hasActiveStreamAttempt( snapshot ) ) { invalidateStreamAttempt( transition, true ); }
     resetSourceAttempt( transition );
     enterSourceState( snapshot, SourceStatus::Failed );
     snapshot.source.failure = event.error;

--- a/src/ui/include/adbliveservices.h
+++ b/src/ui/include/adbliveservices.h
@@ -37,6 +37,7 @@ struct AdbLiveServicesConfig {
     std::chrono::milliseconds readinessProbeInterval{ 100 };
     std::chrono::milliseconds startupTimeout{ 5000 };
     std::chrono::milliseconds healthProbeInterval{ 1000 };
+    std::chrono::milliseconds startupCapabilityProbeInterval{ 2000 };
     std::vector<std::chrono::milliseconds> serverReconnectBackoff{ std::chrono::milliseconds{
         250 } };
     std::vector<std::chrono::milliseconds> trackerReconnectBackoff{ std::chrono::milliseconds{

--- a/src/ui/src/adbliveservices.cpp
+++ b/src/ui/src/adbliveservices.cpp
@@ -184,10 +184,14 @@ AdbInfrastructureManagerConfig managerConfig( const AdbLiveServicesConfig& confi
     result.server.readinessProbeInterval = config.readinessProbeInterval;
     result.server.startupTimeout = config.startupTimeout;
     result.server.healthProbeInterval = config.healthProbeInterval;
+    result.server.startupCapabilityProbeInterval = config.startupCapabilityProbeInterval;
     result.server.reconnectBackoff = config.serverReconnectBackoff;
-    if ( !isValidPackagedHelper( config.applicationDirPath, helperPath ) ) {
-        result.server.configurationError = missingHelperError( helperPath );
-    }
+    const auto applicationDirPath = config.applicationDirPath;
+    result.server.startupCapabilityCheck = [ applicationDirPath, helperPath ] {
+        return isValidPackagedHelper( applicationDirPath, helperPath )
+                   ? std::optional<LiveSourceError>{}
+                   : std::optional<LiveSourceError>{ missingHelperError( helperPath ) };
+    };
     result.tracker.reconnectBackoff = config.trackerReconnectBackoff;
     return result;
 }

--- a/src/ui/src/livelogcontroller.cpp
+++ b/src/ui/src/livelogcontroller.cpp
@@ -365,6 +365,10 @@ void LiveLogController::stopCompleted( live::Generation generation, std::uint64_
     if ( discardedBytes != 0u ) {
         spec_.integrity.gapPossible = true;
         spec_.integrity.record( "transport-tail-discarded", discardedBytes );
+        if ( spec_.sourceKind == SourceKind::AndroidLogcat
+             && snapshot_.retiringAttemptInterrupted ) {
+            replayRiskPending_ = true;
+        }
     }
     dispatch( live::StopCompleted{ generation, clock_->now() } );
 }
@@ -614,11 +618,20 @@ void LiveLogController::commitAcceptedSnapshot( live::LiveStateSnapshot snapshot
 void LiveLogController::observeIntegrityTransition(
     const live::LiveStateSnapshot& previousSnapshot )
 {
-    const bool connectedStreamInterrupted
-        = previousSnapshot.source.status == live::SourceStatus::Streaming
-          && snapshot_.source.status != live::SourceStatus::Streaming
-          && snapshot_.runIntent == live::RunIntent::Running;
-    if ( connectedStreamInterrupted ) {
+    const bool previousAttemptActive
+        = previousSnapshot.source.status == live::SourceStatus::OpeningStream
+          || previousSnapshot.source.status == live::SourceStatus::Streaming;
+    const bool currentAttemptActive
+        = snapshot_.source.status == live::SourceStatus::OpeningStream
+          || snapshot_.source.status == live::SourceStatus::Streaming;
+    const bool payloadStreamInterrupted
+        = previousAttemptActive && !currentAttemptActive
+          && snapshot_.retiringAttemptInterrupted && previousSnapshot.payloadReceived;
+    const bool retiringPayloadObserved
+        = !previousSnapshot.payloadReceived && snapshot_.payloadReceived
+          && snapshot_.source.stoppingGeneration.has_value()
+          && snapshot_.retiringAttemptInterrupted;
+    if ( payloadStreamInterrupted || retiringPayloadObserved ) {
         if ( !spec_.integrity.gapPossible ) {
             spec_.integrity.gapPossible = true;
             spec_.integrity.record( "connected-stream-interrupted" );
@@ -630,14 +643,20 @@ void LiveLogController::observeIntegrityTransition(
     }
 
     if ( snapshot_.runIntent == live::RunIntent::Stopped ) {
-        replayRiskPending_ = false;
+        if ( !snapshot_.source.stoppingGeneration.has_value()
+             || !snapshot_.retiringAttemptInterrupted ) {
+            replayRiskPending_ = false;
+        }
         return;
     }
 
     const bool replacementConnected
         = previousSnapshot.source.status != live::SourceStatus::Streaming
           && snapshot_.source.status == live::SourceStatus::Streaming;
-    if ( replacementConnected && replayRiskPending_ ) {
+    const bool replacementPayloadObserved
+        = !previousSnapshot.payloadReceived && snapshot_.payloadReceived
+          && currentAttemptActive;
+    if ( ( replacementConnected || replacementPayloadObserved ) && replayRiskPending_ ) {
         replayRiskPending_ = false;
         if ( !spec_.integrity.replayPossible ) {
             spec_.integrity.replayPossible = true;

--- a/tests/helpers/test_utils.h
+++ b/tests/helpers/test_utils.h
@@ -152,6 +152,21 @@ class SafeQSignalSpy {
     std::unique_ptr<QSignalSpy> spy_;
 };
 
+inline constexpr int kAsyncCompletionTimeoutMs = 30000;
+
+template <typename Sender, typename Signal, typename Trigger, typename Ready>
+inline void triggerAndWaitForCompletion( Sender* sender, Signal signal, Trigger&& trigger,
+                                         Ready&& ready,
+                                         int timeoutMs = kAsyncCompletionTimeoutMs )
+{
+    SafeQSignalSpy completion( sender, signal );
+    trigger();
+    if ( !ready() ) {
+        REQUIRE( completion.safeWait( timeoutMs ) );
+    }
+    REQUIRE( ready() );
+}
+
 inline void configureProductLikeRegexpEngine( Configuration& config )
 {
 #ifdef KLOGG_HAS_VECTORSCAN

--- a/tests/scripts/test_efsw_patch_contract.py
+++ b/tests/scripts/test_efsw_patch_contract.py
@@ -89,7 +89,7 @@ class EfswPatchContractTest(unittest.TestCase):
             "c9dfe877307cb578f7db72f536a8ce26f4049573ceb434d3a8736862746be677",
             "08283124ae155e995254ef3282fb41882c7599f30b79346764b71ec0815789ee",
             "04357c577d094b3ea8760c3635c776789fb671c1bff010c66a43f479f442eefd",
-            "bd842a94bd5ba6ba87cc475bcd0881f5d53ab6e9b45cd964bc3d4c2ea7f1298a",
+            "505337c394bf0b6ed954a62a865e6814eccab821e4fd22bba5ecbbdd3fb57e8d",
         ):
             self.assertIn(digest, text)
         inotify_patch_call = text.index("fix_efsw_inotify_watcher_uaf.patch")

--- a/tests/scripts/test_ios_native_release_contract.py
+++ b/tests/scripts/test_ios_native_release_contract.py
@@ -1316,6 +1316,44 @@ for name in ("../victim", "..\\\\victim", "/tmp/victim", "patches/../../victim")
         self.assertIn("DYLD_FRAMEWORK_PATH=${KLOGG_SMOKE_QT_RPATH}", root_cmake)
         self.assertIn("DYLD_LIBRARY_PATH=${KLOGG_SMOKE_QT_RPATH}", root_cmake)
 
+    def test_enabled_raw_apps_stage_the_private_ios_runtime_closure(self):
+        app_cmake = required_text(APP_CMAKE)
+        native_block = app_cmake.split("if(KLOGG_ENABLE_IOS_NATIVE_STACK)", 1)[
+            1
+        ].split("\n  endif()", 1)[0]
+        third_party_cmake = required_text(THIRD_PARTY_CMAKE)
+        self.assertIn("KLOGG_IOS_NATIVE_RUNTIME_DYLIBS", third_party_cmake)
+        for direct_alias in (
+            "libcrypto.dylib",
+            "libssl.dylib",
+            "libcurl.dylib",
+            "libtatsu.dylib",
+        ):
+            self.assertIn(direct_alias, third_party_cmake)
+        self.assertIn("get_target_property(", native_block)
+        self.assertIn("native_dylibs klogg_ios_native_stack", native_block)
+        self.assertIn("KLOGG_IOS_NATIVE_RUNTIME_DYLIBS", native_block)
+        self.assertNotIn("file(GLOB native_dylibs", native_block)
+        self.assertIn("function(klogg_stage_ios_native_stack", native_block)
+        self.assertIn("${CMAKE_RUNTIME_OUTPUT_DIRECTORY}", native_block)
+        self.assertIn("GENERATOR_IS_MULTI_CONFIG", native_block)
+        self.assertIn("$<CONFIG>", native_block)
+        self.assertIn("Frameworks/ios-native/lib", native_block)
+        self.assertIn("${KLOGG_IOS_NATIVE_STACK_ROOT}/lib", third_party_cmake)
+        self.assertIn("add_custom_target", native_block)
+        self.assertIn("COMMAND /bin/cp -a", native_block)
+        self.assertIn("COMMAND_EXPAND_LISTS", native_block)
+        self.assertIn("add_dependencies(${target}", native_block)
+        self.assertNotIn("POST_BUILD", native_block)
+        self.assertNotIn("copy_directory", native_block)
+        self.assertIn("klogg_stage_ios_native_stack(klogg)", native_block)
+        self.assertIn("klogg_stage_ios_native_stack(klogg_portable)", native_block)
+        self.assertNotIn(
+            'copy_directory "${KLOGG_IOS_NATIVE_STACK_ROOT}/lib" '
+            '"$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks"',
+            native_block,
+        )
+
     def test_ios_native_homebrew_bootstrap_cleans_aws_formula_and_tap_before_install(self):
         workflow = required_text(CI_BUILD_WORKFLOW)
         producer = workflow.split("  BuildIosNativeStacks:", 1)[1].split("\n  MacPackages:", 1)[0]

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -685,6 +685,14 @@ jobs:
                 '          $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
                 '          # $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
             ),
+            "semicolon-comment-spoofed collector contents": (
+                '          $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
+                '          Write-Output ok;# $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
+            ),
+            "block-comment-spoofed asan collector contents": (
+                '          foreach ($name in @("klogg_vectorscan_tests.exe", "klogg_vectorscan_tests.pdb")) {\n',
+                '          <# foreach ($name in @("klogg_vectorscan_tests.exe", "klogg_vectorscan_tests.pdb")) { #>\n',
+            ),
             "normal upload action": (
                 "      - name: Upload Windows diagnostics artifact\n"
                 "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
@@ -742,6 +750,27 @@ jobs:
         self.assertNotEqual(mutated, workflow)
         issues = MODULE.windows_test_diagnostics_issues(mutated)
         self.assertTrue(any("WindowsX86" in issue for issue in issues))
+
+    def test_powershell_comment_stripper_preserves_active_code(self):
+        script = (
+            '$dumpDir = Join-Path $workspace "build_root\\crash_dumps" # note\n'
+            "<#\n"
+            "klogg_vectorscan_tests.pdb\n"
+            "#>\n"
+            "$outputRoot = 'build_root\\asan_diagnostics'\n"
+            "Write-Output ok;# $dumpDir = Join-Path $workspace \"build_root\\crash_dumps\"\n"
+        )
+        active = MODULE.active_script_content(
+            MODULE.strip_powershell_comments(script)
+        )
+        # The quoted marker survives exactly once; the spoofed copy inside
+        # the ";# ..." comment and the marker inside the block comment do not.
+        self.assertEqual(active.count("build_root\\crash_dumps"), 1)
+        self.assertIn("'build_root\\asan_diagnostics'", active)
+        self.assertNotIn("klogg_vectorscan_tests.pdb", active)
+        heredoc = "@'\nklogg_itests.pdb # not a comment\n'@\nCopy-Item here\n"
+        still = MODULE.strip_powershell_comments(heredoc)
+        self.assertIn("klogg_itests.pdb # not a comment", still)
 
     def test_windows_test_diagnostics_contract_ignores_unrelated_steps(self):
         workflow = """\

--- a/tests/scripts/test_lint_ci_quality.py
+++ b/tests/scripts/test_lint_ci_quality.py
@@ -681,6 +681,10 @@ jobs:
                 '          $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
                 '          $dumpDir = Join-Path $workspace "build_root\\missing_dumps"\n',
             ),
+            "commented normal collector contents": (
+                '          $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
+                '          # $dumpDir = Join-Path $workspace "build_root\\crash_dumps"\n',
+            ),
             "normal upload action": (
                 "      - name: Upload Windows diagnostics artifact\n"
                 "        if: ${{ always() && steps.run-tests.outcome == 'failure' }}\n"
@@ -699,6 +703,10 @@ jobs:
                 "        continue-on-error: true\n",
                 "      - name: Collect Windows ASan diagnostics\n"
                 "        if: ${{ always() && matrix.config.sanitizer == 'address' && steps.run-tests.outcome == 'failure' }}\n",
+            ),
+            "comment-spoofed asan collector contents": (
+                '          foreach ($name in @("klogg_vectorscan_tests.exe", "klogg_vectorscan_tests.pdb")) {\n',
+                '          foreach ($name in @("klogg_vectorscan_tests.exe", "missing.pdb")) { # klogg_vectorscan_tests.pdb\n',
             ),
             "final failure status guard": (
                 "      - name: Fail when tests fail\n"

--- a/tests/scripts/test_lint_platform_fragile.py
+++ b/tests/scripts/test_lint_platform_fragile.py
@@ -98,6 +98,57 @@ TEST_CASE( "uncached async open", "[folder]" )
 """
         self.assertEqual(len(self.check(text)), 1)
 
+    def test_path_assertion_operand_shapes_are_all_flagged(self):
+        literal = """\
+TEST_CASE( "literal path", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( widget.currentMainFilePath() == "some/path" );
+}
+"""
+        reversed_order = """\
+TEST_CASE( "reversed path", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( expectedPath == widget.currentMainFilePath() );
+}
+"""
+        call_operand = """\
+TEST_CASE( "call operand", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( widget.currentMainFilePath() == dir.filePath( "a.log" ) );
+}
+"""
+        self.assertEqual(len(self.check(literal)), 1)
+        self.assertEqual(len(self.check(reversed_order)), 1)
+        self.assertEqual(len(self.check(call_operand)), 1)
+
+    def test_cross_receiver_selection_does_not_hide_the_wait(self):
+        text = """\
+TEST_CASE( "two widgets", "[folder]" )
+{
+    a.selectResultRow( 1_lnum );
+    b.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { return a.currentMainFilePath() == pathA; } ) );
+}
+"""
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 5)
+
+    def test_poll_after_observed_completion_is_allowed(self):
+        text = """\
+TEST_CASE( "grace poll", "[folder]" )
+{
+    SafeQSignalSpy completed( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( completed.safeWait( 30000 ) );
+    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
     def test_unrelated_wait_does_not_become_path_polling(self):
         text = """\
 TEST_CASE( "separate wait", "[folder]" )

--- a/tests/scripts/test_lint_platform_fragile.py
+++ b/tests/scripts/test_lint_platform_fragile.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -30,6 +31,273 @@ class QtryVerifyMacroPatternTest(unittest.TestCase):
         )["regex"]
         self.assertIsNone(pattern.search("waitForQtCondition( ready );"))
         self.assertIsNone(pattern.search("QTRY_COMPARE( actual, expected );"))
+
+
+class KnownCompletionEventPollingTest(unittest.TestCase):
+    def check(self, text, name="tests/ui/foldercrawler_test.cpp"):
+        return lint._check_known_completion_event_polling(text, Path(name))
+
+    def test_folder_file_open_predicate_polling_is_flagged(self):
+        text = """\
+TEST_CASE( "large async open", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );
+}
+"""
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 4)
+
+    def test_folder_file_open_fixed_wait_is_flagged(self):
+        text = """\
+TEST_CASE( "large async open", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 4)
+
+    def test_pointer_wait_ui_state_and_statement_predicates_are_flagged(self):
+        pointer = """\
+TEST_CASE( "pointer async open", "[folder]" )
+{
+    widget->selectResultRow( 1_lnum );
+    REQUIRE( waitUiState( [ & ] { return widget->currentMainFilePath() == a; } ) );
+}
+"""
+        self.assertEqual(len(self.check(pointer)), 1)
+        filtered_view = """\
+TEST_CASE( "filtered result async open", "[folder]" )
+{
+    folderWidget->filteredView()->selectAndDisplayLine( 2_lnum );
+    REQUIRE( waitUiState( [ & ] { return folderWidget->currentMainFilePath() == a; } ) );
+}
+"""
+        self.assertEqual(len(self.check(filtered_view)), 1)
+        statement = """\
+TEST_CASE( "prepared async open", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { prepare(); return widget.currentMainFilePath() == a; } ) );
+}
+"""
+        self.assertEqual(len(self.check(statement)), 1)
+
+    def test_direct_path_assertion_without_completion_is_flagged(self):
+        text = """\
+TEST_CASE( "uncached async open", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(len(self.check(text)), 1)
+
+    def test_unrelated_wait_does_not_become_path_polling(self):
+        text = """\
+TEST_CASE( "separate wait", "[folder]" )
+{
+    SafeQSignalSpy completed{ &widget, &FolderCrawlerWidget::mainViewFileChanged };
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { return layoutReady; } ) );
+    REQUIRE( completed.safeWait( 30000 ) );
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
+    def test_semantic_signal_wait_and_post_completion_grace_are_allowed(self):
+        text = """\
+TEST_CASE( "large async open", "[folder]" )
+{
+    SafeQSignalSpy completed( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( completed.safeWait( 30000 ) );
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
+        brace_initialized = text.replace(
+            "completed( &widget, &FolderCrawlerWidget::mainViewFileChanged )",
+            "completed{ &widget, &FolderCrawlerWidget::mainViewFileChanged }",
+        )
+        self.assertEqual(self.check(brace_initialized), [])
+
+    def test_wrong_or_unasserted_completion_spy_does_not_allow_grace_wait(self):
+        wrong_sender = """\
+TEST_CASE( "wrong sender", "[folder]" )
+{
+    SafeQSignalSpy completed( &otherWidget, &FolderCrawlerWidget::mainViewFileChanged );
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( completed.safeWait( 30000 ) );
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(len(self.check(wrong_sender)), 1)
+        unasserted = """\
+TEST_CASE( "unasserted completion", "[folder]" )
+{
+    SafeQSignalSpy completed( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+    widget.selectResultRow( 1_lnum );
+    completed.safeWait( 30000 );
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(len(self.check(unasserted)), 1)
+
+    def test_synchronous_same_file_assertion_is_allowed(self):
+        text = """\
+TEST_CASE( "same file jump", "[folder]" )
+{
+    REQUIRE( widget.currentMainFilePath() == a );
+    widget.selectResultRow( 2_lnum );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
+    def test_catch_case_boundaries_and_long_sequences_are_handled(self):
+        separate_cases = """\
+SCENARIO( "first", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+}
+SCENARIO( "second", "[folder]" )
+{
+    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );
+}
+"""
+        self.assertEqual(self.check(separate_cases), [])
+        long_gap = (
+            'TEST_CASE( "long", "[folder]" )\n{\n'
+            "    widget.selectResultRow( 1_lnum );\n"
+            + "    doUnrelatedWork();\n" * 150
+            + "    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );\n}\n"
+        )
+        self.assertEqual(len(self.check(long_gap)), 1)
+
+    def test_deadlock_timer_and_unrelated_waits_are_allowed(self):
+        text = """\
+TEST_CASE( "bounded event loop", "[async]" )
+{
+    QEventLoop loop;
+    QTimer timeout;
+    QObject::connect( &timeout, &QTimer::timeout, &loop, &QEventLoop::quit );
+    QObject::connect( data, &LogData::loadingFinished, &loop, &QEventLoop::quit );
+    timeout.start( 30000 );
+    loop.exec();
+    REQUIRE( waitFor( [ & ] { return unrelatedState; } ) );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
+    def test_comments_strings_non_tests_and_incomplete_sequences_are_allowed(self):
+        comments_and_strings = """\
+// widget.selectResultRow( 1_lnum );
+// REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );
+const auto example = R"cpp(widget.selectResultRow( 1_lnum );
+QTest::qWait( 200 );
+REQUIRE( widget.currentMainFilePath() == a );)cpp";
+"""
+        self.assertEqual(self.check(comments_and_strings), [])
+        self.assertEqual(
+            self.check(
+                "widget.selectResultRow( 1_lnum );\n"
+                "REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) );\n",
+                name="src/ui/example.cpp",
+            ),
+            [],
+        )
+        self.assertEqual(
+            self.check("widget.selectResultRow( 1_lnum );\nQTest::qWait( 200 );\n"),
+            [],
+        )
+
+    def test_malformed_polling_sequence_fails_closed(self):
+        text = """\
+TEST_CASE( "malformed async open", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } );
+}
+"""
+        self.assertEqual(len(self.check(text)), 1)
+
+    def test_allow_marker_suppresses_intentional_sequence(self):
+        text = """\
+TEST_CASE( "intentional timing", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    QTest::qWait( 200 ); // lint-allow: platform-fragile
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(self.check(text), [])
+
+    def test_allow_marker_does_not_hide_a_later_completion_wait(self):
+        text = """\
+TEST_CASE( "mixed timing", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    QTest::qWait( 20 ); // lint-allow: platform-fragile -- input pacing
+    QTest::qWait( 200 );
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        findings = self.check(text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0][0], 5)
+
+    def test_allow_marker_inside_a_literal_does_not_suppress(self):
+        polling = """\
+TEST_CASE( "string spoof", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    REQUIRE( waitFor( [ & ] { return widget.currentMainFilePath() == a; } ) ); const auto marker = "lint-allow: platform-fragile";
+}
+"""
+        self.assertEqual(len(self.check(polling)), 1)
+        fixed_wait = """\
+TEST_CASE( "raw string spoof", "[folder]" )
+{
+    widget.selectResultRow( 1_lnum );
+    QTest::qWait( 200 ); const auto marker = R"(lint-allow: platform-fragile)";
+    REQUIRE( widget.currentMainFilePath() == a );
+}
+"""
+        self.assertEqual(len(self.check(fixed_wait)), 1)
+
+    def test_current_tree_is_clean_and_real_incident_mutation_is_rejected(self):
+        path = REPO_ROOT / "tests" / "ui" / "foldercrawler_test.cpp"
+        text = path.read_text(encoding="utf-8")
+        self.assertEqual(self.check(text, name=str(path)), [])
+        corrected_call = re.compile(
+            r"(?m)^(?P<indent>\s*)selectResultRowAndWaitForFile\(\s*"
+            r"widget\s*,\s*1_lnum\s*,\s*a\s*\);(?:\s*//[^\n]*)?$"
+        )
+
+        def restore_escaped_poll(match):
+            indent = match.group("indent")
+            return (
+                f"{indent}widget.selectResultRow( 1_lnum );\n"
+                f"{indent}REQUIRE( waitFor( [ & ]() {{ return "
+                "widget.currentMainFilePath() == a; } ) );\n"
+                f"{indent}QTest::qWait( 200 );"
+            )
+
+        mutated, replacements = corrected_call.subn(restore_escaped_poll, text, count=1)
+        self.assertEqual(replacements, 1)
+        self.assertGreaterEqual(len(self.check(mutated, name=str(path))), 1)
 
 
 class QtSplitBehaviorCompatibilityPatternTest(unittest.TestCase):

--- a/tests/scripts/test_vectorscan_xcode_patch_contract.py
+++ b/tests/scripts/test_vectorscan_xcode_patch_contract.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+THIRD_PARTY_CMAKE = ROOT / "3rdparty" / "CMakeLists.txt"
+PATCH = ROOT / "3rdparty" / "patches" / "fix_vectorscan_xcode_ragel_targets.patch"
+
+
+class VectorscanXcodePatchContractTest(unittest.TestCase):
+    def test_patch_is_registered_before_vectorscan_configuration(self):
+        cmake = THIRD_PARTY_CMAKE.read_text(encoding="utf-8")
+        patch_name = PATCH.name
+        self.assertIn(patch_name, cmake)
+        self.assertLess(
+            cmake.index(patch_name),
+            cmake.index("add_subdirectory(${vectorscan_SOURCE_DIR}"),
+        )
+
+    def test_patch_removes_every_redundant_ragel_root_target(self):
+        patch = PATCH.read_text(encoding="utf-8")
+        deleted = "\n".join(
+            line[1:]
+            for line in patch.splitlines()
+            if line.startswith("-") and not line.startswith("---")
+        )
+        added = "\n".join(
+            line[1:]
+            for line in patch.splitlines()
+            if line.startswith("+") and not line.startswith("+++")
+        )
+
+        redundant_roots = (
+            "add_custom_target(ragel_${src_file} DEPENDS ${rl_out})",
+            "add_dependencies(hs ragel_Parser)",
+            "add_dependencies(hs_shared ragel_Parser)",
+            "add_dependencies(expressionutil ragel_ExpressionParser)",
+            "add_dependencies(hscollider ragel_ColliderCorporaParser)",
+        )
+        for statement in redundant_roots:
+            with self.subTest(statement=statement):
+                self.assertIn(statement, deleted)
+                self.assertNotIn(statement, added)
+
+        self.assertNotIn("CMAKE_GENERATOR", added)
+        self.assertNotIn("Xcode", added)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_xcode_generator_contract.py
+++ b/tests/scripts/test_xcode_generator_contract.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import shlex
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_CMAKE = ROOT / "src" / "app" / "CMakeLists.txt"
+
+
+def cmake_calls(source, command):
+    """Return balanced argument bodies for a CMake command."""
+    calls = []
+    lowered = source.lower()
+    needle = f"{command.lower()}("
+    position = 0
+
+    while True:
+        start = lowered.find(needle, position)
+        if start < 0:
+            return calls
+
+        body_start = start + len(needle)
+        depth = 1
+        quote = None
+        escaped = False
+        cursor = body_start
+        while cursor < len(source) and depth:
+            character = source[cursor]
+            if quote is not None:
+                if escaped:
+                    escaped = False
+                elif character == "\\":
+                    escaped = True
+                elif character == quote:
+                    quote = None
+            elif character in ('"', "'"):
+                quote = character
+            elif character == "(":
+                depth += 1
+            elif character == ")":
+                depth -= 1
+            cursor += 1
+
+        if depth:
+            raise AssertionError(f"Unterminated {command} call")
+        calls.append(source[body_start : cursor - 1])
+        position = cursor
+
+
+def cmake_command_tokens(source, command):
+    return [shlex.split(body, posix=True) for body in cmake_calls(source, command)]
+
+
+class XcodeGeneratorContractTest(unittest.TestCase):
+    def test_generated_resources_have_one_object_library_owner(self):
+        cmake = APP_CMAKE.read_text(encoding="utf-8")
+        libraries = {
+            tokens[0]: tokens[1:]
+            for tokens in cmake_command_tokens(cmake, "add_library")
+        }
+        executables = {
+            tokens[0]: tokens[1:]
+            for tokens in cmake_command_tokens(cmake, "add_executable")
+        }
+        source_sets = {
+            tokens[0]: tokens[1:]
+            for tokens in cmake_command_tokens(cmake, "set")
+            if tokens
+        }
+
+        self.assertEqual(
+            libraries["klogg_common_resources"],
+            [
+                "OBJECT",
+                "${CMAKE_CURRENT_SOURCE_DIR}/klogg.qrc",
+                "${KLOGG_I18N_RES}",
+                "${KLOGG_QT_TRANSLATION_RES}",
+            ],
+        )
+        self.assertEqual(
+            libraries["klogg_documentation_resources"],
+            ["OBJECT", "${DOCUMENTATION_RESOURCE}"],
+        )
+
+        self.assertEqual(
+            set(executables),
+            {"klogg", "klogg_portable", "klogg_grep"},
+        )
+        for target in ("klogg", "klogg_portable", "klogg_grep"):
+            with self.subTest(target=target):
+                self.assertIn(
+                    "$<TARGET_OBJECTS:klogg_common_resources>",
+                    executables[target],
+                )
+        for target in ("klogg", "klogg_portable"):
+            with self.subTest(target=target):
+                self.assertIn(
+                    "$<TARGET_OBJECTS:klogg_documentation_resources>",
+                    executables[target],
+                )
+        self.assertNotIn(
+            "$<TARGET_OBJECTS:klogg_documentation_resources>",
+            executables["klogg_grep"],
+        )
+
+        for generated_resource in (
+            "${KLOGG_I18N_RES}",
+            "${KLOGG_QT_TRANSLATION_RES}",
+        ):
+            self.assertNotIn(generated_resource, source_sets["MAIN_SOURCES"])
+        self.assertNotIn(
+            "${DOCUMENTATION_RESOURCE}", source_sets["KLOGG_UI_SOURCES"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ui/foldercrawler_pending_failure_test.cpp
+++ b/tests/ui/foldercrawler_pending_failure_test.cpp
@@ -13,6 +13,7 @@
 #include "foldercrawlerwidget.h"
 #include "loadingstatus.h"
 #include "logdata.h"
+#include "test_utils.h"
 
 namespace {
 
@@ -57,22 +58,25 @@ TEST_CASE( "FolderCrawlerWidget retries a same-file selection queued behind a fa
     const auto secondLine = widget.folderResults()->sourceForLine( 2_lnum ).localLine;
     REQUIRE( secondLine == 8_lnum );
 
-    widget.selectResultRow( 1_lnum );
-    auto pending = widget.pendingMainDataForTest();
-    REQUIRE( pending != nullptr );
-    const std::weak_ptr<LogData> abandonedPending = pending;
+    std::weak_ptr<LogData> abandonedPending;
+    triggerAndWaitForCompletion(
+        &widget, &FolderCrawlerWidget::mainViewFileChanged,
+        [ & ] {
+            widget.selectResultRow( 1_lnum );
+            auto pending = widget.pendingMainDataForTest();
+            REQUIRE( pending != nullptr );
+            abandonedPending = pending;
 
-    // Queue failure before the second click, but do not process the event loop.
-    // The new click must survive cleanup of the terminal pending load.
-    REQUIRE( QMetaObject::invokeMethod(
-        pending.get(), "loadingFinished", Qt::QueuedConnection,
-        Q_ARG( LoadingStatus, LoadingStatus::Interrupted ) ) );
-    pending->interruptLoading();
-    widget.selectResultRow( 2_lnum );
-    pending.reset();
-
-    REQUIRE( waitFor( [ &widget, &path ] { return widget.currentMainFilePath() == path; } ) );
-    QTest::qWait( 200 );
+            // Queue failure before the second click, but do not process the event loop.
+            // The new click must survive cleanup of the terminal pending load.
+            REQUIRE( QMetaObject::invokeMethod(
+                pending.get(), "loadingFinished", Qt::QueuedConnection,
+                Q_ARG( LoadingStatus, LoadingStatus::Interrupted ) ) );
+            pending->interruptLoading();
+            widget.selectResultRow( 2_lnum );
+        },
+        [ & ] { return widget.currentMainFilePath() == path; } );
+    QTest::qWait( 200 ); // documented post-completion worker-unwind grace
     REQUIRE( abandonedPending.expired() );
     REQUIRE( widget.currentMainViewLine() == secondLine );
 }

--- a/tests/ui/foldercrawler_test.cpp
+++ b/tests/ui/foldercrawler_test.cpp
@@ -125,6 +125,15 @@ bool waitFor( const std::function<bool()>& predicate, int timeoutMs = 5000 )
     return true;
 }
 
+void selectResultRowAndWaitForFile( FolderCrawlerWidget& widget, LineNumber row,
+                                    const QString& expectedPath )
+{
+    triggerAndWaitForCompletion(
+        &widget, &FolderCrawlerWidget::mainViewFileChanged,
+        [ &widget, row ] { widget.selectResultRow( row ); },
+        [ &widget, &expectedPath ] { return widget.currentMainFilePath() == expectedPath; } );
+}
+
 // RAII save/restore of the global Configuration fields the folder ctor reads,
 // so a test can force deterministic non-default values without leaking state
 // into sibling tests (which assert e.g. a default plain-text/regex pattern).
@@ -318,8 +327,7 @@ TEST_CASE( "FolderCrawlerWidget plain click on a result row repaints the selecti
     // Open a.log up front so the later real click takes the synchronous same-file
     // branch of openFileInMainView (file cached): no async load, and the open
     // path touches mainView_ only, never repainting the filtered view.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const view = widget.filteredView();
@@ -439,10 +447,7 @@ TEST_CASE( "FolderCrawlerWidget selecting a result opens the source file", "[fol
     // Visible rows: [header(0), match(1)].
     REQUIRE( widget.folderResults()->lineKind( 1_lnum ) == LineKind::Data );
 
-    widget.selectResultRow( 1_lnum ); // opens a.log at the matched line
-
-    REQUIRE( waitFor( [ & ]() { return !widget.currentMainFilePath().isEmpty(); } ) );
-    REQUIRE( widget.currentMainFilePath() == a );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // opens a.log at the matched line
     // Settle after the load completes before teardown (CLAUDE.md
     // close-after-load pattern): the indexer worker may still be unwinding
     // after the main-thread completion signal fires.
@@ -486,9 +491,7 @@ TEST_CASE( "FolderCrawlerWidget main view search range spans the opened file",
 
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum ); // opens a.log (3 lines) in the main view
-
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // opens a.log in the main view
     QTest::qWait( 200 ); // settle: setDataSource runs in the loadingFinished queue
 
     // The whole 3-line file is in range -> body text is not grayed.
@@ -521,17 +524,15 @@ TEST_CASE( "FolderCrawlerWidget main view line map refreshes on demand after a d
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
     // Open A then B (both async-indexed and cached), settling so maps rebuild.
-    widget.selectResultRow( 1_lnum ); // a.log match -> row 1
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // a.log match -> row 1
     QTest::qWait( 200 );
-    widget.selectResultRow( 3_lnum ); // b.log match -> row 3
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, 3_lnum, b ); // b.log match -> row 3
     QTest::qWait( 200 );
 
     // Cached re-select of A: setDataSource runs synchronously and leaves the map
     // stale/empty (no paint is processed before selectResultRow returns).
     widget.selectResultRow( 1_lnum );
-    REQUIRE( widget.currentMainFilePath() == a );
+    REQUIRE( widget.currentMainFilePath() == a ); // lint-allow: platform-fragile -- cached sync
     REQUIRE_FALSE( widget.mainView()->isLineMapCurrent() );
 
     // The on-demand refresh the mouse handlers use rebuilds the map synchronously.
@@ -561,8 +562,7 @@ TEST_CASE( "FolderCrawlerWidget main view caches the line map across unchanged m
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum ); // open a.log
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // open a.log
     QTest::qWait( 200 );
 
     auto* const mainView = widget.mainView();
@@ -579,8 +579,7 @@ TEST_CASE( "FolderCrawlerWidget main view caches the line map across unchanged m
 
     // Swapping the underlying file changes the map's inputs (data ptr + line
     // count), so the cache must invalidate and the next refresh must rebuild.
-    widget.selectResultRow( 3_lnum ); // open b.log
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, 3_lnum, b ); // open b.log
     QTest::qWait( 200 );
 
     mainView->ensureLineMapFresh();
@@ -624,8 +623,7 @@ TEST_CASE( "FolderCrawlerWidget toolbar status never leaks the opened file path"
 
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum ); // async load of a.log
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // async load of a.log
     QTest::qWait( 200 );
     // No "Opening <path>" leak while/after loading the file.
     REQUIRE_FALSE( widget.statusText().startsWith( QStringLiteral( "Opening" ) ) );
@@ -650,8 +648,7 @@ TEST_CASE( "FolderCrawlerWidget exposes main-view file info for the status bar",
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
     // Visible rows: [H0(a), D1(a match), H2(b), D3(b match)].
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     const auto infoA = widget.currentMainViewInfo();
@@ -661,8 +658,7 @@ TEST_CASE( "FolderCrawlerWidget exposes main-view file info for the status bar",
     REQUIRE( infoA->size > 0 );
     REQUIRE_FALSE( infoA->encodingText.isEmpty() );
 
-    widget.selectResultRow( 3_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, 3_lnum, b );
     QTest::qWait( 200 );
     const auto infoB = widget.currentMainViewInfo();
     REQUIRE( infoB.has_value() );
@@ -688,8 +684,7 @@ TEST_CASE( "FolderCrawlerWidget main-view marks are per-file and survive swaps",
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
     // Open A (match at localLine 0).
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     // Mark line 1 in the current (A) file. markMainViewLine is the programmatic
@@ -723,14 +718,12 @@ TEST_CASE( "FolderCrawlerWidget main-view marks are per-file and survive swaps",
         FAIL( "matchRowForFile: no matching result row found for the requested file" );
         return 0_lnum; // unreachable; FAIL aborts the test case
     };
-    widget.selectResultRow( matchRowForFile( b ) ); // b.log match
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, matchRowForFile( b ), b ); // b.log match
     QTest::qWait( 200 );
     REQUIRE_FALSE( widget.isMainViewLineMarked( 1_lnum ) );
 
     // ...and must reappear when A is reopened (cached swap).
-    widget.selectResultRow( matchRowForFile( a ) ); // a.log match
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, matchRowForFile( a ), a ); // a.log match
     QTest::qWait( 200 );
     REQUIRE( widget.isMainViewLineMarked( 1_lnum ) );
 }
@@ -766,8 +759,7 @@ TEST_CASE( "FolderCrawlerWidget marks survive a filter change and show under Mar
 
     // Open a.log and mark line 3 (ERROR beta): a mark that matches filter1 but
     // NOT the upcoming filter2 (alpha).
-    widget.selectResultRow( 1_lnum ); // ERROR alpha -> opens a.log
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // ERROR alpha -> opens a.log
     QTest::qWait( 200 );
     widget.markMainViewLine( 3_lnum );
     REQUIRE( widget.isLineMarkedInFile( a, 3_lnum ) );
@@ -845,8 +837,9 @@ TEST_CASE( "FolderCrawlerWidget a marked non-match row shows its source line tex
     REQUIRE( widget.folderResults()->getNbLine() == 2_lcount ); // header + 1 match
 
     // Click the result row -> main view opens a.log at the matched line.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
+    // mainViewFileChanged is the semantic completion boundary; retain the
+    // documented grace period only for the index worker's final unwind.
     QTest::qWait( 200 );
 
     // Mark the matched line AND the following (non-matching) line with M.
@@ -872,7 +865,6 @@ TEST_CASE( "FolderCrawlerWidget a marked non-match row shows its source line tex
 
     // Same guarantee under the "Marks" visibility filter: header + both marks.
     widget.setResultsVisibility( FolderSearchResults::Visibility::Marks );
-    QTest::qWait( 50 );
     REQUIRE( widget.folderResults()->getNbLine() == 3_lcount ); // header + 2 mark rows
     const auto srcUnderMarks = widget.folderResults()->sourceForLine( 2_lnum );
     REQUIRE( srcUnderMarks.localLine == 4_lnum );
@@ -903,8 +895,7 @@ TEST_CASE( "FolderCrawlerWidget a marked grep-context line stays visible under M
     REQUIRE( widget.folderResults()->getNbLine() == 4_lcount );
 
     // Open a.log and mark line 2 (a context line).
-    widget.selectResultRow( 1_lnum ); // HIT -> opens a.log
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // HIT -> opens a.log
     QTest::qWait( 200 );
     widget.markMainViewLine( 2_lnum );
     REQUIRE( widget.isLineMarkedInFile( a, 2_lnum ) );
@@ -1054,7 +1045,7 @@ TEST_CASE( "FolderCrawlerWidget coalesces synchronous selections for one pending
 
     SECTION( "same pending file keeps its LogData and completes once at the newest match" )
     {
-        QSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+        SafeQSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
 
         // No event-loop turn between these calls: A is still uncached and pending
         // for both selections.
@@ -1070,7 +1061,8 @@ TEST_CASE( "FolderCrawlerWidget coalesces synchronous selections for one pending
         REQUIRE_FALSE( secondPending.owner_before( firstPending ) );
         REQUIRE( Access::pendingJumpLine( &widget ) == secondALine );
 
-        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+        REQUIRE( completionSpy.safeWait( kAsyncCompletionTimeoutMs ) );
+        REQUIRE( widget.currentMainFilePath() == a );
         QTest::qWait( 200 ); // deterministic close-after-load settle
 
         // One shared pending index completes once, and consumes the second jump.
@@ -1083,7 +1075,7 @@ TEST_CASE( "FolderCrawlerWidget coalesces synchronous selections for one pending
 
     SECTION( "a different pending file still replaces the in-flight LogData" )
     {
-        QSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
+        SafeQSignalSpy completionSpy( &widget, &FolderCrawlerWidget::mainViewFileChanged );
 
         widget.selectResultRow( aRows[ 0 ] );
         const auto pendingA = Access::pendingMainData( &widget );
@@ -1099,7 +1091,8 @@ TEST_CASE( "FolderCrawlerWidget coalesces synchronous selections for one pending
         REQUIRE( ( pendingA.owner_before( pendingB ) || pendingB.owner_before( pendingA ) ) );
         REQUIRE( Access::pendingJumpLine( &widget ) == bLine );
 
-        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+        REQUIRE( completionSpy.safeWait( kAsyncCompletionTimeoutMs ) );
+        REQUIRE( widget.currentMainFilePath() == b );
         QTest::qWait( 200 );
         REQUIRE( completionSpy.count() == 1 );
         const auto selected
@@ -1121,14 +1114,13 @@ TEST_CASE( "FolderCrawlerWidget reselecting the same file reuses it without relo
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum ); // first select -> async load + swap
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // first select -> async load + swap
     QTest::qWait( 200 );
 
-    // Selecting another row in the SAME file must keep the same file loaded.
+    // Selecting another row in the SAME file is a synchronous jump and must keep
+    // the already-loaded file current without waiting for another open.
     widget.selectResultRow( 2_lnum );
-    QTest::qWait( 100 );
-    REQUIRE( widget.currentMainFilePath() == a );
+    REQUIRE( widget.currentMainFilePath() == a ); // lint-allow: platform-fragile -- same file
 }
 
 TEST_CASE( "FolderCrawlerWidget collapse-all and expand-all change visible rows", "[folder]" )
@@ -1263,8 +1255,7 @@ TEST_CASE( "FolderCrawlerWidget forwards search pattern to main view for opened-
                                           /*boolean=*/false, /*plainText=*/true ) );
 
     // Open a result row -> async load + setDataSource swap of mainView_.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 ); // settle per CLAUDE.md
 
     // POST-open wiring: the pattern survived the setDataSource swap (re-applied
@@ -1374,8 +1365,7 @@ TEST_CASE( "FolderCrawlerWidget overview reflects the opened file and swaps on r
     };
 
     // --- Open file A (async first load) ---
-    widget.selectResultRow( 1_lnum ); // a's first match (localLine 0)
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // a's first match (localLine 0)
     QTest::qWait( 200 ); // settle per CLAUDE.md
 
     // refreshOverview must have shown the overview widget alongside the viewport.
@@ -1388,16 +1378,14 @@ TEST_CASE( "FolderCrawlerWidget overview reflects the opened file and swaps on r
     REQUIRE( widget.overview()->getMarkLines()->empty() );
 
     // --- Open file B (different match set -> cached/async swap repoints) ---
-    widget.selectResultRow( 4_lnum ); // b's first match (localLine 0)
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, 4_lnum, b ); // b's first match (localLine 0)
     QTest::qWait( 200 ); // settle
 
     // The overview must now reflect b.log's matches (3): the repoint happened.
     REQUIRE( overviewMatchCount( widget ) == 3 );
 
     // --- Switch back to A (now served from the cache) -> overview repoints again.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
     REQUIRE( overviewMatchCount( widget ) == 2 );
 }
@@ -1419,8 +1407,7 @@ TEST_CASE( "FolderCrawlerWidget overview click emits lineClicked for jump parity
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     const auto firstVisibleBefore = widget.mainView()->getTopLine();
@@ -1701,8 +1688,7 @@ TEST_CASE( "FolderCrawlerWidget setEncoding applies to the opened file", "[folde
 
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return !widget.currentMainFilePath().isEmpty(); } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
 
     // File opened -> applies (re-displays the opened file); must not throw for
     // both an explicit MIB and the detected encoding.
@@ -1811,8 +1797,7 @@ TEST_CASE( "FolderCrawlerWidget filtered-view M shortcut marks the selected resu
                  .testFlag( AbstractLogData::LineTypeFlags::Mark ) );
 
     // The mark is shared with the main view: open a.log and line 0 is marked.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
     REQUIRE( widget.isMainViewLineMarked( 0_lnum ) );
 
@@ -1840,8 +1825,7 @@ TEST_CASE( "FolderCrawlerWidget main-view map rebuilds paint-free on an unrealiz
     widget.setFolder( dir.path(), QStringList{ a } );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum ); // opens a.log -> setDataSource clears the map
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // opens a.log -> setDataSource clears the map
     QTest::qWait( 200 );
 
     // No paint was ever delivered, so the map is empty and hit-testing fails.
@@ -1872,8 +1856,7 @@ TEST_CASE( "FolderCrawlerWidget announces the main-view line position when a res
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
     QSignalSpy spy( widget.mainView(), &LogMainView::newSelection );
-    widget.selectResultRow( 1_lnum ); // opens a.log at the match line (localLine 1)
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a ); // opens a.log at the match line (localLine 1)
     QTest::qWait( 200 ); // settle: setDataSource + announce run in the loadingFinished queue
 
     REQUIRE( spy.count() >= 1 );
@@ -1916,13 +1899,11 @@ TEST_CASE( "FolderCrawlerWidget main view shows each opened file's detected enco
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
     // Rows: [H0(utf8), D1(utf8 match), H2(utf16), D3(utf16 match)].
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == utf8; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, utf8 );
     QTest::qWait( 200 );
     REQUIRE( widget.currentMainViewInfo()->encodingText.toLower().contains( "utf-8" ) );
 
-    widget.selectResultRow( 3_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == utf16File; } ) );
+    selectResultRowAndWaitForFile( widget, 3_lnum, utf16File );
     QTest::qWait( 200 );
     REQUIRE( widget.currentMainViewInfo()->encodingText.toLower().contains( "utf-16" ) );
 }
@@ -2380,8 +2361,7 @@ TEST_CASE( "FolderCrawlerWidget shared view-signal wiring", "[folder][wiring]" )
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const mainView = widget.mainView();
@@ -2638,8 +2618,7 @@ TEST_CASE( "FolderCrawlerWidget mirrors a portion selection into the main view",
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     // Row 1 = a.log local line 1 ("ERROR alpha"). Single-file parity: the main
@@ -2691,8 +2670,7 @@ TEST_CASE( "FolderCrawlerWidget highlights the hovered result line in the minima
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const overviewWidget = widget.mainView()->findChild<OverviewWidget*>();
@@ -2810,8 +2788,7 @@ TEST_CASE( "FolderCrawlerWidget marks appear in the overview", "[folder][overvie
     QTest::qWait( 100 );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const overview = widget.overviewModel();
@@ -2846,16 +2823,14 @@ TEST_CASE( "FolderCrawlerWidget marks appear in the overview", "[folder][overvie
     // Rows: 0 = header(a), 1 = alpha, 2 = beta, 3 = header(b), 4 = gamma.
     // Mark a non-match line in b, then switch between the files: the minimap
     // ticks must track the file currently shown in the main view.
-    widget.selectResultRow( 4_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+    selectResultRowAndWaitForFile( widget, 4_lnum, b );
     QTest::qWait( 100 );
     widget.markMainViewLine( 1_lnum ); // b.log:1 is "line1", not a match
     QTest::qWait( 50 );
     overview->updateView( 100 );
     REQUIRE( !overview->getMarkLines()->empty() );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 100 );
     overview->updateView( 100 );
     // a.log has no marks anymore (unmarked above) -> no stale ticks from b.
@@ -2882,8 +2857,7 @@ TEST_CASE( "FolderCrawlerWidget marks survive a view-context round-trip",
     QTest::qWait( 100 );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     // Mark a main-view line in a.log and a results row from b.log
@@ -2935,8 +2909,7 @@ TEST_CASE( "FolderCrawlerWidget restores marks into a moved folder",
     QTest::qWait( 100 );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
     widget.markMainViewLine( 1_lnum );
     QTest::qWait( 20 );
@@ -3149,8 +3122,7 @@ TEST_CASE( "FolderCrawlerWidget row-encoding override dies with the cached file"
 
     // Open a.log (row 1 = its match): the row decodes with the detected
     // UTF-16 codec at baseline.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; }, 15000 ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 100 );
     REQUIRE( widget.folderResults()->getLineString( 1_lnum )
                  == QStringLiteral( "ERROR x" ) );
@@ -3168,8 +3140,7 @@ TEST_CASE( "FolderCrawlerWidget row-encoding override dies with the cached file"
     for ( int i = 0; i < 9; ++i ) {
         const auto row = LineNumber( static_cast<LineNumber::UnderlyingType>( 3 + i * 2 ) );
         const auto path = files.at( i + 1 );
-        widget.selectResultRow( row );
-        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == path; }, 15000 ) );
+        selectResultRowAndWaitForFile( widget, row, path );
     }
     QTest::qWait( 100 );
 
@@ -3237,8 +3208,7 @@ TEST_CASE( "FolderCrawlerWidget document-level actions", "[folder][actions]" )
     QTest::qWait( 100 );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     SECTION( "focusSearchEdit focuses the search input" )
@@ -3319,8 +3289,7 @@ TEST_CASE( "FolderCrawlerWidget document-level actions", "[folder][actions]" )
 
         // Rows: 0 = header(a), 1 = ERROR alpha, 2 = ERROR beta, 3 = header(b),
         // 4 = ERROR gamma. Selecting a b.log row swaps the main-view file.
-        widget.selectResultRow( 4_lnum );
-        REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == b; } ) );
+        selectResultRowAndWaitForFile( widget, 4_lnum, b );
         QTest::qWait( 100 );
         REQUIRE_FALSE( widget.encodingMib().has_value() );
     }
@@ -3577,8 +3546,7 @@ TEST_CASE( "FolderCrawlerWidget registers the crawler widget shortcut family",
     QTest::qWait( 100 );
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const mainView = widget.mainView();
@@ -3874,8 +3842,7 @@ TEST_CASE( "FolderCrawlerWidget color labels apply to the selection in every vie
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
     // Open a.log in the main view and select the "ERROR" portion of line 1.
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const mainView = widget.mainView();
@@ -4098,8 +4065,7 @@ TEST_CASE( "FolderCrawlerWidget jumpToTop dispatch tops the main view only", "[f
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     // The on-demand index + layout are async: wait until the 200-line file is
     // actually scrollable, then settle so the worker thread unwinds.
     REQUIRE( waitFor(
@@ -4131,8 +4097,7 @@ TEST_CASE( "FolderCrawlerWidget followSet dispatch toggles follow on the main vi
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     auto* const document = static_cast<AbstractCrawlerWidget*>( &widget );
@@ -4163,8 +4128,7 @@ TEST_CASE( "FolderCrawlerWidget re-emits the main view's followModeChanged", "[f
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     QTest::qWait( 200 );
 
     bool fired = false;
@@ -4207,8 +4171,7 @@ TEST_CASE( "FolderCrawlerWidget follow tracks the tail when the file grows", "[f
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     REQUIRE( waitFor(
         [ & ]() { return widget.mainView()->verticalScrollBar()->maximum() > 0; } ) );
     QTest::qWait( 200 );
@@ -4315,8 +4278,7 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
 
     // Open A first (uncached -> async path): after completion A is cached,
     // bound, and -- before the fix -- still carrying its stale pending lambda.
-    widget.selectResultRow( matchRowForFile( a ) );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, matchRowForFile( a ), a );
     QTest::qWait( 200 );
     auto* cachedAData = const_cast<AbstractLogData*>(
         AbstractLogView::access_by<FolderViewTestAccess>::logData( widget.mainView() ) );
@@ -4346,7 +4308,9 @@ TEST_CASE( "FolderCrawlerWidget a cached file's re-index cannot hijack a pending
     QElapsedTimer openBudget;
     openBudget.start();
     while ( widget.currentMainFilePath() != b && openBudget.elapsed() < 30000 ) {
-        QTest::qWait( 100 );
+        // The wait paces deliberate overlapping A re-index notifications; it is
+        // not the completion boundary for B's open.
+        QTest::qWait( 100 ); // lint-allow: platform-fragile
         appendLine( a );
         REQUIRE( notifyChanged( cachedAData, a ) );
     }
@@ -4452,8 +4416,7 @@ TEST_CASE( "FolderCrawlerWidget canceling a pending open keeps the displayed fil
     // ISO 8859-1 (Latin-1): the ASCII fixture decodes fine under it, and it
     // differs from the detected UTF-8 so the override is a real state change.
     constexpr int latin1Mib = 4;
-    widget.selectResultRow( matchRowForFile( a ) );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, matchRowForFile( a ), a );
     QTest::qWait( 200 ); // settle per CLAUDE.md
     widget.setEncoding( latin1Mib );
     REQUIRE( widget.encodingMib().has_value() );
@@ -4466,7 +4429,7 @@ TEST_CASE( "FolderCrawlerWidget canceling a pending open keeps the displayed fil
     // cancel-a-pending-open sequence from the bug report, made deterministic.
     widget.selectResultRow( matchRowForFile( b ) );
     widget.selectResultRow( matchRowForFile( a ) );
-    REQUIRE( widget.currentMainFilePath() == a );
+    REQUIRE( widget.currentMainFilePath() == a ); // lint-allow: platform-fragile -- same file
 
     // The displayed file never changed, so its override must still be pinned.
     // RED: the reset at the start of B's open already wiped it (nullopt).
@@ -4476,7 +4439,7 @@ TEST_CASE( "FolderCrawlerWidget canceling a pending open keeps the displayed fil
     // Settle so any late/queued side effects of the canceled open land, then
     // re-assert: the override must survive the full unwind of the cancel, not
     // just the synchronous fast path.
-    QTest::qWait( 200 );
+    QTest::qWait( 200 ); // lint-allow: platform-fragile -- documented cancel unwind
     REQUIRE( widget.currentMainFilePath() == a );
     REQUIRE( widget.encodingMib().has_value() );
     REQUIRE( *widget.encodingMib() == latin1Mib );
@@ -4505,8 +4468,7 @@ TEST_CASE( "FolderCrawlerWidget follow growth refreshes the overview line count"
     widget.searchFor( "ERROR" );
     REQUIRE( waitFor( [ & ]() { return !widget.isSearchActive(); } ) );
 
-    widget.selectResultRow( 1_lnum );
-    REQUIRE( waitFor( [ & ]() { return widget.currentMainFilePath() == a; } ) );
+    selectResultRowAndWaitForFile( widget, 1_lnum, a );
     REQUIRE( waitFor(
         [ & ]() { return widget.mainView()->verticalScrollBar()->maximum() > 0; } ) );
     QTest::qWait( 200 ); // settle per CLAUDE.md

--- a/tests/ui/mainwindow_test.cpp
+++ b/tests/ui/mainwindow_test.cpp
@@ -2815,9 +2815,14 @@ SCENARIO( "Folder tab receives the polymorphic MainWindow dispatch", "[ui][folde
         REQUIRE( waitUiState( [ & ] { return !folderWidget->isSearchActive(); } ) );
 
         const auto expectedPath = QDir( tempDirPath ).absoluteFilePath( "a.log" );
-        runInUiThread( [ folderWidget ] { folderWidget->selectResultRow( 1_lnum ); } );
-        REQUIRE(
-            waitUiState( [ & ] { return folderWidget->currentMainFilePath() == expectedPath; } ) );
+        triggerAndWaitForCompletion(
+            folderWidget, &FolderCrawlerWidget::mainViewFileChanged,
+            [ & ] {
+                runInUiThread(
+                    [ folderWidget ] { folderWidget->selectResultRow( 1_lnum ); } );
+            },
+            [ & ] { return folderWidget->currentMainFilePath() == expectedPath; } );
+        QTest::qWait( 200 ); // documented post-completion worker-unwind grace
 
         THEN( "the clipboard holds the main-view file path" )
         {
@@ -2904,10 +2909,14 @@ SCENARIO( "Folder tab go-to-top and follow actions apply to the main view file",
         // is a data row; selecting it in the results view opens its file in
         // the main view (newSelection -> onResultSelected, the same path
         // FolderCrawlerWidget::selectResultRow drives).
-        runInUiThread(
-            [ folderWidget ] { folderWidget->filteredView()->selectAndDisplayLine( 2_lnum ); } );
-        REQUIRE(
-            waitUiState( [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        triggerAndWaitForCompletion(
+            folderWidget, &FolderCrawlerWidget::mainViewFileChanged,
+            [ & ] {
+                runInUiThread( [ folderWidget ] {
+                    folderWidget->filteredView()->selectAndDisplayLine( 2_lnum );
+                } );
+            },
+            [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } );
         // The on-demand index + layout of the main-view file are async: wait
         // until the 200-line file is actually scrollable, then settle so the
         // worker thread unwinds before the views are driven further.
@@ -3087,10 +3096,14 @@ SCENARIO( "Folder tab info line shows the main-view file path for a long nested 
 
         // Row 0 is the group header, row 2 a data row: selecting it opens the
         // file in the main view (newSelection -> onResultSelected).
-        runInUiThread(
-            [ folderWidget ] { folderWidget->filteredView()->selectAndDisplayLine( 2_lnum ); } );
-        REQUIRE(
-            waitUiState( [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        triggerAndWaitForCompletion(
+            folderWidget, &FolderCrawlerWidget::mainViewFileChanged,
+            [ & ] {
+                runInUiThread( [ folderWidget ] {
+                    folderWidget->filteredView()->selectAndDisplayLine( 2_lnum );
+                } );
+            },
+            [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } );
         // The main-view index completes async; mainViewFileChanged (fired at
         // its completion) is what re-runs updateInfoLine, so settle the event
         // loop before asserting the label.
@@ -3194,9 +3207,13 @@ TEST_CASE( "Background folder tab must not change the current tab's follow state
         // first data row.
         runInUiThread( [ folderWidget ] { folderWidget->searchFor( QStringLiteral( "ERROR" ) ); } );
         REQUIRE( waitUiState( [ & ] { return !folderWidget->isSearchActive(); } ) );
-        runInUiThread( [ folderWidget ] { folderWidget->selectResultRow( 1_lnum ); } );
-        REQUIRE(
-            waitUiState( [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } ) );
+        triggerAndWaitForCompletion(
+            folderWidget, &FolderCrawlerWidget::mainViewFileChanged,
+            [ & ] {
+                runInUiThread(
+                    [ folderWidget ] { folderWidget->selectResultRow( 1_lnum ); } );
+            },
+            [ & ] { return folderWidget->currentMainFilePath() == logFilePath; } );
         // The on-demand index + layout of the main-view file are async; wait
         // until it is scrollable, then settle so the worker thread unwinds.
         REQUIRE( waitUiState(

--- a/tests/unit/adb_device_tracker_manager_test.cpp
+++ b/tests/unit/adb_device_tracker_manager_test.cpp
@@ -49,6 +49,7 @@ using klogg::livecapture::ErrorScope;
 using klogg::livecapture::Generation;
 using klogg::livecapture::InfrastructureOwnership;
 using klogg::livecapture::InfrastructureStatus;
+using klogg::livecapture::LiveSourceError;
 using klogg::livecapture::RetryPolicy;
 using namespace klogg::livecapture::adb;
 using DomainAdbDeviceInfo = klogg::livecapture::adb::AdbDeviceInfo;
@@ -560,10 +561,10 @@ struct ManagerHarness {
     AdbInfrastructureManager manager;
     ManagerSnapshotRecorder snapshots;
 
-    ManagerHarness()
+    explicit ManagerHarness( AdbInfrastructureManagerConfig config = managerConfig() )
         : client( clientConfig( server.port() ), socketFactory, deadlines )
         , clientOperations( client )
-        , manager( managerConfig(),
+        , manager( std::move( config ),
                    AdbInfrastructureManagerDependencies{ probe, launcher, startupLock, keyStore,
                                                          supervisorScheduler, client,
                                                          trackerScheduler } )
@@ -1030,6 +1031,9 @@ TEST_CASE( "manager forwards explicit ADB key consent without process or PATH di
 
     harness.manager.grantKeyGenerationConsent( true );
 
+    CHECK( harness.keyStore.generationCount == 0 );
+    REQUIRE( harness.probe.requests.size() == 3u );
+    harness.probe.completeAbsent( 2 );
     CHECK( harness.keyStore.generationCount == 1 );
     REQUIRE( harness.launcher.requests.size() == 1u );
     CHECK( harness.launcher.requests.front().request.executable
@@ -1062,6 +1066,61 @@ TEST_CASE( "idle lease reacquisition retries a transient terminal supervisor fai
     CHECK( harness.manager.snapshot().generation == firstGeneration + 1u );
     CHECK( harness.supervisorScheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u );
     REQUIRE( harness.probe.requests.size() == 2u );
+    CHECK( harness.probe.requests.back().active );
+}
+
+TEST_CASE( "idle unavailable manager suspends passive startup capability polling",
+           "[livecapture][adb][manager][lease][startup-capability]" )
+{
+    auto config = managerConfig();
+    config.server.startupCapabilityCheck = [] {
+        return std::optional<LiveSourceError>{ LiveSourceError{
+            ErrorCategory::Configuration, "adb-packaged-helper-missing",
+            ErrorScope::Infrastructure, RetryPolicy::Never,
+            "The packaged ADB helper is unavailable.",
+            "The packaged ADB helper is missing." } };
+    };
+    ManagerHarness harness( std::move( config ) );
+    auto firstLease = harness.manager.acquireLease();
+    const auto firstGeneration = harness.manager.snapshot().generation;
+    harness.probe.completeAbsent( 0 );
+    REQUIRE( harness.supervisorScheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 1u );
+
+    firstLease.reset();
+    REQUIRE( drainEventsUntil( [ &harness ] {
+        return harness.supervisorScheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u;
+    } ) );
+
+    CHECK( harness.manager.activeLeaseCount() == 0u );
+    const auto probeCount = harness.probe.requests.size();
+    CHECK( harness.launcher.requests.empty() );
+
+    auto replacementLease = harness.manager.acquireLease();
+    CHECK( harness.manager.snapshot().generation == firstGeneration + 1u );
+    REQUIRE( harness.probe.requests.size() == probeCount + 1u );
+    CHECK( harness.probe.requests.back().active );
+}
+
+TEST_CASE( "idle ready manager suspends when its observed server later disappears",
+           "[livecapture][adb][manager][lease][health]" )
+{
+    ManagerHarness harness;
+    auto lease = harness.acquireAndReachReady();
+    const auto firstGeneration = harness.manager.snapshot().generation;
+    lease.reset();
+    REQUIRE( harness.manager.activeLeaseCount() == 0u );
+
+    harness.supervisorScheduler.fire( AdbServerScheduleKind::HealthProbe );
+    harness.probe.completeAbsent( 1 );
+    REQUIRE( drainEventsUntil( [ &harness ] {
+        return harness.supervisorScheduler.activeCount( AdbServerScheduleKind::ReconnectBackoff )
+               == 0u;
+    } ) );
+    CHECK( harness.launcher.requests.empty() );
+
+    auto replacementLease = harness.manager.acquireLease();
+    CHECK( harness.manager.snapshot().generation == firstGeneration + 1u );
+    REQUIRE( harness.probe.requests.size() == 3u );
     CHECK( harness.probe.requests.back().active );
 }
 
@@ -1285,7 +1344,7 @@ TEST_CASE( "manager projects recoverable supervisor errors to infrastructure wai
     CHECK( result.error->retryPolicy == RetryPolicy::WaitForInfrastructure );
 }
 
-TEST_CASE( "non-retryable manager configuration errors remain non-retryable in discovery",
+TEST_CASE( "startup capability errors remain recoverable through infrastructure discovery",
            "[livecapture][adb][manager][error][configuration]" )
 {
     TrackDevicesServer server;
@@ -1299,19 +1358,27 @@ TEST_CASE( "non-retryable manager configuration errors remain non-retryable in d
     ManualServerScheduler supervisorScheduler;
     ManualServerScheduler trackerScheduler;
     auto config = managerConfig();
-    config.server.packagedServerPath = QStringLiteral( "relative/adb" );
+    config.server.startupCapabilityCheck = [] {
+        return std::optional<LiveSourceError>{ LiveSourceError{
+            ErrorCategory::Configuration, "adb-packaged-helper-missing",
+            ErrorScope::Infrastructure, RetryPolicy::Never,
+            "The packaged ADB helper is unavailable.",
+            "The packaged ADB helper is missing." } };
+    };
     AdbInfrastructureManager manager(
         std::move( config ),
         AdbInfrastructureManagerDependencies{ probe, launcher, startupLock, keyStore,
                                               supervisorScheduler, client, trackerScheduler } );
 
     auto lease = manager.acquireLease();
+    REQUIRE( probe.requests.size() == 1u );
+    probe.completeAbsent( 0 );
     REQUIRE( manager.snapshot().error.has_value() );
-    CHECK( manager.snapshot().error->category == ErrorCategory::Configuration );
-    CHECK( manager.snapshot().error->retryPolicy == RetryPolicy::Never );
+    CHECK( manager.snapshot().error->category == ErrorCategory::Infrastructure );
+    CHECK( manager.snapshot().error->retryPolicy == RetryPolicy::WaitForInfrastructure );
 
     const auto result = mapTrackedAdbInfrastructureSnapshot( 78u, manager.snapshot() );
     REQUIRE( result.error.has_value() );
-    CHECK( result.error->category == ErrorCategory::Configuration );
-    CHECK( result.error->retryPolicy == RetryPolicy::Never );
+    CHECK( result.error->category == ErrorCategory::Infrastructure );
+    CHECK( result.error->retryPolicy == RetryPolicy::WaitForInfrastructure );
 }

--- a/tests/unit/adb_live_services_composition_test.cpp
+++ b/tests/unit/adb_live_services_composition_test.cpp
@@ -125,6 +125,18 @@ public:
                                                              {} } );
     }
 
+    void completeIncompatible( std::size_t index )
+    {
+        REQUIRE( index < requests.size() );
+        REQUIRE( requests.at( index ).active );
+        requests.at( index ).active = false;
+        requests.at( index ).callback( AdbServerProbeResult{ AdbServerProbeState::Ready,
+                                                             SupportedProtocolVersion - 1u,
+                                                             { "shell_v2" },
+                                                             "adb-server:incompatible",
+                                                             {} } );
+    }
+
     void completeAbsent( std::size_t index )
     {
         REQUIRE( index < requests.size() );
@@ -290,6 +302,14 @@ public:
                 entry.active = false;
             }
         }
+    }
+
+    std::size_t activeCount( AdbServerScheduleKind kind ) const
+    {
+        return static_cast<std::size_t>(
+            std::count_if( entries.cbegin(), entries.cend(), [ kind ]( const Entry& entry ) {
+                return entry.active && entry.kind == kind;
+            } ) );
     }
 
     void fire( AdbServerScheduleKind kind )
@@ -516,12 +536,14 @@ void requireRejectedPackagedHelper( const QString& applicationDir, const QString
     CHECK_FALSE( services.isPackagedHelperAvailable() );
 
     auto lease = services.trackedDeviceProvider().acquireLease();
+    REQUIRE( dependencies.probe.requests.size() == 1u );
+    dependencies.probe.completeAbsent( 0 );
     const auto& snapshot = services.manager().snapshot();
     REQUIRE( snapshot.error.has_value() );
-    CHECK( snapshot.error->category == ErrorCategory::Configuration );
+    CHECK( snapshot.error->category == ErrorCategory::Infrastructure );
     CHECK( snapshot.error->code == "adb-packaged-helper-missing" );
-    CHECK( snapshot.error->retryPolicy == RetryPolicy::Never );
-    CHECK( dependencies.probe.requests.empty() );
+    CHECK( snapshot.error->retryPolicy == RetryPolicy::WaitForInfrastructure );
+    CHECK( dependencies.startupLock.requests.empty() );
     CHECK( dependencies.launcher.requests.empty() );
 }
 
@@ -734,8 +756,8 @@ TEST_CASE( "packaged ADB helper validation rejects non-files non-executables and
     }
 }
 
-TEST_CASE( "missing packaged ADB helper is a structured non-retryable configuration failure",
-           "[livecapture][adb][composition][configuration]" )
+TEST_CASE( "missing packaged helper still permits external ADB server adoption",
+           "[livecapture][adb][composition][configuration][external]" )
 {
     QTemporaryDir root;
     REQUIRE( root.isValid() );
@@ -748,16 +770,75 @@ TEST_CASE( "missing packaged ADB helper is a structured non-retryable configurat
     AdbLiveServices services( servicesConfig( applicationDir, runtimeDir ), dependencies.refs() );
     auto lease = services.trackedDeviceProvider().acquireLease();
 
+    REQUIRE( dependencies.probe.requests.size() == 1u );
+    dependencies.probe.completeReady( 0 );
+
+    const auto& snapshot = services.manager().snapshot();
+    CHECK( snapshot.infrastructure.status == InfrastructureStatus::Ready );
+    REQUIRE( snapshot.infrastructure.ownership.has_value() );
+    CHECK( *snapshot.infrastructure.ownership
+           == klogg::livecapture::InfrastructureOwnership::ExternalShared );
+    CHECK_FALSE( snapshot.error.has_value() );
+    CHECK( dependencies.startupLock.requests.empty() );
+    CHECK( dependencies.launcher.requests.empty() );
+}
+
+TEST_CASE( "a packaged helper restored after startup can launch without reconstructing services",
+           "[livecapture][adb][composition][configuration][retry]" )
+{
+    QTemporaryDir root;
+    REQUIRE( root.isValid() );
+    const auto applicationDir = root.filePath( QStringLiteral( "package/bin" ) );
+    const auto runtimeDir = root.filePath( QStringLiteral( "user/runtime" ) );
+    REQUIRE( QDir().mkpath( applicationDir ) );
+    REQUIRE( QDir().mkpath( runtimeDir ) );
+
+    ServicesDependencies dependencies;
+    AdbLiveServices services( servicesConfig( applicationDir, runtimeDir ), dependencies.refs() );
+    auto lease = services.trackedDeviceProvider().acquireLease();
+    REQUIRE( dependencies.probe.requests.size() == 1u );
+    dependencies.probe.completeAbsent( 0 );
+    REQUIRE( dependencies.supervisorScheduler.activeCount(
+                 AdbServerScheduleKind::StartupRetry )
+             == 1u );
+
+    createPackagedHelper( applicationDir );
+    dependencies.supervisorScheduler.fire( AdbServerScheduleKind::StartupRetry );
+    REQUIRE( dependencies.probe.requests.size() == 2u );
+    dependencies.probe.completeAbsent( 1 );
+
+    CHECK( services.isPackagedHelperAvailable() );
+    CHECK( dependencies.startupLock.requests.size() == 1u );
+    CHECK( dependencies.launcher.requests.empty() );
+}
+
+TEST_CASE( "missing packaged ADB helper remains a recoverable infrastructure wait",
+           "[livecapture][adb][composition][configuration]" )
+{
+    QTemporaryDir root;
+    REQUIRE( root.isValid() );
+    const auto applicationDir = root.filePath( QStringLiteral( "package/bin" ) );
+    const auto runtimeDir = root.filePath( QStringLiteral( "user/runtime" ) );
+    REQUIRE( QDir().mkpath( applicationDir ) );
+    REQUIRE( QDir().mkpath( runtimeDir ) );
+
+    ServicesDependencies dependencies;
+    AdbLiveServices services( servicesConfig( applicationDir, runtimeDir ), dependencies.refs() );
+    auto lease = services.trackedDeviceProvider().acquireLease();
+    REQUIRE( dependencies.probe.requests.size() == 1u );
+    dependencies.probe.completeAbsent( 0 );
+
     const auto& snapshot = services.manager().snapshot();
     REQUIRE( snapshot.error.has_value() );
-    CHECK( snapshot.error->category == ErrorCategory::Configuration );
+    CHECK( snapshot.error->category == ErrorCategory::Infrastructure );
     CHECK( snapshot.error->scope == ErrorScope::Infrastructure );
-    CHECK( snapshot.error->retryPolicy == RetryPolicy::Never );
+    CHECK( snapshot.error->retryPolicy == RetryPolicy::WaitForInfrastructure );
     CHECK( snapshot.error->code == "adb-packaged-helper-missing" );
     CHECK( snapshot.error->nativeDetail.find(
                AdbLiveServices::packagedHelperPath( applicationDir ).toStdString() )
            != std::string::npos );
-    CHECK( dependencies.probe.requests.empty() );
+    CHECK( dependencies.probe.requests.size() == 1u );
+    CHECK( dependencies.startupLock.requests.empty() );
     CHECK( dependencies.launcher.requests.empty() );
 
     auto transport = services.create( smartSocketConfig( QStringLiteral( "restored-device" ) ) );
@@ -768,10 +849,11 @@ TEST_CASE( "missing packaged ADB helper is a structured non-retryable configurat
                           errors.emplace_back( generation, error );
                       } );
     transport->start( 91u );
-    REQUIRE( errors.size() == 1u );
-    CHECK( errors.front().first == 91u );
-    CHECK(
-        errors.front().second.contains( AdbLiveServices::packagedHelperPath( applicationDir ) ) );
+    CHECK( errors.empty() );
+    CHECK( services.manager().activeLeaseCount() == 2u );
+    CHECK( dependencies.supervisorScheduler.activeCount(
+               AdbServerScheduleKind::StartupRetry )
+           == 1u );
 }
 
 TEST_CASE( "one explicit application root shares manager tracker provider and transport leases",
@@ -1084,6 +1166,8 @@ TEST_CASE( "managed transport suppresses a terminal diagnostic made stale by Err
                       } );
 
     transport->start( 85u );
+    REQUIRE( dependencies.probe.requests.size() == 1u );
+    dependencies.probe.completeIncompatible( 0 );
 
     CHECK( errors.empty() );
     CHECK( services.manager().activeLeaseCount() == 0u );
@@ -1292,6 +1376,9 @@ TEST_CASE( "key consent is forwarded once and answers are generation and epoch c
     CHECK( dependencies.launcher.requests.empty() );
 
     services.answerKeyGenerationConsent( prompt.first, prompt.second, true );
+    CHECK( dependencies.keyStore.generationCount == 0 );
+    REQUIRE( dependencies.probe.requests.size() == 3u );
+    dependencies.probe.completeAbsent( 2 );
     CHECK( dependencies.keyStore.generationCount == 1 );
     REQUIRE( dependencies.launcher.requests.size() == 1u );
     CHECK( dependencies.launcher.requests.front().request.executable
@@ -1332,6 +1419,9 @@ TEST_CASE( "synchronous consent UI callback is safe and existing keys are never 
         dependencies.probe.completeAbsent( 1 );
 
         CHECK( promptCount == 1 );
+        CHECK( dependencies.keyStore.generationCount == 0 );
+        REQUIRE( dependencies.probe.requests.size() == 3u );
+        dependencies.probe.completeAbsent( 2 );
         CHECK( dependencies.keyStore.generationCount == 1 );
         CHECK( dependencies.launcher.requests.size() == 1u );
     }

--- a/tests/unit/adb_server_supervisor_test.cpp
+++ b/tests/unit/adb_server_supervisor_test.cpp
@@ -106,6 +106,16 @@ AdbServerSupervisorConfig supervisorConfig()
     return config;
 }
 
+LiveSourceError missingPackagedServerError()
+{
+    return LiveSourceError{ klogg::livecapture::ErrorCategory::Configuration,
+                            "adb-packaged-helper-missing",
+                            klogg::livecapture::ErrorScope::Infrastructure,
+                            klogg::livecapture::RetryPolicy::Never,
+                            "The packaged ADB helper is unavailable.",
+                            "The packaged ADB helper is missing." };
+}
+
 class ManualProbe final : public AdbServerProbe {
 public:
     struct Request {
@@ -707,9 +717,8 @@ QByteArray readFile( const QString& path )
 
 } // namespace
 
-TEST_CASE(
-    "ADB server supervisor rejects invalid endpoint or executable configuration before probing",
-    "[livecapture][adb][supervisor][validation]" )
+TEST_CASE( "ADB server supervisor validates probe and startup configuration at their boundaries",
+           "[livecapture][adb][supervisor][validation]" )
 {
     const std::vector<AdbServerEndpoint> invalidEndpoints{
         { QHostAddress( QStringLiteral( "192.0.2.10" ) ), 5037 },
@@ -737,19 +746,215 @@ TEST_CASE(
         }
     }
 
-    SECTION( "packaged server must be an explicit absolute path" )
+    SECTION( "packaged server is validated only when the endpoint is absent" )
     {
         auto config = supervisorConfig();
         config.packagedServerPath = QStringLiteral( "adb" );
         SupervisorHarness harness( config );
 
         harness.supervisor.start( FirstGeneration );
+        REQUIRE( harness.probe.requests.size() == 1u );
+        harness.probe.complete( 0, absentProbe() );
 
         CHECK( harness.supervisor.snapshot().status
                == AdbServerSupervisorStatus::InvalidConfiguration );
-        CHECK( harness.probe.requests.empty() );
+        CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u );
+        CHECK( harness.startupLock.requests.empty() );
         requireNoEnvironmentChangingWork( harness );
     }
+}
+
+TEST_CASE( "packaged startup failure does not block probing and adopting an external server",
+           "[livecapture][adb][supervisor][external][startup-capability]" )
+{
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    REQUIRE( harness.probe.requests.size() == 1u );
+    CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::Probing );
+
+    harness.probe.complete( 0, readyProbe() );
+
+    const auto& ready = harness.supervisor.snapshot();
+    CHECK( ready.status == AdbServerSupervisorStatus::Ready );
+    REQUIRE( ready.infrastructure.ownership.has_value() );
+    CHECK( *ready.infrastructure.ownership == InfrastructureOwnership::ExternalShared );
+    CHECK_FALSE( ready.error.has_value() );
+    requireNoEnvironmentChangingWork( harness );
+}
+
+TEST_CASE( "packaged startup failure is reported only after the standard endpoint is absent",
+           "[livecapture][adb][supervisor][startup-capability]" )
+{
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    REQUIRE( harness.probe.requests.size() == 1u );
+    harness.probe.complete( 0, absentProbe() );
+
+    const auto& waiting = harness.supervisor.snapshot();
+    CHECK( waiting.status == AdbServerSupervisorStatus::RetryWait );
+    REQUIRE( waiting.error.has_value() );
+    CHECK( waiting.error->code == "adb-packaged-helper-missing" );
+    CHECK( waiting.error->retryPolicy == klogg::livecapture::RetryPolicy::Backoff );
+    CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 1u );
+    CHECK( harness.scheduler.lastDelay( AdbServerScheduleKind::StartupRetry ) == 2s );
+    CHECK( harness.startupLock.requests.empty() );
+    requireNoEnvironmentChangingWork( harness );
+}
+
+TEST_CASE( "packaged startup failure keeps probing until an external server appears",
+           "[livecapture][adb][supervisor][external][startup-capability][retry]" )
+{
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, absentProbe() );
+    REQUIRE( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 1u );
+
+    harness.scheduler.fire( AdbServerScheduleKind::StartupRetry );
+    REQUIRE( harness.probe.requests.size() == 2u );
+    harness.probe.complete( 1, readyProbe() );
+
+    const auto& ready = harness.supervisor.snapshot();
+    CHECK( ready.status == AdbServerSupervisorStatus::Ready );
+    REQUIRE( ready.infrastructure.ownership.has_value() );
+    CHECK( *ready.infrastructure.ownership == InfrastructureOwnership::ExternalShared );
+    CHECK_FALSE( ready.error.has_value() );
+    requireNoEnvironmentChangingWork( harness );
+}
+
+TEST_CASE( "restored startup capability clears its stale diagnostic before lock acquisition",
+           "[livecapture][adb][supervisor][startup-capability][recovery]" )
+{
+    auto config = supervisorConfig();
+    bool helperAvailable = false;
+    config.startupCapabilityCheck = [ & ] {
+        return helperAvailable ? std::optional<LiveSourceError>{}
+                               : std::optional<LiveSourceError>{ missingPackagedServerError() };
+    };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, absentProbe() );
+    REQUIRE( harness.supervisor.snapshot().error.has_value() );
+
+    helperAvailable = true;
+    harness.scheduler.fire( AdbServerScheduleKind::StartupRetry );
+    harness.probe.complete( 1, absentProbe() );
+
+    CHECK( harness.supervisor.snapshot().status
+           == AdbServerSupervisorStatus::WaitingForStartupLock );
+    CHECK_FALSE( harness.supervisor.snapshot().error.has_value() );
+    REQUIRE( harness.startupLock.requests.size() == 1u );
+}
+
+TEST_CASE( "reentrant startup capability check cannot overwrite a replacement run",
+           "[livecapture][adb][supervisor][startup-capability][reentrant]" )
+{
+    auto config = supervisorConfig();
+    AdbServerSupervisor* supervisor = nullptr;
+    bool restarted = false;
+    config.startupCapabilityCheck = [ & ] {
+        if ( !restarted ) {
+            restarted = true;
+            supervisor->stop( FirstGeneration );
+            supervisor->start( SecondGeneration );
+        }
+        return std::optional<LiveSourceError>{ missingPackagedServerError() };
+    };
+    SupervisorHarness harness( config );
+    supervisor = &harness.supervisor;
+
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, absentProbe() );
+
+    CHECK( harness.supervisor.snapshot().generation == SecondGeneration );
+    CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::Probing );
+    CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u );
+    REQUIRE( harness.probe.requests.size() == 2u );
+    harness.probe.complete( 1, readyProbe( ReplacementIdentity ) );
+    CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::Ready );
+}
+
+TEST_CASE( "capability failure notification may destroy the supervisor without scheduling stale work",
+           "[livecapture][adb][supervisor][startup-capability][lifetime]" )
+{
+    ManualProbe probe;
+    ManualLauncher launcher;
+    ManualStartupLock startupLock;
+    FakeAdbKeyStore keyStore;
+    ManualScheduler scheduler;
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    auto supervisor = std::make_unique<AdbServerSupervisor>(
+        config, probe, launcher, startupLock, keyStore, scheduler );
+    QObject::connect(
+        supervisor.get(), &AdbServerSupervisor::stateChanged,
+        [ &supervisor ]( Generation, std::uint64_t,
+                        const AdbServerSupervisorSnapshot& snapshot ) {
+            if ( snapshot.status == AdbServerSupervisorStatus::RetryWait ) {
+                supervisor.reset();
+            }
+        } );
+
+    supervisor->start( FirstGeneration );
+    probe.complete( 0, absentProbe() );
+
+    CHECK_FALSE( supervisor );
+    CHECK( scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u );
+}
+
+TEST_CASE( "lost external server reports unavailable packaged startup capability",
+           "[livecapture][adb][supervisor][external][startup-capability][reconnect]" )
+{
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, readyProbe() );
+    REQUIRE( harness.scheduler.activeCount( AdbServerScheduleKind::HealthProbe ) == 1u );
+    harness.scheduler.fire( AdbServerScheduleKind::HealthProbe );
+    harness.probe.complete( 1, absentProbe( "external server stopped" ) );
+    REQUIRE( harness.scheduler.activeCount( AdbServerScheduleKind::ReconnectBackoff ) == 1u );
+
+    harness.scheduler.fire( AdbServerScheduleKind::ReconnectBackoff );
+    REQUIRE( harness.probe.requests.size() == 3u );
+    harness.probe.complete( 2, absentProbe() );
+
+    const auto& waiting = harness.supervisor.snapshot();
+    CHECK( waiting.status == AdbServerSupervisorStatus::RetryWait );
+    REQUIRE( waiting.error.has_value() );
+    CHECK( waiting.error->code == "adb-packaged-helper-missing" );
+    CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 1u );
+    CHECK( harness.startupLock.requests.empty() );
+}
+
+TEST_CASE( "incompatible external server is diagnosed before packaged startup capability",
+           "[livecapture][adb][supervisor][external][startup-capability]" )
+{
+    auto config = supervisorConfig();
+    config.startupCapabilityCheck = [] { return missingPackagedServerError(); };
+    SupervisorHarness harness( config );
+
+    harness.supervisor.start( FirstGeneration );
+    REQUIRE( harness.probe.requests.size() == 1u );
+    harness.probe.complete(
+        0, readyProbe( FirstIdentity, SupportedAdbProtocolVersion - 1u, { "shell_v2" } ) );
+
+    const auto& incompatible = harness.supervisor.snapshot();
+    CHECK( incompatible.status == AdbServerSupervisorStatus::Incompatible );
+    REQUIRE( incompatible.error.has_value() );
+    CHECK( incompatible.error->code == "incompatible-server" );
+    CHECK( harness.startupLock.requests.empty() );
+    requireNoEnvironmentChangingWork( harness );
 }
 
 TEST_CASE( "compatible server already on the standard endpoint is adopted as external shared",
@@ -813,6 +1018,9 @@ TEST_CASE( "absent server uses one per-user lock re-probe consent and the exact 
     harness.supervisor.grantKeyGenerationConsent( FirstGeneration, true );
 
     CHECK( harness.supervisor.snapshot().keyConsent == AdbServerKeyConsentState::Granted );
+    CHECK( harness.keyStore.generationCount == 0 );
+    REQUIRE( harness.probe.requests.size() == 3u );
+    harness.probe.complete( 2, absentProbe( "still absent after consent" ) );
     CHECK( harness.keyStore.generationCount == 1 );
     REQUIRE( harness.launcher.launches.size() == 1 );
     const auto& request = harness.launcher.launches.front().request;
@@ -827,11 +1035,11 @@ TEST_CASE( "absent server uses one per-user lock re-probe consent and the exact 
     CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::Starting );
     CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupTimeout ) == 1 );
     CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::ReadinessProbe ) == 1 );
-    CHECK( harness.probe.requests.size() == 2 );
+    CHECK( harness.probe.requests.size() == 3 );
 
     harness.scheduler.fire( AdbServerScheduleKind::ReadinessProbe );
-    REQUIRE( harness.probe.requests.size() == 3 );
-    harness.probe.complete( 2, readyProbe() );
+    REQUIRE( harness.probe.requests.size() == 4 );
+    harness.probe.complete( 3, readyProbe() );
 
     const auto ready = harness.supervisor.snapshot();
     CHECK( ready.generation == FirstGeneration );
@@ -885,6 +1093,77 @@ TEST_CASE( "missing standard adb key requires an explicit decision and denial ne
 
     CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::Failed );
     CHECK( harness.supervisor.snapshot().keyConsent == AdbServerKeyConsentState::Denied );
+    CHECK( harness.keyStore.generationCount == 0 );
+    CHECK( harness.launcher.launches.empty() );
+    CHECK( harness.startupLock.wasReleased( 0 ) );
+}
+
+TEST_CASE( "startup capability is revalidated before consent changes the environment",
+           "[livecapture][adb][supervisor][startup-capability][keys][consent]" )
+{
+    auto config = supervisorConfig();
+    bool helperAvailable = true;
+    config.startupCapabilityCheck = [ & ] {
+        return helperAvailable ? std::optional<LiveSourceError>{}
+                               : std::optional<LiveSourceError>{ missingPackagedServerError() };
+    };
+    SupervisorHarness harness( config );
+    harness.keyStore.inspection.state = AdbServerStandardKeyState::Absent;
+
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, absentProbe() );
+    harness.startupLock.complete( 0, true );
+    harness.probe.complete( 1, absentProbe() );
+    REQUIRE( harness.supervisor.snapshot().status
+             == AdbServerSupervisorStatus::AwaitingKeyGenerationConsent );
+
+    helperAvailable = false;
+    harness.supervisor.grantKeyGenerationConsent( FirstGeneration, true );
+    REQUIRE( harness.probe.requests.size() == 3u );
+    harness.probe.complete( 2, absentProbe() );
+
+    CHECK( harness.supervisor.snapshot().status == AdbServerSupervisorStatus::RetryWait );
+    REQUIRE( harness.supervisor.snapshot().error.has_value() );
+    CHECK( harness.supervisor.snapshot().error->code == "adb-packaged-helper-missing" );
+    CHECK( harness.keyStore.generationCount == 0 );
+    CHECK( harness.launcher.launches.empty() );
+    CHECK( harness.startupLock.wasReleased( 0 ) );
+    CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 1u );
+
+    helperAvailable = true;
+    harness.scheduler.fire( AdbServerScheduleKind::StartupRetry );
+    harness.probe.complete( 3, absentProbe() );
+    harness.startupLock.complete( 1, true );
+    harness.probe.complete( 4, absentProbe() );
+
+    CHECK( harness.events.consentRequests.size() == 1u );
+    CHECK( harness.keyStore.generationCount == 1 );
+    CHECK( harness.launcher.launches.size() == 1u );
+}
+
+TEST_CASE( "consent completion re-probes and adopts a newly started external server",
+           "[livecapture][adb][supervisor][race][keys][consent]" )
+{
+    SupervisorHarness harness;
+    harness.keyStore.inspection.state = AdbServerStandardKeyState::Absent;
+    harness.supervisor.start( FirstGeneration );
+    harness.probe.complete( 0, absentProbe() );
+    harness.startupLock.complete( 0, true );
+    harness.probe.complete( 1, absentProbe() );
+    REQUIRE( harness.supervisor.snapshot().status
+             == AdbServerSupervisorStatus::AwaitingKeyGenerationConsent );
+
+    harness.supervisor.grantKeyGenerationConsent( FirstGeneration, true );
+
+    CHECK( harness.keyStore.generationCount == 0 );
+    CHECK( harness.launcher.launches.empty() );
+    REQUIRE( harness.probe.requests.size() == 3u );
+    harness.probe.complete( 2, readyProbe( ReplacementIdentity ) );
+
+    REQUIRE( harness.supervisor.snapshot().infrastructure.ownership.has_value() );
+    CHECK( *harness.supervisor.snapshot().infrastructure.ownership
+           == InfrastructureOwnership::ExternalShared );
+    CHECK( harness.supervisor.snapshot().keyConsent == AdbServerKeyConsentState::NotRequired );
     CHECK( harness.keyStore.generationCount == 0 );
     CHECK( harness.launcher.launches.empty() );
     CHECK( harness.startupLock.wasReleased( 0 ) );
@@ -1076,6 +1355,26 @@ TEST_CASE( "launch failure and readiness timeout preserve actionable diagnostics
         CHECK( harness.launcher.wasCleaned( 0 ) );
         CHECK( harness.startupLock.wasReleased( 0 ) );
     }
+}
+
+TEST_CASE( "repeated packaged launch failures advance the configured startup backoff",
+           "[livecapture][adb][supervisor][startup][backoff]" )
+{
+    SupervisorHarness harness;
+    harness.reachLaunch();
+    harness.launcher.emitResult(
+        0, AdbServerLaunchResult{ AdbServerLaunchState::Failed, false, "first failure" } );
+    CHECK( harness.scheduler.lastDelay( AdbServerScheduleKind::StartupRetry ) == 10ms );
+
+    harness.scheduler.fire( AdbServerScheduleKind::StartupRetry );
+    harness.probe.complete( 2, absentProbe() );
+    harness.startupLock.complete( 1, true );
+    harness.probe.complete( 3, absentProbe() );
+    REQUIRE( harness.launcher.launches.size() == 2u );
+    harness.launcher.emitResult(
+        1, AdbServerLaunchResult{ AdbServerLaunchState::Failed, false, "second failure" } );
+
+    CHECK( harness.scheduler.lastDelay( AdbServerScheduleKind::StartupRetry ) == 20ms );
 }
 
 TEST_CASE( "synchronous owned launch failure is cleaned after the launcher returns its token",
@@ -1654,7 +1953,11 @@ TEST_CASE( "invalid supervisor configuration uses configuration error taxonomy",
     SupervisorHarness harness( config );
 
     harness.supervisor.start( FirstGeneration );
+    REQUIRE( harness.probe.requests.size() == 1u );
+    harness.probe.complete( 0, absentProbe() );
 
+    CHECK( harness.supervisor.snapshot().status
+           == AdbServerSupervisorStatus::InvalidConfiguration );
     REQUIRE( harness.supervisor.snapshot().error.has_value() );
     CHECK( harness.supervisor.snapshot().error->category
            == klogg::livecapture::ErrorCategory::Configuration );
@@ -1662,6 +1965,7 @@ TEST_CASE( "invalid supervisor configuration uses configuration error taxonomy",
            == klogg::livecapture::ErrorScope::Infrastructure );
     CHECK( harness.supervisor.snapshot().error->retryPolicy
            == klogg::livecapture::RetryPolicy::Never );
+    CHECK( harness.scheduler.activeCount( AdbServerScheduleKind::StartupRetry ) == 0u );
 }
 
 TEST_CASE( "startup lock never steals an old lease from a live process",

--- a/tests/unit/livecapture_state_test.cpp
+++ b/tests/unit/livecapture_state_test.cpp
@@ -317,9 +317,14 @@ TEST_CASE( "generation-tagged callbacks accept current work and reject stale wor
     auto state = streamingState();
     const auto currentGeneration = state.generation;
 
+    const auto empty = dispatch( state, StreamBytesReceived{ currentGeneration, 0u, at( 90 ) } );
+    REQUIRE( empty.accepted );
+    REQUIRE_FALSE( empty.snapshot.payloadReceived );
+
     const auto current
-        = dispatch( state, StreamBytesReceived{ currentGeneration, 128u, at( 100 ) } );
+        = dispatch( empty.snapshot, StreamBytesReceived{ currentGeneration, 128u, at( 100 ) } );
     REQUIRE( current.accepted );
+    REQUIRE( current.snapshot.payloadReceived );
     REQUIRE( hasEffect( current, EffectKind::AppendBytes ) );
     REQUIRE( current.effects.back().generation == currentGeneration );
     REQUIRE( current.effects.back().byteCount == 128u );
@@ -431,6 +436,12 @@ TEST_CASE( "device absence waits for discovery without restarting shared infrast
     REQUIRE( absent.snapshot.infrastructure.ownership == InfrastructureOwnership::ExternalShared );
     REQUIRE_FALSE( hasEffect( absent, EffectKind::StartInfrastructure ) );
     REQUIRE_FALSE( absent.snapshot.retryTimer.has_value() );
+    REQUIRE_FALSE( absent.snapshot.payloadReceived );
+
+    const auto retiringPayload = dispatch(
+        absent.snapshot, StreamBytesReceived{ streaming.generation, 64u, at( 110 ) } );
+    REQUIRE( retiringPayload.accepted );
+    REQUIRE( retiringPayload.snapshot.payloadReceived );
 }
 
 TEST_CASE( "output degradation remains orthogonal to Streaming", "[livecapture][state][output]" )

--- a/tests/unit/livelog_controller_test.cpp
+++ b/tests/unit/livelog_controller_test.cpp
@@ -546,6 +546,44 @@ TEST_CASE( "An unconnected stream attempt does not manufacture an integrity gap"
     CHECK_FALSE( controller.spec().integrity.replayPossible );
 }
 
+TEST_CASE( "A connected stream that fails before payload does not manufacture an integrity gap",
+           "[livelog-controller][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto generation = controller.snapshot().generation;
+    controller.streamBytesReceived( generation, QByteArray{} );
+    controller.streamFailed( generation, retryableStreamError() );
+
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "An opening stream that delivered payload records an integrity gap on failure",
+           "[livelog-controller][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToOpening( controller, clock );
+    const auto generation = controller.snapshot().generation;
+    controller.streamBytesReceived( generation, QByteArrayLiteral( "early\n" ) );
+    controller.streamFailed( generation, retryableStreamError() );
+
+    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
 TEST_CASE( "A clean intentional stop does not manufacture an integrity gap",
            "[livelog-controller][live-integrity-policy-red]" )
 {
@@ -563,7 +601,7 @@ TEST_CASE( "A clean intentional stop does not manufacture an integrity gap",
     CHECK_FALSE( controller.spec().integrity.replayPossible );
 }
 
-TEST_CASE( "Automatic retirement waits for the stop barrier and reports real reconnect semantics",
+TEST_CASE( "Zero-payload retirement waits for the stop barrier without inventing a gap",
            "[livelog-controller][w2-control-red][live-integrity-policy-red]" )
 {
     const auto useIos = GENERATE( false, true );
@@ -575,8 +613,9 @@ TEST_CASE( "Automatic retirement waits for the stop barrier and reports real rec
                                            clock, scheduler, effects };
     armToStreaming( controller, clock );
     const auto retiredGeneration = controller.snapshot().generation;
+    controller.streamBytesReceived( retiredGeneration, QByteArray{} );
     controller.deviceAbsent( retiredGeneration );
-    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
     CHECK_FALSE( controller.spec().integrity.replayPossible );
     REQUIRE( controller.snapshot().generation != retiredGeneration );
     const auto replacementGeneration = controller.snapshot().generation;
@@ -592,6 +631,212 @@ TEST_CASE( "Automatic retirement waits for the stop barrier and reports real rec
     controller.streamHandleOpened( replacementGeneration );
     controller.streamReadArmed( replacementGeneration );
     REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "Retiring payload turns a zero-payload interruption into a real integrity gap",
+           "[livelog-controller][w2-control-red][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.deviceAbsent( retiredGeneration );
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "queued-tail\n" ) );
+    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.stopCompleted( retiredGeneration );
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "User stop after retirement does not hide a payload-producing interruption",
+           "[livelog-controller][live-integrity-policy-red][retirement]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.deviceAbsent( retiredGeneration );
+    controller.stopRequested( live::StopDisposition::SettleAccepted );
+    controller.startRequested();
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "queued-tail\n" ) );
+
+    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+
+    controller.stopCompleted( retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "Explicit reconnect after payload does not manufacture an interruption gap",
+           "[livelog-controller][live-integrity-policy-red][reconnect]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    controller.streamBytesReceived( controller.snapshot().generation,
+                                    QByteArrayLiteral( "captured\n" ) );
+
+    controller.reconnectRequested();
+
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "Automatic interruption retains replay risk across a stop-start barrier",
+           "[livelog-controller][live-integrity-policy-red][restart]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "captured\n" ) );
+    controller.deviceAbsent( retiredGeneration );
+    REQUIRE( controller.spec().integrity.gapPossible );
+
+    controller.stopRequested( live::StopDisposition::SettleAccepted );
+    controller.startRequested();
+    controller.stopCompleted( retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "Intentional stop-start tail does not manufacture an interruption gap",
+           "[livelog-controller][live-integrity-policy-red][restart]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.stopRequested( live::StopDisposition::SettleAccepted );
+    controller.startRequested();
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "settled-tail\n" ) );
+
+    CHECK_FALSE( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+}
+
+TEST_CASE( "Payload-producing retirement preserves source-specific reconnect integrity",
+           "[livelog-controller][w2-control-red][live-integrity-policy-red]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "captured\n" ) );
+    controller.deviceAbsent( retiredGeneration );
+    CHECK( controller.spec().integrity.gapPossible );
+    CHECK_FALSE( controller.spec().integrity.replayPossible );
+    REQUIRE( controller.snapshot().generation != retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.stopCompleted( retiredGeneration );
+    CHECK( effects.count( RecordingEffects::Kind::OpenStream ) == 2u );
+
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::Streaming );
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "Replacement payload publishes Android replay risk before readiness completes",
+           "[livelog-controller][live-integrity-policy-red][opening]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.streamBytesReceived( retiredGeneration, QByteArrayLiteral( "captured\n" ) );
+    controller.deviceAbsent( retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.stopCompleted( retiredGeneration );
+    REQUIRE( controller.snapshot().source.status == live::SourceStatus::OpeningStream );
+
+    controller.streamBytesReceived( replacementGeneration, QByteArrayLiteral( "possible-replay\n" ) );
+
+    CHECK( controller.spec().integrity.replayPossible == !useIos );
+}
+
+TEST_CASE( "Discarded retiring payload arms Android replay risk for the replacement",
+           "[livelog-controller][live-integrity-policy-red][retirement]" )
+{
+    const auto useIos = GENERATE( false, true );
+    CAPTURE( useIos );
+    ManualClock clock;
+    ManualScheduler scheduler;
+    RecordingEffects effects;
+    livelog::LiveLogController controller{ useIos ? iosSpec() : androidSpec(), controllerConfig(),
+                                           clock, scheduler, effects };
+    armToStreaming( controller, clock );
+    const auto retiredGeneration = controller.snapshot().generation;
+    controller.deviceAbsent( retiredGeneration );
+    const auto replacementGeneration = controller.snapshot().generation;
+    controller.deviceAvailable( replacementGeneration );
+    controller.stopCompleted( retiredGeneration, 7u );
+    controller.protocolServiceReady( replacementGeneration );
+    controller.streamHandleOpened( replacementGeneration );
+    controller.streamReadArmed( replacementGeneration );
+
+    CHECK( controller.spec().integrity.gapPossible );
     CHECK( controller.spec().integrity.replayPossible == !useIos );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #71, grouped by topic:

- **ADB live capture hardening**: split probe vs startup validation for the packaged ADB helper, dynamically revalidate helper capability around locking and user consent (re-probe after consent), suspend unavailable supervision while idle, guard supervisor callbacks against lifetime and run-identity races, and carry reducer-owned payload plus retirement evidence into integrity classification — so startup failures with no delivered data are now distinguished from genuine payload-producing interruptions.
- **iOS runtime closure in bundles**: expose the verified native os_trace dylibs as an exact 16-file runtime manifest and stage them into both raw macOS bundles (`klogg`, `klogg_portable`) with symlink preservation, single/multi-config output handling, and an always-active staging dependency that repairs stale or deleted closures.
- **Xcode generator support**: pin a Vectorscan patch removing redundant `ragel_*` wrapper targets, and compile shared app resources (translations, docs) once in object libraries consumed by the executables — CMake's Xcode generator now builds `hs`, `klogg_vectorscan_tests`, `klogg`, and `klogg_grep`.
- **Event-driven folder test waits**: folder-result selections wait on a shared observer-before-trigger completion helper (driven by `mainViewFileChanged` at the data-swap boundary) instead of fixed five-second path predicates; an incident-backed lint rule preserves documented fixed waits.
- **CI lint hardening**: the diagnostics-marker contract now strips comments (outside quoted strings) from workflow scripts before validating required markers, so commenting out a required collector no longer satisfies the check.
- **Review and CI-gate follow-up (83a65191, 5775f502, c67c36ef)**:
  - Suppress a cppcheck `knownConditionTrueFalse` false positive on the ADB supervisor's run-identity revalidation — the capability callback may reenter and retire the run; cppcheck's value flow cannot see that reentrancy (Static analysis run 34675223936).
  - Add `strip_powershell_comments()` to the diagnostics contract so `";# ..."` comments and `"<# ... #>"` blocks can no longer spoof required markers (Codex P2 + CodeRabbit findings).
  - Tighten the folder-wait lint: path assertions now detect `currentMainFilePath()` on either side of `==` (literals, calls, reversed operands), selection segments end at the next same-receiver selection so cross-widget selections no longer hide waits, and polls after an asserted completion signal are accepted as post-completion grace.

## Background

- **ADB adoption / integrity** (follow-up to #71):
  - Introduced by: PR #71's lifecycle/integrity split.
  - Use case: Android and iOS live captures must distinguish startup failures with no delivered data from genuine payload-producing interruptions; Android must adopt a compatible system ADB server or start the packaged helper safely.
  - Root cause: packaged-helper validation ran before external-server adoption, capability state went stale, retiring payload evidence was not tied to the interrupted attempt, and synchronous supervisor callbacks could outlive or reenter their run (reproduced as a heap-use-after-free under ASan).
  - How to fix: probe/startup separation, consent-time revalidation, idle suspension, callback lifetime and run-identity guards, reducer-owned payload and retirement evidence in classification.
- **iOS staging**: enabling the verified native stack linked its dylibs but never populated the private bundle runtime directory, and directory-copy staging did not preserve the symlink closure — replaced with manifest-driven, symlink-preserving staging.
- **Xcode**: Xcode's new build system rejects custom commands owned by multiple root targets (Vectorscan's ragel wrapper pattern; QM/docs generated sources reused by several executables) — pinned patch plus object-library compilation of shared resources.
- **Folder waits**: introduced by generic five-second path predicates; Linux TSan run 34597411626 exhausted the predicate budget while indexing a >16 MiB file. Root cause: elapsed time and `currentMainFilePath` polling were treated as completion evidence despite the existing `mainViewFileChanged` signal.
- **Lint / CI gate**: introduced by PR #71's Windows diagnostics workflow contract; marker substring checks ran on raw workflow text, so commented-out commands satisfied them. cppcheck flagged the supervisor's reentrancy guard as constant conditions — false positive kept via inline suppression with rationale, colocated with the code instead of the line-number-qualified baseline.

## Tests

- `python3 scripts/run_ci_quality.py` (all script tests pass) and `git diff --check`.
- Serial full CTest (27/27) including ASan+UBSan; focused supervisor, manager, composition, reducer, and controller suites (including an ASan regression that previously reproduced the heap-use-after-free).
- Folder/main-window scenarios plus Qt 5 targeted folder regressions; the escaped TSan regression repeated 10/10.
- Xcode: fresh project generation; built `hs`, `klogg_vectorscan_tests`, `klogg`, `klogg_grep`; Xcode smoke tests; full Ninja, ASan+UBSan, and TSan suites built and run serially.
- iOS: all 48 release-contract tests pass; both raw bundle closures contain the complete 16-file verified manifest; current-stack verifier and physical-device native/GUI captures passed.
- Review follow-up: the five review findings were reproduced against the pre-fix lint (three escapes, one false positive, two spoof bypasses — all confirmed empirically) and the new test cases now cover each; both lint test suites pass (109 + 144 tests).
- Not run: Linux TSan Docker parity (blocked by Docker Desktop API 500 on the dev host). The cppcheck gate can only be confirmed by the Static analysis run on the push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live ADB capture startup and recovery when packaged tools are unavailable or external servers are running.
  - Improved handling of interrupted streams, payload detection, replay-risk tracking, and idle infrastructure suspension.
  - Improved iOS app bundling by staging required native runtime libraries more reliably.

- **Build and Compatibility**
  - Improved Xcode resource generation and compatibility with the Vectorscan build.

- **Documentation**
  - Added guidance for reliable asynchronous UI synchronization and updated testing recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->